### PR TITLE
Add workflow metadata propagation and smart parameter tests

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -277,8 +277,219 @@ const getAppColor = (category: string) => {
     'Accounting': '#228B22',
     'Recruitment': '#FF69B4'
   };
-  
+
   return colorMap[category] || '#6366F1';
+};
+
+type WorkflowMetadata = {
+  columns?: string[];
+  sample?: Record<string, any> | any[];
+  schema?: Record<string, any>;
+  derivedFrom?: string[];
+};
+
+const canonicalizeMetadataKey = (value: unknown): string => {
+  if (value == null) return '';
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+};
+
+const mergeMetadataValues = (
+  ...sources: Array<WorkflowMetadata | null | undefined>
+): WorkflowMetadata => {
+  const columns = new Set<string>();
+  const derivedFrom = new Set<string>();
+  let sampleObject: Record<string, any> | null = null;
+  let sampleArray: any[] | null = null;
+  let scalarSample: any;
+  let schema: Record<string, any> = {};
+  let hasSchema = false;
+
+  sources.forEach((source) => {
+    if (!source) return;
+    source.columns?.forEach((col) => {
+      if (typeof col === 'string' && col.trim()) columns.add(col);
+    });
+    source.derivedFrom?.forEach((item) => {
+      if (item) derivedFrom.add(item);
+    });
+    const sample = source.sample;
+    if (Array.isArray(sample)) {
+      if (!sampleArray) sampleArray = sample;
+    } else if (sample && typeof sample === 'object') {
+      sampleObject = { ...(sampleObject ?? {}), ...sample };
+    } else if (sample !== undefined && scalarSample === undefined) {
+      scalarSample = sample;
+    }
+    if (source.schema) {
+      schema = { ...schema, ...source.schema };
+      hasSchema = true;
+    }
+  });
+
+  const result: WorkflowMetadata = {};
+  if (columns.size) result.columns = Array.from(columns);
+  if (derivedFrom.size) result.derivedFrom = Array.from(derivedFrom);
+  if (sampleArray) result.sample = sampleArray;
+  else if (sampleObject) result.sample = sampleObject;
+  else if (scalarSample !== undefined) result.sample = scalarSample;
+  if (hasSchema) result.schema = schema;
+  return result;
+};
+
+const collectColumnsFromAny = (source: unknown): string[] => {
+  if (!source) return [];
+  const result = new Set<string>();
+  const visit = (value: unknown, depth = 0) => {
+    if (value == null || depth > 2) return;
+    if (Array.isArray(value)) {
+      value.forEach((entry) => visit(entry, depth + 1));
+      return;
+    }
+    if (typeof value === 'string') {
+      value
+        .split(/[\n,|,]/)
+        .map((v) => v.trim())
+        .filter(Boolean)
+        .forEach((v) => result.add(v));
+      return;
+    }
+    if (typeof value === 'object') {
+      Object.entries(value as Record<string, any>).forEach(([key, val]) => {
+        const lower = key.toLowerCase();
+        if (
+          ['columns', 'headers', 'fields', 'fieldnames', 'selectedcolumns', 'columnnames'].some((token) =>
+            lower.includes(token)
+          )
+        ) {
+          visit(val, depth + 1);
+        } else if (depth === 0 && val && typeof val === 'object' && !Array.isArray(val)) {
+          Object.keys(val as Record<string, any>).forEach((k) => {
+            if (k) result.add(k);
+          });
+        }
+      });
+    }
+  };
+  visit(source);
+  return Array.from(result);
+};
+
+const lookupValueInSource = (source: unknown, key: string, depth = 0): any => {
+  if (!source || depth > 3) return undefined;
+  if (Array.isArray(source)) {
+    for (const entry of source) {
+      const val = lookupValueInSource(entry, key, depth + 1);
+      if (val !== undefined) return val;
+    }
+    return undefined;
+  }
+  if (typeof source !== 'object') return undefined;
+  for (const [entryKey, entryValue] of Object.entries(source as Record<string, any>)) {
+    const normalized = canonicalizeMetadataKey(entryKey).replace(/-/g, '_');
+    if (normalized === key || normalized.replace(/_/g, '') === key.replace(/_/g, '')) {
+      return entryValue;
+    }
+    if (entryValue && typeof entryValue === 'object') {
+      const nested = lookupValueInSource(entryValue, key, depth + 1);
+      if (nested !== undefined) return nested;
+    }
+  }
+  return undefined;
+};
+
+const inferValueType = (value: any): string => {
+  if (value === null || value === undefined) return 'string';
+  if (Array.isArray(value)) return 'array';
+  if (typeof value === 'object') return 'object';
+  if (typeof value === 'number') return 'number';
+  if (typeof value === 'boolean') return 'boolean';
+  if (typeof value === 'string') {
+    const numeric = Number(value);
+    if (!Number.isNaN(numeric) && value.trim() !== '') return 'number';
+  }
+  return 'string';
+};
+
+const buildMetadataFromNode = (node: any): WorkflowMetadata => {
+  const merged = mergeMetadataValues(
+    node?.metadata,
+    node?.data?.metadata,
+    node?.data?.outputMetadata,
+    node?.outputMetadata
+  );
+
+  const params =
+    node?.data?.config ?? node?.data?.parameters ?? node?.params ?? node?.config ?? node?.data?.params ?? {};
+
+  const configColumns = collectColumnsFromAny(params);
+  const schemaColumns = merged.schema ? Object.keys(merged.schema) : [];
+  const combinedColumns = Array.from(
+    new Set([...(merged.columns || []), ...configColumns, ...schemaColumns])
+  ).filter((col): col is string => typeof col === 'string' && col.trim().length > 0);
+
+  let metadata = mergeMetadataValues(merged, {
+    columns: combinedColumns.length ? combinedColumns : undefined,
+  });
+
+  const columns = metadata.columns || [];
+
+  let sample = metadata.sample;
+  if (
+    columns.length > 0 &&
+    (!sample || (typeof sample === 'object' && !Array.isArray(sample) && Object.keys(sample as Record<string, any>).length === 0))
+  ) {
+    const generated: Record<string, any> = {};
+    const valuesArray = Array.isArray(params?.values) ? params.values : null;
+    columns.forEach((column, index) => {
+      const normalized = canonicalizeMetadataKey(column).replace(/-/g, '_');
+      const fromParams = lookupValueInSource(params, normalized);
+      if (fromParams !== undefined && fromParams !== null && fromParams !== '') {
+        generated[column] = fromParams;
+        return;
+      }
+      if (valuesArray && index < valuesArray.length) {
+        generated[column] = valuesArray[index];
+        return;
+      }
+      if (merged.sample && typeof merged.sample === 'object' && !Array.isArray(merged.sample) && column in merged.sample) {
+        generated[column] = (merged.sample as Record<string, any>)[column];
+        return;
+      }
+      generated[column] = `{{${normalized}}}`;
+    });
+    sample = generated;
+  }
+
+  if (sample) {
+    metadata = mergeMetadataValues(metadata, { sample });
+  }
+
+  let schema = metadata.schema;
+  if ((!schema || Object.keys(schema).length === 0) && columns.length > 0) {
+    const generatedSchema: Record<string, any> = {};
+    const sampleObj =
+      sample && typeof sample === 'object' && !Array.isArray(sample) ? (sample as Record<string, any>) : undefined;
+    columns.forEach((column) => {
+      const example = sampleObj?.[column];
+      generatedSchema[column] = {
+        type: inferValueType(example),
+        example,
+      };
+      if (schema && schema[column]) {
+        generatedSchema[column] = { ...schema[column], ...generatedSchema[column] };
+      }
+    });
+    schema = generatedSchema;
+  }
+
+  if (schema && Object.keys(schema).length > 0) {
+    metadata = mergeMetadataValues(metadata, { schema });
+  }
+
+  return metadata;
 };
 
 // Custom Node Components
