### PR TITLE
feat: wire core connectors to real API clients

### DIFF
--- a/server/integrations/NotionAPIClient.ts
+++ b/server/integrations/NotionAPIClient.ts
@@ -1,125 +1,134 @@
-// NOTION API CLIENT
-// Auto-generated API client for Notion integration
+import { APICredentials, APIResponse, BaseAPIClient } from './BaseAPIClient';
 
-import { BaseAPIClient } from './BaseAPIClient';
+interface NotionCreatePageParams {
+  parent: { database_id?: string; page_id?: string };
+  properties: Record<string, any>;
+  children?: any[];
+}
 
-export interface NotionAPIClientConfig {
-  accessToken: string;
-  refreshToken?: string;
-  clientId?: string;
-  clientSecret?: string;
+interface NotionUpdatePageParams {
+  pageId: string;
+  properties?: Record<string, any>;
+  archived?: boolean;
+}
+
+interface NotionGetPageParams {
+  pageId: string;
+}
+
+interface NotionCreateDatabaseEntryParams {
+  databaseId: string;
+  properties: Record<string, any>;
+  children?: any[];
+}
+
+interface NotionQueryDatabaseParams {
+  databaseId: string;
+  filter?: Record<string, any>;
+  sorts?: Array<Record<string, any>>;
+  start_cursor?: string;
+  page_size?: number;
+}
+
+interface NotionAppendBlockParams {
+  blockId: string;
+  children: any[];
+}
+
+interface NotionUpdateBlockParams {
+  blockId: string;
+  data: Record<string, any>;
+}
+
+interface NotionGetBlockChildrenParams {
+  blockId: string;
+  start_cursor?: string;
+  page_size?: number;
 }
 
 export class NotionAPIClient extends BaseAPIClient {
-  protected baseUrl: string;
-  private config: NotionAPIClientConfig;
+  private readonly notionVersion: string;
 
-  constructor(config: NotionAPIClientConfig) {
-    super();
-    this.config = config;
-    this.baseUrl = 'https://api.notion.com';
+  constructor(credentials: APICredentials & { notionVersion?: string }) {
+    if (!credentials.accessToken) {
+      throw new Error('Notion integration requires an access token');
+    }
+
+    super('https://api.notion.com/v1', credentials);
+    this.notionVersion = credentials.notionVersion ?? '2022-06-28';
   }
 
-  /**
-   * Get authentication headers
-   */
   protected getAuthHeaders(): Record<string, string> {
     return {
-      'Authorization': `Bearer ${this.config.accessToken}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'Apps-Script-Automation/1.0'
+      Authorization: `Bearer ${this.credentials.accessToken}`,
+      'Notion-Version': this.notionVersion
     };
   }
 
-  /**
-   * Test API connection
-   */
-  async testConnection(): Promise<boolean> {
-    try {
-      const response = await this.makeRequest('GET', '/');
-      return response.status === 200;
-      return true;
-    } catch (error) {
-      console.error(`❌ ${this.constructor.name} connection test failed:`, error);
-      return false;
-    }
+  public async testConnection(): Promise<APIResponse<any>> {
+    return this.post('/search', { page_size: 1 });
   }
 
-
-  /**
-   * Create new Notion page
-   */
-  async createPage({ parent: Record<string, any>, properties: Record<string, any>, children?: any[] }: { parent: Record<string, any>, properties: Record<string, any>, children?: any[] }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/create_page', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Create Page failed: ${error}`);
-    }
+  public async createPage(params: NotionCreatePageParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['parent', 'properties']);
+    return this.post('/pages', {
+      parent: params.parent,
+      properties: params.properties,
+      children: params.children
+    });
   }
 
-  /**
-   * Update existing page
-   */
-  async updatePage({ pageId: string, properties?: Record<string, any> }: { pageId: string, properties?: Record<string, any> }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/update_page', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Update Page failed: ${error}`);
-    }
+  public async updatePage(params: NotionUpdatePageParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['pageId']);
+    return this.patch(`/pages/${params.pageId}`, {
+      properties: params.properties,
+      archived: params.archived
+    });
   }
 
-  /**
-   * Create entry in Notion database
-   */
-  async createDatabaseEntry({ databaseId: string, properties: Record<string, any> }: { databaseId: string, properties: Record<string, any> }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/create_database_entry', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Create Database Entry failed: ${error}`);
-    }
+  public async getPage(params: NotionGetPageParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['pageId']);
+    return this.get(`/pages/${params.pageId}`);
   }
 
