### PR TITLE
Align workflow build response IDs and improve Graph Editor fallback

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -1288,14 +1288,31 @@ const GraphEditorContent = () => {
 
           for (const source of sources) {
             if (!source.condition) continue;
-            const storageKey = workflowId ? `workflow_${workflowId}` : source.key;
-            const parsed = safeParse(localStorage.getItem(storageKey));
-            const candidate =
-              parsed?.workflow?.graph || parsed?.graph || parsed;
 
-            if (candidate?.nodes?.length) {
-              loadedWorkflow = candidate;
-              loadSource = source.key;
+            const storageKeys = workflowId
+              ? Array.from(
+                  new Set([
+                    source.key,
+                    `workflow_${workflowId}`,
+                    `${source.key}_${workflowId}`,
+                    `workflow_${workflowId}_${source.key}`,
+                  ])
+                )
+              : [source.key];
+
+            for (const storageKey of storageKeys) {
+              const parsed = safeParse(localStorage.getItem(storageKey));
+              const candidate =
+                parsed?.workflow?.graph || parsed?.graph || parsed;
+
+              if (candidate?.nodes?.length) {
+                loadedWorkflow = candidate;
+                loadSource = source.key;
+                break;
+              }
+            }
+
+            if (loadedWorkflow) {
               break;
             }
           }

--- a/server/routes/workflow.build.ts
+++ b/server/routes/workflow.build.ts
@@ -207,12 +207,12 @@ workflowBuildRouter.post('/build', async (req, res) => {
     
     // ChatGPT's fix: Generate workflowId for Graph Editor handoff
     const workflowId = `wf-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+    const compiledWithWorkflowId = { ...compiled, workflowId }; // Keep response ID aligned with stored workflow
     
     // Add enterprise metadata
     const response = {
       success: true,
-      workflowId, // ChatGPT's fix: Include workflowId for Graph Editor navigation
-      ...compiled,
+      ...compiledWithWorkflowId,
       graph: nodeGraph, // Use converted format instead of original
       metadata: {
         generatedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- ensure the workflow build response keeps the generated workflowId consistent with the stored graph
- maintain the nodeGraph response payload while keeping metadata intact
- broaden the Graph Editor localStorage fallback to check original keys before workflow-specific variants

## Testing
- `npm run check --silent` *(fails: repository contains pre-existing TypeScript errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d21949b1bc833190005d4e65e75901