### PR TITLE
Populate workflow output metadata for smart parameters

### DIFF
--- a/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
+++ b/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import "../../../../../server/workflow/__tests__/compile-to-appsscript.ref-params.test.ts";
+import { answersToGraph } from "../../../../../server/workflow/answers-to-graph";
 
 import {
   computeMetadataSuggestions,
@@ -39,6 +40,21 @@ const upstreamNodes: UpstreamNodeSummary[] = [
         }
       }
     }
+  },
+  {
+    id: "node-3",
+    data: {
+      label: "API Fetch",
+      app: "http",
+      outputMetadata: {
+        headers: ["id", "status"],
+        sample: {
+          id: "123",
+          status: "open"
+        },
+        derivedFrom: ["runtime"]
+      }
+    }
   }
 ];
 
@@ -52,17 +68,23 @@ const totalSuggestion = suggestions.find(
 const amountSuggestion = suggestions.find(
   (suggestion) => suggestion.nodeId === "node-2" && suggestion.path === "Amount"
 );
+const statusSuggestion = suggestions.find(
+  (suggestion) => suggestion.nodeId === "node-3" && suggestion.path === "status"
+);
 const entireOutput = suggestions.filter((suggestion) => suggestion.path === "").map((item) => item.nodeId);
 
 assert.ok(invoiceSuggestion, "should include Invoice Number in quick picks");
 assert.ok(invoiceSuggestion?.label.includes("Invoice Number"));
 assert.ok(totalSuggestion, "should include Total column quick pick");
 assert.ok(amountSuggestion, "should surface Amount column quick pick");
+assert.ok(statusSuggestion, "should surface status field from output metadata");
 assert.ok(entireOutput.includes("node-1"), "should include entire output suggestions");
+assert.ok(entireOutput.includes("node-3"), "should include entire output for runtime metadata nodes");
 
 const payload = mapUpstreamNodesForAI(upstreamNodes);
 const first = payload.find((entry) => entry.nodeId === "node-1");
 const second = payload.find((entry) => entry.nodeId === "node-2");
+const third = payload.find((entry) => entry.nodeId === "node-3");
 
 assert.ok(first, "AI payload should include first node");
 assert.ok(first?.columns.includes("Invoice Number"));
@@ -81,6 +103,61 @@ assert.equal(
     ? (second?.sample as Record<string, any>).Amount
     : undefined,
   "99.99"
+);
+assert.ok(third, "AI payload should include third node with runtime metadata");
+assert.ok(third?.columns.includes("status"));
+assert.equal(
+  typeof third?.sample === "object" && !Array.isArray(third?.sample)
+    ? (third?.sample as Record<string, any>).status
+    : undefined,
+  "open",
+  "runtime sample should survive metadata merging"
+);
+
+const generatedPrompt = "Log invoice emails into Google Sheets";
+const generatedAnswers = {
+  trigger: "When an email arrives",
+  search_query: "subject:Invoice",
+  sheets: {
+    sheet_id: "sheet-id-1234567890abcdefghijklmnopqrstuvwxyz",
+    sheet_name: "Invoices",
+    columns: ["Invoice Number", "Amount", "Vendor"]
+  },
+  data_extraction: "Invoice Number, Amount, Vendor",
+  sheet_destination: "Google Sheet"
+};
+
+const generatedWorkflow = answersToGraph(generatedPrompt, generatedAnswers);
+const sheetNode = generatedWorkflow.nodes.find((node) => node.app === "sheets");
+
+assert.ok(sheetNode, "workflow should include a Sheets node");
+assert.ok(sheetNode?.metadata?.headers?.length, "enriched metadata should expose headers");
+assert.ok(
+  sheetNode?.metadata?.sample &&
+    typeof sheetNode.metadata.sample === "object" &&
+    Object.keys(sheetNode.metadata.sample as Record<string, any>).length > 0,
+  "metadata sample should be populated from schema sampling"
+);
+assert.ok(
+  sheetNode?.data?.outputMetadata?.headers?.length,
+  "data.outputMetadata should include derived headers"
+);
+
+const quickPicksFromWorkflow = computeMetadataSuggestions([
+  {
+    id: sheetNode!.id,
+    data: {
+      label: sheetNode!.name,
+      app: sheetNode!.app,
+      metadata: sheetNode!.metadata,
+      outputMetadata: sheetNode!.data?.outputMetadata
+    }
+  }
+]);
+
+assert.ok(
+  quickPicksFromWorkflow.some((pick) => pick.nodeId === sheetNode!.id && pick.path),
+  "generated workflow should expose non-empty quick picks"
 );
 
 const paramSyncBase = {

--- a/common/workflow-types.ts
+++ b/common/workflow-types.ts
@@ -2,8 +2,12 @@ export type NodeType = 'trigger' | 'action' | 'transform';
 
 export type WorkflowNodeMetadata = {
   columns?: string[];
+  headers?: string[];
   sample?: Record<string, any> | any[];
+  sampleRow?: Record<string, any> | any[];
+  outputSample?: Record<string, any> | any[];
   schema?: Record<string, any>;
+  outputSchema?: Record<string, any>;
   derivedFrom?: string[];
 };
 
@@ -20,9 +24,11 @@ export type WorkflowNode = {
     config?: Record<string, any>;
     parameters?: Record<string, any>;
     metadata?: WorkflowNodeMetadata;
+    outputMetadata?: WorkflowNodeMetadata;
     [key: string]: any;
   };
   metadata?: WorkflowNodeMetadata;
+  outputMetadata?: WorkflowNodeMetadata;
 };
 
 export type WorkflowEdge = {


### PR DESCRIPTION
## Summary
- enrich workflow metadata inference to surface headers, samples, and schema on both metadata and data.outputMetadata
- ensure workflow nodes carry merged outputMetadata when generated or converted so downstream consumers have a unified surface
- extend SmartParametersPanel tests to cover runtime metadata and generated workflows for non-empty quick picks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d221bc95b8833183a0f95d44a647a3