### PR TITLE
Handle auth scoped connections in workflow runtime

### DIFF
--- a/server/workflow/WorkflowRuntimeService.ts
+++ b/server/workflow/WorkflowRuntimeService.ts
@@ -415,13 +415,25 @@ export class WorkflowRuntimeService {
     return Object.keys(merged).length > 0 ? merged : undefined;
   }
 
+  /**
+   * Resolve credentials for a node by inspecting supported connection references.
+   * Serializers should populate one of the following locations when using stored connections:
+   * - node.data.auth.connectionId
+   * - node.data.connectionId
+   * - node.connectionId
+   * - node.params.connectionId
+   * - node.parameters.connectionId
+   * - node.data.parameters.connectionId
+   */
   private async resolveCredentials(node: any, userId?: string): Promise<CredentialResolution> {
     const inlineCredentials = this.extractInlineCredentials(node);
     const connectionId = this.selectString(
+      node?.data?.auth?.connectionId,
       node?.data?.connectionId,
       node?.connectionId,
       node?.params?.connectionId,
-      node?.parameters?.connectionId
+      node?.parameters?.connectionId,
+      node?.data?.parameters?.connectionId
     );
 
     if (inlineCredentials) {


### PR DESCRIPTION
## Summary
- allow WorkflowRuntimeService to resolve connection ids provided under data.auth or data.parameters
- document the supported connection id properties for stored credentials
- add a regression test covering nodes that reference connections through data.auth.connectionId

## Testing
- npx tsx server/workflow/__tests__/WorkflowRuntimeService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9690ee1fc8331bc7164aad06fe979