### PR TITLE
Harden startup checks and execution queue reliability

### DIFF
--- a/server/env.ts
+++ b/server/env.ts
@@ -9,7 +9,26 @@ if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = 'development';
 }
 
-console.log(`🌍 Environment: ${process.env.NODE_ENV}`);
+const environment = process.env.NODE_ENV;
+console.log(`🌍 Environment: ${environment}`);
+
+const requiredInProduction = ['DATABASE_URL', 'ENCRYPTION_MASTER_KEY', 'JWT_SECRET'];
+if (environment === 'production') {
+  const missing = requiredInProduction.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables for production: ${missing.join(', ')}`
+    );
+  }
+} else {
+  const missing = requiredInProduction.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    const missingList = missing.join(', ');
+    console.warn(
+      `⚠️ Missing environment variables (${missingList}). The application will run in degraded mode. Set them before production deploys.`
+    );
+  }
+}
 
 // Export environment variables for easy access
 export const env = {
@@ -22,6 +41,7 @@ export const env = {
   GEMINI_API_KEY: process.env.GEMINI_API_KEY,
   JWT_SECRET: process.env.JWT_SECRET,
   PORT: process.env.PORT || '5000',
+  SERVER_PUBLIC_URL: process.env.SERVER_PUBLIC_URL || '',
   ENABLE_LLM_FEATURES: process.env.ENABLE_LLM_FEATURES === 'true',
   GENERIC_EXECUTOR_ENABLED: process.env.GENERIC_EXECUTOR_ENABLED === 'true',
 } as const;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,5 @@
 // Load environment variables FIRST
-import './env';
+import { env } from './env';
 
 // Log LLM API key presence for debugging
 console.log('🔑 LLM API Keys:', { 
@@ -13,6 +13,7 @@ import { redactSecrets } from './utils/redact';
 import { runWithRequestContext, getRequestContext } from './utils/ExecutionContext';
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import { runStartupChecks } from './runtime/startupChecks';
 
 const app = express();
 // Correlation ID + JSON body parsing with audit logging
@@ -59,6 +60,7 @@ app.use((req, res, next) => {
 });
 
 (async () => {
+  await runStartupChecks();
   // Initialize LLM providers
   try {
     const { registerLLMProviders } = await import('./llm');
@@ -95,63 +97,31 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // Serve the app on port 5000 or fallback ports for macOS compatibility
-  const preferredPort = 5000;
-  const fallbackPorts = [5001, 3000, 8000, 8080];
-  
-  const tryPort = (port: number): Promise<void> => {
-    return new Promise((resolve, reject) => {
-      const onError = (err: any) => {
-        if (err.code === 'EADDRINUSE' || err.code === 'ENOTSUP') {
-          reject(err);
-        } else {
-          reject(err);
-        }
-      };
+  const parsedPort = Number.parseInt(env.PORT, 10);
+  if (Number.isNaN(parsedPort) || parsedPort <= 0) {
+    throw new Error(`Invalid PORT value provided: ${env.PORT}`);
+  }
 
-      server.on('error', onError);
+  const host = env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1';
+  const publicUrl = env.SERVER_PUBLIC_URL || `http://${host === '0.0.0.0' ? 'localhost' : host}:${parsedPort}`;
 
-      if (process.env.NODE_ENV === "production") {
-        // Production: bind to all interfaces
-        server.listen({
-          port,
-          host: "0.0.0.0",
-          reusePort: true,
-        }, () => {
-          server.removeListener('error', onError);
-          log(`serving on 0.0.0.0:${port}`);
-          resolve();
-        });
-      } else {
-        // Development: use localhost for macOS compatibility
-        server.listen(port, () => {
-          server.removeListener('error', onError);
-          log(`serving on localhost:${port}`);
-          resolve();
-        });
-      }
-    });
-  };
-
-  // Try preferred port first, then fallback ports
-  const startServer = async () => {
-    const portsToTry = [preferredPort, ...fallbackPorts];
-    
-    for (const port of portsToTry) {
-      try {
-        await tryPort(port);
-        return; // Success, exit the loop
-      } catch (err: any) {
-        log(`Port ${port} failed: ${err.message}`);
-        if (port === portsToTry[portsToTry.length - 1]) {
-          // Last port failed
-          log(`All ports failed. Please check if another service is using these ports.`);
-          log(`On macOS, you might need to disable AirPlay Receiver in System Preferences > Sharing`);
-          process.exit(1);
-        }
-      }
+  server.on('error', (error: NodeJS.ErrnoException) => {
+    if (error.code === 'EADDRINUSE') {
+      console.error(`❌ Port ${parsedPort} is already in use. Set PORT to a free port.`);
+    } else {
+      console.error('❌ Failed to start HTTP server:', error);
     }
-  };
+    process.exit(1);
+  });
 
-  startServer();
+  server.listen({
+    port: parsedPort,
+    host,
+    reusePort: env.NODE_ENV === 'production',
+  }, () => {
+    log(`serving on ${host}:${parsedPort}`);
+    if (publicUrl) {
+      log(`public url: ${publicUrl}`);
+    }
+  });
 })();

