### PR TITLE
Add connection type/test metadata columns and coverage

### DIFF
--- a/server/database/migrations/20250305_add_connection_type_test_columns.sql
+++ b/server/database/migrations/20250305_add_connection_type_test_columns.sql
@@ -1,0 +1,18 @@
+ALTER TABLE connections
+ADD COLUMN IF NOT EXISTS type text;
+
+UPDATE connections
+SET type = 'saas'
+WHERE type IS NULL;
+
+ALTER TABLE connections
+ALTER COLUMN type SET DEFAULT 'saas';
+
+ALTER TABLE connections
+ALTER COLUMN type SET NOT NULL;
+
+ALTER TABLE connections
+ADD COLUMN IF NOT EXISTS test_status text;
+
+ALTER TABLE connections
+ADD COLUMN IF NOT EXISTS test_error text;

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -68,12 +68,15 @@ export const connections = pgTable(
     userId: uuid('user_id').references(() => users.id, { onDelete: 'cascade' }).notNull(),
     name: text('name').notNull(),
     provider: text('provider').notNull(), // gemini, openai, claude, slack, hubspot, jira, etc.
+    type: text('type').default('saas').notNull(),
     encryptedCredentials: text('encrypted_credentials').notNull(),
     iv: text('iv').notNull(), // AES-256-GCM IV
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
     lastUsed: timestamp('last_used'),
     lastTested: timestamp('last_tested'),
+    testStatus: text('test_status'),
+    testError: text('test_error'),
     lastError: text('last_error'),
     isActive: boolean('is_active').default(true).notNull(),
     

--- a/server/services/__tests__/ConnectionService.test.ts
+++ b/server/services/__tests__/ConnectionService.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+process.env.NODE_ENV = 'development';
+process.env.ENCRYPTION_MASTER_KEY = process.env.ENCRYPTION_MASTER_KEY ?? 'a'.repeat(32);
+
+const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'connection-service-'));
+const storePath = path.join(tempDir, 'connections.json');
+process.env.CONNECTION_STORE_PATH = storePath;
+
+const { EncryptionService } = await import('../EncryptionService.js');
+await EncryptionService.init();
+
+const { ConnectionService } = await import('../ConnectionService.js');
+
+const service = new ConnectionService();
+
+const request = {
+  userId: 'user-123',
+  name: 'Test Connection',
+  provider: 'custom-service',
+  type: 'saas' as const,
+  credentials: {
+    token: 'abc123',
+  },
+  metadata: {
+    region: 'us-east-1',
+  },
+};
+
+const connectionId = await service.createConnection(request);
+assert.ok(connectionId, 'should return a connection id');
+
+const testResult = await service.testConnection(connectionId, request.userId);
+assert.equal(testResult.provider, request.provider, 'test returns provider name');
+assert.equal(testResult.success, false, 'unknown providers fall back to not implemented');
+
+const userConnections = await service.getUserConnections(request.userId);
+assert.equal(userConnections.length, 1, 'user should have exactly one connection');
+const [connection] = userConnections;
+
+assert.equal(connection?.id, connectionId, 'connection ids should match');
+assert.equal(connection?.type, request.type, 'connection type persisted');
+assert.equal(connection?.testStatus, 'failed', 'test status persisted');
+assert.equal(
+  connection?.testError,
+  testResult.message,
+  'test error message captured during failed test'
+);
+
+const fetched = await service.getConnection(connectionId, request.userId);
+assert.ok(fetched, 'connection can be fetched by id');
+assert.equal(fetched?.type, request.type, 'fetched connection preserves type');
+assert.equal(fetched?.testStatus, 'failed', 'fetched connection includes test status');
+assert.equal(fetched?.testError, testResult.message, 'fetched connection includes test error');
+
+await fs.rm(tempDir, { recursive: true, force: true });
+
+console.log('ConnectionService stores type/test status metadata in sync with schema.');


### PR DESCRIPTION
## Summary
- add missing `type`, `test_status`, and `test_error` columns to the connections schema with a migration
- add regression coverage that exercises create/test/list flows for ConnectionService to keep the schema and service in sync

## Testing
- npx tsx server/services/__tests__/ConnectionService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9199b11e08331938b4a99036ca9c3