### PR TITLE
Fix SmartParametersPanel LLM mode placeholder and tests

### DIFF
--- a/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
+++ b/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
@@ -13,6 +13,8 @@ import {
   augmentSchemaWithSheetTabs,
   fetchSheetTabs,
   renderStaticFieldControl,
+  createDefaultLLMValue,
+  mergeLLMValueWithDefaults,
   type UpstreamNodeSummary,
   type JSONSchema
 } from "../SmartParametersPanel";
@@ -442,6 +444,36 @@ assert.ok(
     updatedPathsForSheet.includes("sheet"),
   "updated suggestions should include a sheet name quick pick"
 );
+
+// Ensure the AI Mapping mode placeholder keeps the LLM mode active so the UI can render the Map with AI button
+{
+  const fieldName = "recipient";
+  const fieldSchema: JSONSchema = {
+    type: "string",
+    title: "Recipient",
+    description: "Destination email address"
+  };
+  const llmDefaults = createDefaultLLMValue(fieldName, fieldSchema, upstreamNodes);
+  const placeholder = mergeLLMValueWithDefaults(
+    { mode: "ref", nodeId: upstreamNodes[0]!.id, path: "Email" },
+    llmDefaults
+  );
+
+  assert.equal(
+    placeholder.mode,
+    "llm",
+    "Switching to AI Mapping should yield an llm evaluated value"
+  );
+  assert.equal(
+    placeholder.provider,
+    "openai",
+    "LLM placeholder should target the default OpenAI provider"
+  );
+  assert.ok(
+    typeof placeholder.prompt === "string" && placeholder.prompt.includes("Recipient"),
+    "Default LLM prompt should reference the field name so the Map with AI button has context"
+  );
+}
 
 const paramSyncBase = {
   label: "Mailer",


### PR DESCRIPTION
## Summary
- update SmartParametersPanel to build default LLM evaluated values and commit them when switching modes
- normalize existing LLM parameter values with sensible defaults and skip static-state updates while in LLM mode
- extend the SmartParametersPanel test suite to assert the AI Mapping placeholder preserves LLM mode

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9033183dc8331a4d7d0f961a9ee9b