### PR TITLE
Add local integrations for Sheets and Time core apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "db:push": "drizzle-kit push",
-    "test": "tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts"
+    "test": "tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts && tsx server/workflow/__tests__/workflow-runtime.core-apps.test.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",

--- a/server/integrations/__tests__/IntegrationManager.test.ts
+++ b/server/integrations/__tests__/IntegrationManager.test.ts
@@ -1,18 +1,18 @@
 import assert from 'node:assert/strict';
 
-import { IntegrationManager } from '../IntegrationManager.js';
+import { BUILDER_CORE_APP_IDS, IntegrationManager } from '../IntegrationManager.js';
 import { APICredentials } from '../BaseAPIClient.js';
 import { IMPLEMENTED_CONNECTOR_IDS } from '../supportedApps.js';
 
 const manager = new IntegrationManager();
 
 const supportedApps = manager.getSupportedApplications().sort();
-const implementedApps = [...IMPLEMENTED_CONNECTOR_IDS].sort();
+const expectedApps = [...new Set([...IMPLEMENTED_CONNECTOR_IDS, ...BUILDER_CORE_APP_IDS])].sort();
 
 assert.deepEqual(
   supportedApps,
-  implementedApps,
-  'IntegrationManager supported apps should match the implemented connector list'
+  expectedApps,
+  'IntegrationManager supported apps should include implemented connectors and core builder apps'
 );
 
 const credentialFixtures: Record<string, { credentials: APICredentials; additionalConfig?: Record<string, any> }> = {
@@ -31,6 +31,12 @@ const credentialFixtures: Record<string, { credentials: APICredentials; addition
   },
   slack: {
     credentials: { botToken: 'xoxb-test-token' }
+  },
+  sheets: {
+    credentials: { mode: 'local' }
+  },
+  time: {
+    credentials: { mode: 'local' }
   }
 };
 
@@ -40,7 +46,7 @@ const createClient = (manager as any).createAPIClient.bind(manager) as (
   additionalConfig?: Record<string, any>
 ) => unknown;
 
-for (const appId of IMPLEMENTED_CONNECTOR_IDS) {
+for (const appId of expectedApps) {
   const fixture = credentialFixtures[appId];
   assert.ok(fixture, `Missing credential fixture for supported app ${appId}`);
 
@@ -50,5 +56,5 @@ for (const appId of IMPLEMENTED_CONNECTOR_IDS) {
 
 console.log(
   'IntegrationManager createAPIClient returns concrete clients for:',
-  IMPLEMENTED_CONNECTOR_IDS.join(', ')
+  expectedApps.join(', ')
 );

--- a/server/workflow/__tests__/workflow-runtime.core-apps.test.ts
+++ b/server/workflow/__tests__/workflow-runtime.core-apps.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+
+import { WorkflowRuntimeService } from '../WorkflowRuntimeService.js';
+import { integrationManager } from '../../integrations/IntegrationManager.js';
+
+const runtime = new WorkflowRuntimeService();
+const context = {
+  workflowId: 'wf-core-apps',
+  executionId: 'exec-core-apps',
+  nodeOutputs: {} as Record<string, any>,
+  timezone: 'UTC'
+};
+
+const sheetsNode = {
+  id: 'node-sheets',
+  type: 'action.sheets.append_row',
+  data: {
+    app: 'sheets',
+    function: 'append_row',
+    parameters: {
+      spreadsheetId: 'sheet-123',
+      sheetName: 'Entries',
+      values: ['alpha', 'beta', 'gamma']
+    },
+    credentials: { mode: 'local' }
+  }
+};
+
+const timeNode = {
+  id: 'node-time',
+  type: 'action.time.delay',
+  data: {
+    app: 'time',
+    function: 'delay',
+    parameters: {
+      delayMs: 5,
+      seconds: 0
+    },
+    credentials: { mode: 'local' }
+  }
+};
+
+try {
+  const sheetsResult = await runtime.executeNode(sheetsNode, context);
+  assert.equal(sheetsResult.summary, 'Executed sheets.append_row', 'Sheets node should report successful execution');
+  assert.ok(sheetsResult.output, 'Sheets node should produce output data');
+  assert.equal(sheetsResult.output?.rowIndex, 1, 'Sheets node should append the first row');
+  assert.deepEqual(
+    context.nodeOutputs['node-sheets'],
+    sheetsResult.output,
+    'Sheets node output should be stored in execution context'
+  );
+
+  const timeResult = await runtime.executeNode(timeNode, context);
+  assert.equal(timeResult.summary, 'Executed time.delay', 'Time node should report successful execution');
+  assert.ok(timeResult.output, 'Time node should produce output data');
+  assert.equal(timeResult.output?.requestedDelayMs, 5, 'Time node should capture requested delay');
+  assert.equal(context.nodeOutputs['node-time'], timeResult.output, 'Time node output should be stored in execution context');
+
+  console.log('WorkflowRuntimeService executes Sheets append row and Time delay nodes successfully.');
+} finally {
+  integrationManager.removeIntegration('sheets');
+  integrationManager.removeIntegration('time');
+}


### PR DESCRIPTION
## Summary
- extend the integration manager to recognise builder core apps and provide lightweight local clients for Sheets and Time operations
- update integration manager tests to cover the expanded supported application list
- add a workflow runtime regression test exercising Sheets append row and Time delay nodes, and include it in the test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d919f9f6588331be7f792e4298949b