### PR TITLE
Ensure auth connection metadata persists through spec serialization

### DIFF
--- a/client/src/graph/__tests__/transform.test.ts
+++ b/client/src/graph/__tests__/transform.test.ts
@@ -29,6 +29,12 @@ const spec = {
 
 const { nodes, edges } = specToReactFlow(spec);
 
+const reactNode = nodes[0];
+
+assert.equal(reactNode.data.connectionId, 'conn-123');
+assert.equal(reactNode.data.auth?.connectionId, 'conn-123');
+assert.equal(reactNode.data.parameters.connectionId, 'conn-123');
+
 const payload = serializeGraphPayload({
   nodes,
   edges,
@@ -98,4 +104,32 @@ assert.equal(actionNode?.type, 'action.example.run');
 assert.equal(actionNode?.nodeType, 'action.example.run');
 assert.equal(actionNode?.data?.type, 'action.example.run');
 assert.equal(actionNode?.data?.nodeType, 'action.example.run');
+
+const inputsOnlySpec = {
+  version: '1.0' as const,
+  name: 'Inputs Carry Connection',
+  triggers: [],
+  nodes: [
+    {
+      id: 'node-2',
+      type: 'action.example',
+      app: 'example-app',
+      label: 'Example Node With Params',
+      inputs: {
+        connectionId: 'conn-from-inputs',
+        foo: 'baz'
+      },
+      outputs: []
+    }
+  ],
+  edges: []
+};
+
+const inputsOnlyGraph = specToReactFlow(inputsOnlySpec);
+
+const inputsOnlyNode = inputsOnlyGraph.nodes[0];
+
+assert.equal(inputsOnlyNode.data.parameters.connectionId, 'conn-from-inputs');
+assert.equal(inputsOnlyNode.data.connectionId, 'conn-from-inputs');
+assert.equal(inputsOnlyNode.data.auth?.connectionId, undefined);
 

--- a/client/src/graph/transform.ts
+++ b/client/src/graph/transform.ts
@@ -13,7 +13,7 @@ export function specToReactFlow(spec: AutomationSpec) {
 
     const parameters = { ...(n.inputs || {}) };
     const auth = n.auth ? { ...n.auth } : undefined;
-    const connectionId = auth?.connectionId;
+    const connectionId = auth?.connectionId ?? parameters.connectionId;
 
     if (connectionId && parameters.connectionId === undefined) {
       parameters.connectionId = connectionId;


### PR DESCRIPTION
## Summary
- include auth metadata when constructing AutomationSpecs from AI-generated graphs and derive connection IDs from node parameters
- allow specToReactFlow to recover connection IDs that are stored on node inputs
- extend transform tests to cover auth-enabled nodes and input-derived connections

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7e1f7f2cc8331b3f901d832e4b6ff