### PR TITLE
Add AI deployment prerequisites alias and client handling

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -41,6 +41,7 @@ import { getComprehensiveAppFunctions } from './comprehensive-app-functions';
 import { normalizeAppId } from "./services/PromptBuilder.js";
 import { executionQueueService } from './services/ExecutionQueueService.js';
 import { WorkflowRepository } from './workflow/WorkflowRepository.js';
+import { registerDeploymentPrerequisiteRoutes } from "./routes/deployment-prerequisites.js";
 
 const SUPPORTED_CONNECTION_PROVIDERS = [
   'openai',
@@ -575,14 +576,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   );
 
-  app.get('/api/deployment/prerequisites', process.env.NODE_ENV === 'development' ? optionalAuth : authenticateToken, async (req, res) => {
-    try {
-      const result = await productionDeployer.validatePrerequisites();
-      res.json({ success: true, data: result });
-    } catch (error) {
-      res.status(500).json({ success: false, error: getErrorMessage(error) });
-    }
-  });
+  registerDeploymentPrerequisiteRoutes(app);
 
   // ===== CONNECTOR FRAMEWORK ROUTES =====
 

--- a/server/routes/__tests__/deployment.test.ts
+++ b/server/routes/__tests__/deployment.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import express from 'express';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+const originalNodeEnv = process.env.NODE_ENV;
+process.env.NODE_ENV = 'development';
+
+const { registerDeploymentPrerequisiteRoutes } = await import('../deployment-prerequisites.js');
+const { productionDeployer } = await import('../../core/ProductionDeployer.js');
+
+const stubResult = {
+  valid: false,
+  issues: ['Clasp is not installed', 'Node.js version is too old'],
+  recommendations: ['Install @google/clasp globally', 'Upgrade to Node.js 18 or later'],
+};
+
+const originalValidate = productionDeployer.validatePrerequisites.bind(productionDeployer);
+let callCount = 0;
+(productionDeployer as any).validatePrerequisites = async () => {
+  callCount += 1;
+  return stubResult;
+};
+
+const app = express();
+app.use(express.json());
+registerDeploymentPrerequisiteRoutes(app);
+
+const server: Server = await new Promise((resolve) => {
+  const listener = app.listen(0, () => resolve(listener));
+});
+
+try {
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  for (const path of ['/api/deployment/prerequisites', '/api/ai/deployment/prerequisites']) {
+    const response = await fetch(`${baseUrl}${path}`);
+    assert.equal(response.status, 200, `${path} should respond with 200`);
+    const body = await response.json();
+    assert.equal(body.success, true, `${path} should report success`);
+    assert.deepEqual(body.data, stubResult, `${path} should return the stubbed prerequisite payload`);
+  }
+
+  assert.equal(callCount, 2, 'validatePrerequisites should be invoked once per endpoint');
+} finally {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+
+  (productionDeployer as any).validatePrerequisites = originalValidate;
+
+  if (originalNodeEnv) {
+    process.env.NODE_ENV = originalNodeEnv;
+  } else {
+    delete process.env.NODE_ENV;
+  }
+}

--- a/server/routes/deployment-prerequisites.ts
+++ b/server/routes/deployment-prerequisites.ts
@@ -1,0 +1,21 @@
+import type { Express, Request, Response } from 'express';
+
+import { productionDeployer } from '../core/ProductionDeployer';
+import { authenticateToken, optionalAuth } from '../middleware/auth';
+import { getErrorMessage } from '../types/common';
+
+export function registerDeploymentPrerequisiteRoutes(app: Express) {
+  const deploymentPrerequisiteAuth = process.env.NODE_ENV === 'development' ? optionalAuth : authenticateToken;
+
+  const deploymentPrerequisiteHandler = async (req: Request, res: Response) => {
+    try {
+      const result = await productionDeployer.validatePrerequisites();
+      res.json({ success: true, data: result });
+    } catch (error) {
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+
+  app.get('/api/deployment/prerequisites', deploymentPrerequisiteAuth, deploymentPrerequisiteHandler);
+  app.get('/api/ai/deployment/prerequisites', deploymentPrerequisiteAuth, deploymentPrerequisiteHandler);
+}


### PR DESCRIPTION
## Summary
- register the deployment prerequisites handler through a shared helper and expose an /api/ai alias
- adjust the AI workflow builder UI to interpret the server payload and show friendly messages on API errors
- add API coverage verifying both deployment prerequisite endpoints reuse the same validation logic

## Testing
- npx tsx server/routes/__tests__/deployment.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68da11e831c083318d7e3d0ed6a00e42