### PR TITLE
Expose connection IV field and add encryption regression test

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "db:push": "drizzle-kit push",
-    "test": "tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts"
+    "test": "tsx server/services/__tests__/ConnectionService.encryption.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",

--- a/server/services/ConnectionService.ts
+++ b/server/services/ConnectionService.ts
@@ -37,6 +37,7 @@ export interface DecryptedConnection {
   name: string;
   provider: string;
   type: string;
+  iv: string;
   credentials: Record<string, any>;
   metadata?: Record<string, any>;
   isActive: boolean;
@@ -125,6 +126,7 @@ export class ConnectionService {
       name: record.name,
       provider: record.provider,
       type: record.type,
+      iv: record.iv,
       credentials,
       metadata: record.metadata,
       isActive: record.isActive,
@@ -236,6 +238,7 @@ export class ConnectionService {
       name: connection.name,
       provider: connection.provider,
       type: connection.type,
+      iv: connection.iv,
       credentials,
       metadata: connection.metadata,
       isActive: connection.isActive,
@@ -288,6 +291,7 @@ export class ConnectionService {
         name: connection.name,
         provider: connection.provider,
         type: connection.type,
+        iv: connection.iv,
         credentials,
         metadata: connection.metadata,
         isActive: connection.isActive,
@@ -336,6 +340,7 @@ export class ConnectionService {
       name: connection.name,
       provider: connection.provider,
       type: connection.type,
+      iv: connection.iv,
       credentials,
       metadata: connection.metadata,
       isActive: connection.isActive,

--- a/server/services/__tests__/ConnectionService.encryption.test.ts
+++ b/server/services/__tests__/ConnectionService.encryption.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+process.env.NODE_ENV = 'development';
+process.env.ENCRYPTION_MASTER_KEY = 'a'.repeat(32);
+
+const tempDir = await mkdtemp(path.join(os.tmpdir(), 'connection-service-'));
+process.env.CONNECTION_STORE_PATH = path.join(tempDir, 'connections.json');
+
+const { EncryptionService } = await import('../EncryptionService.js');
+await EncryptionService.init();
+
+const { ConnectionService } = await import('../ConnectionService.js');
+const service = new ConnectionService();
+
+const originalCredentials = {
+  apiKey: `sk-${'a'.repeat(50)}`,
+  region: 'us-east-1',
+};
+
+const connectionId = await service.createConnection({
+  userId: 'user-123',
+  name: 'Test Connection',
+  provider: 'OpenAI',
+  type: 'llm',
+  credentials: originalCredentials,
+  metadata: { createdBy: 'unit-test' },
+});
+
+const storedRaw = await readFile(process.env.CONNECTION_STORE_PATH!, 'utf8');
+const storedRecords = JSON.parse(storedRaw);
+assert.equal(storedRecords.length, 1, 'a single connection record should be stored');
+assert.ok(storedRecords[0].iv, 'stored connection should include an iv field');
+assert.equal('credentialsIv' in storedRecords[0], false, 'legacy credentialsIv field should not be present');
+
+const fetched = await service.getConnection(connectionId, 'user-123');
+assert.ok(fetched, 'connection should be retrievable');
+assert.equal(fetched?.iv, storedRecords[0].iv, 'fetched connection exposes iv');
+assert.deepEqual(fetched?.credentials, originalCredentials, 'credentials should decrypt to original payload');
+
+const byProvider = await service.getConnectionByProvider('user-123', 'openai');
+assert.ok(byProvider, 'connection should be retrievable by provider');
+assert.equal(byProvider?.iv, storedRecords[0].iv, 'provider lookup exposes iv');
+assert.deepEqual(byProvider?.credentials, originalCredentials, 'provider lookup decrypts credentials');
+
+const allConnections = await service.getUserConnections('user-123', 'openai');
+assert.equal(allConnections.length, 1, 'user should have one connection after creation');
+assert.equal(allConnections[0].iv, storedRecords[0].iv, 'list entries expose iv');
+assert.deepEqual(allConnections[0].credentials, originalCredentials, 'list entries decrypt credentials');
+
+await rm(tempDir, { recursive: true, force: true });
+delete process.env.CONNECTION_STORE_PATH;
+
+console.log('ConnectionService encrypt/decrypt round trip verified via file store.');


### PR DESCRIPTION
## Summary
- expose the encrypted credential IV on decrypted connection DTOs when reading from either the file store or database
- add a regression test ensuring connection creation, retrieval, and provider lookups retain the IV and decrypt credentials correctly
- include the new regression test in the npm test suite so encryption round-trips remain covered

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9197184b48331bf009fc48bdec737