### PR TITLE
feat: share workflow metadata types

### DIFF
--- a/common/workflow-types.ts
+++ b/common/workflow-types.ts
@@ -1,15 +1,8 @@
+import type { WorkflowMetadata } from '../shared/workflow/metadata';
+
 export type NodeType = 'trigger' | 'action' | 'transform';
 
-export type WorkflowNodeMetadata = {
-  columns?: string[];
-  headers?: string[];
-  sample?: Record<string, any> | any[];
-  sampleRow?: Record<string, any> | any[];
-  outputSample?: Record<string, any> | any[];
-  schema?: Record<string, any>;
-  outputSchema?: Record<string, any>;
-  derivedFrom?: string[];
-};
+export type WorkflowNodeMetadata = WorkflowMetadata;
 
 export type WorkflowNode = {
   id: string;

--- a/shared/workflow/metadata.ts
+++ b/shared/workflow/metadata.ts
@@ -1,0 +1,72 @@
+export type WorkflowMetadataFieldType = 'string' | 'number' | 'boolean' | 'object' | 'array';
+
+/** Describes a single field in workflow metadata schema definitions. */
+export interface WorkflowMetadataFieldSchema {
+  type?: WorkflowMetadataFieldType | string;
+  description?: string;
+  example?: unknown;
+  enum?: unknown[];
+  format?: string;
+  default?: unknown;
+  [key: string]: unknown;
+}
+
+export type WorkflowMetadataSchema = Record<string, WorkflowMetadataFieldSchema>;
+
+export type WorkflowMetadataValue =
+  | Record<string, unknown>
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null;
+
+/**
+ * Canonical metadata shape exchanged between the server enrichment pipeline
+ * and UI helpers. Connector authors should provide at least `columns` and
+ * either a representative `sample` or `schema` when returning metadata.
+ */
+export interface WorkflowMetadata {
+  columns?: string[];
+  headers?: string[];
+  sample?: WorkflowMetadataValue;
+  sampleRow?: WorkflowMetadataValue;
+  outputSample?: WorkflowMetadataValue;
+  schema?: WorkflowMetadataSchema;
+  outputSchema?: WorkflowMetadataSchema;
+  derivedFrom?: string[];
+  [key: string]: unknown;
+}
+
+export type WorkflowMetadataSource = WorkflowMetadata | null | undefined;
+
+export const canonicalizeMetadataKey = (value: unknown): string => {
+  if (value == null) return '';
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+};
+
+export const toMetadataLookupKey = (value: unknown): string =>
+  canonicalizeMetadataKey(value).replace(/-/g, '_');
+
+export const createMetadataPlaceholder = (value: string, fallback = 'value'): string => {
+  const normalized = toMetadataLookupKey(value);
+  return `{{${normalized || fallback}}}`;
+};
+
+export const inferWorkflowValueType = (value: unknown): WorkflowMetadataFieldType => {
+  if (value === null || value === undefined) return 'string';
+  if (Array.isArray(value)) return 'array';
+  if (typeof value === 'object') return 'object';
+  if (typeof value === 'number') return 'number';
+  if (typeof value === 'boolean') return 'boolean';
+  if (typeof value === 'string') {
+    const numeric = Number(value);
+    if (!Number.isNaN(numeric) && value.trim() !== '') {
+      return 'number';
+    }
+  }
+  return 'string';
+};


### PR DESCRIPTION
## Summary
- add a shared WorkflowMetadata interface plus helper utilities under shared/workflow
- update the client metadata helper to use the shared types and document connector expectations
- switch the server metadata enrichment to the shared shape and add inline guidance for connector authors

## Testing
- npm run check *(fails: existing type errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c2855470833188fd76ab5c5f4082