### PR TITLE
Fix ensureSupportedNodes hook initialization order

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -1277,12 +1277,6 @@ const GraphEditorContent = () => {
     void loadCatalog();
   }, [loadCatalog]);
 
-  useEffect(() => {
-    if (!catalogLoading) {
-      ensureSupportedNodes();
-    }
-  }, [catalogLoading, ensureSupportedNodes]);
-
   const nodeRequiresConnection = useCallback((node: any) => {
     if (!node) return false;
     const role = String(node.type || node?.data?.role || '').toLowerCase();
@@ -1350,6 +1344,12 @@ const GraphEditorContent = () => {
     }
     return true;
   }, [findUnsupportedNode, setRunBanner]);
+
+  useEffect(() => {
+    if (!catalogLoading) {
+      ensureSupportedNodes();
+    }
+  }, [catalogLoading, ensureSupportedNodes]);
   const [showWelcomeModal, setShowWelcomeModal] = useState(true);
   const { project, getViewport, setViewport } = useReactFlow();
   const spec = useSpecStore((state) => state.spec);


### PR DESCRIPTION
## Summary
- move the ensureSupportedNodes callback definition ahead of the effect that consumes it to avoid temporal dead zone errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da0d8010ec833181c489133ffac78f