### PR TITLE
Preserve full node type metadata in workflow serialization

### DIFF
--- a/client/src/components/workflow/graphPayload.ts
+++ b/client/src/components/workflow/graphPayload.ts
@@ -94,7 +94,12 @@ export const serializeGraphPayload = ({
       node.data?.nodeType,
       node.nodeType as string | undefined,
       typeof node.type === 'string' ? node.type : undefined,
-      sanitizedData.type
+      sanitizedData.type,
+      node.data?.type,
+      sanitizedData.function,
+      node.data?.function,
+      sanitizedData.operation,
+      node.data?.operation
     ];
     const canonicalType = candidateTypes.find((value) => typeof value === 'string' && value.includes('.'))
       || candidateTypes.find((value) => typeof value === 'string' && value.trim().length > 0)

--- a/client/src/graph/__tests__/transform.test.ts
+++ b/client/src/graph/__tests__/transform.test.ts
@@ -45,3 +45,57 @@ assert.equal(serializedNode.params.connectionId, 'conn-123');
 assert.equal(serializedNode.data.auth?.connectionId, 'conn-123');
 assert.equal(serializedNode.data.parameters.connectionId, 'conn-123');
 
+const dottedSpec = {
+  version: '1.0' as const,
+  name: 'Dotted Types Workflow',
+  description: 'ensures dotted types survive round trip',
+  triggers: [
+    {
+      id: 'trigger-1',
+      type: 'trigger.example.listen',
+      app: 'example-app',
+      label: 'Example Trigger',
+      inputs: {},
+      outputs: ['event']
+    }
+  ],
+  nodes: [
+    {
+      id: 'action-1',
+      type: 'action.example.run',
+      app: 'example-app',
+      label: 'Example Action',
+      inputs: {},
+      outputs: ['result']
+    }
+  ],
+  edges: []
+};
+
+const dottedGraph = specToReactFlow(dottedSpec);
+
+const dottedPayload = serializeGraphPayload({
+  nodes: dottedGraph.nodes,
+  edges: dottedGraph.edges,
+  workflowIdentifier: 'wf-dotted',
+  specName: dottedSpec.name,
+  specVersion: 1,
+  metadata: {}
+});
+
+const triggerNode = dottedPayload.nodes.find((node) => node.id === 'trigger-1');
+const actionNode = dottedPayload.nodes.find((node) => node.id === 'action-1');
+
+assert(triggerNode, 'expected trigger node to be serialized');
+assert(actionNode, 'expected action node to be serialized');
+
+assert.equal(triggerNode?.type, 'trigger.example.listen');
+assert.equal(triggerNode?.nodeType, 'trigger.example.listen');
+assert.equal(triggerNode?.data?.type, 'trigger.example.listen');
+assert.equal(triggerNode?.data?.nodeType, 'trigger.example.listen');
+
+assert.equal(actionNode?.type, 'action.example.run');
+assert.equal(actionNode?.nodeType, 'action.example.run');
+assert.equal(actionNode?.data?.type, 'action.example.run');
+assert.equal(actionNode?.data?.nodeType, 'action.example.run');
+

--- a/client/src/graph/transform.ts
+++ b/client/src/graph/transform.ts
@@ -27,6 +27,8 @@ export function specToReactFlow(spec: AutomationSpec) {
         label: n.label,
         app: n.app,
         function: n.type,
+        type: n.type,
+        nodeType: n.type,
         parameters,
         outputs: n.outputs || [],
         auth,


### PR DESCRIPTION
## Summary
- persist each spec node's fully qualified type when building React Flow nodes
- update graph payload canonical type inference to fall back to function/operation metadata
- add regression coverage ensuring dotted trigger/action types survive serialization

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6a45ffa848331907ebf2b83208042