### PR TITLE
Handle AI builder fetch errors with inline fallbacks

### DIFF
--- a/client/src/components/ai/ConversationalWorkflowBuilder.tsx
+++ b/client/src/components/ai/ConversationalWorkflowBuilder.tsx
@@ -123,7 +123,22 @@ What would you like to automate?`,
       });
 
       if (!response.ok) {
-        throw new Error(`API Error: ${response.status}`);
+        const statusText = response.statusText ? ` ${response.statusText}` : '';
+        const errorText = await response.text().catch(() => '');
+        const message = errorText?.trim()?.length
+          ? errorText
+          : `API Error: ${response.status}${statusText}`;
+
+        // Remove thinking message and surface inline error
+        setMessages(prev => prev.filter(m => m.id !== thinkingMessage.id));
+        const errorMessage: ChatMessage = {
+          id: `error-${Date.now()}`,
+          role: 'assistant',
+          content: `❌ Sorry, I encountered an error: ${message}\n\nPlease check your API key in Admin Settings and try again.`,
+          timestamp: new Date()
+        };
+        setMessages(prev => [...prev, errorMessage]);
+        return;
       }
 
       const aiResponse = await response.json();

--- a/client/src/components/workflow/AIParameterEditor.tsx
+++ b/client/src/components/workflow/AIParameterEditor.tsx
@@ -138,7 +138,11 @@ export const AIParameterEditor: React.FC<AIParameterEditorProps> = ({
       });
 
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        const fallback = response.statusText || 'Request failed';
+        const errorText = await response.text().catch(() => '');
+        const message = errorText?.trim()?.length ? errorText : `HTTP ${response.status}: ${fallback}`;
+        setAiSuggestion(`Error: ${message}`);
+        return;
       }
 
       const result = await response.json();

--- a/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
+++ b/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
@@ -539,7 +539,8 @@ try {
     } as any;
   }) as any;
 
-  const tabs = await fetchSheetTabs("spreadsheet-123");
+  const { tabs, error } = await fetchSheetTabs("spreadsheet-123");
+  assert.equal(error, undefined, "successful metadata fetch should not report an error");
   assert.ok(Array.isArray(tabs) && tabs.length === 3, "should return tab names from stubbed metadata fetch");
   assert.ok(
     typeof capturedUrl === "string" && capturedUrl.includes("/api/google/sheets/spreadsheet-123/metadata"),


### PR DESCRIPTION
## Summary
- replace thrown fetch errors in the AI builder flows with inline error states and destructive toasts
- return safe defaults from SmartParametersPanel sheet metadata helpers and surface inline warnings for failures
- extend the resilience test suite to cover planner and sheet metadata failure scenarios

## Testing
- ⚠️ `npx tsx client/src/components/__tests__/resilience.test.tsx` *(fails: npm registry access returns 403 for tsx)*
- ⚠️ `npx tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts` *(fails: npm registry access returns 403 for tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68da415f2da8833185295245e8ae9cb0