### PR TITLE
Restore experimental connectors in node catalog

### DIFF
--- a/server/ConnectorRegistry.ts
+++ b/server/ConnectorRegistry.ts
@@ -702,7 +702,7 @@ export class ConnectorRegistry {
     const categories: Record<string, any> = {};
 
     for (const [appId, entry] of this.registry.entries()) {
-      if (entry.availability !== 'stable') {
+      if (entry.availability === 'disabled') {
         continue;
       }
       const def = entry.definition;


### PR DESCRIPTION
## Summary
- include experimental connectors in the node catalog so the graph builder continues to list them even without full implementations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8f80285b08331b540c200b87a52da