-  /**
-   * Query Notion database
-   */
-  async queryDatabase({ databaseId: string, filter?: Record<string, any>, sorts?: any[] }: { databaseId: string, filter?: Record<string, any>, sorts?: any[] }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/query_database', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Query Database failed: ${error}`);
-    }
+  public async createDatabaseEntry(params: NotionCreateDatabaseEntryParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['databaseId', 'properties']);
+    return this.post('/pages', {
+      parent: { database_id: params.databaseId },
+      properties: params.properties,
+      children: params.children
+    });
   }
 
-
-  /**
-   * Poll for Trigger when page is created
-   */
-  async pollPageCreated({ parentId?: string }: { parentId?: string }): Promise<any[]> {
-    try {
-      const response = await this.makeRequest('GET', '/api/page_created', params);
-      const data = this.handleResponse(response);
-      return Array.isArray(data) ? data : [data];
-    } catch (error) {
-      console.error(`Polling Page Created failed:`, error);
-      return [];
-    }
+  public async queryDatabase(params: NotionQueryDatabaseParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['databaseId']);
+    return this.post(`/databases/${params.databaseId}/query`, {
+      filter: params.filter,
+      sorts: params.sorts,
+      start_cursor: params.start_cursor,
+      page_size: params.page_size
+    });
   }
 
-  /**
-   * Poll for Trigger when database entry is created
-   */
-  async pollDatabaseEntryCreated({ databaseId: string }: { databaseId: string }): Promise<any[]> {
-    try {
-      const response = await this.makeRequest('GET', '/api/database_entry_created', params);
-      const data = this.handleResponse(response);
-      return Array.isArray(data) ? data : [data];
-    } catch (error) {
-      console.error(`Polling Database Entry Created failed:`, error);
-      return [];
-    }
+  public async appendBlockChildren(params: NotionAppendBlockParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['blockId', 'children']);
+    return this.patch(`/blocks/${params.blockId}/children`, {
+      children: params.children
+    });
+  }
+
+  public async updateBlock(params: NotionUpdateBlockParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['blockId', 'data']);
+    return this.patch(`/blocks/${params.blockId}`, params.data);
+  }
+
+  public async getBlockChildren(params: NotionGetBlockChildrenParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['blockId']);
+    const query = this.buildQueryString({
+      start_cursor: params.start_cursor,
+      page_size: params.page_size
+    });
+
+    return this.get(`/blocks/${params.blockId}/children${query}`);
   }
 }