--- a/server/runtime/startupChecks.ts
+++ b/server/runtime/startupChecks.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import path from 'node:path';
+import { env } from '../env';
+import { EncryptionService } from '../services/EncryptionService';
+import { getErrorMessage } from '../types/common';
+import { connectorDefinitions, db } from '../database/schema';
+import { count } from 'drizzle-orm';
+
+async function ensureEncryptionReady(): Promise<void> {
+  await EncryptionService.init();
+  const healthy = await EncryptionService.selfTest();
+  if (!healthy) {
+    throw new Error('Encryption self-test failed. Check ENCRYPTION_MASTER_KEY configuration.');
+  }
+}
+
+async function ensureConnectorCatalog(): Promise<void> {
+  const connectorDir = path.resolve(process.cwd(), 'connectors');
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(connectorDir, { withFileTypes: true });
+  } catch (error) {
+    throw new Error(`Failed to read connectors directory (${connectorDir}): ${getErrorMessage(error)}`);
+  }
+
+  const connectorFiles = entries.filter((entry) => entry.isFile() && entry.name.endsWith('.json'));
+  if (connectorFiles.length === 0) {
+    throw new Error(`No connector JSON definitions found in ${connectorDir}`);
+  }
+
+  let parsed = 0;
+  for (const file of connectorFiles) {
+    const fullPath = path.join(connectorDir, file.name);
+    try {
+      const raw = await fs.readFile(fullPath, 'utf8');
+      JSON.parse(raw);
+      parsed++;
+    } catch (error) {
+      throw new Error(`Invalid connector definition ${file.name}: ${getErrorMessage(error)}`);
+    }
+  }
+
+  console.log(`✅ Startup check: parsed ${parsed} connector definitions from ${connectorDir}`);
+
+  if (db) {
+    try {
+      const [{ value: storedCount }] = await db.select({ value: count() }).from(connectorDefinitions);
+      if (storedCount === 0) {
+        console.warn('⚠️ Connector catalog database table is empty. Run scripts/seed-all-connectors.ts to sync definitions.');
+      } else if (storedCount !== parsed) {
+        console.warn(
+          `⚠️ Connector catalog mismatch: ${storedCount} stored vs ${parsed} files. Ensure seed script ran successfully.`
+        );
+      }
+    } catch (error) {
+      throw new Error(`Failed to validate connector catalog in database: ${getErrorMessage(error)}`);
+    }
+  }
+}
+
+function ensureServerUrl(): void {
+  if (env.NODE_ENV === 'production' && !env.SERVER_PUBLIC_URL) {
+    throw new Error('SERVER_PUBLIC_URL must be set in production to guarantee OAuth callback URLs.');
+  }
+}
+
+export async function runStartupChecks(): Promise<void> {
+  await ensureEncryptionReady();
+  await ensureConnectorCatalog();
+  ensureServerUrl();
+}

