### PR TITLE
Handle missing LLM providers for AI mapping

### DIFF
--- a/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
+++ b/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
@@ -15,6 +15,7 @@ import {
   renderStaticFieldControl,
   createDefaultLLMValue,
   mergeLLMValueWithDefaults,
+  parseAIMappingCapability,
   type UpstreamNodeSummary,
   type JSONSchema
 } from "../SmartParametersPanel";
@@ -92,6 +93,33 @@ assert.ok(amountSuggestion, "should surface Amount column quick pick");
 assert.ok(statusSuggestion, "should surface status field from output metadata");
 assert.ok(entireOutput.includes("node-1"), "should include entire output suggestions");
 assert.ok(entireOutput.includes("node-3"), "should include entire output for runtime metadata nodes");
+
+const disabledCapability = parseAIMappingCapability({
+  aiAvailable: false,
+  providers: { available: [] },
+  models: []
+});
+assert.equal(
+  disabledCapability.available,
+  false,
+  "AI mapping capability helper should report unavailable when backend disables providers"
+);
+assert.deepEqual(
+  disabledCapability.providers,
+  [],
+  "AI mapping capability helper should normalize provider lists"
+);
+
+const legacyCapability = parseAIMappingCapability({
+  models: [
+    { id: "gemini-1.5-flash", provider: "gemini" }
+  ]
+});
+assert.equal(
+  legacyCapability.available,
+  true,
+  "AI mapping capability helper should treat legacy payloads with models as available"
+);
 
 const resolverNodeFixtures: Array<{
   description: string;

--- a/server/routes/__tests__/ai-disabled.test.ts
+++ b/server/routes/__tests__/ai-disabled.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import express from 'express';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import aiRouter from '../ai.js';
+
+const originalEnv = {
+  openai: process.env.OPENAI_API_KEY,
+  gemini: process.env.GEMINI_API_KEY,
+  claude: process.env.CLAUDE_API_KEY,
+};
+
+delete process.env.OPENAI_API_KEY;
+delete process.env.GEMINI_API_KEY;
+delete process.env.CLAUDE_API_KEY;
+
+const app = express();
+app.use(express.json());
+app.use('/api/ai', aiRouter);
+
+const server: Server = await new Promise((resolve) => {
+  const listener = app.listen(0, () => resolve(listener));
+});
+
+try {
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  const modelsResponse = await fetch(`${baseUrl}/api/ai/models`);
+  assert.equal(modelsResponse.status, 200, 'models endpoint should respond with 200');
+  const modelsBody = await modelsResponse.json();
+
+  assert.equal(modelsBody.success, true, 'models endpoint should report success');
+  assert.equal(modelsBody.aiAvailable, false, 'aiAvailable should be false when no providers are configured');
+  assert.deepEqual(modelsBody.models, [], 'models list should be empty when providers are unavailable');
+
+  const mapResponse = await fetch(`${baseUrl}/api/ai/map-params`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      parameter: { name: 'email', schema: {}, description: 'Recipient email' },
+      upstream: [
+        {
+          nodeId: 'node-1',
+          label: 'Source Node',
+          columns: ['email'],
+          sample: { email: 'example@example.com' }
+        }
+      ],
+      instruction: 'Map to email column'
+    })
+  });
+
+  assert.equal(mapResponse.status, 503, 'map-params should respond with 503 when providers are unavailable');
+  const mapBody = await mapResponse.json();
+  assert.equal(mapBody.success, false, 'map-params should report failure');
+  assert.equal(mapBody.code, 'ai_mapping_disabled', 'map-params should include a capability error code');
+} finally {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+
+  if (originalEnv.openai) {
+    process.env.OPENAI_API_KEY = originalEnv.openai;
+  } else {
+    delete process.env.OPENAI_API_KEY;
+  }
+
+  if (originalEnv.gemini) {
+    process.env.GEMINI_API_KEY = originalEnv.gemini;
+  } else {
+    delete process.env.GEMINI_API_KEY;
+  }
+
+  if (originalEnv.claude) {
+    process.env.CLAUDE_API_KEY = originalEnv.claude;
+  } else {
+    delete process.env.CLAUDE_API_KEY;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `NoLLMProvidersError` and make the LLM provider selector return `null` when no vendors are configured
- surface the provider capability flag through `/api/ai/models`, guard `/api/ai/map-params`, and add regression coverage for the disabled state
- disable the AI mapping option in the Smart Parameters panel when the backend reports no providers and expand the UI test suite to cover the new helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d91a6addbc8331a6f56d4b12d3169a