### PR TITLE
Improve AutomationPlannerService fallback heuristics

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "db:push": "drizzle-kit push",
-    "test": "tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts"
+    "test": "tsx server/services/__tests__/AutomationPlannerService.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",

--- a/server/services/__tests__/AutomationPlannerService.test.ts
+++ b/server/services/__tests__/AutomationPlannerService.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+
+import { AutomationPlannerService } from '../AutomationPlannerService.js';
+import { MultiAIService } from '../../aiModels.js';
+
+const mockFailure = async () => {
+  throw new Error('LLM failure');
+};
+
+// Test: all mode should surface prompt-specific apps when the LLM fails.
+{
+  const originalGenerateText = MultiAIService.generateText;
+  try {
+    AutomationPlannerService.setGeminiJsonGenerator(() => Promise.reject(new Error('Gemini unavailable')));
+    (MultiAIService as any).generateText = mockFailure;
+
+    const prompt = 'When Jira has a new ticket, post an update to Slack and notify the support channel.';
+    const plan = await AutomationPlannerService.planAutomation(prompt, 'all');
+
+    assert(plan.apps.includes('slack'), 'fallback plan should include Slack when mentioned in prompt');
+    assert(plan.apps.includes('jira'), 'fallback plan should include Jira when mentioned in prompt');
+    assert.equal(plan.description, prompt, 'fallback description should echo the user prompt');
+    assert(plan.follow_up_questions?.some(q => q.id === 'slack_channel'), 'should ask for Slack channel configuration');
+    assert.notDeepEqual(
+      [...plan.apps].sort(),
+      ['gmail', 'sheets'].sort(),
+      'fallback should not revert to the static Gmail/Sheets recipe in all mode'
+    );
+
+    console.log('AutomationPlannerService uses heuristic fallback for all-mode failures.');
+  } finally {
+    AutomationPlannerService.resetGeminiJsonGenerator();
+    (MultiAIService as any).generateText = originalGenerateText;
+  }
+}
+
+// Test: gas-only mode should constrain fallback to Google Workspace apps.
+{
+  const originalGenerateText = MultiAIService.generateText;
+  try {
+    AutomationPlannerService.setGeminiJsonGenerator(() => Promise.reject(new Error('Gemini unavailable')));
+    (MultiAIService as any).generateText = mockFailure;
+
+    const prompt = 'Send Slack alerts when a new support email arrives.';
+    const plan = await AutomationPlannerService.planAutomation(prompt, 'gas-only');
+
+    assert(plan.apps.every(app => ['gmail', 'sheets'].includes(app)), 'gas-only fallback should stay within Workspace apps');
+    assert(!plan.apps.includes('slack'), 'gas-only fallback must omit non-Google connectors');
+    assert.equal(plan.description, prompt, 'gas-only fallback should still reference the prompt');
+
+    console.log('AutomationPlannerService respects gas-only mode when falling back.');
+  } finally {
+    AutomationPlannerService.resetGeminiJsonGenerator();
+    (MultiAIService as any).generateText = originalGenerateText;
+  }
+}


### PR DESCRIPTION
## Summary
- allow AutomationPlannerService to inject the Gemini JSON generator, consolidate fallback handling, and keep heuristic plans while respecting planner modes
- enrich fallback outputs with follow-up question metadata for both heuristic and gas-only flows
- add automation planner fallback failure tests and wire them into the npm test suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9018b1edc8331b32dd7f88e4101ee