### PR TITLE
Sync workflow node parameters across aliases

### DIFF
--- a/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
+++ b/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   computeMetadataSuggestions,
   mapUpstreamNodesForAI,
+  syncNodeParameters,
   type UpstreamNodeSummary
 } from "../SmartParametersPanel";
 
@@ -80,5 +81,23 @@ assert.equal(
     : undefined,
   "99.99"
 );
+
+const paramSyncBase = {
+  label: "Mailer",
+  params: { old: "value" },
+  metadata: { example: true }
+};
+const nextParams = { subject: "Hello" };
+const mirrored = syncNodeParameters(paramSyncBase, nextParams);
+
+assert.deepEqual(mirrored.parameters, nextParams, "parameters should mirror latest edits");
+assert.deepEqual(mirrored.params, nextParams, "params should mirror latest edits");
+assert.strictEqual(
+  mirrored.parameters,
+  mirrored.params,
+  "parameter stores should reference the same object"
+);
+assert.equal(mirrored.label, "Mailer", "other node data should be preserved");
+assert.deepEqual(paramSyncBase.params, { old: "value" }, "original data should not be mutated");
 
 console.log("SmartParametersPanel metadata helper checks passed.");


### PR DESCRIPTION
## Summary
- ensure SmartParametersPanel mirrors parameter edits into both `parameters` and `params`, with a shared helper
- normalize ProfessionalGraphEditor node creation/loading so both parameter keys stay synchronized and legacy data is preserved
- extend SmartParametersPanel tests to cover the new synchronization helper

## Testing
- npm test
- npm run check *(fails: existing TypeScript errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d16e2e9fe88331b9113c0bce4dbae4