### PR TITLE
Fix graph hydration node types and selection handling

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -1469,7 +1469,7 @@ const GraphEditorContent = () => {
       setShowWelcomeModal(false);
 
       const firstNode = specNodes[0] as any;
-      setSelectedNode(firstNode);
+      setSelectedNodeId(String(firstNode.id));
       setNodes((prev: any) => prev.map((n: any) => ({ ...n, selected: n.id === firstNode.id })));
       specHydratedRef.current = true;
     } catch (error) {

--- a/client/src/graph/transform.ts
+++ b/client/src/graph/transform.ts
@@ -3,23 +3,31 @@ import type { AutomationSpec } from '../core/spec';
 export function specToReactFlow(spec: AutomationSpec) {
   const all = [...spec.triggers, ...spec.nodes];
 
-  const nodes = all.map((n, idx) => ({
-    id: n.id,
-    // keep generic node type; port handles will be rendered by UI from data
-    type: 'action.core',
-    position: { x: 120 + (idx % 6) * 260, y: 120 + Math.floor(idx / 6) * 180 },
-    data: {
-      label: n.label,
-      app: n.app,
-      function: n.type,
-      parameters: n.inputs || {},
-      outputs: n.outputs || [],
-      ports: {
-        inputs: Object.keys(n.inputs || {}),
-        outputs: n.outputs || []
+  const nodes = all.map((n, idx) => {
+    const [category] = n.type.split('.') as [string];
+    const reactFlowType = category === 'trigger'
+      ? 'trigger'
+      : category === 'transform'
+        ? 'transform'
+        : 'action';
+
+    return {
+      id: n.id,
+      type: reactFlowType,
+      position: { x: 120 + (idx % 6) * 260, y: 120 + Math.floor(idx / 6) * 180 },
+      data: {
+        label: n.label,
+        app: n.app,
+        function: n.type,
+        parameters: n.inputs || {},
+        outputs: n.outputs || [],
+        ports: {
+          inputs: Object.keys(n.inputs || {}),
+          outputs: n.outputs || []
+        }
       }
-    }
-  }));
+    };
+  });
 
   const edges = spec.edges.map((e) => ({
     id: `${e.from.nodeId}:${e.from.port}->${e.to.nodeId}:${e.to.port}`,


### PR DESCRIPTION
## Summary
- map automation spec nodes to the correct React Flow node types instead of using the fallback action.core renderer
- avoid calling an undefined setter when hydrating the graph by updating the selected node id directly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5753bd47c8331b334c598c05aec64