### PR TITLE
Add provider credential management and observability tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "init:roadmap": "node scripts/init-roadmap.js",
     "audit:bronze": "node scripts/audit-bronze.js",
     "smoke:e2e": "node scripts/e2e-smoke.js",
-    "smoke:connectors": "tsx scripts/connector-smoke.ts"
+    "smoke:connectors": "tsx scripts/connector-smoke.ts",
+    "scan:secrets": "tsx scripts/secrets-scan.ts"
   },
   "dependencies": {
     "@google/clasp": "^3.0.6-alpha",

--- a/scripts/secrets-scan.ts
+++ b/scripts/secrets-scan.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env tsx
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+
+const patterns: Array<{ name: string; regex: RegExp }> = [
+  { name: 'OpenAI API key', regex: /sk-[a-zA-Z0-9]{40,}/g },
+  { name: 'Google API key', regex: /AIza[0-9A-Za-z\-_]{35}/g },
+  { name: 'AWS Access Key', regex: /AKIA[0-9A-Z]{16}/g },
+  { name: 'Private key block', regex: /-----BEGIN (RSA|DSA|EC|OPENSSH) PRIVATE KEY-----/g },
+];
+
+function getTrackedFiles(): string[] {
+  try {
+    const output = execSync('git ls-files', { encoding: 'utf8' });
+    return output.split('\n').filter(Boolean);
+  } catch (error) {
+    console.error('Failed to list git files:', (error as any)?.message || error);
+    process.exit(1);
+  }
+}
+
+function scanFile(file: string): Array<{ pattern: string; match: string }> {
+  try {
+    const contents = readFileSync(file, 'utf8');
+    const findings: Array<{ pattern: string; match: string }> = [];
+    for (const pattern of patterns) {
+      const matches = contents.match(pattern.regex);
+      if (matches) {
+        matches.forEach((match) => findings.push({ pattern: pattern.name, match }));
+      }
+    }
+    return findings;
+  } catch (error: any) {
+    if (error?.code === 'EISDIR') return [];
+    if (error?.code === 'ENOENT') return [];
+    console.warn(`Skipping ${file}: ${(error as any)?.message || error}`);
+    return [];
+  }
+}
+
+const files = getTrackedFiles();
+const results: Array<{ file: string; pattern: string; match: string }> = [];
+
+files.forEach((file) => {
+  if (file.startsWith('node_modules') || file.startsWith('dist')) return;
+  const findings = scanFile(file);
+  findings.forEach((finding) => {
+    results.push({ file, pattern: finding.pattern, match: finding.match });
+  });
+});
+
+if (results.length > 0) {
+  console.error('❌ Potential secrets detected:');
+  results.forEach((result) => {
+    console.error(` - [${result.pattern}] ${result.file}: ${result.match.substring(0, 6)}***`);
+  });
+  process.exit(1);
+}
+
+console.log('✅ No high-risk secrets detected.');

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -116,6 +116,27 @@ export const connections = pgTable(
   })
 );
 
+export const providerConfigs = pgTable(
+  'provider_configs',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    provider: text('provider').notNull(),
+    encryptedConfig: text('encrypted_config').notNull(),
+    iv: text('iv').notNull(),
+    rotationVersion: integer('rotation_version').default(1).notNull(),
+    lastTested: timestamp('last_tested'),
+    testStatus: text('test_status'),
+    testError: text('test_error'),
+    metadata: json('metadata').$type<Record<string, any>>().default({}).notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    providerIdx: uniqueIndex('provider_configs_provider_idx').on(table.provider),
+    testStatusIdx: index('provider_configs_test_status_idx').on(table.testStatus),
+  })
+);
+
 // Workflows table with indexes for ALL application types
 export const workflows = pgTable(
   'workflows',

--- a/server/env.ts
+++ b/server/env.ts
@@ -9,7 +9,26 @@ if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = 'development';
 }
 
