### PR TITLE
Preserve auth connection ids in graph serialization

### DIFF
--- a/client/src/components/workflow/graphPayload.ts
+++ b/client/src/components/workflow/graphPayload.ts
@@ -1,0 +1,166 @@
+export const applyExecutionStateDefaults = (data: any = {}) => {
+  const base = (data && typeof data === 'object') ? { ...data } : {};
+  if (!('executionStatus' in base)) {
+    base.executionStatus = 'idle';
+  }
+  if (!('executionError' in base)) {
+    base.executionError = null;
+  }
+  if (!('lastExecution' in base)) {
+    base.lastExecution = null;
+  }
+  return base;
+};
+
+export const sanitizeExecutionState = (data: any = {}) => {
+  if (!data || typeof data !== 'object') {
+    return data;
+  }
+  const sanitized = { ...data };
+  delete sanitized.executionStatus;
+  delete sanitized.executionError;
+  delete sanitized.lastExecution;
+  delete sanitized.isRunning;
+  delete sanitized.isCompleted;
+  return sanitized;
+};
+
+export interface GraphPayloadOptions {
+  nodes: Array<any>;
+  edges: Array<any>;
+  workflowIdentifier: string;
+  specName?: string;
+  specVersion?: number | string;
+  metadata?: Record<string, any> | null | undefined;
+}
+
+export const serializeGraphPayload = ({
+  nodes,
+  edges,
+  workflowIdentifier,
+  specName,
+  specVersion,
+  metadata
+}: GraphPayloadOptions) => {
+  const uniqueScopes = new Set<string>();
+  const nowIso = new Date().toISOString();
+  const metadataSource: Record<string, any> = (metadata && typeof metadata === 'object')
+    ? { ...metadata }
+    : {};
+  const metadataCreatedAt =
+    (typeof metadataSource.createdAt === 'string' && metadataSource.createdAt) ||
+    (typeof metadataSource.created_at === 'string' && metadataSource.created_at) ||
+    nowIso;
+  const metadataVersion =
+    (typeof metadataSource.version === 'string' && metadataSource.version.trim().length > 0)
+      ? metadataSource.version.trim()
+      : '1.0.0';
+
+  const serializedNodes = nodes.map((node, index) => {
+    const baseData = applyExecutionStateDefaults(node.data || {});
+    const sanitizedData = sanitizeExecutionState(baseData);
+    const paramsSource =
+      sanitizedData.parameters ??
+      sanitizedData.params ??
+      baseData.parameters ??
+      {};
+    const params = { ...paramsSource };
+
+    sanitizedData.parameters = params;
+    sanitizedData.params = params;
+
+    const connectionId =
+      sanitizedData.connectionId ??
+      sanitizedData.auth?.connectionId ??
+      baseData.connectionId ??
+      baseData.auth?.connectionId ??
+      params.connectionId;
+
+    if (connectionId) {
+      sanitizedData.connectionId = connectionId;
+      const authSource = sanitizedData.auth ?? baseData.auth;
+      sanitizedData.auth = { ...(authSource || {}), connectionId };
+      if (params.connectionId === undefined) {
+        params.connectionId = connectionId;
+      }
+    }
+
+    if (Array.isArray(sanitizedData.requiredScopes)) {
+      sanitizedData.requiredScopes.forEach((scope: string) => uniqueScopes.add(scope));
+    }
+
+    const candidateTypes: Array<string | undefined> = [
+      sanitizedData.nodeType,
+      node.data?.nodeType,
+      node.nodeType as string | undefined,
+      typeof node.type === 'string' ? node.type : undefined,
+      sanitizedData.type
+    ];
+    const canonicalType = candidateTypes.find((value) => typeof value === 'string' && value.includes('.'))
+      || candidateTypes.find((value) => typeof value === 'string' && value.trim().length > 0)
+      || (sanitizedData.kind ? `${sanitizedData.kind}.custom` : 'action.custom');
+
+    if (sanitizedData) {
+      sanitizedData.nodeType = canonicalType;
+      sanitizedData.type = canonicalType;
+    }
+
+    const position = (node.position && typeof node.position.x === 'number' && typeof node.position.y === 'number')
+      ? node.position
+      : { x: Number(node.position?.x) || 0, y: Number(node.position?.y) || 0 };
+
+    return {
+      id: String(node.id),
+      type: canonicalType,
+      nodeType: canonicalType,
+      label: sanitizedData.label || node.data?.label || `Node ${index + 1}`,
+      params,
+      data: sanitizedData,
+      app: sanitizedData.app || node.data?.app,
+      position,
+    };
+  });
+
+  const serializedEdges = edges
+    .filter((edge) => edge.source && edge.target)
+    .map((edge, index) => {
+      const source = String(edge.source);
+      const target = String(edge.target);
+      const baseData = edge.data ?? {};
+      const edgeId =
+        typeof edge.id === 'string' && edge.id.trim().length > 0
+          ? edge.id
+          : `edge-${index}-${source}-${target}`;
+
+      return {
+        id: edgeId,
+        source,
+        target,
+        from: source,
+        to: target,
+        label: edge.label || baseData.label || '',
+        dataType: baseData.dataType || 'default',
+        sourceHandle: edge.sourceHandle ?? baseData.sourceHandle,
+        targetHandle: edge.targetHandle ?? baseData.targetHandle,
+        data: baseData,
+      };
+    });
+
+  return {
+    id: String(workflowIdentifier),
+    name: specName || 'Graph Editor Workflow',
+    version: typeof specVersion === 'number' ? specVersion : 1,
+    nodes: serializedNodes,
+    edges: serializedEdges,
+    scopes: Array.from(uniqueScopes),
+    secrets: [],
+    metadata: {
+      ...metadataSource,
+      version: metadataVersion,
+      createdAt: metadataCreatedAt,
+      updatedAt: nowIso,
+      runPreview: true,
+    }
+  };
+};
+