@@ -1102,6 +1313,8 @@ const GraphEditorContent = () => {
               node.data?.actionId ||
               "noop") + "";
 
+          const metadata = buildMetadataFromNode(node);
+
           return {
             id: `${node.id || `node_${index}`}`,
             type: "action.core",
@@ -1132,7 +1345,7 @@ const GraphEditorContent = () => {
                   : "#9AA0A6"),
               connectorId: node.data?.connectorId || app,
               actionId: operation,
-              metadata: node.data?.metadata || {},
+              metadata,
               isValid: true,
               loadSource,
             },

--- a/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
+++ b/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+
+import {
+  computeMetadataSuggestions,
+  mapUpstreamNodesForAI,
+  type UpstreamNodeSummary
+} from "../SmartParametersPanel";
+
+const upstreamNodes: UpstreamNodeSummary[] = [
+  {
+    id: "node-1",
+    data: {
+      label: "Email Parser",
+      app: "gmail",
+      metadata: {
+        columns: ["Invoice Number", "Total"],
+        sample: {
+          "Invoice Number": "INV-001",
+          Total: "$120.00"
+        },
+        schema: {
+          "Invoice Number": { type: "string" },
+          Total: { type: "number" }
+        }
+      }
+    }
+  },
+  {
+    id: "node-2",
+    data: {
+      label: "Sheet Logger",
+      app: "sheets",
+      metadata: {
+        headers: ["Amount"],
+        sampleRow: {
+          Amount: "99.99"
+        }
+      }
+    }
+  }
+];
+
+const suggestions = computeMetadataSuggestions(upstreamNodes);
+const invoiceSuggestion = suggestions.find(
+  (suggestion) => suggestion.nodeId === "node-1" && suggestion.path === "Invoice Number"
+);
+const totalSuggestion = suggestions.find(
+  (suggestion) => suggestion.nodeId === "node-1" && suggestion.path === "Total"
+);
+const amountSuggestion = suggestions.find(
+  (suggestion) => suggestion.nodeId === "node-2" && suggestion.path === "Amount"
+);
+const entireOutput = suggestions.filter((suggestion) => suggestion.path === "").map((item) => item.nodeId);
+
+assert.ok(invoiceSuggestion, "should include Invoice Number in quick picks");
+assert.ok(invoiceSuggestion?.label.includes("Invoice Number"));
+assert.ok(totalSuggestion, "should include Total column quick pick");
+assert.ok(amountSuggestion, "should surface Amount column quick pick");
+assert.ok(entireOutput.includes("node-1"), "should include entire output suggestions");
+
+const payload = mapUpstreamNodesForAI(upstreamNodes);
+const first = payload.find((entry) => entry.nodeId === "node-1");
+const second = payload.find((entry) => entry.nodeId === "node-2");
+
+assert.ok(first, "AI payload should include first node");
+assert.ok(first?.columns.includes("Invoice Number"));
+assert.equal(
+  typeof first?.sample === "object" && !Array.isArray(first?.sample)
+    ? (first?.sample as Record<string, any>).Total
+    : undefined,
+  "$120.00"
+);
+assert.equal(first?.schema?.["Invoice Number"]?.type, "string");
+
+assert.ok(second, "AI payload should include second node");
+assert.ok(second?.columns.includes("Amount"));
+assert.equal(
+  typeof second?.sample === "object" && !Array.isArray(second?.sample)
+    ? (second?.sample as Record<string, any>).Amount
+    : undefined,
+  "99.99"
+);
+
+console.log("SmartParametersPanel metadata helper checks passed.");

