### PR TITLE
Fix Gemini provider tracking and add normalization test

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "db:push": "drizzle-kit push",
-    "test": "tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts"
+    "test": "tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",

--- a/server/services/__tests__/AnswerNormalizerService.test.ts
+++ b/server/services/__tests__/AnswerNormalizerService.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+
+import { AnswerNormalizerService } from '../AnswerNormalizerService.js';
+
+const questions = [
+  { id: 'trigger', question: 'How often should this run?' },
+  { id: 'sheet_url', question: 'What sheet should we use?' }
+];
+
+const rawAnswers = {
+  trigger: 'every 15 minutes',
+  sheet_url: 'https://docs.google.com/spreadsheets/d/mock-sheet'
+};
+
+const mockResponse = {
+  normalized: {
+    trigger: { type: 'time', frequency: { value: 15, unit: 'minutes' } },
+    apps: { source: ['gmail'], destination: ['sheets'] },
+    sheets: {
+      sheet_url: 'https://docs.google.com/spreadsheets/d/mock-sheet',
+      sheet_name: 'Sheet1',
+      columns: ['Column A', 'Column B']
+    },
+    mapping: {
+      pairs: [
+        { from: 'Column A', to: 'Column B', transform: null }
+      ]
+    }
+  },
+  __issues: []
+};
+
+AnswerNormalizerService.setGeminiJsonGenerator(async () => JSON.stringify(mockResponse));
+
+const originalFallback = AnswerNormalizerService['fallbackNormalization'] as any;
+let fallbackCalled = false;
+AnswerNormalizerService['fallbackNormalization'] = ((...args: any[]) => {
+  fallbackCalled = true;
+  return originalFallback.apply(AnswerNormalizerService, args);
+}) as typeof originalFallback;
+
+try {
+  const result = await AnswerNormalizerService.normalizeAnswersLLM(questions as any, rawAnswers, 'UTC');
+
+  assert.equal(result.provider, 'gemini');
+  assert.deepEqual(result.normalized, mockResponse.normalized);
+  assert.deepEqual(result.__issues, mockResponse.__issues);
+  assert.equal(fallbackCalled, false, 'should not use fallback when Gemini returns valid JSON');
+
+  console.log('AnswerNormalizerService normalizeAnswersLLM handles Gemini JSON responses.');
+} finally {
+  AnswerNormalizerService.resetGeminiJsonGenerator();
+  AnswerNormalizerService['fallbackNormalization'] = originalFallback;
+}


### PR DESCRIPTION
## Summary
- capture the Gemini provider when normalizing answers and reuse it across success and fallback flows
- allow overriding the Gemini generator for tests and ensure fallback returns deterministic provider metadata
- add a unit test covering successful Gemini normalization and run it as part of the test suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d21ce1a45483319cc39bc33ae73ef9