### PR TITLE
Handle schema aliases for dynamic parameter forms

### DIFF
--- a/client/src/components/workflow/DynamicParameterForm.tsx
+++ b/client/src/components/workflow/DynamicParameterForm.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { buildSchemaRequestPaths } from '@shared/appSchemaAlias';
 import { Input } from '../ui/input';
 import { Textarea } from '../ui/textarea';
 import { Button } from '../ui/button';
@@ -64,7 +65,8 @@ export const DynamicParameterForm: React.FC<DynamicParameterFormProps> = ({
     const loadSchema = async () => {
       setLoading(true);
       try {
-        const response = await fetch(`/api/app-schemas/schemas/${app}/${operation}`);
+        const { schemaPath } = buildSchemaRequestPaths(app, operation);
+        const response = await fetch(schemaPath);
         if (response.ok) {
           const result = await response.json();
           if (result.success) {
@@ -87,7 +89,8 @@ export const DynamicParameterForm: React.FC<DynamicParameterFormProps> = ({
 
     setValidationStatus('validating');
     try {
-      const response = await fetch(`/api/app-schemas/schemas/${app}/${operation}/validate`, {
+      const { validationPath } = buildSchemaRequestPaths(app, operation);
+      const response = await fetch(validationPath, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ parameters })

--- a/client/src/components/workflow/__tests__/NodeConfigurationModal.regression.test.ts
+++ b/client/src/components/workflow/__tests__/NodeConfigurationModal.regression.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import express from 'express';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import appSchemasRouter from '../../../../../server/routes/app-schemas.js';
+import { buildSchemaRequestPaths } from '@shared/appSchemaAlias';
+
+const app = express();
+app.use(express.json());
+app.use('/api/app-schemas', appSchemasRouter);
+
+const server: Server = await new Promise((resolve) => {
+  const listener = app.listen(0, () => resolve(listener));
+});
+
+try {
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  const { schemaPath, validationPath, resolvedApp, resolvedOperation } = buildSchemaRequestPaths(
+    'google-sheets',
+    'action.google-sheets.append_row'
+  );
+
+  const schemaResponse = await fetch(`${baseUrl}${schemaPath}`);
+  assert.equal(schemaResponse.status, 200, 'schema endpoint should resolve the sheets alias');
+  const schemaPayload = await schemaResponse.json();
+  assert.equal(schemaPayload.app, resolvedApp, 'response should return the canonical app id');
+  assert.equal(
+    schemaPayload.operation,
+    resolvedOperation,
+    'response should return the canonical operation id'
+  );
+  assert.ok(schemaPayload.parameters, 'schema payload should include parameters');
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(schemaPayload.parameters, 'spreadsheetUrl'),
+    'append row schema should expose spreadsheetUrl field'
+  );
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(schemaPayload.parameters, 'values'),
+    'append row schema should expose values field'
+  );
+
+  const validationResponse = await fetch(`${baseUrl}${validationPath}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ parameters: { spreadsheetUrl: 'https://example.com', values: 'one,two' } })
+  });
+
+  assert.equal(
+    validationResponse.status,
+    200,
+    'validation endpoint should respect the sheets alias without 404s'
+  );
+  const validationPayload = await validationResponse.json();
+  assert.equal(validationPayload.app, resolvedApp, 'validation should report canonical app id');
+  assert.equal(
+    validationPayload.operation,
+    resolvedOperation,
+    'validation should report canonical operation id'
+  );
+  assert.ok(validationPayload.validation, 'validation payload should include validation results');
+} finally {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "db:push": "drizzle-kit push",
-    "test": "tsx server/services/__tests__/ConnectionService.encryption.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts && tsx server/workflow/__tests__/WorkflowRuntimeService.test.ts && tsx server/core/__tests__/ParameterResolver.llm.test.ts"
+    "test": "tsx server/services/__tests__/ConnectionService.encryption.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/components/workflow/__tests__/NodeConfigurationModal.regression.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts && tsx server/workflow/__tests__/WorkflowRuntimeService.test.ts && tsx server/core/__tests__/ParameterResolver.llm.test.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",

--- a/server/schemas/app-parameter-schemas.ts
+++ b/server/schemas/app-parameter-schemas.ts
@@ -1,6 +1,8 @@
+import { resolveAppSchemaKey, resolveSchemaOperationKey } from '@shared/appSchemaAlias';
+
 /**
  * P1-6: Per-app typed parameter schemas for better UX
- * 
+ *
  * This file defines the parameter schemas for each application,
  * providing proper form validation, input types, and user guidance.
  */
@@ -386,10 +388,12 @@ export const APP_PARAMETER_SCHEMAS: Record<string, AppParameterSchema> = {
 
 // Helper function to get schema for a specific app and operation
 export function getParameterSchema(app: string, operation: string): Record<string, ParameterSchema> | null {
-  const appSchema = APP_PARAMETER_SCHEMAS[app];
+  const resolvedApp = resolveAppSchemaKey(app) ?? app;
+  const resolvedOperation = resolveSchemaOperationKey(operation);
+  const appSchema = APP_PARAMETER_SCHEMAS[resolvedApp];
   if (!appSchema) return null;
-  
-  return appSchema[operation] || null;
+
+  return appSchema[resolvedOperation] || null;
 }
 
 // Helper function to validate parameters against schema

--- a/shared/appSchemaAlias.ts
+++ b/shared/appSchemaAlias.ts
@@ -1,0 +1,89 @@
+export type AppSchemaAliasKey = 'sheets' | 'time';
+
+const ALIAS_GROUPS: Record<AppSchemaAliasKey, string[]> = {
+  sheets: [
+    'sheets',
+    'sheet',
+    'google-sheets',
+    'google_sheets',
+    'google sheets',
+    'googlesheets',
+    'gsheets',
+    'g-sheets',
+    'google-sheets-enhanced'
+  ],
+  time: [
+    'time',
+    'delay',
+    'wait',
+    'timer',
+    'schedule',
+    'time-delay'
+  ]
+};
+
+const aliasMap = new Map<string, AppSchemaAliasKey>();
+
+const normalizeKey = (value: string): string => {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, '-')
+    .replace(/[^a-z0-9-]/g, '-');
+};
+
+for (const [canonical, aliases] of Object.entries(ALIAS_GROUPS)) {
+  for (const alias of aliases) {
+    aliasMap.set(normalizeKey(alias), canonical as AppSchemaAliasKey);
+  }
+}
+
+export const resolveAppSchemaKey = (app?: string | null): string | null => {
+  if (!app) return null;
+  const normalized = normalizeKey(app);
+  if (aliasMap.has(normalized)) {
+    return aliasMap.get(normalized)!;
+  }
+
+  const rawSegments = String(app)
+    .trim()
+    .toLowerCase()
+    .split(/[.:/]/)
+    .filter(Boolean);
+
+  for (let i = rawSegments.length - 1; i >= 0; i--) {
+    const candidate = normalizeKey(rawSegments[i]);
+    if (aliasMap.has(candidate)) {
+      return aliasMap.get(candidate)!;
+    }
+  }
+
+  return null;
+};
+
+export const resolveSchemaOperationKey = (operation?: string | null): string => {
+  if (!operation) return '';
+  const trimmed = operation.trim();
+  if (!trimmed) return '';
+
+  const segments = trimmed.split(/[.:]/).filter(Boolean);
+  if (segments.length === 0) {
+    return trimmed;
+  }
+
+  return segments[segments.length - 1];
+};
+
+export const buildSchemaRequestPaths = (
+  app: string,
+  operation: string
+): { resolvedApp: string; resolvedOperation: string; schemaPath: string; validationPath: string } => {
+  const resolvedApp = resolveAppSchemaKey(app) ?? app;
+  const resolvedOperation = resolveSchemaOperationKey(operation) || operation;
+  return {
+    resolvedApp,
+    resolvedOperation,
+    schemaPath: `/api/app-schemas/schemas/${resolvedApp}/${resolvedOperation}`,
+    validationPath: `/api/app-schemas/schemas/${resolvedApp}/${resolvedOperation}/validate`
+  };
+};


### PR DESCRIPTION
## Summary
- add a shared app schema alias map so dynamic parameter tooling can resolve Google Sheets and other normalized connector ids
- update the dynamic parameter form and app schema routes to translate alias keys before fetching schemas or running validation
- cover the Google Sheets append row modal flow with a regression test and include it in the test suite

## Testing
- npx tsx client/src/components/workflow/__tests__/NodeConfigurationModal.regression.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d924fbd690833199b547bc14cef0ee