-console.log(`🌍 Environment: ${process.env.NODE_ENV}`);
+const environment = process.env.NODE_ENV;
+console.log(`🌍 Environment: ${environment}`);
+
+const requiredInProduction = ['DATABASE_URL', 'ENCRYPTION_MASTER_KEY', 'JWT_SECRET'];
+if (environment === 'production') {
+  const missing = requiredInProduction.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables for production: ${missing.join(', ')}`
+    );
+  }
+} else {
+  const missing = requiredInProduction.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    const missingList = missing.join(', ');
+    console.warn(
+      `⚠️ Missing environment variables (${missingList}). The application will run in degraded mode. Set them before production deploys.`
+    );
+  }
+}
 
 // Export environment variables for easy access
 export const env = {
@@ -22,6 +41,7 @@ export const env = {
   GEMINI_API_KEY: process.env.GEMINI_API_KEY,
   JWT_SECRET: process.env.JWT_SECRET,
   PORT: process.env.PORT || '5000',
+  SERVER_PUBLIC_URL: process.env.SERVER_PUBLIC_URL || '',
   ENABLE_LLM_FEATURES: process.env.ENABLE_LLM_FEATURES === 'true',
   GENERIC_EXECUTOR_ENABLED: process.env.GENERIC_EXECUTOR_ENABLED === 'true',
 } as const;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,5 @@
 // Load environment variables FIRST
-import './env';
+import { env } from './env';
 
 // Log LLM API key presence for debugging
 console.log('🔑 LLM API Keys:', { 
@@ -13,6 +13,7 @@ import { redactSecrets } from './utils/redact';
 import { runWithRequestContext, getRequestContext } from './utils/ExecutionContext';
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import { runStartupChecks } from './runtime/startupChecks';
 
 const app = express();
 // Correlation ID + JSON body parsing with audit logging
@@ -59,6 +60,7 @@ app.use((req, res, next) => {
 });
 
 (async () => {
+  await runStartupChecks();
   // Initialize LLM providers
   try {
     const { registerLLMProviders } = await import('./llm');
@@ -95,63 +97,31 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // Serve the app on port 5000 or fallback ports for macOS compatibility
-  const preferredPort = 5000;
-  const fallbackPorts = [5001, 3000, 8000, 8080];
-  
-  const tryPort = (port: number): Promise<void> => {
-    return new Promise((resolve, reject) => {
-      const onError = (err: any) => {
-        if (err.code === 'EADDRINUSE' || err.code === 'ENOTSUP') {
-          reject(err);
-        } else {
-          reject(err);
-        }
-      };
+  const parsedPort = Number.parseInt(env.PORT, 10);
+  if (Number.isNaN(parsedPort) || parsedPort <= 0) {
+    throw new Error(`Invalid PORT value provided: ${env.PORT}`);
+  }
 
-      server.on('error', onError);
+  const host = env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1';
+  const publicUrl = env.SERVER_PUBLIC_URL || `http://${host === '0.0.0.0' ? 'localhost' : host}:${parsedPort}`;
 
-      if (process.env.NODE_ENV === "production") {
-        // Production: bind to all interfaces
-        server.listen({
-          port,
-          host: "0.0.0.0",
-          reusePort: true,
-        }, () => {
-          server.removeListener('error', onError);
-          log(`serving on 0.0.0.0:${port}`);
-          resolve();
-        });
-      } else {
-        // Development: use localhost for macOS compatibility
-        server.listen(port, () => {
-          server.removeListener('error', onError);
-          log(`serving on localhost:${port}`);
-          resolve();
-        });
-      }
-    });
-  };
-
-  // Try preferred port first, then fallback ports
-  const startServer = async () => {
-    const portsToTry = [preferredPort, ...fallbackPorts];
-    
-    for (const port of portsToTry) {
-      try {
-        await tryPort(port);
-        return; // Success, exit the loop
-      } catch (err: any) {
-        log(`Port ${port} failed: ${err.message}`);
-        if (port === portsToTry[portsToTry.length - 1]) {
-          // Last port failed
-          log(`All ports failed. Please check if another service is using these ports.`);
-          log(`On macOS, you might need to disable AirPlay Receiver in System Preferences > Sharing`);
-          process.exit(1);
-        }
-      }
+  server.on('error', (error: NodeJS.ErrnoException) => {
+    if (error.code === 'EADDRINUSE') {
+      console.error(`❌ Port ${parsedPort} is already in use. Set PORT to a free port.`);
+    } else {
+      console.error('❌ Failed to start HTTP server:', error);
     }
-  };
+    process.exit(1);
+  });
 
-  startServer();
+  server.listen({
+    port: parsedPort,
+    host,
+    reusePort: env.NODE_ENV === 'production',
+  }, () => {
+    log(`serving on ${host}:${parsedPort}`);
+    if (publicUrl) {
+      log(`public url: ${publicUrl}`);
+    }
+  });
 })();

--- a/server/runtime/startupChecks.ts
+++ b/server/runtime/startupChecks.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import path from 'node:path';
+import { env } from '../env';
+import { EncryptionService } from '../services/EncryptionService';
+import { getErrorMessage } from '../types/common';
+import { connectorDefinitions, db } from '../database/schema';
+import { providerConfigService } from '../services/ProviderConfigService';
+import { count } from 'drizzle-orm';
+
+async function ensureEncryptionReady(): Promise<void> {
+  await EncryptionService.init();
+  const healthy = await EncryptionService.selfTest();
+  if (!healthy) {
+    throw new Error('Encryption self-test failed. Check ENCRYPTION_MASTER_KEY configuration.');
+  }
+}
+
+async function ensureConnectorCatalog(): Promise<void> {
+  const connectorDir = path.resolve(process.cwd(), 'connectors');
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(connectorDir, { withFileTypes: true });
+  } catch (error) {
+    throw new Error(`Failed to read connectors directory (${connectorDir}): ${getErrorMessage(error)}`);
+  }
+
+  const connectorFiles = entries.filter((entry) => entry.isFile() && entry.name.endsWith('.json'));
+  if (connectorFiles.length === 0) {
+    throw new Error(`No connector JSON definitions found in ${connectorDir}`);
+  }
+
+  let parsed = 0;
+  for (const file of connectorFiles) {
+    const fullPath = path.join(connectorDir, file.name);
+    try {
+      const raw = await fs.readFile(fullPath, 'utf8');
+      JSON.parse(raw);
+      parsed++;
+    } catch (error) {
+      throw new Error(`Invalid connector definition ${file.name}: ${getErrorMessage(error)}`);
+    }
+  }
+
+  console.log(`✅ Startup check: parsed ${parsed} connector definitions from ${connectorDir}`);
+
+  if (db) {
+    try {
+      const [{ value: storedCount }] = await db.select({ value: count() }).from(connectorDefinitions);
+      if (storedCount === 0) {
+        console.warn('⚠️ Connector catalog database table is empty. Run scripts/seed-all-connectors.ts to sync definitions.');
+      } else if (storedCount !== parsed) {
+        console.warn(
+          `⚠️ Connector catalog mismatch: ${storedCount} stored vs ${parsed} files. Ensure seed script ran successfully.`
+        );
+      }
+    } catch (error) {
+      throw new Error(`Failed to validate connector catalog in database: ${getErrorMessage(error)}`);
+    }
+  }
+}
+
+function ensureServerUrl(): void {
+  if (env.NODE_ENV === 'production' && !env.SERVER_PUBLIC_URL) {
+    throw new Error('SERVER_PUBLIC_URL must be set in production to guarantee OAuth callback URLs.');
+  }
+}
+
+function ensureEncryptionRotation(): void {
+  const lastRotated = process.env.ENCRYPTION_KEY_LAST_ROTATED;
+  const maxAgeDays = Math.max(1, Number.parseInt(process.env.ENCRYPTION_KEY_MAX_AGE_DAYS ?? '90', 10));
+
+  if (!lastRotated) {
+    if (env.NODE_ENV === 'production') {
+      throw new Error('ENCRYPTION_KEY_LAST_ROTATED must be set in production environments.');
+    }
+    console.warn('⚠️ ENCRYPTION_KEY_LAST_ROTATED not set. Set this value after each rotation.');
+    return;
+  }
+
+  const rotatedAt = Date.parse(lastRotated);
+  if (Number.isNaN(rotatedAt)) {
+    throw new Error(`Invalid ENCRYPTION_KEY_LAST_ROTATED value: ${lastRotated}`);
+  }
+
+  const ageMs = Date.now() - rotatedAt;
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  if (ageDays > maxAgeDays) {
+    throw new Error(
+      `Encryption key rotation overdue. Last rotated ${Math.floor(ageDays)} days ago (max ${maxAgeDays}).`
+    );
+  }
+}
+
+export async function runStartupChecks(): Promise<void> {
+  await ensureEncryptionReady();
+  await ensureConnectorCatalog();
+  ensureServerUrl();
+  ensureEncryptionRotation();
+  await providerConfigService.bootstrap();
+}