--- a/client/src/graph/__tests__/transform.test.ts
+++ b/client/src/graph/__tests__/transform.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+
+import { specToReactFlow } from '../transform';
+import { serializeGraphPayload } from '../../components/workflow/graphPayload';
+
+const spec = {
+  version: '1.0' as const,
+  name: 'Connection Workflow',
+  description: 'ensures connection id survives hydration',
+  triggers: [],
+  nodes: [
+    {
+      id: 'node-1',
+      type: 'action.example',
+      app: 'example-app',
+      label: 'Example Node',
+      inputs: {
+        foo: 'bar'
+      },
+      outputs: ['result'],
+      auth: {
+        strategy: 'oauth' as const,
+        connectionId: 'conn-123'
+      }
+    }
+  ],
+  edges: []
+};
+
+const { nodes, edges } = specToReactFlow(spec);
+
+const payload = serializeGraphPayload({
+  nodes,
+  edges,
+  workflowIdentifier: 'wf-1',
+  specName: spec.name,
+  specVersion: 1,
+  metadata: {}
+});
+
+const serializedNode = payload.nodes[0];
+
+assert.equal(serializedNode.data.connectionId, 'conn-123');
+assert.equal(serializedNode.params.connectionId, 'conn-123');
+assert.equal(serializedNode.data.auth?.connectionId, 'conn-123');
+assert.equal(serializedNode.data.parameters.connectionId, 'conn-123');
+

--- a/client/src/graph/transform.ts
+++ b/client/src/graph/transform.ts
@@ -11,6 +11,14 @@ export function specToReactFlow(spec: AutomationSpec) {
         ? 'transform'
         : 'action';
 
+    const parameters = { ...(n.inputs || {}) };
+    const auth = n.auth ? { ...n.auth } : undefined;
+    const connectionId = auth?.connectionId;
+
+    if (connectionId && parameters.connectionId === undefined) {
+      parameters.connectionId = connectionId;
+    }
+
     return {
       id: n.id,
       type: reactFlowType,
@@ -19,8 +27,10 @@ export function specToReactFlow(spec: AutomationSpec) {
         label: n.label,
         app: n.app,
         function: n.type,
-        parameters: n.inputs || {},
+        parameters,
         outputs: n.outputs || [],
+        auth,
+        connectionId,
         ports: {
           inputs: Object.keys(n.inputs || {}),
           outputs: n.outputs || []

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "db:push": "drizzle-kit push",
-    "test": "tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts"
+    "test": "tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",


### PR DESCRIPTION
## Summary
- ensure auth metadata and connection ids flow into hydrated React Flow nodes
- extract graph serialization helpers so connection ids persist when building execution payloads
- cover the connection id round-trip with a new regression test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d691e3eb6483318ff35dbe2d0d2566