### PR TITLE
Add Postgres configuration and workflow repository integration test

### DIFF
--- a/.env
+++ b/.env
@@ -8,8 +8,8 @@ ANTHROPIC_API_KEY=
 CLAUDE_API_KEY=
 GOOGLE_API_KEY=
 
-# Database Configuration (commented out for testing)
-# DATABASE_URL="sqlite://./dev.db"
+# Database Configuration
+DATABASE_URL="postgresql://automation_user:supersecurepassword@managed-postgres.example.com:5432/automation_platform"
 
 # JWT Secret for authentication
 JWT_SECRET="your-super-secret-jwt-key-here-change-in-production"

--- a/migrations/0000_lyrical_malice.sql
+++ b/migrations/0000_lyrical_malice.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"username" text NOT NULL,
+	"password" text NOT NULL,
+	CONSTRAINT "users_username_unique" UNIQUE("username")
+);

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -1,0 +1,58 @@
+{
+  "id": "73d3119f-639c-4ddb-ae03-0ed538681247",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1759121970491,
+      "tag": "0000_lyrical_malice",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
     "npm": ">=10.0.0"
   },
   "scripts": {
-    "dev": "npm run check:deps && NODE_ENV=development tsx server/index.ts",
-    "dev:fast": "NODE_ENV=development tsx server/index.ts",
+    "dev": "npm run check:deps && npx drizzle-kit push && NODE_ENV=development tsx server/index.ts",
+    "dev:fast": "npx drizzle-kit push && NODE_ENV=development tsx server/index.ts",
     "build": "npm run check:deps && vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "db:push": "drizzle-kit push",
-    "test": "tsx server/services/__tests__/ConnectionService.encryption.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/components/workflow/__tests__/NodeConfigurationModal.regression.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts && tsx server/workflow/__tests__/WorkflowRuntimeService.test.ts && tsx server/core/__tests__/ParameterResolver.llm.test.ts"
+    "test": "tsx server/services/__tests__/ConnectionService.encryption.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/components/workflow/__tests__/NodeConfigurationModal.regression.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts && tsx server/workflow/__tests__/WorkflowRuntimeService.test.ts && tsx server/core/__tests__/ParameterResolver.llm.test.ts && tsx server/workflow/__tests__/WorkflowRepository.test.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",

--- a/production/deployment-checklist.md
+++ b/production/deployment-checklist.md
@@ -95,7 +95,7 @@ PORT=5000
 HOST=0.0.0.0
 
 # Database (PostgreSQL recommended)
-DATABASE_URL="postgresql://user:pass@host:5432/automation_platform"
+DATABASE_URL="postgresql://automation_user:supersecurepassword@managed-postgres.example.com:5432/automation_platform"
 
 # LLM Provider (Gemini recommended)
 LLM_PROVIDER=gemini

--- a/production/environment-config.ts
+++ b/production/environment-config.ts
@@ -76,7 +76,7 @@ HOST=0.0.0.0
 # =================================
 # DATABASE CONFIGURATION
 # =================================
-DATABASE_URL="postgresql://username:password@host:5432/automation_platform"
+DATABASE_URL="postgresql://automation_user:supersecurepassword@managed-postgres.example.com:5432/automation_platform"
 DATABASE_POOL_SIZE=20
 DATABASE_SSL=true
 

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -562,6 +562,14 @@ if (!connectionString) {
 }
 
 
+export function setDatabaseClientForTests(databaseClient: any): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('setDatabaseClientForTests should only be used in test environment');
+  }
+
+  db = databaseClient;
+}
+
 export { db };
 
 console.log('✅ Database schema loaded with comprehensive indexes and PII tracking for ALL applications');

