### PR TITLE
Handle missing LLM provider configuration

### DIFF
--- a/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
+++ b/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
@@ -13,6 +13,8 @@ import {
   augmentSchemaWithSheetTabs,
   fetchSheetTabs,
   renderStaticFieldControl,
+  interpretAIMappingAvailability,
+  type AiModelsMetadata,
   type UpstreamNodeSummary,
   type JSONSchema
 } from "../SmartParametersPanel";
@@ -646,6 +648,33 @@ assert.equal(normalizedAction.data.parameters.range, "A1:C1", "action parameters
 assert.ok(
   normalizedAction.data.metadata?.sample?.sheetName === "Invoices",
   "action metadata sampling should include sheet name from config"
+);
+
+const disabledAIMetadata: AiModelsMetadata = {
+  llmAvailable: false,
+  providerCapabilities: { gemini: false, openai: false, claude: false }
+};
+
+assert.equal(
+  interpretAIMappingAvailability(disabledAIMetadata),
+  false,
+  "AI mapping helper should disable mapping when llmAvailable=false"
+);
+
+const partialAIMetadata: AiModelsMetadata = {
+  providerCapabilities: { gemini: true, openai: false, claude: false }
+};
+
+assert.equal(
+  interpretAIMappingAvailability(partialAIMetadata),
+  true,
+  "AI mapping helper should enable mapping when any provider capability is true"
+);
+
+assert.equal(
+  interpretAIMappingAvailability(null),
+  true,
+  "AI mapping helper should default to enabled when metadata is missing"
 );
 
 console.log("SmartParametersPanel metadata helper checks (including sheet metadata) passed.");

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "db:push": "drizzle-kit push",
-    "test": "tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts"
+    "test": "tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/services/__tests__/LLMProviderService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx server/routes/__tests__/ai-no-provider.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",

--- a/server/routes/__tests__/ai-no-provider.test.ts
+++ b/server/routes/__tests__/ai-no-provider.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import express from 'express';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import aiRouter from '../ai.js';
+
+const originalEnv = {
+  GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  CLAUDE_API_KEY: process.env.CLAUDE_API_KEY,
+  LLM_PROVIDER: process.env.LLM_PROVIDER
+};
+
+delete process.env.GEMINI_API_KEY;
+delete process.env.OPENAI_API_KEY;
+delete process.env.CLAUDE_API_KEY;
+delete process.env.LLM_PROVIDER;
+
+const app = express();
+app.use(express.json());
+app.use('/api/ai', aiRouter);
+
+const server: Server = await new Promise((resolve) => {
+  const listener = app.listen(0, () => resolve(listener));
+});
+
+try {
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  const modelsResponse = await fetch(`${baseUrl}/api/ai/models`);
+  assert.equal(modelsResponse.status, 200, 'models endpoint should respond with 200');
+  const modelsJson = await modelsResponse.json();
+  assert.equal(modelsJson.success, true, 'models endpoint should return success flag');
+  assert.equal(modelsJson.llmAvailable, false, 'llmAvailable should be false when no providers configured');
+  assert.ok(Array.isArray(modelsJson.models) && modelsJson.models.length === 0, 'no models should be advertised without providers');
+
+  const mapParamsResponse = await fetch(`${baseUrl}/api/ai/map-params`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      parameter: {
+        name: 'subject',
+        schema: { type: 'string' }
+      },
+      upstream: [
+        {
+          nodeId: 'upstream-1',
+          label: 'Source Node',
+          app: 'demo',
+          columns: ['subject'],
+          sample: { subject: 'Example' },
+          schema: { subject: { type: 'string' } }
+        }
+      ]
+    })
+  });
+
+  assert.equal(mapParamsResponse.status, 503, 'map-params should return 503 when AI is disabled');
+  const mapParamsJson = await mapParamsResponse.json();
+  assert.equal(mapParamsJson.code, 'no_llm_providers', 'map-params should emit no_llm_providers code');
+  assert.match(
+    mapParamsJson.error || '',
+    /not available/i,
+    'map-params should return a clear error message when AI is disabled'
+  );
+
+  console.log('AI routes respond with graceful errors when no providers are configured.');
+} finally {
+  server.close();
+
+  if (originalEnv.GEMINI_API_KEY != null) {
+    process.env.GEMINI_API_KEY = originalEnv.GEMINI_API_KEY;
+  } else {
+    delete process.env.GEMINI_API_KEY;
+  }
+
+  if (originalEnv.OPENAI_API_KEY != null) {
+    process.env.OPENAI_API_KEY = originalEnv.OPENAI_API_KEY;
+  } else {
+    delete process.env.OPENAI_API_KEY;
+  }
+
+  if (originalEnv.CLAUDE_API_KEY != null) {
+    process.env.CLAUDE_API_KEY = originalEnv.CLAUDE_API_KEY;
+  } else {
+    delete process.env.CLAUDE_API_KEY;
+  }
+
+  if (originalEnv.LLM_PROVIDER != null) {
+    process.env.LLM_PROVIDER = originalEnv.LLM_PROVIDER;
+  } else {
+    delete process.env.LLM_PROVIDER;
+  }
+}

--- a/server/routes/ai.ts
+++ b/server/routes/ai.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { MultiAIService, buildWorkflowFromAnswersNew, generateWorkflowFromAnalysis } from '../aiModels';
-import { LLMProviderService } from '../services/LLMProviderService.js';
+import { LLMProviderService, NoLLMProvidersAvailableError, type LLMProviderCapabilities } from '../services/LLMProviderService.js';
 import { getErrorMessage } from '../types/common';
 
 export const aiRouter = Router();