--- a/server/llm/MultiAIService.ts
+++ b/server/llm/MultiAIService.ts
@@ -2,6 +2,113 @@
 import { LLMProviderService } from '../services/LLMProviderService.js';
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
+type GenerateArgs = {
+  model?: string;
+  prompt: string;
+  maxTokens?: number;
+  temperature?: number;
+};
+
+function normalizeGenerateArgs(args: GenerateArgs | string): GenerateArgs {
+  if (typeof args === 'string') {
+    return { prompt: args };
+  }
+
+  if (!args?.prompt) {
+    throw new Error('Prompt is required for generateText');
+  }
+
+  return args;
+}
+
+function detectProviderFromModel(model?: string): 'gemini' | 'openai' | 'claude' | undefined {
+  if (!model) {
+    return undefined;
+  }
+
+  const lowerModel = model.toLowerCase();
+
+  if (lowerModel.includes('gemini')) {
+    return 'gemini';
+  }
+
+  if (lowerModel.includes('gpt') || lowerModel.includes('openai')) {
+    return 'openai';
+  }
+
+  if (lowerModel.includes('claude')) {
+    return 'claude';
+  }
+
+  return undefined;
+}
+
+function buildStructuredFallback(): string {
+  const fallbackPlan = {
+    apps: ['gmail', 'sheets'],
+    trigger: {
+      type: 'time',
+      app: 'time',
+      operation: 'schedule',
+      description: 'Time-based trigger',
+      required_inputs: ['frequency'],
+      missing_inputs: ['frequency'],
+    },
+    steps: [
+      {
+        app: 'gmail',
+        operation: 'search_emails',
+        description: 'Search emails',
+        required_inputs: ['search_query'],
+        missing_inputs: ['search_query'],
+      },
+    ],
+    missing_inputs: [
+      {
+        id: 'frequency',
+        question: 'How often should this automation run?',
+        type: 'select',
+        required: true,
+        category: 'trigger',
+      },
+      {
+        id: 'search_query',
+        question: 'What email search criteria should we use?',
+        type: 'text',
+        required: true,
+        category: 'action',
+      },
+    ],
+    workflow_name: 'Custom Automation',
+    description: 'Automated workflow',
+    complexity: 'medium',
+  };
+
+  const fallbackResponse = {
+    status: 'llm_fallback',
+    message: 'LLM provider unavailable. Returning structured fallback response.',
+    is_complete: false,
+    questions:
+      fallbackPlan.missing_inputs?.map((input) => ({
+        id: input.id,
+        question: input.question,
+        type: input.type,
+        required: input.required,
+        category: input.category,
+      })) || [],
+    workflow_draft: {
+      nodes: [],
+      edges: [],
+      metadata: {
+        automationType: 'fallback',
+      },
+    },
+    ...fallbackPlan,
+  };
+
+  return JSON.stringify(fallbackResponse);
+}
+
 // ChatGPT Fix: Force Gemini to return JSON
 export async function generateJsonWithGemini(modelId: string, prompt: string) {
   const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
@@ -19,19 +126,19 @@ export async function generateJsonWithGemini(modelId: string, prompt: string) {
   return text;
 }
 
-type GenerateArgs = { model?: string; prompt: string };
-
 export const MultiAIService = {
-  async generateText({ model, prompt }: GenerateArgs): Promise<string> {
+  async generateText(args: GenerateArgs | string): Promise<string> {
+    const { model, prompt, maxTokens, temperature } = normalizeGenerateArgs(args);
     console.log('🤖 MultiAIService.generateText called');
     console.log('📝 Prompt length:', prompt.length);
-    
+
     try {
       // CRITICAL FIX: Use centralized provider selection
       const result = await LLMProviderService.generateText(prompt, {
         model,
-        temperature: 0.3,
-        maxTokens: 2000
+        temperature: temperature ?? 0.3,
+        maxTokens: maxTokens ?? 2000,
+        preferredProvider: detectProviderFromModel(model),
       });
 
       console.log(`✅ LLM Response from ${result.provider}:`, {
@@ -45,37 +152,7 @@ export const MultiAIService = {
       console.error('❌ Centralized LLM generation failed:', error);
       
       // Return structured fallback for automation planning
-      return this.getStructuredFallback();
+      return buildStructuredFallback();
     }
   },
-
-  getStructuredFallback(): string {
-    return `{
-      "apps": ["gmail", "sheets"],
-      "trigger": {
-        "type": "time",
-        "app": "time",
-        "operation": "schedule",
-        "description": "Time-based trigger",
-        "required_inputs": ["frequency"],
-        "missing_inputs": ["frequency"]
-      },
-      "steps": [
-        {
-          "app": "gmail",
-          "operation": "search_emails", 
-          "description": "Search emails",
-          "required_inputs": ["search_query"],
-          "missing_inputs": ["search_query"]
-        }
-      ],
-      "missing_inputs": [
-        {"id": "frequency", "question": "How often should this automation run?", "type": "select", "required": true, "category": "trigger"},
-        {"id": "search_query", "question": "What email search criteria?", "type": "text", "required": true, "category": "trigger"}
-      ],
-      "workflow_name": "Custom Automation",
-      "description": "Automated workflow",
-      "complexity": "medium"
-    }`;
-  }
 };


### PR DESCRIPTION
## Summary
- replace the Slack connector stub with a BaseAPIClient-powered implementation that calls the Slack Web API for messaging, channel management, reactions, and scheduling
- implement Airtable CRUD and listing operations against the Airtable REST API and enforce required credentials during client creation
- add a Notion API client with page and database helpers and update the IntegrationManager to instantiate and route Slack, Notion, and Airtable functions

## Testing
- npm run check *(fails: repository already contains 700+ unrelated TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d419d50aac833183f647edc90bb515