### PR TITLE
Fix connection IV handling and add regression tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "db:push": "drizzle-kit push",
-    "test": "tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts"
+    "test": "tsx server/services/__tests__/ConnectionService.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",

--- a/server/services/ConnectionService.ts
+++ b/server/services/ConnectionService.ts
@@ -34,6 +34,7 @@ export interface DecryptedConnection {
   provider: string;
   type: string;
   credentials: Record<string, any>;
+  iv: string;
   metadata?: Record<string, any>;
   isActive: boolean;
   lastTested?: Date;
@@ -91,7 +92,7 @@ export class ConnectionService {
       provider: request.provider,
       type: request.type,
       encryptedCredentials: encrypted.encryptedData,
-      credentialsIv: encrypted.iv,
+      iv: encrypted.iv,
       metadata: request.metadata || {},
       isActive: true,
     }).returning({ id: connections.id });
@@ -121,7 +122,7 @@ export class ConnectionService {
     // Decrypt credentials
     const credentials = EncryptionService.decryptCredentials(
       connection.encryptedCredentials,
-      connection.credentialsIv
+      connection.iv
     );
 
     return {
@@ -131,6 +132,7 @@ export class ConnectionService {
       provider: connection.provider,
       type: connection.type,
       credentials,
+      iv: connection.iv,
       metadata: connection.metadata,
       isActive: connection.isActive,
       lastTested: connection.lastTested,
@@ -165,7 +167,7 @@ export class ConnectionService {
     return userConnections.map(connection => {
       const credentials = EncryptionService.decryptCredentials(
         connection.encryptedCredentials,
-        connection.credentialsIv
+        connection.iv
       );
 
       return {
@@ -175,6 +177,7 @@ export class ConnectionService {
         provider: connection.provider,
         type: connection.type,
         credentials,
+        iv: connection.iv,
         metadata: connection.metadata,
         isActive: connection.isActive,
         lastTested: connection.lastTested,
@@ -373,7 +376,7 @@ export class ConnectionService {
       // Re-encrypt credentials
       const encrypted = EncryptionService.encryptCredentials(updates.credentials);
       updateData.encryptedCredentials = encrypted.encryptedData;
-      updateData.credentialsIv = encrypted.iv;
+      updateData.iv = encrypted.iv;
     }
 
     this.ensureDb();

--- a/server/services/__tests__/ConnectionService.test.ts
+++ b/server/services/__tests__/ConnectionService.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+
+import type { CreateConnectionRequest } from '../ConnectionService.js';
+
+class MockConnectionDatabase {
+  public rows: any[] = [];
+
+  insert(_table: unknown) {
+    return {
+      values: (value: Record<string, any>) => {
+        const now = new Date();
+        const row = {
+          id: value.id ?? randomUUID(),
+          createdAt: value.createdAt ?? now,
+          updatedAt: value.updatedAt ?? now,
+          lastTested: value.lastTested ?? null,
+          testStatus: value.testStatus ?? null,
+          testError: value.testError ?? null,
+          ...value,
+        };
+
+        this.rows.push(row);
+
+        return {
+          returning: () => Promise.resolve([{ id: row.id }]),
+        };
+      },
+    };
+  }
+
+  select() {
+    return {
+      from: (_table: unknown) => ({
+        where: () => {
+          const result = [...this.rows];
+          return {
+            orderBy: () => Promise.resolve(result),
+            then: (resolve: (value: any[]) => unknown, reject?: (reason: unknown) => unknown) =>
+              Promise.resolve(result).then(resolve, reject),
+          };
+        },
+      }),
+    };
+  }
+
+  update(_table: unknown) {
+    return {
+      set: (update: Record<string, any>) => ({
+        where: () => {
+          this.rows = this.rows.map((row) => ({ ...row, ...update }));
+          return Promise.resolve([]);
+        },
+      }),
+    };
+  }
+}
+
+process.env.NODE_ENV = 'development';
+process.env.ENCRYPTION_MASTER_KEY = '0123456789abcdef0123456789abcdef';
+
+const { EncryptionService } = await import('../EncryptionService.js');
+await EncryptionService.init();
+
+const { ConnectionService } = await import('../ConnectionService.js');
+
+const mockDb = new MockConnectionDatabase();
+const service = new ConnectionService();
+(service as any).db = mockDb;
+
+const request: CreateConnectionRequest = {
+  userId: randomUUID(),
+  name: 'Test Connection',
+  provider: 'openai',
+  type: 'llm',
+  credentials: {
+    apiKey: `sk-${'a'.repeat(48)}`,
+  },
+  metadata: { region: 'us-east-1' },
+};
+
+const connectionId = await service.createConnection(request);
+
+assert.ok(connectionId, 'should return generated connection id');
+
+const stored = mockDb.rows.find((row) => row.id === connectionId);
+assert.ok(stored, 'should persist encrypted connection');
+assert.ok(stored.iv, 'should store initialization vector');
+
+const decrypted = await service.getConnection(connectionId, request.userId);
+
+assert.ok(decrypted, 'should retrieve connection');
+assert.equal(decrypted?.credentials.apiKey, request.credentials.apiKey, 'should decrypt credentials');
+assert.equal(decrypted?.iv, stored.iv, 'should expose IV on decrypted connection');
+
+const allConnections = await service.getUserConnections(request.userId, request.provider);
+
+assert.equal(allConnections.length, 1, 'should return stored connection for user');
+assert.equal(allConnections[0].credentials.apiKey, request.credentials.apiKey, 'should decrypt credentials in list response');
+assert.equal(allConnections[0].iv, stored.iv, 'should expose IV in list response');
+
+console.log('ConnectionService encrypts, stores, and decrypts credentials with IV round-trip.');


### PR DESCRIPTION
## Summary
- align the connection service with the iv column when persisting and decrypting credentials
- expose the iv on decrypted connection objects and update consumers
- add a regression test for encryption round-trips and wire it into the test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8fbb1a55c8331a7aec8ac78f006a6