--- a/server/workflow/__tests__/WorkflowRepository.test.ts
+++ b/server/workflow/__tests__/WorkflowRepository.test.ts
@@ -1,0 +1,298 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL = '';
+
+const schemaModule = await import('../../database/schema.js');
+const { workflows, users, setDatabaseClientForTests } = schemaModule;
+
+type TableType = typeof workflows | typeof users;
+
+interface WhereCondition {
+  column: string;
+  value: unknown;
+}
+
+class FakeDb {
+  private tables = new Map<string, any[]>();
+  public readonly operationLog: string[] = [];
+
+  public insert(table: TableType) {
+    return new InsertBuilder(this, table);
+  }
+
+  public select(columns?: Record<string, any>) {
+    return new SelectBuilder(this, columns);
+  }
+
+  public getTableRows(tableName: string) {
+    return this.tables.get(tableName) ?? [];
+  }
+
+  public getOrCreateTable(tableName: string) {
+    if (!this.tables.has(tableName)) {
+      this.tables.set(tableName, []);
+    }
+    return this.tables.get(tableName)!;
+  }
+
+  public resolveTableName(table: TableType): string {
+    const symbol = Object.getOwnPropertySymbols(table).find((sym) => sym.description === 'drizzle:Name');
+    if (!symbol) {
+      throw new Error('Unable to resolve table name for fake database');
+    }
+    return table[symbol] as string;
+  }
+
+  public resolveColumnName(column: any): string {
+    if (column && typeof column === 'object' && 'name' in column) {
+      return column.name as string;
+    }
+    throw new Error('Unable to resolve column name for fake database');
+  }
+
+  public logOperation(operation: string): void {
+    this.operationLog.push(operation);
+  }
+
+  public prepareInsertRecord(tableName: string, values: Record<string, any>): Record<string, any> {
+    const record = structuredClone(values);
+    const now = new Date();
+
+    if (!record.id) {
+      record.id = randomUUID();
+    }
+
+    if (tableName === this.resolveTableName(users)) {
+      record.createdAt ??= now;
+      record.updatedAt ??= now;
+      record.role ??= 'user';
+      record.plan ??= 'free';
+      record.planType ??= 'free';
+    }
+
+    if (tableName === this.resolveTableName(workflows)) {
+      record.createdAt ??= now;
+      record.updatedAt ??= now;
+      record.isActive ??= true;
+      record.executionCount ??= 0;
+      record.totalRuns ??= 0;
+      record.successfulRuns ??= 0;
+    }
+
+    return record;
+  }
+
+  public applyUpdateRecord(
+    tableName: string,
+    existing: Record<string, any>,
+    setValues: Record<string, any> | undefined,
+  ): Record<string, any> {
+    const updated = structuredClone(existing);
+    if (setValues) {
+      for (const [key, value] of Object.entries(setValues)) {
+        updated[key] = value;
+      }
+    }
+
+    if (tableName === this.resolveTableName(workflows)) {
+      updated.updatedAt ??= new Date();
+    }
+
+    return updated;
+  }
+
+  public parseWhere(condition: any): WhereCondition[] {
+    if (!condition) {
+      return [];
+    }
+
+    const chunks: any[] = Array.isArray(condition.queryChunks) ? condition.queryChunks : [];
+    const columnChunk = chunks.find((chunk) => chunk && typeof chunk === 'object' && 'name' in chunk);
+    const paramChunk = chunks.find((chunk) => chunk && typeof chunk === 'object' && 'value' in chunk);
+
+    if (!columnChunk || !paramChunk) {
+      throw new Error('Unsupported where clause for fake database');
+    }
+
+    return [
+      {
+        column: this.resolveColumnName(columnChunk),
+        value: paramChunk.value,
+      },
+    ];
+  }
+
+  public projectRow(row: Record<string, any>, columns?: Record<string, any>): Record<string, any> {
+    if (!columns) {
+      return structuredClone(row);
+    }
+
+    const result: Record<string, any> = {};
+    for (const [alias, column] of Object.entries(columns)) {
+      if (column && typeof column === 'object' && 'name' in column) {
+        result[alias] = row[this.resolveColumnName(column)];
+      } else {
+        result[alias] = row[alias];
+      }
+    }
+    return result;
+  }
+}
+
+class InsertBuilder {
+  private readonly tableName: string;
+  private values: Record<string, any> | null = null;
+  private conflict?: { target: any; set?: Record<string, any> };
+
+  constructor(private readonly db: FakeDb, private readonly table: TableType) {
+    this.tableName = db.resolveTableName(table);
+  }
+
+  public values(values: Record<string, any>) {
+    this.values = values;
+    return this;
+  }
+
+  public onConflictDoUpdate(config: { target: any; set?: Record<string, any> }) {
+    this.conflict = config;
+    return this;
+  }
+
+  public returning() {
+    return this.execute();
+  }
+
+  private async execute() {
+    if (!this.values) {
+      throw new Error('Insert values must be provided before returning is called');
+    }
+
+    const table = this.db.getOrCreateTable(this.tableName);
+    const record = this.db.prepareInsertRecord(this.tableName, this.values);
+
+    if (this.conflict) {
+      const conflictTarget = this.conflict.target;
+      const columnName = Array.isArray(conflictTarget)
+        ? this.db.resolveColumnName(conflictTarget[0])
+        : this.db.resolveColumnName(conflictTarget);
+
+      const conflictValue = record[columnName];
+      if (conflictValue !== undefined) {
+        const existingIndex = table.findIndex((row) => row[columnName] === conflictValue);
+        if (existingIndex >= 0) {
+          const updated = this.db.applyUpdateRecord(this.tableName, table[existingIndex], this.conflict.set);
+          table[existingIndex] = updated;
+          this.db.logOperation(`update:${this.tableName}`);
+          return [structuredClone(updated)];
+        }
+      }
+    }
+
+    table.push(record);
+    this.db.logOperation(`insert:${this.tableName}`);
+    return [structuredClone(record)];
+  }
+}
+
+class SelectBuilder {
+  private tableName: string | null = null;
+  private whereClause: any = null;
+  private limitValue: number | null = null;
+
+  constructor(private readonly db: FakeDb, private readonly columns?: Record<string, any>) {}
+
+  public from(table: TableType) {
+    this.tableName = this.db.resolveTableName(table);
+    return this;
+  }
+
+  public where(condition: any) {
+    this.whereClause = condition;
+    return this;
+  }
+
+  public limit(value: number) {
+    this.limitValue = value;
+    return this.execute();
+  }
+
+  private async execute() {
+    if (!this.tableName) {
+      throw new Error('Select queries must specify a table with from(...)');
+    }
+
+    const table = this.db.getTableRows(this.tableName);
+    const filters = this.db.parseWhere(this.whereClause);
+
+    let rows = table.slice();
+
+    for (const filter of filters) {
+      rows = rows.filter((row) => row[filter.column] === filter.value);
+    }
+
+    if (this.limitValue !== null) {
+      rows = rows.slice(0, this.limitValue);
+    }
+
+    this.db.logOperation(`select:${this.tableName}`);
+    return rows.map((row) => this.db.projectRow(row, this.columns));
+  }
+}
+
+const fakeDb = new FakeDb();
+setDatabaseClientForTests(fakeDb);
+
+const { WorkflowRepository } = await import('../WorkflowRepository.js');
+
+async function runWorkflowPersistenceIntegration(): Promise<void> {
+  const initialGraph = { nodes: [], edges: [] };
+  const initialMetadata = { version: '1.0.0', createdBy: 'integration-test' };
+
+  const created = await WorkflowRepository.saveWorkflowGraph({
+    name: 'Integration Workflow',
+    description: 'Ensures database branch works',
+    graph: initialGraph,
+    metadata: initialMetadata,
+    tags: ['integration'],
+  });
+
+  assert.ok(created.id, 'Inserted workflow should include an id');
+  assert.equal(created.name, 'Integration Workflow', 'Workflow name should be persisted through the database branch');
+  assert.deepEqual(created.graph, initialGraph, 'Workflow graph should be stored and returned from the database');
+  assert.equal(fakeDb.operationLog.filter((entry) => entry === 'insert:workflows').length, 1, 'Workflow insert should call the database path');
+
+  const updatedGraph = { nodes: [{ id: 'node-1', type: 'trigger' }], edges: [] };
+  const updated = await WorkflowRepository.saveWorkflowGraph({
+    id: created.id,
+    name: 'Integration Workflow Updated',
+    description: 'Updated description',
+    graph: updatedGraph,
+    metadata: { ...initialMetadata, version: '1.1.0' },
+  });
+
+  assert.equal(updated.id, created.id, 'Updating the workflow should preserve the id');
+  assert.equal(updated.name, 'Integration Workflow Updated', 'Updated workflow name should be returned');
+  assert.deepEqual(updated.graph, updatedGraph, 'Updated workflow graph should be stored');
+  assert.ok(fakeDb.operationLog.includes('update:workflows'), 'Updating a workflow should use the database conflict branch');
+
+  const retrieved = await WorkflowRepository.getWorkflowById(created.id);
+  assert.ok(retrieved, 'Saved workflow should be retrievable by id');
+  assert.equal(retrieved?.name, 'Integration Workflow Updated', 'Retrieved workflow should include updated fields');
+  assert.deepEqual(retrieved?.graph, updatedGraph, 'Retrieved workflow graph should match the most recent update');
+  assert.ok(fakeDb.operationLog.filter((entry) => entry === 'select:workflows').length >= 1, 'Selecting a workflow should execute a database query');
+
+  const systemUser = fakeDb.getTableRows(fakeDb.resolveTableName(users)).find((row) => row.email === 'system@automation.local');
+  assert.ok(systemUser, 'System user should be created in the database when none is provided');
+  assert.ok(systemUser?.id, 'System user created during the test should include an id');
+}
+
+try {
+  await runWorkflowPersistenceIntegration();
+  console.log('WorkflowRepository database integration test passed.');
+  process.exit(0);
+} catch (error) {
+  console.error('WorkflowRepository database integration test failed.', error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- document the managed Postgres connection in .env and production deployment artifacts
- run drizzle-kit generate to emit the shared schema migrations and wire dev scripts to push schema before starting the server
- add a WorkflowRepository integration test with a fake database adapter to exercise the database code path end to end

## Testing
- npm test *(fails: Neon HTTP client cannot resolve api.example.com in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da11cfdd9483318c94182c74d5a1ee