### PR TITLE
Add metadata resolver support for workflow nodes

### DIFF
--- a/server/workflow/__tests__/metadata-resolver.integration.test.ts
+++ b/server/workflow/__tests__/metadata-resolver.integration.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+
+import { enrichWorkflowNode } from '../node-metadata';
+import {
+  registerMetadataResolver,
+  __clearMetadataResolverRegistryForTests,
+} from '../metadata-resolvers';
+
+__clearMetadataResolverRegistryForTests();
+
+registerMetadataResolver('example-app', () => ({
+  metadata: {
+    columns: ['id', 'name'],
+    sample: { id: '123', name: 'Example User' },
+    derivedFrom: ['resolver:example-app'],
+  },
+  outputMetadata: {
+    columns: ['id', 'name'],
+    sample: { id: '123', name: 'Example User' },
+    derivedFrom: ['resolver:example-app-output'],
+  },
+}));
+
+const enriched = enrichWorkflowNode({
+  id: 'example-node',
+  type: 'action.example',
+  app: 'example-app',
+  name: 'Example Node',
+  op: 'example-app.performAction',
+  params: {},
+  data: {
+    operation: 'performAction',
+    config: {},
+  },
+} as any);
+
+assert.ok(enriched.metadata, 'enriched node should include metadata');
+assert.ok(enriched.outputMetadata, 'enriched node should include output metadata');
+assert.deepEqual(
+  enriched.metadata?.columns,
+  ['id', 'name'],
+  'resolver columns should be preserved in metadata'
+);
+assert.ok(
+  enriched.outputMetadata?.derivedFrom?.includes('resolver:example-app-output'),
+  'resolver output metadata should include derivedFrom flag'
+);
+assert.deepEqual(
+  enriched.data?.metadata?.sample,
+  { id: '123', name: 'Example User' },
+  'resolver metadata should be embedded in workflow payload'
+);
+assert.deepEqual(
+  enriched.data?.outputMetadata?.sample,
+  { id: '123', name: 'Example User' },
+  'resolver output metadata should be embedded in workflow payload'
+);
+
+console.log('Metadata resolver integration checks passed.');
+
+__clearMetadataResolverRegistryForTests();

--- a/server/workflow/graph-format-converter.ts
+++ b/server/workflow/graph-format-converter.ts
@@ -31,7 +31,9 @@ export function convertToNodeGraph(workflowGraph: WorkflowGraph): NodeGraph {
       // Preserve original data for Graph Editor
       data: node.data,
       app: app,
-      op: node.op || `${app}.${operation}`
+      op: node.op || `${app}.${operation}`,
+      metadata: node.metadata,
+      outputMetadata: node.outputMetadata
     };
   });
 

