### PR TITLE
Add metadata refresh flow for smart parameters

### DIFF
--- a/client/src/components/workflow/NodeConfigurationModal.tsx
+++ b/client/src/components/workflow/NodeConfigurationModal.tsx
@@ -128,6 +128,17 @@ export const NodeConfigurationModal: React.FC<NodeConfigurationModalProps> = ({
   const handleConnectionSelect = (conn: Connection) => {
     setSelectedConnection(conn);
     setActiveTab('parameters');
+    if (typeof window !== 'undefined') {
+      const detail = {
+        nodeId: nodeData.id,
+        connectionId: conn.id,
+        app: nodeData.appName,
+        status: conn.status,
+        reason: 'connection',
+      };
+      window.dispatchEvent(new CustomEvent('automation:connection-selected', { detail }));
+      window.dispatchEvent(new CustomEvent('automation:auth-complete', { detail }));
+    }
   };
 
   // Test connection


### PR DESCRIPTION
## Summary
- add metadata refresh tracking and backend discovery call in `SmartParametersPanel`
- trigger discovery on parameter commits and auth events while keeping optimistic node metadata
- dispatch connection selection events from the configuration modal to drive refreshes

## Testing
- `npx tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts`
- `npm run check` *(fails: pre-existing TypeScript errors across server/client files)*
- `npm test` *(fails: pre-existing TypeScript errors across server/client files)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c289a1b483319d1919a5a0b0ae41