--- a/server/security/SecretsAuditLog.ts
+++ b/server/security/SecretsAuditLog.ts
@@ -1,0 +1,42 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
+import path from 'path';
+
+export type SecretAuditEvent = {
+  ts: string;
+  type: 'read' | 'write' | 'delete';
+  provider: string;
+  source: 'connection' | 'provider-config';
+  userId?: string;
+  metadata?: Record<string, any>;
+};
+
+const AUDIT_PATH = path.resolve(process.cwd(), 'production', 'reports', 'secret-access-log.jsonl');
+
+export function recordSecretEvent(event: Omit<SecretAuditEvent, 'ts'>): void {
+  try {
+    const dir = path.dirname(AUDIT_PATH);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    const payload: SecretAuditEvent = { ...event, ts: new Date().toISOString() };
+    appendFileSync(AUDIT_PATH, JSON.stringify(payload) + '\n', { encoding: 'utf8' });
+  } catch (error) {
+    console.warn('⚠️ Failed to record secret audit event:', (error as any)?.message || error);
+  }
+}
+
+export function readSecretEvents(limit = 50): SecretAuditEvent[] {
+  try {
+    if (!existsSync(AUDIT_PATH)) {
+      return [];
+    }
+    const lines = readFileSync(AUDIT_PATH, 'utf8').trim().split('\n');
+    return lines
+      .slice(-limit)
+      .map((line) => JSON.parse(line) as SecretAuditEvent)
+      .filter((item) => item && item.provider);
+  } catch (error) {
+    console.warn('⚠️ Failed to read secret audit log:', (error as any)?.message || error);
+    return [];
+  }
+}