@@ -130,22 +130,30 @@ aiRouter.post('/process-answers', async (req, res) => {
 // Get available AI models endpoint  
 aiRouter.get('/models', async (req, res) => {
   try {
-    // Return available models
+    const capabilities = LLMProviderService.getProviderCapabilities();
+    const availableProviders = Object.entries(capabilities)
+      .filter(([, enabled]) => enabled)
+      .map(([provider]) => provider);
+
+    const availableModels = [
+      { id: 'gemini-1.5-flash', name: 'Gemini 1.5 Flash', provider: 'gemini' },
+      { id: 'gemini-1.5-flash-8b', name: 'Gemini 1.5 Flash 8B', provider: 'gemini' },
+      { id: 'gemini-2.0-flash-exp', name: 'Gemini 2.0 Flash (Experimental)', provider: 'gemini' },
+      { id: 'claude-3-sonnet', name: 'Claude 3 Sonnet', provider: 'claude' },
+      { id: 'gpt-4', name: 'GPT-4', provider: 'openai' }
+    ].filter((model) => capabilities[model.provider as keyof LLMProviderCapabilities]);
+
     res.json({
       success: true,
-      models: [
-        { id: 'gemini-1.5-flash', name: 'Gemini 1.5 Flash', provider: 'gemini' },
-        { id: 'gemini-1.5-flash-8b', name: 'Gemini 1.5 Flash 8B', provider: 'gemini' }, 
-        { id: 'gemini-2.0-flash-exp', name: 'Gemini 2.0 Flash (Experimental)', provider: 'gemini' },
-        { id: 'claude-3-sonnet', name: 'Claude 3 Sonnet', provider: 'claude' },
-        { id: 'gpt-4', name: 'GPT-4', provider: 'openai' }
-      ]
+      models: availableModels,
+      providerCapabilities: capabilities,
+      llmAvailable: availableProviders.length > 0
     });
   } catch (error: any) {
     console.error('❌ AI models error:', error);
-    res.status(500).json({ 
-      success: false, 
-      error: error?.message || 'Failed to get AI models' 
+    res.status(500).json({
+      success: false,
+      error: error?.message || 'Failed to get AI models'
     });
   }
 });
@@ -216,6 +224,14 @@ aiRouter.post('/map-params', async (req, res) => {
 
     res.json({ success: true, mapping });
   } catch (error) {
+    if (error instanceof NoLLMProvidersAvailableError) {
+      return res.status(503).json({
+        success: false,
+        error: 'AI mapping is not available because no AI providers are configured.',
+        code: 'no_llm_providers'
+      });
+    }
+
     res.status(500).json({ success: false, error: getErrorMessage(error) });
   }
 });

--- a/server/services/__tests__/LLMProviderService.test.ts
+++ b/server/services/__tests__/LLMProviderService.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+
+import { LLMProviderService, NoLLMProvidersAvailableError } from '../LLMProviderService.js';
+
+const originalEnv = {
+  GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  CLAUDE_API_KEY: process.env.CLAUDE_API_KEY,
+  LLM_PROVIDER: process.env.LLM_PROVIDER
+};
+
+try {
+  delete process.env.GEMINI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.CLAUDE_API_KEY;
+  delete process.env.LLM_PROVIDER;
+
+  const provider = LLMProviderService.selectProvider();
+  assert.equal(provider, null, 'selectProvider should return null when no providers are configured');
+
+  await assert.rejects(
+    () => LLMProviderService.generateText('Hello world'),
+    (error: any) => {
+      assert.ok(error instanceof NoLLMProvidersAvailableError, 'should throw NoLLMProvidersAvailableError');
+      assert.equal(error.message, 'No LLM providers are configured');
+      return true;
+    },
+    'generateText should reject when no providers are available'
+  );
+
+  const status = LLMProviderService.getProviderStatus();
+  assert.equal(status.selected, null, 'status.selected should be null when no providers configured');
+  assert.equal(status.configured, false, 'status.configured should be false when no providers configured');
+  assert.deepEqual(status.available, [], 'no providers should be reported as available');
+
+  console.log('LLMProviderService no-provider safeguards verified.');
+} finally {
+  if (originalEnv.GEMINI_API_KEY != null) {
+    process.env.GEMINI_API_KEY = originalEnv.GEMINI_API_KEY;
+  } else {
+    delete process.env.GEMINI_API_KEY;
+  }
+
+  if (originalEnv.OPENAI_API_KEY != null) {
+    process.env.OPENAI_API_KEY = originalEnv.OPENAI_API_KEY;
+  } else {
+    delete process.env.OPENAI_API_KEY;
+  }
+
+  if (originalEnv.CLAUDE_API_KEY != null) {
+    process.env.CLAUDE_API_KEY = originalEnv.CLAUDE_API_KEY;
+  } else {
+    delete process.env.CLAUDE_API_KEY;
+  }
+
+  if (originalEnv.LLM_PROVIDER != null) {
+    process.env.LLM_PROVIDER = originalEnv.LLM_PROVIDER;
+  } else {
+    delete process.env.LLM_PROVIDER;
+  }
+}


### PR DESCRIPTION
## Summary
- make LLMProviderService explicitly signal when no providers are configured and surface that state in the AI routes
- return provider capabilities from /api/ai/models and short-circuit /api/ai/map-params with a 503 when AI is disabled
- disable AI mapping controls in the Smart Parameters panel when the backend reports no providers and add regression coverage for API/UI fallbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9032b80c88331bed25e0c5ed4159f