### PR TITLE
Add Gemini and Claude adapters to LLM registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "db:push": "drizzle-kit push",
-    "test": "tsx server/services/__tests__/ConnectionService.encryption.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts"
+    "test": "tsx server/services/__tests__/ConnectionService.encryption.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts && tsx server/core/__tests__/ParameterResolver.llm.test.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",

--- a/server/core/ParameterResolver.ts
+++ b/server/core/ParameterResolver.ts
@@ -152,8 +152,16 @@ async function resolveLLMValue(
   
   try {
     // Get LLM provider
-    const llmProvider = llmRegistry.get(provider);
-    
+    let llmProvider: ReturnType<typeof llmRegistry.get>;
+    try {
+      llmProvider = llmRegistry.get(provider);
+    } catch (registryError) {
+      const availableAdapters = llmRegistry.getAvailableProviders();
+      const message = `LLM provider adapter "${provider}" is not registered. Available adapters: ${availableAdapters.join(', ') || 'none'}.`;
+      console.warn(message);
+      return message;
+    }
+
     // Interpolate prompt with context
     const interpolatedPrompt = interpolatePrompt(prompt, context);
     

--- a/server/core/__tests__/ParameterResolver.llm.test.ts
+++ b/server/core/__tests__/ParameterResolver.llm.test.ts
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+
+import { resolveAllParams } from '../ParameterResolver.js';
+import { registerLLMProviders, llmRegistry } from '../../llm/index.js';
+
+const originalEnv = {
+  GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  CLAUDE_API_KEY: process.env.CLAUDE_API_KEY,
+  LLM_PROVIDER: process.env.LLM_PROVIDER,
+};
+
+const originalFetch = globalThis.fetch;
+
+function clearRegistry() {
+  const providers: Map<string, any> | undefined = (llmRegistry as any).providers;
+  if (providers) {
+    providers.clear();
+  }
+}
+
+async function runGeminiScenario() {
+  clearRegistry();
+  process.env.GEMINI_API_KEY = 'test-gemini-key';
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.CLAUDE_API_KEY;
+  process.env.LLM_PROVIDER = '';
+
+  globalThis.fetch = async (input: RequestInfo | URL, _init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (!url.includes('generativelanguage.googleapis.com')) {
+      throw new Error(`Unexpected fetch call for Gemini test: ${url}`);
+    }
+
+    const body = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              { text: 'Gemini says hi' },
+            ],
+          },
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 10,
+        candidatesTokenCount: 5,
+        totalTokenCount: 15,
+      },
+    };
+
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  registerLLMProviders();
+
+  const params = {
+    summary: {
+      mode: 'llm',
+      provider: 'google',
+      model: 'google:gemini-1.5-flash',
+      prompt: 'Say hello',
+    },
+  } as const;
+
+  const context = {
+    nodeOutputs: {},
+    currentNodeId: 'node-1',
+    workflowId: 'workflow-1',
+    executionId: 'exec-1',
+  };
+
+  const resolved = await resolveAllParams(params as any, context as any);
+
+  assert.equal(resolved.summary, 'Gemini says hi');
+  console.log('✅ resolveAllParams returns Gemini data when only GEMINI_API_KEY is set.');
+}
+
+async function runClaudeScenario() {
+  clearRegistry();
+  delete process.env.GEMINI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  process.env.CLAUDE_API_KEY = 'test-claude-key';
+  process.env.LLM_PROVIDER = '';
+
+  globalThis.fetch = async (input: RequestInfo | URL, _init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (!url.includes('api.anthropic.com')) {
+      throw new Error(`Unexpected fetch call for Claude test: ${url}`);
+    }
+
+    const body = {
+      content: [
+        { text: 'Claude says hi' },
+      ],
+      usage: {
+        input_tokens: 20,
+        output_tokens: 7,
+      },
+    };
+
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  registerLLMProviders();
+
+  const params = {
+    summary: {
+      mode: 'llm',
+      provider: 'anthropic',
+      model: 'anthropic:claude-3-5-sonnet',
+      prompt: 'Say hello',
+    },
+  } as const;
+
+  const context = {
+    nodeOutputs: {},
+    currentNodeId: 'node-1',
+    workflowId: 'workflow-1',
+    executionId: 'exec-1',
+  };
+
+  const resolved = await resolveAllParams(params as any, context as any);
+
+  assert.equal(resolved.summary, 'Claude says hi');
+  console.log('✅ resolveAllParams returns Claude data when only CLAUDE_API_KEY is set.');
+}
+
+try {
+  await runGeminiScenario();
+  await runClaudeScenario();
+  console.log('ParameterResolver LLM integration scenarios completed successfully.');
+} finally {
+  clearRegistry();
+  globalThis.fetch = originalFetch;
+  process.env.GEMINI_API_KEY = originalEnv.GEMINI_API_KEY;
+  process.env.OPENAI_API_KEY = originalEnv.OPENAI_API_KEY;
+  process.env.CLAUDE_API_KEY = originalEnv.CLAUDE_API_KEY;
+  process.env.LLM_PROVIDER = originalEnv.LLM_PROVIDER;
+}

--- a/server/llm/index.ts
+++ b/server/llm/index.ts
@@ -1,8 +1,7 @@
 import { llmRegistry } from './LLMProvider';
 import { OpenAIProvider } from './providers/OpenAIProvider';
-// Future providers can be added here:
-// import { AnthropicProvider } from './providers/AnthropicProvider';
-// import { GoogleProvider } from './providers/GoogleProvider';
+import { GeminiProvider } from './providers/GeminiProvider';
+import { ClaudeProvider } from './providers/ClaudeProvider';
 
 export function registerLLMProviders() {
   console.log('🤖 Registering LLM providers...');
@@ -12,8 +11,9 @@ export function registerLLMProviders() {
   const available: Provider[] = [];
 
   // Register Gemini if API key is available
-  if (process.env.GEMINI_API_KEY) {
-    // Note: Using LLMProviderService which handles Gemini
+  const geminiApiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
+  if (geminiApiKey) {
+    llmRegistry.register(new GeminiProvider(geminiApiKey));
     available.push('gemini');
     console.log('✅ Gemini provider registered');
   } else {
@@ -28,12 +28,22 @@ export function registerLLMProviders() {
   } else {
     console.log('⚠️ OPENAI_API_KEY not found - skipping OpenAI provider');
   }
+
+  // Register Claude if API key is available
+  if (process.env.CLAUDE_API_KEY) {
+    llmRegistry.register(new ClaudeProvider(process.env.CLAUDE_API_KEY));
+    available.push('claude');
+    console.log('✅ Claude provider registered');
+  } else {
+    console.log('⚠️ CLAUDE_API_KEY not found - skipping Claude provider');
+  }
   
   // Choose default intelligently (ChatGPT's fix)
   const defaultProvider =
     (available.includes(envProvider) && envProvider) ||
     (available.includes('gemini') ? 'gemini' :
-     available.includes('openai') ? 'openai' : null);
+     available.includes('openai') ? 'openai' :
+     available.includes('claude') ? 'claude' : null);
 
   if (!defaultProvider) {
     console.error('❌ No LLM provider available');

--- a/server/llm/providers/ClaudeProvider.ts
+++ b/server/llm/providers/ClaudeProvider.ts
@@ -1,0 +1,121 @@
+import { LLMProvider, LLMResult, LLMModelId, LLMMessage, LLMTool } from '../LLMProvider';
+
+function normalizeClaudeRole(role: LLMMessage['role']): 'user' | 'assistant' {
+  switch (role) {
+    case 'assistant':
+      return 'assistant';
+    case 'system':
+    case 'tool':
+    case 'user':
+    default:
+      return 'user';
+  }
+}
+
+function safeParseJSON(payload?: string) {
+  try {
+    return payload ? JSON.parse(payload) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export class ClaudeProvider implements LLMProvider {
+  readonly id = 'anthropic' as const;
+
+  constructor(private apiKey: string) {}
+
+  supportsJSON = (model: LLMModelId) => String(model).startsWith('anthropic:');
+
+  async generate(params: {
+    model: LLMModelId;
+    messages: LLMMessage[];
+    temperature?: number;
+    maxTokens?: number;
+    tools?: LLMTool[];
+    toolChoice?: 'auto' | 'none' | { name: string };
+    responseFormat?: 'text' | { type: 'json_object'; schema?: any };
+    abortSignal?: AbortSignal;
+  }): Promise<LLMResult> {
+    const model = String(params.model).replace('anthropic:', '');
+
+    const systemMessages = params.messages.filter(m => m.role === 'system');
+    const conversation = params.messages
+      .filter(m => m.role !== 'system')
+      .map(message => ({
+        role: normalizeClaudeRole(message.role),
+        content: [
+          {
+            type: 'text',
+            text: message.content,
+          },
+        ],
+      }));
+
+    const body: Record<string, any> = {
+      model,
+      max_tokens: params.maxTokens ?? 1024,
+      temperature: params.temperature ?? 0.2,
+      messages: conversation,
+    };
+
+    if (systemMessages.length > 0) {
+      body.system = systemMessages.map(m => m.content).join('\n');
+    }
+
+    if (params.responseFormat && typeof params.responseFormat !== 'string') {
+      body.response_format = { type: 'json_object' };
+    }
+
+    if (params.tools && params.tools.length > 0) {
+      body.tools = params.tools.map(tool => ({
+        name: tool.name,
+        description: tool.description,
+        input_schema: tool.parameters,
+      }));
+
+      if (params.toolChoice) {
+        body.tool_choice = params.toolChoice;
+      }
+    }
+
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify(body),
+      signal: params.abortSignal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Claude API error (${response.status}): ${errorText}`);
+    }
+
+    const data = await response.json();
+    const contentEntry = data.content?.[0];
+    const text: string | undefined = contentEntry?.text;
+
+    let jsonResult;
+    if (params.responseFormat && typeof params.responseFormat !== 'string') {
+      jsonResult = safeParseJSON(text);
+    }
+
+    const usage = data.usage
+      ? {
+          promptTokens: data.usage.input_tokens,
+          completionTokens: data.usage.output_tokens,
+          costUSD: undefined,
+        }
+      : undefined;
+
+    return {
+      text,
+      json: jsonResult,
+      usage,
+    };
+  }
+}

--- a/server/llm/providers/GeminiProvider.ts
+++ b/server/llm/providers/GeminiProvider.ts
@@ -1,0 +1,120 @@
+import { LLMProvider, LLMResult, LLMModelId, LLMMessage, LLMTool } from '../LLMProvider';
+
+function toGeminiRole(role: LLMMessage['role']): 'user' | 'model' {
+  switch (role) {
+    case 'assistant':
+    case 'tool':
+      return 'model';
+    case 'system':
+    case 'user':
+    default:
+      return 'user';
+  }
+}
+
+function safeParseJSON(payload?: string) {
+  try {
+    return payload ? JSON.parse(payload) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export class GeminiProvider implements LLMProvider {
+  readonly id = 'google' as const;
+
+  constructor(private apiKey: string) {}
+
+  supportsJSON = (model: LLMModelId) => String(model).startsWith('google:');
+
+  async generate(params: {
+    model: LLMModelId;
+    messages: LLMMessage[];
+    temperature?: number;
+    maxTokens?: number;
+    tools?: LLMTool[];
+    toolChoice?: 'auto' | 'none' | { name: string };
+    responseFormat?: 'text' | { type: 'json_object'; schema?: any };
+    abortSignal?: AbortSignal;
+  }): Promise<LLMResult> {
+    const model = String(params.model).replace('google:', '');
+
+    const contents = params.messages.map(message => ({
+      role: toGeminiRole(message.role),
+      parts: [
+        {
+          text: message.content,
+        },
+      ],
+    }));
+
+    const body: Record<string, any> = {
+      contents,
+      generationConfig: {
+        temperature: params.temperature ?? 0.2,
+        maxOutputTokens: params.maxTokens ?? 1024,
+        topP: 0.8,
+        topK: 40,
+      },
+    };
+
+    if (params.responseFormat && typeof params.responseFormat !== 'string') {
+      body.generationConfig.responseMimeType = 'application/json';
+      if (params.responseFormat.schema) {
+        body.generationConfig.responseSchema = params.responseFormat.schema;
+      }
+    }
+
+    if (params.tools && params.tools.length > 0) {
+      body.tools = params.tools.map(tool => ({
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      }));
+    }
+
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${this.apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: params.abortSignal,
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Gemini API error (${response.status}): ${errorText}`);
+    }
+
+    const data = await response.json();
+    const candidate = data.candidates?.[0];
+
+    const textPart = candidate?.content?.parts?.find((part: any) => typeof part?.text === 'string');
+    const text: string | undefined = textPart?.text;
+
+    let jsonResult;
+    if (params.responseFormat && typeof params.responseFormat !== 'string') {
+      jsonResult = safeParseJSON(text);
+      if (!jsonResult) {
+        const jsonPart = candidate?.content?.parts?.find((part: any) => part?.mimeType === 'application/json');
+        jsonResult = safeParseJSON(jsonPart?.text);
+      }
+    }
+
+    const usage = data.usageMetadata
+      ? {
+          promptTokens: data.usageMetadata.promptTokenCount,
+          completionTokens: data.usageMetadata.candidatesTokenCount,
+          costUSD: undefined,
+        }
+      : undefined;
+
+    return {
+      text,
+      json: jsonResult,
+      usage,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- register Gemini and Claude providers when their API keys are configured
- add adapter-awareness to the LLM provider service and improve missing-adapter handling
- guard ParameterResolver LLM lookups and add tests covering Gemini/Claude-only environments

## Testing
- npx tsx server/core/__tests__/ParameterResolver.llm.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d91eabd844833198ce2f69712d361e