--- a/common/workflow-types.ts
+++ b/common/workflow-types.ts
@@ -1,5 +1,12 @@
 export type NodeType = 'trigger' | 'action' | 'transform';
 
+export type WorkflowNodeMetadata = {
+  columns?: string[];
+  sample?: Record<string, any> | any[];
+  schema?: Record<string, any>;
+  derivedFrom?: string[];
+};
+
 export type WorkflowNode = {
   id: string;
   type: NodeType;
@@ -7,12 +14,29 @@ export type WorkflowNode = {
   name: string;     // human name, e.g., 'Gmail Trigger'
   op: string;       // machine op, e.g., 'gmail.watchInbox'
   params: Record<string, any>;
+  data?: {
+    label?: string;
+    operation?: string;
+    config?: Record<string, any>;
+    parameters?: Record<string, any>;
+    metadata?: WorkflowNodeMetadata;
+    [key: string]: any;
+  };
+  metadata?: WorkflowNodeMetadata;
 };
 
-export type WorkflowEdge = { id: string; from: string; to: string };
+export type WorkflowEdge = {
+  id: string;
+  from?: string;
+  to?: string;
+  source?: string;
+  target?: string;
+  [key: string]: any;
+};
 
 export type WorkflowGraph = {
   id: string;
+  name?: string;
   nodes: WorkflowNode[];
   edges: WorkflowEdge[];
   meta?: Record<string, any>;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "check": "tsc",
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",

--- a/server/workflow/ai-workflow-generator.ts
+++ b/server/workflow/ai-workflow-generator.ts
@@ -1,9 +1,10 @@
 // TRUE AI-DRIVEN WORKFLOW GENERATOR
 // No presets, no templates - pure AI intelligence
 
-import { WorkflowGraph, WorkflowNode, WorkflowEdge } from './types';
+import { WorkflowGraph, WorkflowNode, WorkflowEdge } from '../../common/workflow-types';
+import { enrichWorkflowGraph } from './node-metadata';
 
-export async function generateWorkflowWithAI(prompt: string, answers: Record<string, string>): Promise<WorkflowGraph> {
+export async function generateWorkflowWithAI(prompt: string, answers: Record<string, any>): Promise<WorkflowGraph> {
   console.log('🤖 Using AI to dynamically generate workflow...');
   
   // Construct intelligent prompt for LLM
@@ -78,13 +79,14 @@ RESPOND ONLY WITH VALID JSON:`;
     console.log('✅ AI Reasoning:', aiResult.reasoning);
     
     // Return the AI-generated workflow
-    const workflow = aiResult.workflow;
+    const workflow = aiResult.workflow as WorkflowGraph;
     workflow.id = `wf-${Date.now()}`;
-    
+
     console.log('🎯 AI Generated Workflow:', workflow.name);
-    console.log(`📊 Nodes: ${workflow.nodes.length}, Apps: [${workflow.nodes.map(n => n.app).join(', ')}]`);
-    
-    return workflow;
+    const appSummary = (workflow.nodes as WorkflowNode[]).map((node) => node.app).join(', ');
+    console.log(`📊 Nodes: ${workflow.nodes.length}, Apps: [${appSummary}]`);
+
+    return enrichWorkflowGraph(workflow, { answers });
     
   } catch (error) {
     console.error('❌ AI workflow generation failed:', error);
@@ -94,7 +96,7 @@ RESPOND ONLY WITH VALID JSON:`;
   }
 }
 
-function generateDynamicWorkflow(prompt: string, answers: Record<string, string>): WorkflowGraph {
+function generateDynamicWorkflow(prompt: string, answers: Record<string, any>): WorkflowGraph {
   console.log('🔄 Generating dynamic workflow from user intent...');
   
   // Analyze user intent dynamically (no presets)
@@ -138,7 +140,7 @@ function generateDynamicWorkflow(prompt: string, answers: Record<string, string>
     });
   });
   
-  return {
+  const workflow = {
     id: `wf-${Date.now()}`,
     name: `Dynamic Workflow: ${apps.join(' + ')}`,
     nodes,
@@ -150,6 +152,7 @@ function generateDynamicWorkflow(prompt: string, answers: Record<string, string>
       userAnswers: answers
     }
   };
+  return enrichWorkflowGraph(workflow, { answers });
 }
 
 function extractAppsFromAnswers(answers: Record<string, string>): string[] {

--- a/server/workflow/answers-to-graph.ts
+++ b/server/workflow/answers-to-graph.ts
@@ -1,7 +1,8 @@
 import { WorkflowGraph, WorkflowNode, WorkflowEdge } from '../../common/workflow-types';
+import { enrichWorkflowGraph } from './node-metadata';
 
 // Use standard WorkflowNode interface from common/workflow-types.ts
-export function answersToGraph(prompt: string, answers: Record<string, string>): WorkflowGraph {
+export function answersToGraph(prompt: string, answers: Record<string, any>): WorkflowGraph {
   console.log(`🤖 Generating workflow from user answers (NO PRESETS)`);
   console.log(`📝 User Prompt: "${prompt}"`);
   console.log(`📋 User Answers:`, answers);
@@ -10,7 +11,7 @@ export function answersToGraph(prompt: string, answers: Record<string, string>):
   return generateWorkflowFromUserAnswers(prompt, answers);
 }
 
-function generateWorkflowFromUserAnswers(prompt: string, answers: Record<string, string>): WorkflowGraph {
+function generateWorkflowFromUserAnswers(prompt: string, answers: Record<string, any>): WorkflowGraph {
   console.log('👤 Building workflow from user requirements only...');
   
   // Parse what the user actually wants
@@ -73,7 +74,7 @@ function generateWorkflowFromUserAnswers(prompt: string, answers: Record<string,
     }
   }
   
-  return {
+  const workflow: WorkflowGraph = {
     id: `wf-${Date.now()}`,
     name: userRequirements.workflowName,
     nodes,
@@ -85,9 +86,10 @@ function generateWorkflowFromUserAnswers(prompt: string, answers: Record<string,
       userAnswers: answers
     }
   };
+  return enrichWorkflowGraph(workflow, { answers });
 }
 
-function parseUserRequirements(prompt: string, answers: Record<string, string>): {
+function parseUserRequirements(prompt: string, answers: Record<string, any>): {
   trigger: {app: string, label: string, operation: string, config: any} | null,
   actions: Array<{app: string, label: string, operation: string, config: any}>,
   workflowName: string,

--- a/server/workflow/convert.ts
+++ b/server/workflow/convert.ts
@@ -1,4 +1,5 @@
 import type { AutomationSpec } from '../../../shared/core/spec';
+import { enrichWorkflowNode } from './node-metadata';
 
 export type WorkflowGraph = {
   id: string;
@@ -19,11 +20,32 @@ export type WorkflowGraph = {
 export function specToWorkflowGraph(spec: AutomationSpec): WorkflowGraph {
   return {
     id: spec.name,
-    nodes: [...(spec.triggers || []), ...(spec.nodes || [])].map((n) => ({
-      id: n.id,
-      type: n.type.startsWith('trigger') ? 'trigger' : 'action',
-      data: { app: n.app, label: n.label, params: n.inputs, outputs: n.outputs || [] }
-    })),
+    nodes: [...(spec.triggers || []), ...(spec.nodes || [])].map((n) => {
+      const typeParts = n.type.split('.');
+      const kind = typeParts[0]?.startsWith('trigger') ? 'trigger' : 'action';
+      const opSegments = typeParts.slice(1);
+      const operationName = opSegments.slice(1).join('.') || opSegments[0] || '';
+      const fullOperation = n.app && operationName ? `${n.app}.${operationName}` : operationName;
+
+      const baseNode = {
+        id: n.id,
+        type: kind as 'trigger' | 'action',
+        app: n.app,
+        name: n.label,
+        op: fullOperation || n.type,
+        params: n.inputs,
+        data: {
+          app: n.app,
+          label: n.label,
+          operation: operationName,
+          parameters: n.inputs,
+          config: n.inputs,
+          outputs: n.outputs || [],
+        },
+      } as any;
+
+      return enrichWorkflowNode(baseNode);
+    }),
     edges: (spec.edges || []).map((e) => ({
       id: `${e.from.nodeId}:${e.from.port}->${e.to.nodeId}:${e.to.port}`,
       source: e.from.nodeId,

--- a/server/workflow/graph-format-converter.ts
+++ b/server/workflow/graph-format-converter.ts
@@ -1,14 +1,17 @@
 // GRAPH FORMAT CONVERTER
 // Converts AI-generated WorkflowGraph to Graph Editor compatible NodeGraph
 
-import { WorkflowGraph, WorkflowNode, WorkflowEdge } from './types';
+import { WorkflowGraph, WorkflowNode, WorkflowEdge } from '../../common/workflow-types';
+import { enrichWorkflowGraph } from './node-metadata';
 import { NodeGraph, GraphNode, Edge } from '../../shared/nodeGraphSchema';
 
 export function convertToNodeGraph(workflowGraph: WorkflowGraph): NodeGraph {
   console.log('🔄 Converting AI graph to Graph Editor format...');
-  
+
+  const enrichedGraph = enrichWorkflowGraph(workflowGraph);
+
   // Convert nodes from AI format to Graph Editor format
-  const graphNodes: GraphNode[] = workflowGraph.nodes.map((node, index) => {
+  const graphNodes: GraphNode[] = enrichedGraph.nodes.map((node, index) => {
     // Handle both old format (with op) and new format (with data.operation)
     const operation = node.op?.split('.').pop() || node.data?.operation || 'default';
     const app = node.app || node.type?.split('.')[1] || 'unknown';
@@ -31,9 +34,9 @@ export function convertToNodeGraph(workflowGraph: WorkflowGraph): NodeGraph {
       op: node.op || `${app}.${operation}`
     };
   });
-  
+
   // Convert edges from AI format to Graph Editor format
-  const graphEdges: Edge[] = workflowGraph.edges.map(edge => ({
+  const graphEdges: Edge[] = enrichedGraph.edges.map(edge => ({
     from: edge.source || edge.from,
     to: edge.target || edge.to,
     label: edge.label || '',

--- a/server/workflow/node-metadata.ts
+++ b/server/workflow/node-metadata.ts
@@ -1,0 +1,444 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { WorkflowGraph, WorkflowNode } from '../../common/workflow-types';
+
+export type WorkflowNodeMetadata = {
+  columns?: string[];
+  sample?: Record<string, any> | any[];
+  schema?: Record<string, any>;
+  derivedFrom?: string[];
+};
+
+type ConnectorDefinition = {
+  id?: string;
+  name?: string;
+  actions?: Array<{ id?: string; name?: string; title?: string; parameters?: { properties?: Record<string, any> } }>;
+  triggers?: Array<{ id?: string; name?: string; title?: string; parameters?: { properties?: Record<string, any> } }>;
+};
+
+type MetadataSource = WorkflowNodeMetadata | undefined | null;
+
+type EnrichContext = {
+  answers?: Record<string, any>;
+};
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONNECTOR_DIR = path.resolve(__dirname, '../../connectors');
+
+let connectorCache: Array<{ definition: ConnectorDefinition; tokens: Set<string> }> | null = null;
+
+const canonicalize = (value: unknown): string => {
+  if (value == null) return '';
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+};
+
+const normalizeOperationId = (operation?: string): string => {
+  if (!operation) return '';
+  const cleaned = operation.split(/[.:]/).pop() ?? operation;
+  return canonicalize(cleaned);
+};
+
+const unique = <T,>(values: Iterable<T>): T[] => {
+  const seen = new Set<T>();
+  const result: T[] = [];
+  for (const value of values) {
+    if (!seen.has(value) && value !== undefined && value !== null && (typeof value !== 'string' || value.trim() !== '')) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+};
+
+const ensureConnectorCache = () => {
+  if (connectorCache) return connectorCache;
+  try {
+    const files = readdirSync(CONNECTOR_DIR).filter((file) => file.endsWith('.json'));
+    connectorCache = files.map((file) => {
+      try {
+        const content = readFileSync(path.join(CONNECTOR_DIR, file), 'utf8');
+        const definition = JSON.parse(content) as ConnectorDefinition;
+        const tokens = new Set<string>();
+        const id = canonicalize(definition.id ?? file.replace(/\.json$/i, ''));
+        const name = canonicalize(definition.name ?? '');
+        if (id) tokens.add(id);
+        if (name) tokens.add(name);
+        if (id) {
+          tokens.add(id.replace(/-/g, ''));
+          tokens.add(id.replace(/-/g, '_'));
+        }
+        if (name) {
+          tokens.add(name.replace(/-/g, ''));
+          tokens.add(name.replace(/-/g, '_'));
+        }
+        return { definition, tokens };
+      } catch (error) {
+        console.warn('Failed to load connector definition', file, error);
+        return { definition: {}, tokens: new Set<string>() };
+      }
+    });
+  } catch (error) {
+    console.warn('Failed to index connector definitions', error);
+    connectorCache = [];
+  }
+  return connectorCache;
+};
+
+const findConnector = (app?: string): ConnectorDefinition | undefined => {
+  if (!app) return undefined;
+  const target = canonicalize(app);
+  if (!target) return undefined;
+  const index = ensureConnectorCache();
+
+  let fallback: ConnectorDefinition | undefined;
+  for (const entry of index) {
+    if (entry.tokens.has(target)) return entry.definition;
+    if (!fallback) {
+      for (const token of entry.tokens) {
+        if (token && (token.includes(target) || target.includes(token))) {
+          fallback = entry.definition;
+          break;
+        }
+      }
+    }
+  }
+  return fallback;
+};
+
+const operationMatches = (candidate: any, target: string): boolean => {
+  if (!candidate) return false;
+  const id = canonicalize(candidate.id);
+  const name = canonicalize(candidate.name ?? candidate.title);
+  const candidateTokens = unique([
+    id,
+    name,
+    id.replace(/-/g, ''),
+    id.replace(/-/g, '_'),
+    name.replace(/-/g, ''),
+    name.replace(/-/g, '_'),
+  ]);
+  const targetTokens = unique([target, target.replace(/-/g, ''), target.replace(/-/g, '_')]);
+  for (const token of candidateTokens) {
+    if (!token) continue;
+    if (targetTokens.includes(token)) return true;
+  }
+  return false;
+};
+
+const findOperation = (
+  connector: ConnectorDefinition | undefined,
+  nodeType: string,
+  operationId: string
+): { parameters?: { properties?: Record<string, any> } } | undefined => {
+  if (!connector || !operationId) return undefined;
+  const target = normalizeOperationId(operationId);
+  if (!target) return undefined;
+  const pools: Array<Array<any> | undefined> = [];
+  if (nodeType.startsWith('trigger')) {
+    pools.push(connector.triggers, connector.actions);
+  } else {
+    pools.push(connector.actions, connector.triggers);
+  }
+  for (const pool of pools) {
+    if (!pool) continue;
+    for (const candidate of pool) {
+      if (operationMatches(candidate, target)) return candidate as any;
+    }
+  }
+  return undefined;
+};
+
+const collectColumnsFromValue = (value: unknown): string[] => {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === 'string' ? entry : typeof entry === 'object' && entry ? Object.keys(entry) : []))
+      .flat()
+      .map((entry) => (typeof entry === 'string' ? entry : ''))
+      .filter((entry) => entry && entry.trim().length > 0);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/[\n,|]/)
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0);
+  }
+  if (typeof value === 'object') {
+    return Object.keys(value as Record<string, any>);
+  }
+  return [];
+};
+
+const collectColumnsFromSource = (source: unknown): string[] => {
+  if (!source || typeof source !== 'object') return [];
+  const result = new Set<string>();
+  const entries = Object.entries(source as Record<string, any>);
+  for (const [key, value] of entries) {
+    const lowerKey = key.toLowerCase();
+    if (['columns', 'headers', 'fields', 'fieldnames', 'selectedcolumns', 'columnnames'].some((token) => lowerKey.includes(token))) {
+      collectColumnsFromValue(value).forEach((col) => result.add(col));
+    } else if (typeof value === 'object' && value) {
+      collectColumnsFromValue(value).forEach((col) => result.add(col));
+    }
+  }
+  return Array.from(result);
+};
+
+const mergeMetadataSources = (...sources: MetadataSource[]): WorkflowNodeMetadata => {
+  const columns = new Set<string>();
+  const derivedFrom = new Set<string>();
+  let sampleObject: Record<string, any> | null = null;
+  let sampleArray: any[] | null = null;
+  let scalarSample: any;
+  let schema: Record<string, any> | null = null;
+
+  for (const source of sources) {
+    if (!source) continue;
+    source.columns?.forEach((col) => {
+      if (typeof col === 'string' && col.trim()) columns.add(col);
+    });
+    source.derivedFrom?.forEach((item) => {
+      if (item) derivedFrom.add(item);
+    });
+
+    const sample = source.sample;
+    if (Array.isArray(sample)) {
+      if (!sampleArray) sampleArray = sample;
+    } else if (sample && typeof sample === 'object') {
+      sampleObject = { ...(sampleObject ?? {}), ...sample };
+    } else if (sample !== undefined && scalarSample === undefined) {
+      scalarSample = sample;
+    }
+
+    if (source.schema) {
+      schema = { ...(schema ?? {}), ...source.schema };
+    }
+  }
+
+  const result: WorkflowNodeMetadata = {};
+  if (columns.size > 0) result.columns = Array.from(columns);
+  if (derivedFrom.size > 0) result.derivedFrom = Array.from(derivedFrom);
+  if (sampleArray) {
+    result.sample = sampleArray;
+  } else if (sampleObject) {
+    result.sample = sampleObject;
+  } else if (scalarSample !== undefined) {
+    result.sample = scalarSample;
+  }
+  if (schema && Object.keys(schema).length > 0) {
+    result.schema = schema;
+  }
+  return result;
+};
+
+const lookupValue = (source: unknown, key: string, depth = 0): any => {
+  if (!source || depth > 3) return undefined;
+  if (Array.isArray(source)) {
+    for (const entry of source) {
+      const value = lookupValue(entry, key, depth + 1);
+      if (value !== undefined) return value;
+    }
+    return undefined;
+  }
+  if (typeof source !== 'object') return undefined;
+  for (const [entryKey, entryValue] of Object.entries(source as Record<string, any>)) {
+    const normalized = canonicalize(entryKey).replace(/-/g, '_');
+    if (normalized === key || normalized.replace(/_/g, '') === key.replace(/_/g, '')) {
+      return entryValue;
+    }
+    if (typeof entryValue === 'object' && entryValue !== null) {
+      const nested = lookupValue(entryValue, key, depth + 1);
+      if (nested !== undefined) return nested;
+    }
+  }
+  return undefined;
+};
+
+const createPlaceholder = (column: string): string => {
+  const key = canonicalize(column).replace(/-/g, '_') || 'value';
+  return `{{${key}}}`;
+};
+
+const inferType = (value: any): string => {
+  if (value === null || value === undefined) return 'string';
+  if (Array.isArray(value)) return 'array';
+  if (typeof value === 'object') return 'object';
+  if (typeof value === 'number') return 'number';
+  if (typeof value === 'boolean') return 'boolean';
+  if (typeof value === 'string') {
+    const numeric = Number(value);
+    if (!Number.isNaN(numeric) && value.trim() !== '') {
+      return 'number';
+    }
+  }
+  return 'string';
+};
+
+const buildSampleRow = (
+  columns: string[],
+  params: Record<string, any>,
+  answers: Record<string, any>,
+  existingSample: any
+): Record<string, any> => {
+  const sample: Record<string, any> = {};
+  const valuesArray = Array.isArray(params?.values) ? params.values : null;
+  columns.forEach((column, index) => {
+    const normalized = canonicalize(column).replace(/-/g, '_');
+    const direct = lookupValue(params, normalized);
+    if (direct !== undefined && direct !== null && direct !== '') {
+      sample[column] = direct;
+      return;
+    }
+    if (valuesArray && index < valuesArray.length) {
+      sample[column] = valuesArray[index];
+      return;
+    }
+    const fromAnswers = lookupValue(answers, normalized);
+    if (fromAnswers !== undefined && fromAnswers !== null && fromAnswers !== '') {
+      sample[column] = fromAnswers;
+      return;
+    }
+    if (existingSample && typeof existingSample === 'object' && !Array.isArray(existingSample) && column in existingSample) {
+      sample[column] = (existingSample as Record<string, any>)[column];
+      return;
+    }
+    sample[column] = createPlaceholder(column);
+  });
+  return sample;
+};
+
+const buildSchemaFromConnector = (properties?: Record<string, any>): Record<string, any> | undefined => {
+  if (!properties) return undefined;
+  const schema: Record<string, any> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    schema[key] = {
+      type: value?.type ?? (value?.enum ? 'string' : inferType(value?.default)),
+      description: value?.description,
+      enum: value?.enum,
+      format: value?.format,
+      default: value?.default,
+    };
+  }
+  return Object.keys(schema).length > 0 ? schema : undefined;
+};
+
+const deriveMetadata = (
+  node: Partial<WorkflowNode>,
+  params: Record<string, any>,
+  answers: Record<string, any>,
+  existing: WorkflowNodeMetadata
+): WorkflowNodeMetadata => {
+  const metadata: WorkflowNodeMetadata = {};
+  const derivedFrom: string[] = [];
+
+  const nodeType = typeof node.type === 'string' ? node.type : node?.data?.nodeType ?? '';
+  const app = node.app ?? node.data?.app ?? node.data?.connectorId ?? '';
+  const op = node.op ?? node.data?.operation ?? node.data?.actionId ?? '';
+  const operationId = normalizeOperationId(op);
+
+  const connector = findConnector(app);
+  const opDefinition = findOperation(connector, nodeType ?? '', operationId);
+  const schemaFromConnector = buildSchemaFromConnector(opDefinition?.parameters?.properties);
+
+  if (schemaFromConnector) {
+    metadata.schema = schemaFromConnector;
+    derivedFrom.push(`connector:${canonicalize(connector?.id ?? app)}`);
+    const schemaColumns = Object.keys(schemaFromConnector);
+    if (schemaColumns.length > 0) {
+      metadata.columns = unique([...(existing.columns ?? []), ...schemaColumns]);
+    }
+  }
+
+  const configColumns = collectColumnsFromSource(params);
+  if (configColumns.length > 0) {
+    metadata.columns = unique([...(metadata.columns ?? existing.columns ?? []), ...configColumns]);
+    derivedFrom.push('config');
+  }
+
+  const answerColumns = collectColumnsFromSource(answers);
+  if (answerColumns.length > 0) {
+    metadata.columns = unique([...(metadata.columns ?? existing.columns ?? []), ...answerColumns]);
+    derivedFrom.push('answers');
+  }
+
+  const columns = metadata.columns ?? existing.columns ?? [];
+  if (columns.length > 0) {
+    const sampleRow = buildSampleRow(columns, params, answers, existing.sample);
+    if (Object.keys(sampleRow).length > 0) {
+      metadata.sample = sampleRow;
+    }
+    if (!metadata.schema) {
+      const schema: Record<string, any> = {};
+      columns.forEach((column) => {
+        const normalized = canonicalize(column).replace(/-/g, '_');
+        const fromSample = sampleRow[column];
+        schema[column] = {
+          type: inferType(fromSample),
+          example: fromSample,
+        };
+        const existingSchema = existing.schema?.[column];
+        if (existingSchema) {
+          schema[column] = { ...existingSchema, ...schema[column] };
+        }
+      });
+      metadata.schema = schema;
+    }
+  }
+
+  if (derivedFrom.length > 0) {
+    metadata.derivedFrom = unique([...(existing.derivedFrom ?? []), ...derivedFrom]);
+  }
+
+  return metadata;
+};
+
+export const enrichWorkflowNode = <T extends WorkflowNode>(
+  node: T,
+  context: EnrichContext = {}
+): T & { metadata?: WorkflowNodeMetadata } => {
+  const params =
+    node.params ??
+    node.data?.config ??
+    node.data?.parameters ??
+    (typeof node.data === 'object' ? (node.data as any)?.params : undefined) ??
+    {};
+  const answers = context.answers ?? {};
+
+  const combinedExisting = mergeMetadataSources(node.metadata as any, node.data?.metadata as any);
+  const derived = deriveMetadata(node, params, answers, combinedExisting);
+  const metadata = mergeMetadataSources(combinedExisting, derived);
+
+  const data = {
+    ...(node.data || {}),
+    app: node.data?.app ?? node.app,
+    operation: node.data?.operation ?? node.op?.split('.').pop() ?? node.data?.actionId,
+    parameters: node.data?.parameters ?? params,
+    config: node.data?.config ?? params,
+    metadata,
+  };
+
+  return {
+    ...node,
+    app: node.app ?? data.app,
+    name: node.name ?? data.label,
+    op: node.op ?? (data.app && data.operation ? `${data.app}.${data.operation}` : node.op),
+    params: params,
+    data,
+    metadata,
+  } as T & { metadata?: WorkflowNodeMetadata };
+};
+
+export const enrichWorkflowGraph = (
+  graph: WorkflowGraph,
+  context: EnrichContext = {}
+): WorkflowGraph => {
+  if (!graph?.nodes) return graph;
+  const nodes = graph.nodes.map((node) => enrichWorkflowNode(node, context));
+  return { ...graph, nodes };
+};
+

--- a/server/workflow/pure-ai-generator.ts
+++ b/server/workflow/pure-ai-generator.ts
@@ -1,9 +1,10 @@
 // PURE AI-DRIVEN WORKFLOW GENERATOR
 // NO PRESETS, NO TEMPLATES - ONLY AI INTELLIGENCE
 
-import { WorkflowGraph, WorkflowNode, WorkflowEdge } from './types';
+import { WorkflowGraph, WorkflowNode, WorkflowEdge } from '../../common/workflow-types';
+import { enrichWorkflowGraph } from './node-metadata';
 
-export async function generatePureAIWorkflow(prompt: string, answers: Record<string, string>): Promise<WorkflowGraph> {
+export async function generatePureAIWorkflow(prompt: string, answers: Record<string, any>): Promise<WorkflowGraph> {
   console.log('🤖 PURE AI GENERATION - No presets, templates, or hardcoded patterns');
   
   // Construct intelligent AI prompt that analyzes user intent
@@ -71,7 +72,7 @@ RESPOND WITH VALID JSON:
     const workflow = aiResult.workflow;
     workflow.id = `ai-${Date.now()}`;
     
-    return workflow;
+    return enrichWorkflowGraph(workflow, { answers });
     
   } catch (error) {
     console.error('❌ Pure AI generation failed:', error);
@@ -81,7 +82,7 @@ RESPOND WITH VALID JSON:
   }
 }
 
-function generateFromUserWordsOnly(prompt: string, answers: Record<string, string>): WorkflowGraph {
+function generateFromUserWordsOnly(prompt: string, answers: Record<string, any>): WorkflowGraph {
   console.log('📝 Generating workflow from user words only (no AI, no presets)');
   
   // Just parse what the user literally said
@@ -146,7 +147,7 @@ function generateFromUserWordsOnly(prompt: string, answers: Record<string, strin
     }
   });
   
-  return {
+  const workflow: WorkflowGraph = {
     id: `user-${Date.now()}`,
     name: `User Request: ${prompt.substring(0, 30)}...`,
     nodes,
@@ -157,6 +158,7 @@ function generateFromUserWordsOnly(prompt: string, answers: Record<string, strin
       userPrompt: prompt
     }
   };
+  return enrichWorkflowGraph(workflow, { answers });
 }
 
 function buildQueryFromCriteria(criteria: string): string {


### PR DESCRIPTION
## Summary
- add a workflow metadata enrichment module and wire it through workflow generators and converters so nodes expose columns, sample rows, and schemas alongside existing data
- preserve that metadata when normalizing nodes for the professional graph editor so React Flow state retains connector context
- enhance the smart parameters panel to surface metadata-driven quick picks, send enriched payloads to AI mapping, and cover the helpers with a Node-based test

## Testing
- npm run test
- npm run check *(fails: pre-existing type errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d164b39d3c83318e9776a8ff4ae0cb