--- a/server/security/__tests__/SecretsAuditLog.test.ts
+++ b/server/security/__tests__/SecretsAuditLog.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { rmSync, existsSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+process.env.NODE_ENV = 'development';
+
+const originalCwd = process.cwd();
+const tempDir = path.join(originalCwd, '.data', 'secret-audit-log-test');
+if (!existsSync(tempDir)) {
+  mkdirSync(tempDir, { recursive: true });
+}
+process.chdir(tempDir);
+
+const { recordSecretEvent, readSecretEvents } = await import('../SecretsAuditLog.js');
+
+recordSecretEvent({ type: 'write', provider: 'gmail', source: 'provider-config', metadata: { action: 'upsert' } });
+recordSecretEvent({ type: 'read', provider: 'gmail', source: 'provider-config', metadata: { action: 'test' } });
+
+const events = readSecretEvents(10);
+assert.ok(events.length >= 2, 'events are persisted to audit log');
+assert.equal(events.at(-1)?.type, 'read');
+
+process.chdir(originalCwd);
+rmSync(tempDir, { recursive: true, force: true });
+
+console.log('SecretsAuditLog records and retrieves secret events.');

--- a/server/services/EncryptionService.ts
+++ b/server/services/EncryptionService.ts
@@ -17,15 +17,7 @@ export class EncryptionService {
   static async init(): Promise<void> {
     const masterKey = process.env.ENCRYPTION_MASTER_KEY;
     if (!masterKey) {
-      if (process.env.NODE_ENV === 'development') {
-        console.warn('⚠️ ENCRYPTION_MASTER_KEY not set - using development fallback (NOT SECURE)');
-        // Use a development-only fallback key
-        this.encryptionKey = Buffer.from('dev-fallback-key-not-secure-32b');
-        console.log('🔐 Development encryption service initialized (NOT SECURE)');
-        return;
-      } else {
-        throw new Error('ENCRYPTION_MASTER_KEY environment variable is required');
-      }
+      throw new Error('ENCRYPTION_MASTER_KEY environment variable is required');
     }
     
     if (masterKey.length < 32) {
@@ -213,10 +205,12 @@ export class EncryptionService {
 }
 
 // Initialize encryption service on import
-try {
-  EncryptionService.init();
-  console.log('🔐 Encryption service initialized successfully');
-} catch (error) {
-  console.error('❌ Failed to initialize encryption service:', getErrorMessage(error));
-  console.error('Please set ENCRYPTION_MASTER_KEY and JWT_SECRET environment variables');
-}
+void (async () => {
+  try {
+    await EncryptionService.init();
+    console.log('🔐 Encryption service initialized successfully');
+  } catch (error) {
+    console.error('❌ Failed to initialize encryption service:', getErrorMessage(error));
+    console.error('Please set ENCRYPTION_MASTER_KEY and JWT_SECRET environment variables');
+  }
+})();

--- a/server/services/ExecutionQueueService.ts
+++ b/server/services/ExecutionQueueService.ts
@@ -2,7 +2,8 @@ import { getErrorMessage } from '../types/common.js';
 import { WorkflowRepository } from '../workflow/WorkflowRepository.js';
 import { workflowRuntime } from '../core/WorkflowRuntime.js';
 import { db, workflowExecutions } from '../database/schema.js';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, asc } from 'drizzle-orm';
+import { observabilityService } from './ObservabilityService.js';
 
 type QueueRunRequest = {
   workflowId: string;
@@ -25,10 +26,41 @@ class ExecutionQueueService {
   private concurrency: number;
   private pollingMs: number;
   private timer: NodeJS.Timeout | null = null;
+  private pendingWake: NodeJS.Timeout | null = null;
+  private readonly maxRetries: number;
+  private readonly baseRetryDelayMs: number;
+  private readonly maxRetryDelayMs: number;
 
   private constructor(concurrency = 2, pollingMs = 1000) {
     this.concurrency = Math.max(1, concurrency);
     this.pollingMs = Math.max(250, pollingMs);
+    this.maxRetries = Math.max(0, Number.parseInt(process.env.EXECUTION_MAX_RETRIES ?? '3', 10));
+    this.baseRetryDelayMs = Math.max(500, Number.parseInt(process.env.EXECUTION_RETRY_DELAY_MS ?? '1000', 10));
+    this.maxRetryDelayMs = Math.max(
+      this.baseRetryDelayMs,
+      Number.parseInt(process.env.EXECUTION_MAX_RETRY_DELAY_MS ?? `${5 * 60 * 1000}`, 10)
+    );
+  }
+
+  private computeBackoff(attempt: number): number {
+    const exponent = Math.pow(2, Math.max(0, attempt - 1));
+    const jitter = Math.floor(Math.random() * this.baseRetryDelayMs * 0.2);
+    return Math.min(exponent * this.baseRetryDelayMs + jitter, this.maxRetryDelayMs);
+  }
+
+  private scheduleWake(delayMs: number): void {
+    if (this.pendingWake) {
+      clearTimeout(this.pendingWake);
+      this.pendingWake = null;
+    }
+
+    const clamped = Math.min(Math.max(delayMs, 100), this.maxRetryDelayMs);
+    this.pendingWake = setTimeout(() => {
+      this.pendingWake = null;
+      this.tick().catch((error) => {
+        console.error('ExecutionQueue wake error:', getErrorMessage(error));
+      });
+    }, clamped);
   }
 
   public static getInstance(): ExecutionQueueService {
@@ -49,7 +81,7 @@ class ExecutionQueueService {
       status: 'queued',
       triggerType: req.triggerType ?? 'manual',
       triggerData: req.triggerData ?? null,
-      metadata: { queuedAt: new Date().toISOString() },
+      metadata: { queuedAt: new Date().toISOString(), retryCount: 0 },
     });
     return { executionId: execution.id };
   }
@@ -58,12 +90,19 @@ class ExecutionQueueService {
     if (this.timer) return;
     this.timer = setInterval(() => this.tick().catch(() => {}), this.pollingMs);
     console.log(`🧵 ExecutionQueueService started (concurrency=${this.concurrency})`);
+    this.tick().catch((error) => {
+      console.error('ExecutionQueue initial tick error:', getErrorMessage(error));
+    });
   }
 
   public stop(): void {
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
+    }
+    if (this.pendingWake) {
+      clearTimeout(this.pendingWake);
+      this.pendingWake = null;
     }
   }
 
@@ -82,7 +121,7 @@ class ExecutionQueueService {
     }
   }
 
-  private async claimNextQueued(): Promise<{ id: string; workflowId: string; userId?: string } | null> {
+  private async claimNextQueued(): Promise<{ id: string; workflowId: string; userId?: string; metadata?: Record<string, any> } | null> {
     if (!this.isDbEnabled()) {
       // Memory mode: rely on WorkflowRepository to store an in-memory record; we cannot list queued ones.
       // For dev, skip DB claim and return null so queue is driven via direct enqueue->immediate run fallback.
@@ -90,30 +129,56 @@ class ExecutionQueueService {
     }
 
     try {
-      const result = await db
-        .select({ id: workflowExecutions.id, workflowId: workflowExecutions.workflowId, userId: workflowExecutions.userId })
+      const candidates = await db
+        .select({
+          id: workflowExecutions.id,
+          workflowId: workflowExecutions.workflowId,
+          userId: workflowExecutions.userId,
+          metadata: workflowExecutions.metadata,
+        })
         .from(workflowExecutions)
         .where(eq(workflowExecutions.status, 'queued'))
-        .limit(1);
+        .orderBy(asc(workflowExecutions.startedAt))
+        .limit(this.concurrency * 2);
 
-      const row = result[0];
-      if (!row) return null;
+      for (const candidate of candidates) {
+        const metadata = (candidate.metadata ?? {}) as Record<string, any>;
+        const nextRetryAt = typeof metadata.nextRetryAt === 'string' ? Date.parse(metadata.nextRetryAt) : NaN;
+        if (!Number.isNaN(nextRetryAt) && nextRetryAt > Date.now()) {
+          this.scheduleWake(nextRetryAt - Date.now());
+          continue;
+        }
 
-      // Mark as running
-      await db
-        .update(workflowExecutions)
-        .set({ status: 'running', startedAt: new Date() })
-        .where(and(eq(workflowExecutions.id, row.id), eq(workflowExecutions.status, 'queued')));
+        const sanitizedMetadata = { ...metadata };
+        if ('nextRetryAt' in sanitizedMetadata) {
+          delete sanitizedMetadata.nextRetryAt;
+        }
 
-      return row;
+        await db
+          .update(workflowExecutions)
+          .set({ status: 'running', startedAt: new Date(), metadata: sanitizedMetadata })
+          .where(and(eq(workflowExecutions.id, candidate.id), eq(workflowExecutions.status, 'queued')));
+
+        return {
+          id: candidate.id,
+          workflowId: candidate.workflowId,
+          userId: candidate.userId,
+          metadata: sanitizedMetadata,
+        };
+      }
+
+      return null;
     } catch (error) {
       console.error('Failed to claim queued execution:', getErrorMessage(error));
       return null;
     }
   }
 
-  private async process(job: { id: string; workflowId: string; userId?: string }): Promise<void> {
+  private async process(job: { id: string; workflowId: string; userId?: string; metadata?: Record<string, any> }): Promise<void> {
     const startedAt = Date.now();
+    const executionRecord = await WorkflowRepository.getExecutionById(job.id);
+    const baseMetadata = { ...(executionRecord?.metadata ?? job.metadata ?? {}) } as Record<string, any>;
+    observabilityService.recordQueueStart(job.id, job.workflowId);
     try {
       const wf = await WorkflowRepository.getWorkflowById(job.workflowId);
       if (!wf || !wf.graph) {
@@ -123,22 +188,75 @@ class ExecutionQueueService {
       const initialData = { trigger: { id: 'queue', source: 'queue', timestamp: new Date().toISOString() } };
       const result = await workflowRuntime.executeWorkflow(wf.graph as any, initialData, job.userId);
 
+      if (!result.success) {
+        throw new Error(result.error || 'Execution returned unsuccessful result');
+      }
+
+      const metadata = { ...baseMetadata, retryCount: 0, finishedAt: new Date().toISOString() };
+      delete metadata.nextRetryAt;
+      delete metadata.lastError;
+
       await WorkflowRepository.updateWorkflowExecution(job.id, {
-        status: result.success ? 'completed' : 'failed',
+        status: 'completed',
         completedAt: new Date(),
         duration: Date.now() - startedAt,
         nodeResults: result.nodeOutputs,
-        errorDetails: result.success ? null : { error: result.error || 'Execution failed' },
-        metadata: { queued: true, finishedAt: new Date().toISOString() },
+        errorDetails: null,
+        metadata,
       });
+      observabilityService.recordQueueCompletion(job.id, job.workflowId, Date.now() - startedAt, result.nodeOutputs ?? {});
     } catch (error: any) {
+      const errorMessage = getErrorMessage(error);
+      const currentRetries = typeof baseMetadata.retryCount === 'number' ? baseMetadata.retryCount : 0;
+      const nextRetryCount = currentRetries + 1;
+
+      if (nextRetryCount <= this.maxRetries) {
+        const delay = this.computeBackoff(nextRetryCount);
+        const nextRetryAt = new Date(Date.now() + delay).toISOString();
+        const retryMetadata = {
+          ...baseMetadata,
+          retryCount: nextRetryCount,
+          nextRetryAt,
+          lastError: errorMessage,
+        };
+
+        await WorkflowRepository.updateWorkflowExecution(job.id, {
+          status: 'queued',
+          completedAt: null,
+          duration: null,
+          errorDetails: { error: errorMessage },
+          metadata: retryMetadata,
+          startedAt: new Date(),
+        });
+
+        console.warn(
+          `⚠️ Execution ${job.id} failed (attempt ${nextRetryCount}). Retrying in ${delay}ms: ${errorMessage}`
+        );
+        observabilityService.recordQueueRetry(job.id, job.workflowId, nextRetryCount, delay, errorMessage);
+        this.scheduleWake(delay);
+        return;
+      }
+
+      const failedMetadata = {
+        ...baseMetadata,
+        retryCount: nextRetryCount,
+        lastError: errorMessage,
+      };
+      if ('nextRetryAt' in failedMetadata) {
+        delete failedMetadata.nextRetryAt;
+      }
+
       await WorkflowRepository.updateWorkflowExecution(job.id, {
         status: 'failed',
         completedAt: new Date(),
         duration: Date.now() - startedAt,
-        errorDetails: { error: getErrorMessage(error) },
+        errorDetails: { error: errorMessage },
+        metadata: failedMetadata,
       });
-      console.error(`❌ Execution ${job.id} failed:`, getErrorMessage(error));
+
+      console.error(`❌ Execution ${job.id} failed after ${nextRetryCount} attempts:`, errorMessage);
+      observabilityService.recordQueueFailure(job.id, job.workflowId, Date.now() - startedAt, errorMessage);
+      observabilityService.recordNodeError(job.id, job.workflowId, errorMessage);
     }
   }
 }

--- a/server/services/ObservabilityService.ts
+++ b/server/services/ObservabilityService.ts
@@ -1,0 +1,186 @@
+import { recordExecution } from './ExecutionAuditService.js';
+
+type QueueEvent = {
+  executionId: string;
+  workflowId: string;
+  status: 'queued' | 'running' | 'completed' | 'failed' | 'retrying';
+  durationMs?: number;
+  retries?: number;
+  delayMs?: number;
+  error?: string;
+  timestamp: string;
+};
+
+type NodeLogEntry = {
+  executionId: string;
+  nodeId: string;
+  level: 'info' | 'warn' | 'error';
+  message: string;
+  timestamp: string;
+};
+
+class ObservabilityService {
+  private static instance: ObservabilityService;
+  private readonly queueHistory: QueueEvent[] = [];
+  private readonly nodeLogs: NodeLogEntry[] = [];
+  private readonly queueStats = {
+    started: 0,
+    completed: 0,
+    failed: 0,
+    retries: 0,
+    running: 0,
+  };
+  private readonly maxQueueHistory = 250;
+  private readonly maxNodeLogs = 500;
+
+  private constructor() {}
+
+  static getInstance(): ObservabilityService {
+    if (!ObservabilityService.instance) {
+      ObservabilityService.instance = new ObservabilityService();
+    }
+    return ObservabilityService.instance;
+  }
+
+  recordQueueStart(executionId: string, workflowId: string): void {
+    this.queueStats.started += 1;
+    this.queueStats.running += 1;
+    this.pushQueueEvent({
+      executionId,
+      workflowId,
+      status: 'running',
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  recordQueueCompletion(
+    executionId: string,
+    workflowId: string,
+    durationMs: number,
+    nodeOutputs?: Record<string, any>
+  ): void {
+    this.queueStats.completed += 1;
+    this.queueStats.running = Math.max(0, this.queueStats.running - 1);
+    this.pushQueueEvent({
+      executionId,
+      workflowId,
+      status: 'completed',
+      durationMs,
+      timestamp: new Date().toISOString(),
+    });
+
+    if (nodeOutputs) {
+      this.recordNodeOutputs(executionId, nodeOutputs);
+    }
+  }
+
+  recordQueueFailure(executionId: string, workflowId: string, durationMs: number, error: string): void {
+    this.queueStats.failed += 1;
+    this.queueStats.running = Math.max(0, this.queueStats.running - 1);
+    this.pushQueueEvent({
+      executionId,
+      workflowId,
+      status: 'failed',
+      durationMs,
+      error,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  recordQueueRetry(
+    executionId: string,
+    workflowId: string,
+    attempt: number,
+    delayMs: number,
+    error: string
+  ): void {
+    this.queueStats.retries += 1;
+    this.pushQueueEvent({
+      executionId,
+      workflowId,
+      status: 'retrying',
+      retries: attempt,
+      delayMs,
+      error,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  recordNodeOutputs(executionId: string, outputs: Record<string, any>): void {
+    const timestamp = new Date().toISOString();
+    Object.entries(outputs).forEach(([nodeId, payload]) => {
+      const serialized = JSON.stringify(payload).slice(0, 500);
+      this.pushNodeLog({
+        executionId,
+        nodeId,
+        level: 'info',
+        message: serialized,
+        timestamp,
+      });
+    });
+  }
+
+  recordNodeError(executionId: string, nodeId: string, error: string): void {
+    this.pushNodeLog({
+      executionId,
+      nodeId,
+      level: 'error',
+      message: error,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  getQueueMetrics() {
+    return {
+      ...this.queueStats,
+      history: [...this.queueHistory],
+    };
+  }
+
+  getNodeLogSnapshot(limit = 100): NodeLogEntry[] {
+    return this.nodeLogs.slice(-limit);
+  }
+
+  getSnapshot() {
+    return {
+      queue: this.getQueueMetrics(),
+      nodeLogs: this.getNodeLogSnapshot(50),
+    };
+  }
+
+  resetForTests(): void {
+    this.queueHistory.length = 0;
+    this.nodeLogs.length = 0;
+    this.queueStats.started = 0;
+    this.queueStats.completed = 0;
+    this.queueStats.failed = 0;
+    this.queueStats.retries = 0;
+    this.queueStats.running = 0;
+  }
+
+  private pushQueueEvent(event: QueueEvent): void {
+    this.queueHistory.push(event);
+    if (this.queueHistory.length > this.maxQueueHistory) {
+      this.queueHistory.splice(0, this.queueHistory.length - this.maxQueueHistory);
+    }
+  }
+
+  private pushNodeLog(entry: NodeLogEntry): void {
+    this.nodeLogs.push(entry);
+    if (this.nodeLogs.length > this.maxNodeLogs) {
+      this.nodeLogs.splice(0, this.nodeLogs.length - this.maxNodeLogs);
+    }
+
+    recordExecution({
+      requestId: entry.executionId,
+      appId: 'workflow',
+      functionId: entry.nodeId,
+      durationMs: 0,
+      success: entry.level !== 'error',
+      error: entry.level === 'error' ? entry.message : undefined,
+      meta: { level: entry.level },
+    });
+  }
+}
+
+export const observabilityService = ObservabilityService.getInstance();

--- a/server/services/ProviderConfigService.ts
+++ b/server/services/ProviderConfigService.ts
@@ -1,0 +1,291 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { eq } from 'drizzle-orm';
+import { db, providerConfigs } from '../database/schema.js';
+import { EncryptionService } from './EncryptionService.js';
+import { oauthManager } from '../oauth/OAuthManager.js';
+import { getErrorMessage } from '../types/common.js';
+import { recordSecretEvent } from '../security/SecretsAuditLog.js';
+
+export interface ProviderCredentialInput {
+  provider: string;
+  clientId: string;
+  clientSecret: string;
+  scopes?: string[];
+  metadata?: Record<string, any>;
+}
+
+export interface ProviderCredentialRecord {
+  provider: string;
+  clientId: string;
+  clientSecret: string;
+  scopes: string[];
+  metadata: Record<string, any>;
+  lastTested?: Date;
+  testStatus?: string;
+  testError?: string;
+  rotationVersion: number;
+  updatedAt: Date;
+}
+
+type StoredProviderRecord = {
+  provider: string;
+  encryptedConfig: string;
+  iv: string;
+  rotationVersion: number;
+  metadata: Record<string, any>;
+  lastTested?: string;
+  testStatus?: string;
+  testError?: string;
+  updatedAt: string;
+};
+
+function normalizeProvider(provider: string): string {
+  return provider.trim().toLowerCase();
+}
+
+export class ProviderConfigService {
+  private readonly useFileStore: boolean;
+  private readonly allowFileStore: boolean;
+  private readonly filePath: string;
+
+  constructor() {
+    this.allowFileStore = process.env.ALLOW_PROVIDER_CONFIG_FILE_STORE === 'true';
+    this.filePath = path.resolve(
+      process.env.PROVIDER_CONFIG_STORE_PATH || path.join(process.cwd(), '.data', 'provider-configs.json')
+    );
+
+    if (!db) {
+      if (!this.allowFileStore) {
+        throw new Error(
+          'Database connection not available. Set DATABASE_URL or enable ALLOW_PROVIDER_CONFIG_FILE_STORE for development.'
+        );
+      }
+      this.useFileStore = true;
+    } else {
+      this.useFileStore = false;
+    }
+  }
+
+  private async ensureFileDir(): Promise<void> {
+    const dir = path.dirname(this.filePath);
+    await fs.mkdir(dir, { recursive: true });
+  }
+
+  private encryptConfig(config: Omit<ProviderCredentialRecord, 'provider' | 'updatedAt' | 'rotationVersion'>) {
+    return EncryptionService.encryptCredentials({
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+      scopes: config.scopes,
+      metadata: config.metadata,
+    });
+  }
+
+  private decryptConfig(record: StoredProviderRecord): ProviderCredentialRecord {
+    const decrypted = EncryptionService.decryptCredentials(record.encryptedConfig, record.iv) as {
+      clientId: string;
+      clientSecret: string;
+      scopes?: string[];
+      metadata?: Record<string, any>;
+    };
+
+    return {
+      provider: record.provider,
+      clientId: decrypted.clientId,
+      clientSecret: decrypted.clientSecret,
+      scopes: decrypted.scopes ?? [],
+      metadata: decrypted.metadata ?? {},
+      lastTested: record.lastTested ? new Date(record.lastTested) : undefined,
+      testStatus: record.testStatus,
+      testError: record.testError,
+      rotationVersion: record.rotationVersion,
+      updatedAt: new Date(record.updatedAt),
+    };
+  }
+
+  private async readFileStore(): Promise<StoredProviderRecord[]> {
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed as StoredProviderRecord[];
+      }
+      return [];
+    } catch (error: any) {
+      if (error?.code === 'ENOENT') {
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  private async writeFileStore(records: StoredProviderRecord[]): Promise<void> {
+    await this.ensureFileDir();
+    await fs.writeFile(this.filePath, JSON.stringify(records, null, 2), 'utf8');
+  }
+
+  public async listCredentials(): Promise<ProviderCredentialRecord[]> {
+    if (this.useFileStore) {
+      const records = await this.readFileStore();
+      return records.map((record) => this.decryptConfig(record));
+    }
+
+    const rows = await db!.select().from(providerConfigs);
+    return rows.map((row) =>
+      this.decryptConfig({
+        provider: row.provider,
+        encryptedConfig: row.encryptedConfig,
+        iv: row.iv,
+        rotationVersion: row.rotationVersion,
+        metadata: row.metadata,
+        lastTested: row.lastTested?.toISOString(),
+        testStatus: row.testStatus ?? undefined,
+        testError: row.testError ?? undefined,
+        updatedAt: row.updatedAt.toISOString(),
+      })
+    );
+  }
+
+  public async bootstrap(): Promise<void> {
+    try {
+      const credentials = await this.listCredentials();
+      if (credentials.length === 0) {
+        console.warn('⚠️ No provider credentials found in store. OAuth providers may remain disabled.');
+        return;
+      }
+
+      oauthManager.hydrateProviderCredentials(
+        credentials.map((cred) => ({
+          provider: cred.provider,
+          clientId: cred.clientId,
+          clientSecret: cred.clientSecret,
+          scopes: cred.scopes,
+        }))
+      );
+    } catch (error) {
+      console.error('❌ Failed to bootstrap provider credentials:', getErrorMessage(error));
+      throw error;
+    }
+  }
+
+  public async upsertCredential(input: ProviderCredentialInput): Promise<ProviderCredentialRecord> {
+    const provider = normalizeProvider(input.provider);
+    const payload = {
+      provider,
+      clientId: input.clientId,
+      clientSecret: input.clientSecret,
+      scopes: input.scopes ?? [],
+      metadata: input.metadata ?? {},
+      lastTested: undefined as Date | undefined,
+      testStatus: undefined as string | undefined,
+      testError: undefined as string | undefined,
+      rotationVersion: 1,
+      updatedAt: new Date(),
+    };
+
+    const encrypted = this.encryptConfig(payload);
+    const storedRecord: StoredProviderRecord = {
+      provider,
+      encryptedConfig: encrypted.encryptedData,
+      iv: encrypted.iv,
+      rotationVersion: payload.rotationVersion,
+      metadata: payload.metadata,
+      updatedAt: payload.updatedAt.toISOString(),
+    };
+
+    if (this.useFileStore) {
+      const existing = await this.readFileStore();
+      const idx = existing.findIndex((item) => item.provider === provider);
+      if (idx >= 0) {
+        existing[idx] = { ...existing[idx], ...storedRecord };
+      } else {
+        existing.push(storedRecord);
+      }
+      await this.writeFileStore(existing);
+    } else {
+      await db!
+        .insert(providerConfigs)
+        .values({
+          provider,
+          encryptedConfig: storedRecord.encryptedConfig,
+          iv: storedRecord.iv,
+          rotationVersion: storedRecord.rotationVersion,
+          metadata: storedRecord.metadata,
+          updatedAt: new Date(storedRecord.updatedAt),
+        })
+        .onConflictDoUpdate({
+          target: providerConfigs.provider,
+          set: {
+            encryptedConfig: storedRecord.encryptedConfig,
+            iv: storedRecord.iv,
+            rotationVersion: storedRecord.rotationVersion,
+            metadata: storedRecord.metadata,
+            updatedAt: new Date(storedRecord.updatedAt),
+          },
+        });
+    }
+
+    oauthManager.applyProviderCredential(provider, {
+      clientId: payload.clientId,
+      clientSecret: payload.clientSecret,
+      scopes: payload.scopes,
+    });
+
+    recordSecretEvent({
+      type: 'write',
+      provider,
+      source: 'provider-config',
+      metadata: { action: 'upsert' },
+    });
+
+    return {
+      ...payload,
+    };
+  }
+
+  public async deleteCredential(providerId: string): Promise<void> {
+    const provider = normalizeProvider(providerId);
+
+    if (this.useFileStore) {
+      const existing = await this.readFileStore();
+      const filtered = existing.filter((item) => item.provider !== provider);
+      await this.writeFileStore(filtered);
+    } else {
+      await db!.delete(providerConfigs).where(eq(providerConfigs.provider, provider));
+    }
+
+    recordSecretEvent({
+      type: 'delete',
+      provider,
+      source: 'provider-config',
+      metadata: { action: 'delete' },
+    });
+
+    oauthManager.disableProvider(provider, 'Removed via admin API');
+  }
+
+  public async testCredential(providerId: string): Promise<{ success: boolean; message: string }> {
+    const provider = normalizeProvider(providerId);
+    const status = oauthManager.getProviderConfigurationStatus(provider);
+    if (!status.configured) {
+      return {
+        success: false,
+        message: status.reason ?? 'Provider remains disabled after configuration update',
+      };
+    }
+
+    recordSecretEvent({
+      type: 'read',
+      provider,
+      source: 'provider-config',
+      metadata: { action: 'test' },
+    });
+
+    return {
+      success: true,
+      message: 'Provider credentials loaded and provider is enabled.',
+    };
+  }
+}
+
+export const providerConfigService = new ProviderConfigService();

--- a/server/services/__tests__/ConnectionService.encryption.test.ts
+++ b/server/services/__tests__/ConnectionService.encryption.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 process.env.NODE_ENV = 'development';
 process.env.ENCRYPTION_MASTER_KEY = 'a'.repeat(32);
+process.env.ALLOW_FILE_CONNECTION_STORE = 'true';
 
 const tempDir = await mkdtemp(path.join(os.tmpdir(), 'connection-service-'));
 process.env.CONNECTION_STORE_PATH = path.join(tempDir, 'connections.json');
@@ -52,5 +53,6 @@ assert.deepEqual(allConnections[0].credentials, originalCredentials, 'list entri
 
 await rm(tempDir, { recursive: true, force: true });
 delete process.env.CONNECTION_STORE_PATH;
+delete process.env.ALLOW_FILE_CONNECTION_STORE;
 
 console.log('ConnectionService encrypt/decrypt round trip verified via file store.');

--- a/server/services/__tests__/ConnectionService.test.ts
+++ b/server/services/__tests__/ConnectionService.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 process.env.NODE_ENV = 'development';
 process.env.ENCRYPTION_MASTER_KEY = process.env.ENCRYPTION_MASTER_KEY ?? 'a'.repeat(32);
+process.env.ALLOW_FILE_CONNECTION_STORE = 'true';
 
 const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'connection-service-'));
 const storePath = path.join(tempDir, 'connections.json');
@@ -57,5 +58,7 @@ assert.equal(fetched?.testStatus, 'failed', 'fetched connection includes test st
 assert.equal(fetched?.testError, testResult.message, 'fetched connection includes test error');
 
 await fs.rm(tempDir, { recursive: true, force: true });
+
+delete process.env.ALLOW_FILE_CONNECTION_STORE;
 
 console.log('ConnectionService stores type/test status metadata in sync with schema.');

--- a/server/services/__tests__/ObservabilityService.test.ts
+++ b/server/services/__tests__/ObservabilityService.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { observabilityService } from '../ObservabilityService.js';
+
+observabilityService.resetForTests();
+
+observabilityService.recordQueueStart('exec-1', 'wf-1');
+observabilityService.recordQueueRetry('exec-1', 'wf-1', 1, 1000, 'temporary error');
+observabilityService.recordQueueFailure('exec-1', 'wf-1', 250, 'temporary error');
+
+let metrics = observabilityService.getQueueMetrics();
+assert.equal(metrics.started, 1);
+assert.equal(metrics.retries, 1);
+assert.equal(metrics.failed, 1);
+
+observabilityService.resetForTests();
+observabilityService.recordQueueStart('exec-2', 'wf-1');
+observabilityService.recordQueueCompletion('exec-2', 'wf-1', 150, { nodeA: { ok: true } });
+
+const snapshot = observabilityService.getSnapshot();
+assert.equal(snapshot.queue.completed, 1);
+assert.equal(snapshot.nodeLogs.length > 0, true);
+
+observabilityService.resetForTests();
+
+console.log('ObservabilityService captures queue stats and node logs.');

--- a/server/services/__tests__/ProviderConfigService.test.ts
+++ b/server/services/__tests__/ProviderConfigService.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+process.env.NODE_ENV = 'development';
+process.env.ENCRYPTION_MASTER_KEY = process.env.ENCRYPTION_MASTER_KEY ?? 'b'.repeat(32);
+process.env.ALLOW_PROVIDER_CONFIG_FILE_STORE = 'true';
+process.env.ALLOW_FILE_CONNECTION_STORE = 'true';
+
+const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'provider-config-service-'));
+const storePath = path.join(tempDir, 'provider-configs.json');
+process.env.PROVIDER_CONFIG_STORE_PATH = storePath;
+process.env.CONNECTION_STORE_PATH = path.join(tempDir, 'connections.json');
+
+const { EncryptionService } = await import('../EncryptionService.js');
+await EncryptionService.init();
+
+const { providerConfigService } = await import('../ProviderConfigService.js');
+const { oauthManager } = await import('../../oauth/OAuthManager.js');
+
+const record = await providerConfigService.upsertCredential({
+  provider: 'gmail',
+  clientId: 'client-id-1234567890',
+  clientSecret: 'secret-value-1234567890',
+  scopes: ['email', 'profile'],
+});
+
+assert.equal(record.provider, 'gmail');
+
+const configs = await providerConfigService.listCredentials();
+assert.ok(configs.some((config) => config.provider === 'gmail'), 'gmail config persisted');
+
+const status = oauthManager.getProviderConfigurationStatus('gmail');
+assert.equal(status.configured, true, 'gmail provider enabled after bootstrap');
+
+const testResult = await providerConfigService.testCredential('gmail');
+assert.equal(testResult.success, true);
+
+await fs.rm(tempDir, { recursive: true, force: true });
+
+delete process.env.ALLOW_PROVIDER_CONFIG_FILE_STORE;
+delete process.env.ALLOW_FILE_CONNECTION_STORE;
+
+delete process.env.PROVIDER_CONFIG_STORE_PATH;
+delete process.env.CONNECTION_STORE_PATH;
+
+console.log('ProviderConfigService encrypts and hydrates provider credentials.');

--- a/server/workflow/WorkflowRepository.ts
+++ b/server/workflow/WorkflowRepository.ts
@@ -52,6 +52,7 @@ export interface CreateWorkflowExecutionInput {
 export interface UpdateWorkflowExecutionInput {
   status?: string;
   completedAt?: Date | null;
+  startedAt?: Date | null;
   duration?: number | null;
   nodeResults?: Record<string, any> | null;
   errorDetails?: Record<string, any> | null;
@@ -439,6 +440,7 @@ export class WorkflowRepository {
         ...existing,
         status: updates.status ?? existing.status,
         completedAt: updates.completedAt ?? existing.completedAt,
+        startedAt: updates.startedAt ?? existing.startedAt,
         duration: updates.duration ?? existing.duration,
         nodeResults: updates.nodeResults ?? existing.nodeResults,
         errorDetails: updates.errorDetails ?? existing.errorDetails,
@@ -454,6 +456,7 @@ export class WorkflowRepository {
 
     if (updates.status !== undefined) updateSet.status = updates.status;
     if (updates.completedAt !== undefined) updateSet.completedAt = updates.completedAt;
+    if (updates.startedAt !== undefined) updateSet.startedAt = updates.startedAt;
     if (updates.duration !== undefined) updateSet.duration = updates.duration;
     if (updates.nodeResults !== undefined) updateSet.nodeResults = updates.nodeResults;
     if (updates.errorDetails !== undefined) updateSet.errorDetails = updates.errorDetails;


### PR DESCRIPTION
## Summary
- add a provider configuration service with encrypted storage, admin APIs, and startup hydration so OAuth providers can be enabled without environment secrets
- instrument execution observability and secret access auditing, wiring queue lifecycle metrics and exposing admin endpoints for metrics, node logs, and secret access history
- extend connection handling and startup checks with security auditing and key rotation enforcement, and add a secrets scanning script alongside new unit coverage

## Testing
- `npm exec tsx server/services/__tests__/ProviderConfigService.test.ts`
- `npm exec tsx server/services/__tests__/ObservabilityService.test.ts`
- `npm exec tsx server/security/__tests__/SecretsAuditLog.test.ts`
- `npm exec tsx server/services/__tests__/ConnectionService.test.ts`
- `npm exec tsx server/services/__tests__/ConnectionService.encryption.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68de0768fc44833182265b2809aa4bb0