### PR TITLE
Add email verification support to auth service

### DIFF
--- a/server/database/migrations/20241120_add_email_verified_to_users.sql
+++ b/server/database/migrations/20241120_add_email_verified_to_users.sql
@@ -1,0 +1,11 @@
+-- Ensure the users table has an email_verified flag for tracking verification state
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "email_verified" boolean DEFAULT false NOT NULL;
+
+-- Backfill existing records with the default (false) to avoid NULL states
+UPDATE "users"
+SET "email_verified" = COALESCE("email_verified", false);
+
+-- Support lookups by verification state in combination with active status
+CREATE INDEX IF NOT EXISTS "users_email_verified_idx"
+  ON "users" ("email_verified", "is_active");

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -29,6 +29,7 @@ export const users = pgTable(
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
     lastLogin: timestamp('last_login'),
     isActive: boolean('is_active').default(true).notNull(),
+    emailVerified: boolean('email_verified').default(false).notNull(),
     quotaResetDate: timestamp('quota_reset_date').defaultNow().notNull(),
     
     // Usage quotas and tracking
@@ -53,6 +54,7 @@ export const users = pgTable(
     planIdx: index('users_plan_idx').on(table.plan),
     createdAtIdx: index('users_created_at_idx').on(table.createdAt),
     lastLoginIdx: index('users_last_login_idx').on(table.lastLogin),
+    emailVerifiedIdx: index('users_email_verified_idx').on(table.emailVerified, table.isActive),
     activeUsersIdx: index('users_active_idx').on(table.isActive, table.plan),
     quotaResetIdx: index('users_quota_reset_idx').on(table.quotaResetDate),
   })

--- a/server/services/AuthService.ts
+++ b/server/services/AuthService.ts
@@ -22,6 +22,7 @@ export interface AuthResponse {
     name?: string;
     role: string;
     planType: string;
+    emailVerified: boolean;
     quotaApiCalls: number;
     quotaTokens: number;
   };
@@ -111,6 +112,7 @@ export class AuthService {
         name: users.name,
         role: users.role,
         planType: users.planType,
+        emailVerified: users.emailVerified,
         quotaApiCalls: users.quotaApiCalls,
         quotaTokens: users.quotaTokens,
       });
@@ -190,6 +192,7 @@ export class AuthService {
           name: user.name,
           role: user.role,
           planType: user.planType,
+          emailVerified: user.emailVerified,
           quotaApiCalls: user.quotaApiCalls,
           quotaTokens: user.quotaTokens,
         },
@@ -261,6 +264,7 @@ export class AuthService {
           name: user.name,
           role: user.role,
           planType: user.planType,
+          emailVerified: user.emailVerified,
           quotaApiCalls: user.quotaApiCalls,
           quotaTokens: user.quotaTokens,
         },

--- a/server/services/__tests__/AuthService.test.ts
+++ b/server/services/__tests__/AuthService.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+
+process.env.NODE_ENV = 'development';
+
+const { AuthService } = await import('../AuthService.js');
+const { users } = await import('../../database/schema.js');
+
+interface MockUserRecord {
+  id: string;
+  email: string;
+  passwordHash: string;
+  name?: string;
+  role: string;
+  planType: string;
+  isActive: boolean;
+  emailVerified: boolean;
+  monthlyApiCalls: number;
+  monthlyTokensUsed: number;
+  quotaApiCalls: number;
+  quotaTokens: number;
+}
+
+const mockUsers: MockUserRecord[] = [];
+
+const mockDb = {
+  insert(table: unknown) {
+    if (table !== users) {
+      throw new Error('Mock DB only supports inserting into users table for this test');
+    }
+
+    return {
+      values(value: any) {
+        const record: MockUserRecord = {
+          id: `user-${mockUsers.length + 1}`,
+          email: value.email,
+          passwordHash: value.passwordHash,
+          name: value.name,
+          role: value.role,
+          planType: value.planType,
+          isActive: value.isActive ?? true,
+          emailVerified: value.emailVerified ?? false,
+          monthlyApiCalls: value.monthlyApiCalls ?? 0,
+          monthlyTokensUsed: value.monthlyTokensUsed ?? 0,
+          quotaApiCalls: value.quotaApiCalls ?? 0,
+          quotaTokens: value.quotaTokens ?? 0,
+        };
+
+        mockUsers.push(record);
+
+        return {
+          returning(selection?: Record<string, unknown>) {
+            return [mapSelection(record, selection)];
+          },
+        };
+      },
+    };
+  },
+};
+
+function mapSelection(record: MockUserRecord, selection?: Record<string, unknown>) {
+  if (!selection) {
+    return record;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(selection)) {
+    result[key] = (record as any)[key];
+  }
+  return result;
+}
+
+const authService = new AuthService();
+(authService as any).db = mockDb;
+(authService as any).getUserByEmail = async (email: string) => {
+  return mockUsers.find((user) => user.email === email.toLowerCase()) ?? null;
+};
+(authService as any).getUserById = async (userId: string) => {
+  return mockUsers.find((user) => user.id === userId) ?? null;
+};
+(authService as any).generateTokens = async () => ({
+  token: 'token',
+  refreshToken: 'refresh-token',
+  expiresAt: new Date(Date.now() + 60_000),
+});
+(authService as any).updateLastLogin = async () => {};
+
+const registration = await authService.register({
+  email: 'new-user@example.com',
+  password: 'ValidPass123',
+  name: 'Example User',
+});
+
+assert.equal(registration.success, true, 'registration should succeed');
+assert.equal(mockUsers.length, 1, 'a user record should be stored');
+assert.equal(mockUsers[0].emailVerified, false, 'new accounts default to unverified');
+
+const login = await authService.login({
+  email: 'new-user@example.com',
+  password: 'ValidPass123',
+});
+
+assert.equal(login.success, true, 'login should succeed for newly created user');
+assert.equal(login.user?.emailVerified, false, 'login response reflects verification state');
+assert.ok(login.token, 'login returns an access token');
+
+console.log('AuthService register/login keep emailVerified defaults intact.');


### PR DESCRIPTION
## Summary
- add an `email_verified` column to the users table with a supporting index and migration
- include the email verification flag in auth responses and ensure new users default to unverified
- add a regression test that exercises registration and login flows with the verification state

## Testing
- npx tsx server/services/__tests__/AuthService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8fefd90b48331b620fa9b0a2bf867