--- a/server/services/EncryptionService.ts
+++ b/server/services/EncryptionService.ts
@@ -17,15 +17,7 @@ export class EncryptionService {
   static async init(): Promise<void> {
     const masterKey = process.env.ENCRYPTION_MASTER_KEY;
     if (!masterKey) {
-      if (process.env.NODE_ENV === 'development') {
-        console.warn('⚠️ ENCRYPTION_MASTER_KEY not set - using development fallback (NOT SECURE)');
-        // Use a development-only fallback key
-        this.encryptionKey = Buffer.from('dev-fallback-key-not-secure-32b');
-        console.log('🔐 Development encryption service initialized (NOT SECURE)');
-        return;
-      } else {
-        throw new Error('ENCRYPTION_MASTER_KEY environment variable is required');
-      }
+      throw new Error('ENCRYPTION_MASTER_KEY environment variable is required');
     }
     
     if (masterKey.length < 32) {
@@ -213,10 +205,12 @@ export class EncryptionService {
 }
 
 // Initialize encryption service on import
-try {
-  EncryptionService.init();
-  console.log('🔐 Encryption service initialized successfully');
-} catch (error) {
-  console.error('❌ Failed to initialize encryption service:', getErrorMessage(error));
-  console.error('Please set ENCRYPTION_MASTER_KEY and JWT_SECRET environment variables');
-}
+void (async () => {
+  try {
+    await EncryptionService.init();
+    console.log('🔐 Encryption service initialized successfully');
+  } catch (error) {
+    console.error('❌ Failed to initialize encryption service:', getErrorMessage(error));
+    console.error('Please set ENCRYPTION_MASTER_KEY and JWT_SECRET environment variables');
+  }
+})();

--- a/server/services/ExecutionQueueService.ts
+++ b/server/services/ExecutionQueueService.ts
@@ -2,7 +2,7 @@ import { getErrorMessage } from '../types/common.js';
 import { WorkflowRepository } from '../workflow/WorkflowRepository.js';
 import { workflowRuntime } from '../core/WorkflowRuntime.js';
 import { db, workflowExecutions } from '../database/schema.js';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, asc } from 'drizzle-orm';
 
 type QueueRunRequest = {
   workflowId: string;
@@ -25,10 +25,41 @@ class ExecutionQueueService {
   private concurrency: number;
   private pollingMs: number;
   private timer: NodeJS.Timeout | null = null;
+  private pendingWake: NodeJS.Timeout | null = null;
+  private readonly maxRetries: number;
+  private readonly baseRetryDelayMs: number;
+  private readonly maxRetryDelayMs: number;
 
   private constructor(concurrency = 2, pollingMs = 1000) {
     this.concurrency = Math.max(1, concurrency);
     this.pollingMs = Math.max(250, pollingMs);
+    this.maxRetries = Math.max(0, Number.parseInt(process.env.EXECUTION_MAX_RETRIES ?? '3', 10));
+    this.baseRetryDelayMs = Math.max(500, Number.parseInt(process.env.EXECUTION_RETRY_DELAY_MS ?? '1000', 10));
+    this.maxRetryDelayMs = Math.max(
+      this.baseRetryDelayMs,
+      Number.parseInt(process.env.EXECUTION_MAX_RETRY_DELAY_MS ?? `${5 * 60 * 1000}`, 10)
+    );
+  }
+
+  private computeBackoff(attempt: number): number {
+    const exponent = Math.pow(2, Math.max(0, attempt - 1));
+    const jitter = Math.floor(Math.random() * this.baseRetryDelayMs * 0.2);
+    return Math.min(exponent * this.baseRetryDelayMs + jitter, this.maxRetryDelayMs);
+  }
+
+  private scheduleWake(delayMs: number): void {
+    if (this.pendingWake) {
+      clearTimeout(this.pendingWake);
+      this.pendingWake = null;
+    }
+
+    const clamped = Math.min(Math.max(delayMs, 100), this.maxRetryDelayMs);
+    this.pendingWake = setTimeout(() => {
+      this.pendingWake = null;
+      this.tick().catch((error) => {
+        console.error('ExecutionQueue wake error:', getErrorMessage(error));
+      });
+    }, clamped);
   }
 
   public static getInstance(): ExecutionQueueService {
@@ -49,7 +80,7 @@ class ExecutionQueueService {
       status: 'queued',
       triggerType: req.triggerType ?? 'manual',
       triggerData: req.triggerData ?? null,
-      metadata: { queuedAt: new Date().toISOString() },
+      metadata: { queuedAt: new Date().toISOString(), retryCount: 0 },
     });
     return { executionId: execution.id };
   }
@@ -58,12 +89,19 @@ class ExecutionQueueService {
     if (this.timer) return;
     this.timer = setInterval(() => this.tick().catch(() => {}), this.pollingMs);
     console.log(`🧵 ExecutionQueueService started (concurrency=${this.concurrency})`);
+    this.tick().catch((error) => {
+      console.error('ExecutionQueue initial tick error:', getErrorMessage(error));
+    });
   }
 
   public stop(): void {
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
+    }
+    if (this.pendingWake) {
+      clearTimeout(this.pendingWake);
+      this.pendingWake = null;
     }
   }
 
@@ -82,7 +120,7 @@ class ExecutionQueueService {
     }
   }
 
-  private async claimNextQueued(): Promise<{ id: string; workflowId: string; userId?: string } | null> {
+  private async claimNextQueued(): Promise<{ id: string; workflowId: string; userId?: string; metadata?: Record<string, any> } | null> {
     if (!this.isDbEnabled()) {
       // Memory mode: rely on WorkflowRepository to store an in-memory record; we cannot list queued ones.
       // For dev, skip DB claim and return null so queue is driven via direct enqueue->immediate run fallback.
@@ -90,30 +128,55 @@ class ExecutionQueueService {
     }
 
     try {
-      const result = await db
-        .select({ id: workflowExecutions.id, workflowId: workflowExecutions.workflowId, userId: workflowExecutions.userId })
+      const candidates = await db
+        .select({
+          id: workflowExecutions.id,
+          workflowId: workflowExecutions.workflowId,
+          userId: workflowExecutions.userId,
+          metadata: workflowExecutions.metadata,
+        })
         .from(workflowExecutions)
         .where(eq(workflowExecutions.status, 'queued'))
-        .limit(1);
+        .orderBy(asc(workflowExecutions.startedAt))
+        .limit(this.concurrency * 2);
 
-      const row = result[0];
-      if (!row) return null;
+      for (const candidate of candidates) {
+        const metadata = (candidate.metadata ?? {}) as Record<string, any>;
+        const nextRetryAt = typeof metadata.nextRetryAt === 'string' ? Date.parse(metadata.nextRetryAt) : NaN;
+        if (!Number.isNaN(nextRetryAt) && nextRetryAt > Date.now()) {
+          this.scheduleWake(nextRetryAt - Date.now());
+          continue;
+        }
 
-      // Mark as running
-      await db
-        .update(workflowExecutions)
-        .set({ status: 'running', startedAt: new Date() })
-        .where(and(eq(workflowExecutions.id, row.id), eq(workflowExecutions.status, 'queued')));
+        const sanitizedMetadata = { ...metadata };
+        if ('nextRetryAt' in sanitizedMetadata) {
+          delete sanitizedMetadata.nextRetryAt;
+        }
 
-      return row;
+        await db
+          .update(workflowExecutions)
+          .set({ status: 'running', startedAt: new Date(), metadata: sanitizedMetadata })
+          .where(and(eq(workflowExecutions.id, candidate.id), eq(workflowExecutions.status, 'queued')));
+
+        return {
+          id: candidate.id,
+          workflowId: candidate.workflowId,
+          userId: candidate.userId,
+          metadata: sanitizedMetadata,
+        };
+      }
+
+      return null;
     } catch (error) {
       console.error('Failed to claim queued execution:', getErrorMessage(error));
       return null;
     }
   }
 
-  private async process(job: { id: string; workflowId: string; userId?: string }): Promise<void> {
+  private async process(job: { id: string; workflowId: string; userId?: string; metadata?: Record<string, any> }): Promise<void> {
     const startedAt = Date.now();
+    const executionRecord = await WorkflowRepository.getExecutionById(job.id);
+    const baseMetadata = { ...(executionRecord?.metadata ?? job.metadata ?? {}) } as Record<string, any>;
     try {
       const wf = await WorkflowRepository.getWorkflowById(job.workflowId);
       if (!wf || !wf.graph) {
@@ -123,22 +186,71 @@ class ExecutionQueueService {
       const initialData = { trigger: { id: 'queue', source: 'queue', timestamp: new Date().toISOString() } };
       const result = await workflowRuntime.executeWorkflow(wf.graph as any, initialData, job.userId);
 
+      if (!result.success) {
+        throw new Error(result.error || 'Execution returned unsuccessful result');
+      }
+
+      const metadata = { ...baseMetadata, retryCount: 0, finishedAt: new Date().toISOString() };
+      delete metadata.nextRetryAt;
+      delete metadata.lastError;
+
       await WorkflowRepository.updateWorkflowExecution(job.id, {
-        status: result.success ? 'completed' : 'failed',
+        status: 'completed',
         completedAt: new Date(),
         duration: Date.now() - startedAt,
         nodeResults: result.nodeOutputs,
-        errorDetails: result.success ? null : { error: result.error || 'Execution failed' },
-        metadata: { queued: true, finishedAt: new Date().toISOString() },
+        errorDetails: null,
+        metadata,
       });
     } catch (error: any) {
+      const errorMessage = getErrorMessage(error);
+      const currentRetries = typeof baseMetadata.retryCount === 'number' ? baseMetadata.retryCount : 0;
+      const nextRetryCount = currentRetries + 1;
+
+      if (nextRetryCount <= this.maxRetries) {
+        const delay = this.computeBackoff(nextRetryCount);
+        const nextRetryAt = new Date(Date.now() + delay).toISOString();
+        const retryMetadata = {
+          ...baseMetadata,
+          retryCount: nextRetryCount,
+          nextRetryAt,
+          lastError: errorMessage,
+        };
+
+        await WorkflowRepository.updateWorkflowExecution(job.id, {
+          status: 'queued',
+          completedAt: null,
+          duration: null,
+          errorDetails: { error: errorMessage },
+          metadata: retryMetadata,
+          startedAt: new Date(),
+        });
+
+        console.warn(
+          `⚠️ Execution ${job.id} failed (attempt ${nextRetryCount}). Retrying in ${delay}ms: ${errorMessage}`
+        );
+        this.scheduleWake(delay);
+        return;
+      }
+
+      const failedMetadata = {
+        ...baseMetadata,
+        retryCount: nextRetryCount,
+        lastError: errorMessage,
+      };
+      if ('nextRetryAt' in failedMetadata) {
+        delete failedMetadata.nextRetryAt;
+      }
+
       await WorkflowRepository.updateWorkflowExecution(job.id, {
         status: 'failed',
         completedAt: new Date(),
         duration: Date.now() - startedAt,
-        errorDetails: { error: getErrorMessage(error) },
+        errorDetails: { error: errorMessage },
+        metadata: failedMetadata,
       });
-      console.error(`❌ Execution ${job.id} failed:`, getErrorMessage(error));
+
+      console.error(`❌ Execution ${job.id} failed after ${nextRetryCount} attempts:`, errorMessage);
     }
   }
 }

--- a/server/services/__tests__/ConnectionService.encryption.test.ts
+++ b/server/services/__tests__/ConnectionService.encryption.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 process.env.NODE_ENV = 'development';
 process.env.ENCRYPTION_MASTER_KEY = 'a'.repeat(32);
+process.env.ALLOW_FILE_CONNECTION_STORE = 'true';
 
 const tempDir = await mkdtemp(path.join(os.tmpdir(), 'connection-service-'));
 process.env.CONNECTION_STORE_PATH = path.join(tempDir, 'connections.json');
@@ -52,5 +53,6 @@ assert.deepEqual(allConnections[0].credentials, originalCredentials, 'list entri
 
 await rm(tempDir, { recursive: true, force: true });
 delete process.env.CONNECTION_STORE_PATH;
+delete process.env.ALLOW_FILE_CONNECTION_STORE;
 
 console.log('ConnectionService encrypt/decrypt round trip verified via file store.');

--- a/server/services/__tests__/ConnectionService.test.ts
+++ b/server/services/__tests__/ConnectionService.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 process.env.NODE_ENV = 'development';
 process.env.ENCRYPTION_MASTER_KEY = process.env.ENCRYPTION_MASTER_KEY ?? 'a'.repeat(32);
+process.env.ALLOW_FILE_CONNECTION_STORE = 'true';
 
 const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'connection-service-'));
 const storePath = path.join(tempDir, 'connections.json');
@@ -57,5 +58,7 @@ assert.equal(fetched?.testStatus, 'failed', 'fetched connection includes test st
 assert.equal(fetched?.testError, testResult.message, 'fetched connection includes test error');
 
 await fs.rm(tempDir, { recursive: true, force: true });
+
+delete process.env.ALLOW_FILE_CONNECTION_STORE;
 
 console.log('ConnectionService stores type/test status metadata in sync with schema.');

--- a/server/workflow/WorkflowRepository.ts
+++ b/server/workflow/WorkflowRepository.ts
@@ -52,6 +52,7 @@ export interface CreateWorkflowExecutionInput {
 export interface UpdateWorkflowExecutionInput {
   status?: string;
   completedAt?: Date | null;
+  startedAt?: Date | null;
   duration?: number | null;
   nodeResults?: Record<string, any> | null;
   errorDetails?: Record<string, any> | null;
@@ -439,6 +440,7 @@ export class WorkflowRepository {
         ...existing,
         status: updates.status ?? existing.status,
         completedAt: updates.completedAt ?? existing.completedAt,
+        startedAt: updates.startedAt ?? existing.startedAt,
         duration: updates.duration ?? existing.duration,
         nodeResults: updates.nodeResults ?? existing.nodeResults,
         errorDetails: updates.errorDetails ?? existing.errorDetails,
@@ -454,6 +456,7 @@ export class WorkflowRepository {
 
     if (updates.status !== undefined) updateSet.status = updates.status;
     if (updates.completedAt !== undefined) updateSet.completedAt = updates.completedAt;
+    if (updates.startedAt !== undefined) updateSet.startedAt = updates.startedAt;
     if (updates.duration !== undefined) updateSet.duration = updates.duration;
     if (updates.nodeResults !== undefined) updateSet.nodeResults = updates.nodeResults;
     if (updates.errorDetails !== undefined) updateSet.errorDetails = updates.errorDetails;


### PR DESCRIPTION
## Summary
- require production env variables and run startup checks for encryption and connector catalog integrity before booting the server
- replace the multi-port listener fallback with a single configurable PORT/public URL and add a reusable startup check module
- gate the connection file-store behind an explicit flag, tighten encryption initialization, and enhance the execution queue with structured retries/backoff metadata
- update repository helpers and tests to reflect the hardened configuration path

## Testing
- `npm exec tsx server/services/__tests__/ConnectionService.encryption.test.ts`
- `npm exec tsx server/services/__tests__/ConnectionService.test.ts`
- `npm exec tsx server/workflow/__tests__/WorkflowRepository.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68de0768fc44833182265b2809aa4bb0