--- a/server/workflow/metadata-resolvers/index.ts
+++ b/server/workflow/metadata-resolvers/index.ts
@@ -1,0 +1,170 @@
+import { canonicalizeMetadataKey, type WorkflowMetadata } from '@shared/workflow/metadata';
+import type { WorkflowNode } from '../../../common/workflow-types';
+
+export type ConnectorDefinition = {
+  id?: string;
+  name?: string;
+  actions?: Array<{
+    id?: string;
+    name?: string;
+    title?: string;
+    parameters?: { properties?: Record<string, any> };
+  }>;
+  triggers?: Array<{
+    id?: string;
+    name?: string;
+    title?: string;
+    parameters?: { properties?: Record<string, any> };
+  }>;
+  [key: string]: any;
+};
+
+export type MetadataResolverAuth = Record<string, any>;
+
+export interface MetadataResolverContext {
+  node: Partial<WorkflowNode>;
+  params: Record<string, any>;
+  connector?: ConnectorDefinition;
+  answers?: Record<string, any>;
+  auth?: MetadataResolverAuth;
+  operation?: string;
+}
+
+export interface MetadataResolverResult {
+  metadata?: WorkflowMetadata;
+  outputMetadata?: WorkflowMetadata;
+}
+
+export type MetadataResolverResponse =
+  | MetadataResolverResult
+  | WorkflowMetadata
+  | null
+  | undefined
+  | void;
+
+export type MetadataResolver = (context: MetadataResolverContext) => MetadataResolverResponse;
+
+export interface MetadataResolverRegistrationOptions {
+  aliases?: string[];
+}
+
+type ResolverRegistryEntry = {
+  tokens: Set<string>;
+  resolver: MetadataResolver;
+};
+
+const canonicalize = canonicalizeMetadataKey;
+
+const registry: ResolverRegistryEntry[] = [];
+
+const toTokens = (value?: string): string[] => {
+  if (!value) return [];
+  const canonical = canonicalize(value);
+  if (!canonical) return [];
+  const normalized = canonical.trim();
+  if (!normalized) return [];
+  const tokens = new Set<string>();
+  tokens.add(normalized);
+  tokens.add(normalized.replace(/-/g, ''));
+  tokens.add(normalized.replace(/-/g, '_'));
+  return Array.from(tokens).filter(Boolean);
+};
+
+const addTokens = (collection: Set<string>, value?: string) => {
+  if (!value) return;
+  toTokens(value).forEach((token) => collection.add(token));
+};
+
+export const registerMetadataResolver = (
+  id: string,
+  resolver: MetadataResolver,
+  options: MetadataResolverRegistrationOptions = {}
+): void => {
+  if (!id || typeof resolver !== 'function') return;
+  const tokens = new Set<string>();
+  addTokens(tokens, id);
+  options.aliases?.forEach((alias) => addTokens(tokens, alias));
+  if (tokens.size === 0) return;
+  registry.push({ tokens, resolver });
+};
+
+const findResolver = (
+  connector: ConnectorDefinition | undefined,
+  app: string | undefined
+): MetadataResolver | undefined => {
+  const searchTokens = new Set<string>();
+  addTokens(searchTokens, connector?.id);
+  addTokens(searchTokens, connector?.name);
+  addTokens(searchTokens, app);
+  if (searchTokens.size === 0) return undefined;
+
+  const candidates = Array.from(searchTokens);
+  for (const entry of registry) {
+    for (const token of candidates) {
+      if (entry.tokens.has(token)) {
+        return entry.resolver;
+      }
+    }
+  }
+  return undefined;
+};
+
+const isResolverEnvelope = (value: any): value is MetadataResolverResult => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  return 'metadata' in value || 'outputMetadata' in value;
+};
+
+const isWorkflowMetadata = (value: any): value is WorkflowMetadata => {
+  return value && typeof value === 'object' && !Array.isArray(value);
+};
+
+const normalizeResolverResult = (value: MetadataResolverResponse): MetadataResolverResult => {
+  if (!value) return {};
+  if (isResolverEnvelope(value)) {
+    const normalized: MetadataResolverResult = {};
+    if (value.metadata && typeof value.metadata === 'object') {
+      normalized.metadata = value.metadata;
+    }
+    if (value.outputMetadata && typeof value.outputMetadata === 'object') {
+      normalized.outputMetadata = value.outputMetadata;
+    }
+    return normalized;
+  }
+  if (isWorkflowMetadata(value)) {
+    return { metadata: value };
+  }
+  return {};
+};
+
+export const getMetadataResolver = (
+  connector?: ConnectorDefinition,
+  app?: string
+): MetadataResolver | undefined => findResolver(connector, app);
+
+export const resolveConnectorMetadata = (
+  app: string | undefined,
+  context: MetadataResolverContext
+): MetadataResolverResult => {
+  const resolver = findResolver(context.connector, app);
+  if (!resolver) return {};
+  try {
+    const result = resolver(context);
+    return normalizeResolverResult(result);
+  } catch (error) {
+    const identifier =
+      app ??
+      context.connector?.id ??
+      context.connector?.name ??
+      (context.node?.app as string | undefined) ??
+      'unknown-connector';
+    console.warn('Failed to resolve connector metadata', identifier, error);
+    return {};
+  }
+};
+
+export const __clearMetadataResolverRegistryForTests = (): void => {
+  registry.length = 0;
+};
+
+export const listRegisteredMetadataResolvers = (): string[] =>
+  registry.map((entry) => Array.from(entry.tokens)[0] ?? '');

--- a/shared/nodeGraphSchema.ts
+++ b/shared/nodeGraphSchema.ts
@@ -1,6 +1,8 @@
 // NODEGRAPH SCHEMA - Formal DAG Structure for Automation Workflows
 // Based on ChatGPT's architecture but extended for 500+ applications
 
+import type { WorkflowMetadata } from './workflow/metadata';
+
 export interface NodeGraph {
   id: string;
   name: string;
@@ -29,6 +31,11 @@ export interface GraphNode {
   position?: { x: number; y: number };
   color?: string;
   icon?: string;
+  metadata?: WorkflowMetadata;
+  outputMetadata?: WorkflowMetadata;
+  data?: Record<string, any>;
+  app?: string;
+  op?: string;
 }
 
 export interface Edge {


### PR DESCRIPTION
## Summary
- introduce a connector metadata resolver registry so connectors can register custom metadata enrichment hooks
- invoke the resolver during workflow node enrichment and persist the returned metadata/outputMetadata alongside existing heuristics
- retain resolver metadata in stored node graphs and cover the behavior with a metadata resolver integration test

## Testing
- npm test
- npx tsx server/workflow/__tests__/metadata-resolver.integration.test.ts
- npm run check *(fails: repository already has numerous pre-existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d36e63356c83318cb8864d218cb039