### PR TITLE
Add multi-tenant organization selection and quotas

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,6 +23,7 @@ import AIBuilder from "./pages/AIBuilder";
 import AdminSettings from "./pages/AdminSettings";
 import WorkflowBuilder from "./pages/WorkflowBuilder";
 import GraphEditor from "./pages/GraphEditor";
+import WorkspaceSelector from "./pages/WorkspaceSelector";
 
 const queryClient = new QueryClient();
 
@@ -40,6 +41,7 @@ const App = () => (
             <Route path="/ai-builder" element={<AIBuilder />} />
             <Route path="/workflow-builder" element={<WorkflowBuilder />} />
             <Route path="/graph-editor" element={<GraphEditor />} />
+            <Route path="/workspaces" element={<WorkspaceSelector />} />
             <Route path="/admin/settings" element={<AdminSettings />} />
             <Route path="/pre-built-apps" element={<PreBuiltApps />} />
             <Route path="/schedule" element={<Schedule />} />

--- a/client/src/components/layout/Navbar.tsx
+++ b/client/src/components/layout/Navbar.tsx
@@ -10,6 +10,7 @@ const navItems = [
   { to: "/", label: "Home" },
   { to: "/ai-builder", label: "🤖 AI Builder" },
   { to: "/graph-editor", label: "🎨 Graph Editor" },
+  { to: "/workspaces", label: "Workspaces" },
   { to: "/#demos", label: "Demos" },
   { to: "/pre-built-apps", label: "Pre-Built Apps" },
   { to: "/schedule", label: "Schedule" },
@@ -24,8 +25,12 @@ export const Navbar = () => {
   const user = useAuthStore((state) => state.user);
   const status = useAuthStore((state) => state.status);
   const logout = useAuthStore((state) => state.logout);
+  const organizations = useAuthStore((state) => state.organizations);
+  const activeOrganizationId = useAuthStore((state) => state.activeOrganizationId);
   const [authOpen, setAuthOpen] = useState(false);
   const isAuthLoading = status === 'loading';
+
+  const activeOrganization = organizations.find((org) => org.id === activeOrganizationId);
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 8);
@@ -72,10 +77,24 @@ export const Navbar = () => {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="outline" disabled={isAuthLoading}>
-                  {user.name || user.email}
+                  <span className="flex flex-col items-start">
+                    <span>{user.name || user.email}</span>
+                    {activeOrganization && (
+                      <span className="text-xs text-muted-foreground">{activeOrganization.name}</span>
+                    )}
+                  </span>
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                {activeOrganization && (
+                  <DropdownMenuItem disabled>
+                    Active workspace: {activeOrganization.name}
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem asChild>
+                  <Link to="/workspaces">Switch workspaces</Link>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
                 <DropdownMenuItem asChild>
                   <Link to="/admin/settings">Account settings</Link>
                 </DropdownMenuItem>

--- a/client/src/hooks/useRequireOrganization.ts
+++ b/client/src/hooks/useRequireOrganization.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/store/authStore';
+
+export const useRequireOrganization = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const initialized = useAuthStore((state) => state.initialized);
+  const user = useAuthStore((state) => state.user);
+  const activeOrganizationId = useAuthStore((state) => state.activeOrganizationId);
+
+  useEffect(() => {
+    if (!initialized) return;
+    if (!user) return;
+    if (!activeOrganizationId) {
+      const redirectPath = encodeURIComponent(`${location.pathname}${location.search}`);
+      if (!location.pathname.startsWith('/workspaces')) {
+        navigate(`/workspaces?redirect=${redirectPath}`, { replace: true });
+      }
+    }
+  }, [initialized, activeOrganizationId, navigate, location.pathname, location.search, user]);
+
+  return Boolean(activeOrganizationId);
+};
+
+export default useRequireOrganization;

--- a/client/src/pages/GraphEditor.tsx
+++ b/client/src/pages/GraphEditor.tsx
@@ -1,7 +1,26 @@
 import { Helmet } from "react-helmet-async";
 import ProfessionalGraphEditor from "@/components/workflow/ProfessionalGraphEditor";
+import useRequireOrganization from "@/hooks/useRequireOrganization";
+import { useAuthStore } from "@/store/authStore";
 
 export default function GraphEditor() {
+  const hasOrganization = useRequireOrganization();
+  const initialized = useAuthStore((state) => state.initialized);
+
+  if (!initialized || !hasOrganization) {
+    return (
+      <>
+        <Helmet>
+          <title>Workflow Designer - Apps Script Studio</title>
+          <meta name="description" content="Design and build automation workflows with our professional n8n-style visual editor. Drag, drop, and connect nodes to create powerful automations." />
+        </Helmet>
+        <div className="flex h-screen items-center justify-center text-muted-foreground">
+          Select a workspace to design workflows.
+        </div>
+      </>
+    );
+  }
+
   return (
     <>
       <Helmet>

--- a/client/src/pages/WorkflowBuilder.tsx
+++ b/client/src/pages/WorkflowBuilder.tsx
@@ -1,7 +1,26 @@
 import { Helmet } from "react-helmet-async";
 import { N8NStyleWorkflowBuilder } from "@/components/ai/N8NStyleWorkflowBuilder";
+import useRequireOrganization from "@/hooks/useRequireOrganization";
+import { useAuthStore } from "@/store/authStore";
 
 export default function WorkflowBuilder() {
+  const hasOrganization = useRequireOrganization();
+  const initialized = useAuthStore((state) => state.initialized);
+
+  if (!initialized || !hasOrganization) {
+    return (
+      <>
+        <Helmet>
+          <title>Workflow Builder - Apps Script Studio</title>
+          <meta name="description" content="Professional n8n-style workflow builder with AI assistance. Build automation workflows visually." />
+        </Helmet>
+        <div className="flex h-screen items-center justify-center text-muted-foreground">
+          Select a workspace to start building workflows.
+        </div>
+      </>
+    );
+  }
+
   return (
     <>
       <Helmet>

--- a/client/src/pages/WorkspaceSelector.tsx
+++ b/client/src/pages/WorkspaceSelector.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useMemo, useState } from "react";
+import { Helmet } from "react-helmet-async";
+import { useLocation, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { useAuthStore } from "@/store/authStore";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+
+const plans = [
+  { value: "starter", label: "Starter" },
+  { value: "professional", label: "Professional" },
+  { value: "enterprise", label: "Enterprise" },
+  { value: "enterprise_plus", label: "Enterprise Plus" },
+];
+
+const WorkspaceSelector = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const user = useAuthStore((state) => state.user);
+  const organizations = useAuthStore((state) => state.organizations);
+  const activeOrganizationId = useAuthStore((state) => state.activeOrganizationId);
+  const fetchOrganizations = useAuthStore((state) => state.fetchOrganizations);
+  const setActiveOrganization = useAuthStore((state) => state.setActiveOrganization);
+  const createOrganization = useAuthStore((state) => state.createOrganization);
+  const initialized = useAuthStore((state) => state.initialized);
+  const status = useAuthStore((state) => state.status);
+
+  const [selectingId, setSelectingId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [workspaceName, setWorkspaceName] = useState("");
+  const [workspaceDomain, setWorkspaceDomain] = useState("");
+  const [plan, setPlan] = useState("starter");
+
+  const redirectPath = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get("redirect") || "/workflow-builder";
+  }, [location.search]);
+
+  useEffect(() => {
+    if (user) {
+      fetchOrganizations();
+    }
+  }, [user, fetchOrganizations]);
+
+  useEffect(() => {
+    if (initialized && user && activeOrganizationId && location.pathname === "/workspaces") {
+      // If the user already has an active organization and navigated here manually, do not auto-redirect.
+    }
+  }, [initialized, user, activeOrganizationId, location.pathname]);
+
+  const handleSelect = async (organizationId: string) => {
+    setSelectingId(organizationId);
+    const result = await setActiveOrganization(organizationId);
+    setSelectingId(null);
+    if (result.success) {
+      toast.success("Workspace selected");
+      navigate(redirectPath, { replace: true });
+    } else {
+      toast.error(result.error || "Unable to switch workspace");
+    }
+  };
+
+  const handleCreate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!workspaceName.trim()) {
+      toast.error("Workspace name is required");
+      return;
+    }
+    setCreating(true);
+    const result = await createOrganization({
+      name: workspaceName.trim(),
+      domain: workspaceDomain.trim() || undefined,
+      plan,
+      makeDefault: true,
+    });
+    setCreating(false);
+    if (result.success) {
+      toast.success("Workspace created");
+      await fetchOrganizations();
+      navigate(redirectPath, { replace: true });
+    } else {
+      toast.error(result.error || "Unable to create workspace");
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="container mx-auto max-w-4xl py-16">
+        <Card>
+          <CardHeader>
+            <CardTitle>Sign in to manage workspaces</CardTitle>
+            <CardDescription>You must be authenticated to view and manage workspaces.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Please sign in to continue. Once signed in, you will be able to create or select a workspace to access the workflow
+              builder.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const isLoading = status === "loading" || !initialized;
+
+  return (
+    <>
+      <Helmet>
+        <title>Select a Workspace - Apps Script Studio</title>
+        <meta name="description" content="Choose or create a workspace before building automation workflows." />
+      </Helmet>
+      <div className="container mx-auto max-w-6xl py-12 space-y-10">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Choose your workspace</h1>
+          <p className="text-muted-foreground mt-2">
+            Workspaces let you collaborate with your team, manage usage limits, and keep automation projects organized.
+          </p>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+          <Card className="border-muted">
+            <CardHeader>
+              <CardTitle>Available workspaces</CardTitle>
+              <CardDescription>Select a workspace to continue building workflows.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {organizations.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  You don&apos;t have any workspaces yet. Create one using the form on the right to get started.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {organizations.map((organization) => {
+                    const isActive = organization.id === activeOrganizationId;
+                    return (
+                      <Card key={organization.id} className={isActive ? "border-primary/60" : "border-muted"}>
+                        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                          <div>
+                            <CardTitle className="text-lg">{organization.name}</CardTitle>
+                            <CardDescription className="mt-1 text-sm">
+                              Plan: {organization.plan.replace(/_/g, ' ')} • Members can {organization.permissions.canManageUsers ? "manage users" : "collaborate"}
+                            </CardDescription>
+                          </div>
+                          {isActive && <Badge>Active</Badge>}
+                        </CardHeader>
+                        <CardContent className="space-y-2 text-sm">
+                          <div className="flex items-center justify-between text-muted-foreground">
+                            <span>Executions</span>
+                            <span>{organization.usage.workflowExecutions} / {organization.limits.executions}</span>
+                          </div>
+                          <div className="flex items-center justify-between text-muted-foreground">
+                            <span>API calls</span>
+                            <span>{organization.usage.apiCalls} / {organization.limits.apiCalls}</span>
+                          </div>
+                          <div className="flex items-center justify-between text-muted-foreground">
+                            <span>Members</span>
+                            <span>{organization.usage.usersActive} / {organization.limits.users}</span>
+                          </div>
+                        </CardContent>
+                        <CardFooter className="flex justify-end">
+                          <Button
+                            variant={isActive ? "secondary" : "default"}
+                            disabled={isActive || selectingId === organization.id || isLoading}
+                            onClick={() => handleSelect(organization.id)}
+                          >
+                            {isActive ? 'Current workspace' : selectingId === organization.id ? 'Switching…' : 'Use this workspace'}
+                          </Button>
+                        </CardFooter>
+                      </Card>
+                    );
+                  })}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="border-muted">
+            <CardHeader>
+              <CardTitle>Create a new workspace</CardTitle>
+              <CardDescription>Spin up a new workspace for a client, department, or sandbox environment.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form className="space-y-4" onSubmit={handleCreate}>
+                <div className="space-y-2">
+                  <Label htmlFor="workspace-name">Workspace name</Label>
+                  <Input
+                    id="workspace-name"
+                    placeholder="Acme Corp Automation"
+                    value={workspaceName}
+                    onChange={(event) => setWorkspaceName(event.target.value)}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="workspace-domain">Company domain (optional)</Label>
+                  <Input
+                    id="workspace-domain"
+                    placeholder="acme.com"
+                    value={workspaceDomain}
+                    onChange={(event) => setWorkspaceDomain(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="workspace-plan">Plan</Label>
+                  <Select value={plan} onValueChange={setPlan}>
+                    <SelectTrigger id="workspace-plan">
+                      <SelectValue placeholder="Select a plan" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {plans.map((item) => (
+                        <SelectItem key={item.value} value={item.value}>
+                          {item.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button type="submit" className="w-full" disabled={creating || isLoading}>
+                  {creating ? 'Creating workspace…' : 'Create workspace'}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default WorkspaceSelector;

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -10,6 +10,43 @@ type AuthUser = {
   emailVerified?: boolean;
   quotaApiCalls?: number;
   quotaTokens?: number;
+  activeOrganizationId?: string | null;
+  organizationRole?: string;
+  organizationPermissions?: OrganizationPermissions;
+};
+
+type OrganizationPermissions = {
+  canCreateWorkflows: boolean;
+  canEditWorkflows: boolean;
+  canDeleteWorkflows: boolean;
+  canManageUsers: boolean;
+  canViewAnalytics: boolean;
+  canManageBilling: boolean;
+  canAccessApi: boolean;
+};
+
+type OrganizationSummary = {
+  id: string;
+  name: string;
+  domain?: string | null;
+  plan: string;
+  status: string;
+  role: string;
+  isDefault: boolean;
+  limits: {
+    workflows: number;
+    executions: number;
+    apiCalls: number;
+    users: number;
+    storage: number;
+  };
+  usage: {
+    apiCalls: number;
+    workflowExecutions: number;
+    storage: number;
+    usersActive: number;
+  };
+  permissions: OrganizationPermissions;
 };
 
 type AuthStatus = 'idle' | 'loading';
@@ -20,6 +57,8 @@ type StoredAuthState = {
   token?: string;
   refreshToken?: string;
   user?: AuthUser;
+  organizations?: OrganizationSummary[];
+  activeOrganizationId?: string | null;
 };
 
 type AuthState = StoredAuthState & {
@@ -31,6 +70,10 @@ type AuthState = StoredAuthState & {
   register: (payload: { name?: string; email: string; password: string }) => Promise<AuthResult>;
   logout: (silent?: boolean) => Promise<void>;
   authFetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+  fetchOrganizations: () => Promise<void>;
+  setActiveOrganization: (organizationId: string) => Promise<AuthResult>;
+  createOrganization: (payload: { name: string; domain?: string; plan?: string; makeDefault?: boolean }) => Promise<AuthResult>;
+  inviteToOrganization: (organizationId: string, payload: { email: string; role?: string; expiresInDays?: number }) => Promise<AuthResult>;
 };
 
 const STORAGE_KEY = 'automation.auth.v1';
@@ -57,112 +100,256 @@ const restoreState = (): StoredAuthState => {
   }
 };
 
-export const useAuthStore = create<AuthState>((set, get) => ({
-  status: 'idle',
-  initialized: false,
-  ...restoreState(),
-  initialize: () => {
-    if (get().initialized) return;
-    const restored = restoreState();
-    set({ ...restored, initialized: true, status: 'idle', error: undefined });
-  },
-  login: async (email, password) => {
-    set({ status: 'loading', error: undefined });
-    try {
-      const response = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
-      });
-      const result = await response.json();
-      if (!response.ok || !result.success) {
-        const error = result?.error || 'Login failed';
-        set({ status: 'idle', error });
-        return { success: false, error };
-      }
+export const useAuthStore = create<AuthState>((set, get) => {
+  const restored = restoreState();
 
-      const nextState: StoredAuthState = {
-        token: result.token,
-        refreshToken: result.refreshToken,
-        user: result.user
-      };
-      persistState(nextState);
-      set({ ...nextState, status: 'idle', error: undefined });
-      toast.success('Signed in successfully');
-      return { success: true };
-    } catch (error: any) {
-      const message = error?.message || 'Unable to sign in';
-      set({ status: 'idle', error: message });
-      return { success: false, error: message };
-    }
-  },
-  register: async ({ name, email, password }) => {
-    set({ status: 'loading', error: undefined });
-    try {
-      const response = await fetch('/api/auth/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, email, password })
+  return {
+    status: 'idle',
+    initialized: false,
+    ...restored,
+    organizations: restored.organizations ?? [],
+    activeOrganizationId: restored.activeOrganizationId ?? null,
+    initialize: () => {
+      if (get().initialized) return;
+      const state = restoreState();
+      set({
+        ...state,
+        organizations: state.organizations ?? [],
+        activeOrganizationId: state.activeOrganizationId ?? null,
+        initialized: true,
+        status: 'idle',
+        error: undefined,
       });
-      const result = await response.json();
-      if (!response.ok || !result.success) {
-        const error = result?.error || 'Registration failed';
-        set({ status: 'idle', error });
-        return { success: false, error };
-      }
-
-      const nextState: StoredAuthState = {
-        token: result.token,
-        refreshToken: result.refreshToken,
-        user: result.user
-      };
-      persistState(nextState);
-      set({ ...nextState, status: 'idle', error: undefined });
-      toast.success('Account created and signed in');
-      return { success: true };
-    } catch (error: any) {
-      const message = error?.message || 'Unable to register';
-      set({ status: 'idle', error: message });
-      return { success: false, error: message };
-    }
-  },
-  logout: async (silent = false) => {
-    const token = get().token;
-    try {
-      if (token) {
-        await fetch('/api/auth/logout', {
+    },
+    login: async (email, password) => {
+      set({ status: 'loading', error: undefined });
+      try {
+        const response = await fetch('/api/auth/login', {
           method: 'POST',
-          headers: { Authorization: `Bearer ${token}` }
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password })
+        });
+        const result = await response.json();
+        if (!response.ok || !result.success) {
+          const error = result?.error || 'Login failed';
+          set({ status: 'idle', error });
+          return { success: false, error };
+        }
+
+        const nextState: StoredAuthState = {
+          token: result.token,
+          refreshToken: result.refreshToken,
+          user: result.user,
+          organizations: result.organizations || [],
+          activeOrganizationId: result.activeOrganizationId ?? result.user?.activeOrganizationId ?? null,
+        };
+        persistState(nextState);
+        set({
+          ...nextState,
+          organizations: nextState.organizations ?? [],
+          activeOrganizationId: nextState.activeOrganizationId ?? null,
+          status: 'idle',
+          error: undefined,
+        });
+        toast.success('Signed in successfully');
+        return { success: true };
+      } catch (error: any) {
+        const message = error?.message || 'Unable to sign in';
+        set({ status: 'idle', error: message });
+        return { success: false, error: message };
+      }
+    },
+    register: async ({ name, email, password }) => {
+      set({ status: 'loading', error: undefined });
+      try {
+        const response = await fetch('/api/auth/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, email, password })
+        });
+        const result = await response.json();
+        if (!response.ok || !result.success) {
+          const error = result?.error || 'Registration failed';
+          set({ status: 'idle', error });
+          return { success: false, error };
+        }
+
+        const nextState: StoredAuthState = {
+          token: result.token,
+          refreshToken: result.refreshToken,
+          user: result.user,
+          organizations: result.organizations || [],
+          activeOrganizationId: result.activeOrganizationId ?? result.user?.activeOrganizationId ?? null,
+        };
+        persistState(nextState);
+        set({
+          ...nextState,
+          organizations: nextState.organizations ?? [],
+          activeOrganizationId: nextState.activeOrganizationId ?? null,
+          status: 'idle',
+          error: undefined,
+        });
+        toast.success('Account created and signed in');
+        return { success: true };
+      } catch (error: any) {
+        const message = error?.message || 'Unable to register';
+        set({ status: 'idle', error: message });
+        return { success: false, error: message };
+      }
+    },
+    logout: async (silent = false) => {
+      const token = get().token;
+      try {
+        if (token) {
+          await fetch('/api/auth/logout', {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${token}` }
+          });
+        }
+      } catch (error) {
+        if (!silent) {
+          console.warn('Logout request failed', error);
+        }
+      } finally {
+        persistState({});
+        set({
+          token: undefined,
+          refreshToken: undefined,
+          user: undefined,
+          status: 'idle',
+          error: undefined,
+          organizations: [],
+          activeOrganizationId: null,
+        });
+        if (!silent) {
+          toast.success('Signed out');
+        }
+      }
+    },
+    authFetch: async (input, init) => {
+      const token = get().token;
+      const headers = new Headers(init?.headers);
+      if (!headers.has('Content-Type') && init?.body && !(init.body instanceof FormData)) {
+        headers.set('Content-Type', 'application/json');
+      }
+      if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+      }
+
+      const response = await fetch(input, { ...init, headers });
+      if (response.status === 401) {
+        await get().logout(true);
+      }
+      return response;
+    },
+    async fetchOrganizations() {
+      const response = await get().authFetch('/api/organizations');
+      const result = await response.json();
+      if (response.ok && result?.success) {
+        set((state) => {
+          const updatedUser = state.user ? {
+            ...state.user,
+            activeOrganizationId: result.activeOrganizationId ?? state.user?.activeOrganizationId ?? null,
+            organizationRole: result.organizations?.find((org: OrganizationSummary) => org.id === (result.activeOrganizationId ?? state.user?.activeOrganizationId))?.role ?? state.user?.organizationRole,
+            organizationPermissions: result.organizations?.find((org: OrganizationSummary) => org.id === (result.activeOrganizationId ?? state.user?.activeOrganizationId))?.permissions ?? state.user?.organizationPermissions,
+          } : state.user;
+          const nextState: StoredAuthState = {
+            token: state.token,
+            refreshToken: state.refreshToken,
+            user: updatedUser,
+            organizations: result.organizations,
+            activeOrganizationId: result.activeOrganizationId ?? updatedUser?.activeOrganizationId ?? null,
+          };
+          persistState(nextState);
+          return {
+            ...state,
+            user: updatedUser,
+            organizations: result.organizations ?? [],
+            activeOrganizationId: result.activeOrganizationId ?? updatedUser?.activeOrganizationId ?? null,
+          };
         });
       }
-    } catch (error) {
-      if (!silent) {
-        console.warn('Logout request failed', error);
+    },
+    async setActiveOrganization(organizationId) {
+      const response = await get().authFetch(`/api/organizations/${organizationId}/activate`, { method: 'POST' });
+      const result = await response.json();
+      if (!response.ok || !result?.success) {
+        const error = result?.error || 'Unable to switch workspace';
+        return { success: false, error };
       }
-    } finally {
-      persistState({});
-      set({ token: undefined, refreshToken: undefined, user: undefined, status: 'idle', error: undefined });
-      if (!silent) {
-        toast.success('Signed out');
+      set((state) => {
+        const activeOrg: OrganizationSummary | undefined = result.organizations?.find((org: OrganizationSummary) => org.id === result.activeOrganizationId);
+        const updatedUser = state.user ? {
+          ...state.user,
+          activeOrganizationId: result.activeOrganizationId ?? null,
+          organizationRole: activeOrg?.role,
+          organizationPermissions: activeOrg?.permissions,
+        } : state.user;
+        const nextState: StoredAuthState = {
+          token: state.token,
+          refreshToken: state.refreshToken,
+          user: updatedUser,
+          organizations: result.organizations,
+          activeOrganizationId: result.activeOrganizationId ?? null,
+        };
+        persistState(nextState);
+        return {
+          ...state,
+          user: updatedUser,
+          organizations: result.organizations ?? [],
+          activeOrganizationId: result.activeOrganizationId ?? null,
+        };
+      });
+      return { success: true };
+    },
+    async createOrganization(payload) {
+      const response = await get().authFetch('/api/organizations', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      const result = await response.json();
+      if (!response.ok || !result?.success) {
+        const error = result?.error || 'Unable to create workspace';
+        return { success: false, error };
       }
+      set((state) => {
+        const activeOrg: OrganizationSummary | undefined = result.organizations?.find((org: OrganizationSummary) => org.id === result.activeOrganizationId);
+        const updatedUser = state.user ? {
+          ...state.user,
+          activeOrganizationId: result.activeOrganizationId ?? state.user.activeOrganizationId ?? null,
+          organizationRole: activeOrg?.role ?? state.user.organizationRole,
+          organizationPermissions: activeOrg?.permissions ?? state.user.organizationPermissions,
+        } : state.user;
+        const nextState: StoredAuthState = {
+          token: state.token,
+          refreshToken: state.refreshToken,
+          user: updatedUser,
+          organizations: result.organizations,
+          activeOrganizationId: result.activeOrganizationId ?? updatedUser?.activeOrganizationId ?? null,
+        };
+        persistState(nextState);
+        return {
+          ...state,
+          user: updatedUser,
+          organizations: result.organizations ?? [],
+          activeOrganizationId: result.activeOrganizationId ?? updatedUser?.activeOrganizationId ?? null,
+        };
+      });
+      return { success: true };
+    },
+    async inviteToOrganization(organizationId, payload) {
+      const response = await get().authFetch(`/api/organizations/${organizationId}/invite`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      const result = await response.json();
+      if (!response.ok || !result?.success) {
+        const error = result?.error || 'Unable to send invitation';
+        return { success: false, error };
+      }
+      return { success: true };
     }
-  },
-  authFetch: async (input, init) => {
-    const token = get().token;
-    const headers = new Headers(init?.headers);
-    if (!headers.has('Content-Type') && init?.body && !(init.body instanceof FormData)) {
-      headers.set('Content-Type', 'application/json');
-    }
-    if (token) {
-      headers.set('Authorization', `Bearer ${token}`);
-    }
-
-    const response = await fetch(input, { ...init, headers });
-    if (response.status === 401) {
-      await get().logout(true);
-    }
-    return response;
-  }
-}));
+};
+});
 
 export const authStore = useAuthStore;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,7 @@ import workflowReadRoutes from "./routes/workflow-read.js";
 import productionHealthRoutes from "./routes/production-health.js";
 import flowRoutes from "./routes/flows.js";
 import { RealAIService, ConversationManager } from "./realAIService";
+import organizationRoutes from "./routes/organizations.js";
 
 // Production services
 import { authService } from "./services/AuthService";
@@ -116,6 +117,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   // P2-3: Advanced analytics routes
   app.use('/api/analytics', analyticsRoutes);
+
+  // Organization management routes
+  app.use('/api/organizations', organizationRoutes);
   
   // CRITICAL FIX: LLM automation planner routes (replaces static Q&A)
   app.use('/api/ai-planner', aiPlannerRoutes);
@@ -487,7 +491,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const result = await productionLLMOrchestrator.clarifyIntent({
           prompt: req.body.prompt,
           userId: req.user?.id || 'dev-user',
-          context: req.body.context || {}
+          context: req.body.context || {},
+          organizationId: req.organizationId || req.body.organizationId
         });
 
         // Record usage (only for authenticated users)
@@ -520,7 +525,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
           prompt: req.body.prompt,
           answers: req.body.answers,
           userId: req.user?.id || 'dev-user',
-          context: req.body.context || {}
+          context: req.body.context || {},
+          organizationId: req.organizationId || req.body.organizationId
         });
 
         // Record usage (only for authenticated users)
@@ -552,7 +558,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const result = await productionLLMOrchestrator.fixWorkflow({
           graph: req.body.graph,
           errors: req.body.errors,
-          userId: req.user!.id
+          userId: req.user!.id,
+          organizationId: req.organizationId || req.body.organizationId
         });
 
         // Record usage

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -1,0 +1,258 @@
+import { Router } from 'express';
+import { eq } from 'drizzle-orm';
+import { authenticateToken } from '../middleware/auth';
+import { authService, OrganizationPlan } from '../services/AuthService';
+import { getErrorMessage } from '../types/common';
+import { securityService } from '../services/SecurityService';
+import { db, organizationMembers, organizationInvites } from '../database/schema';
+
+const router = Router();
+
+router.use(authenticateToken);
+
+router.get('/', (req, res) => {
+  return res.json({
+    success: true,
+    organizations: req.organizations ?? [],
+    activeOrganizationId: req.organizationId ?? null,
+  });
+});
+
+router.post(
+  '/',
+  securityService.validateInput([
+    { field: 'name', type: 'string', required: true, maxLength: 255, sanitize: true },
+    { field: 'domain', type: 'string', required: false, maxLength: 255, sanitize: true },
+    {
+      field: 'plan',
+      type: 'string',
+      required: false,
+      allowedValues: ['starter', 'professional', 'enterprise', 'enterprise_plus'],
+    },
+    { field: 'makeDefault', type: 'boolean', required: false },
+  ]),
+  async (req, res) => {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ success: false, error: 'Authentication required' });
+      }
+
+      const plan = (req.body.plan || 'starter') as OrganizationPlan;
+      const result = await authService.createOrganization(req.user.id, {
+        name: req.body.name,
+        domain: req.body.domain,
+        plan,
+        makeDefault: req.body.makeDefault ?? true,
+      });
+
+      req.organizations = result.organizations;
+      req.organizationId = result.activeOrganizationId ?? null;
+      req.organizationRole = result.activeOrganization?.role;
+      req.organizationPermissions = result.activeOrganization?.permissions;
+      req.user.activeOrganizationId = result.activeOrganizationId ?? null;
+      req.user.organizationRole = result.activeOrganization?.role;
+      req.user.organizationPermissions = result.activeOrganization?.permissions;
+
+      return res.json({
+        success: true,
+        organizations: result.organizations,
+        activeOrganizationId: result.activeOrganizationId,
+        createdOrganization: result.createdOrganization,
+      });
+    } catch (error) {
+      const message = getErrorMessage(error);
+      return res.status(400).json({ success: false, error: message });
+    }
+  }
+);
+
+router.post('/:organizationId/activate', async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+
+    const token = req.headers.authorization?.split(' ')[1];
+    if (!token) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+
+    const result = await authService.setActiveOrganization(req.user.id, token, req.params.organizationId);
+
+    req.organizations = result.organizations;
+    req.organizationId = result.activeOrganizationId ?? null;
+    req.organizationRole = result.activeOrganization?.role;
+    req.organizationPermissions = result.activeOrganization?.permissions;
+    req.user.activeOrganizationId = result.activeOrganizationId ?? null;
+    req.user.organizationRole = result.activeOrganization?.role;
+    req.user.organizationPermissions = result.activeOrganization?.permissions;
+
+    return res.json({
+      success: true,
+      organizations: result.organizations,
+      activeOrganizationId: result.activeOrganizationId,
+    });
+  } catch (error) {
+    const message = getErrorMessage(error);
+    return res.status(400).json({ success: false, error: message });
+  }
+});
+
+router.post(
+  '/:organizationId/invite',
+  securityService.validateInput([
+    { field: 'email', type: 'email', required: true, sanitize: true },
+    {
+      field: 'role',
+      type: 'string',
+      required: false,
+      allowedValues: ['owner', 'admin', 'member', 'viewer'],
+    },
+    { field: 'expiresInDays', type: 'number', required: false, min: 1, max: 90 },
+  ]),
+  async (req, res) => {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ success: false, error: 'Authentication required' });
+      }
+
+      const membership = (req.organizations || []).find((org) => org.id === req.params.organizationId);
+      if (!membership) {
+        return res.status(403).json({ success: false, error: 'Not a member of this organization' });
+      }
+      if (!membership.permissions.canManageUsers) {
+        return res.status(403).json({ success: false, error: 'Insufficient permissions' });
+      }
+
+      const invite = await authService.inviteToOrganization(req.user.id, req.params.organizationId, {
+        email: req.body.email,
+        role: req.body.role,
+        expiresInDays: req.body.expiresInDays,
+        metadata: req.body.metadata,
+      });
+
+      return res.json({ success: true, invite });
+    } catch (error) {
+      const message = getErrorMessage(error);
+      return res.status(400).json({ success: false, error: message });
+    }
+  }
+);
+
+router.post('/:organizationId/invites/:inviteId/revoke', async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+
+    const membership = (req.organizations || []).find((org) => org.id === req.params.organizationId);
+    if (!membership) {
+      return res.status(403).json({ success: false, error: 'Not a member of this organization' });
+    }
+    if (!membership.permissions.canManageUsers) {
+      return res.status(403).json({ success: false, error: 'Insufficient permissions' });
+    }
+
+    await authService.revokeInvite(req.user.id, req.params.organizationId, req.params.inviteId);
+    return res.json({ success: true });
+  } catch (error) {
+    const message = getErrorMessage(error);
+    return res.status(400).json({ success: false, error: message });
+  }
+});
+
+router.delete('/:organizationId/members/:membershipId', async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+
+    const membership = (req.organizations || []).find((org) => org.id === req.params.organizationId);
+    if (!membership) {
+      return res.status(403).json({ success: false, error: 'Not a member of this organization' });
+    }
+    if (!membership.permissions.canManageUsers) {
+      return res.status(403).json({ success: false, error: 'Insufficient permissions' });
+    }
+
+    await authService.removeMember(req.user.id, req.params.organizationId, req.params.membershipId);
+    const organizations = await authService.listUserOrganizations(req.user.id);
+    req.organizations = organizations;
+    req.organizationId = organizations.find((org) => org.isDefault)?.id ?? req.organizationId ?? null;
+    req.user.activeOrganizationId = req.organizationId ?? null;
+    req.organizationRole = organizations.find((org) => org.id === req.organizationId)?.role;
+    req.organizationPermissions = organizations.find((org) => org.id === req.organizationId)?.permissions;
+
+    return res.json({ success: true });
+  } catch (error) {
+    const message = getErrorMessage(error);
+    return res.status(400).json({ success: false, error: message });
+  }
+});
+
+router.get('/:organizationId/members', async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+
+    const membership = (req.organizations || []).find((org) => org.id === req.params.organizationId);
+    if (!membership) {
+      return res.status(403).json({ success: false, error: 'Not a member of this organization' });
+    }
+
+    const members = await db
+      .select({
+        id: organizationMembers.id,
+        userId: organizationMembers.userId,
+        email: organizationMembers.email,
+        firstName: organizationMembers.firstName,
+        lastName: organizationMembers.lastName,
+        role: organizationMembers.role,
+        status: organizationMembers.status,
+        mfaEnabled: organizationMembers.mfaEnabled,
+        isDefault: organizationMembers.isDefault,
+        lastLoginAt: organizationMembers.lastLoginAt,
+      })
+      .from(organizationMembers)
+      .where(eq(organizationMembers.organizationId, req.params.organizationId));
+
+    return res.json({ success: true, members });
+  } catch (error) {
+    const message = getErrorMessage(error);
+    return res.status(400).json({ success: false, error: message });
+  }
+});
+
+router.get('/:organizationId/invites', async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+
+    const membership = (req.organizations || []).find((org) => org.id === req.params.organizationId);
+    if (!membership) {
+      return res.status(403).json({ success: false, error: 'Not a member of this organization' });
+    }
+
+    const invites = await db
+      .select({
+        id: organizationInvites.id,
+        email: organizationInvites.email,
+        role: organizationInvites.role,
+        status: organizationInvites.status,
+        expiresAt: organizationInvites.expiresAt,
+        createdAt: organizationInvites.createdAt,
+        revokedAt: organizationInvites.revokedAt,
+      })
+      .from(organizationInvites)
+      .where(eq(organizationInvites.organizationId, req.params.organizationId));
+
+    return res.json({ success: true, invites });
+  } catch (error) {
+    const message = getErrorMessage(error);
+    return res.status(400).json({ success: false, error: message });
+  }
+});
+
+export default router;

--- a/server/services/AuthService.ts
+++ b/server/services/AuthService.ts
@@ -1,5 +1,12 @@
-import { eq, and } from 'drizzle-orm';
-import { users, sessions, db } from '../database/schema';
+import { eq, and, count } from 'drizzle-orm';
+import {
+  users,
+  sessions,
+  organizations,
+  organizationMembers,
+  organizationInvites,
+  db
+} from '../database/schema';
 import { EncryptionService } from './EncryptionService';
 import { JWTPayload } from '../types/common';
 
@@ -14,6 +21,42 @@ export interface LoginRequest {
   password: string;
 }
 
+export type OrganizationPlan = 'starter' | 'professional' | 'enterprise' | 'enterprise_plus';
+
+export interface OrganizationPermissions {
+  canCreateWorkflows: boolean;
+  canEditWorkflows: boolean;
+  canDeleteWorkflows: boolean;
+  canManageUsers: boolean;
+  canViewAnalytics: boolean;
+  canManageBilling: boolean;
+  canAccessApi: boolean;
+}
+
+export interface OrganizationSummary {
+  id: string;
+  name: string;
+  domain?: string | null;
+  plan: OrganizationPlan;
+  status: string;
+  role: string;
+  isDefault: boolean;
+  limits: {
+    workflows: number;
+    executions: number;
+    apiCalls: number;
+    users: number;
+    storage: number;
+  };
+  usage: {
+    apiCalls: number;
+    workflowExecutions: number;
+    storage: number;
+    usersActive: number;
+  };
+  permissions: OrganizationPermissions;
+}
+
 export interface AuthResponse {
   success: boolean;
   user?: {
@@ -25,7 +68,12 @@ export interface AuthResponse {
     emailVerified: boolean;
     quotaApiCalls: number;
     quotaTokens: number;
+    activeOrganizationId: string | null;
+    organizationRole?: string;
+    organizationPermissions?: OrganizationPermissions;
   };
+  organizations?: OrganizationSummary[];
+  activeOrganizationId?: string | null;
   token?: string;
   refreshToken?: string;
   expiresAt?: Date;
@@ -45,16 +93,635 @@ export interface AuthUser {
   quotaApiCalls: number;
   quotaTokens: number;
   createdAt: Date;
+  activeOrganizationId?: string | null;
+  organizationRole?: string;
+  organizationPermissions?: OrganizationPermissions;
+  organizations?: OrganizationSummary[];
 }
 
 export class AuthService {
   private db: any;
+
+  private static readonly PLAN_LIMITS: Record<OrganizationPlan, {
+    workflows: number;
+    executions: number;
+    apiCalls: number;
+    users: number;
+    storage: number;
+  }> = {
+    starter: { workflows: 25, executions: 1000, apiCalls: 10000, users: 5, storage: 1024 },
+    professional: { workflows: 100, executions: 10000, apiCalls: 100000, users: 25, storage: 10240 },
+    enterprise: { workflows: 250, executions: 50000, apiCalls: 500000, users: 250, storage: 51200 },
+    enterprise_plus: { workflows: 1000, executions: 200000, apiCalls: 2000000, users: 1000, storage: 204800 },
+  };
+
+  private static readonly PLAN_FEATURES: Record<OrganizationPlan, {
+    ssoEnabled: boolean;
+    auditLogging: boolean;
+    customBranding: boolean;
+    advancedAnalytics: boolean;
+    prioritySupport: boolean;
+    customIntegrations: boolean;
+    onPremiseDeployment: boolean;
+    dedicatedInfrastructure: boolean;
+  }> = {
+    starter: {
+      ssoEnabled: false,
+      auditLogging: false,
+      customBranding: false,
+      advancedAnalytics: false,
+      prioritySupport: false,
+      customIntegrations: false,
+      onPremiseDeployment: false,
+      dedicatedInfrastructure: false,
+    },
+    professional: {
+      ssoEnabled: true,
+      auditLogging: true,
+      customBranding: true,
+      advancedAnalytics: true,
+      prioritySupport: true,
+      customIntegrations: false,
+      onPremiseDeployment: false,
+      dedicatedInfrastructure: false,
+    },
+    enterprise: {
+      ssoEnabled: true,
+      auditLogging: true,
+      customBranding: true,
+      advancedAnalytics: true,
+      prioritySupport: true,
+      customIntegrations: true,
+      onPremiseDeployment: false,
+      dedicatedInfrastructure: true,
+    },
+    enterprise_plus: {
+      ssoEnabled: true,
+      auditLogging: true,
+      customBranding: true,
+      advancedAnalytics: true,
+      prioritySupport: true,
+      customIntegrations: true,
+      onPremiseDeployment: true,
+      dedicatedInfrastructure: true,
+    },
+  };
+
+  private static readonly DEFAULT_SECURITY = {
+    ipWhitelist: [] as string[],
+    mfaRequired: false,
+    sessionTimeout: 480,
+    passwordPolicy: {
+      minLength: 8,
+      requireSpecialChars: true,
+      requireNumbers: true,
+      requireUppercase: true,
+    },
+    apiKeyRotationDays: 90,
+  };
+
+  private static readonly DEFAULT_COMPLIANCE = {
+    gdprEnabled: true,
+    hipaaCompliant: false,
+    soc2Type2: false,
+    dataResidency: 'us' as const,
+    retentionPolicyDays: 2555,
+  };
+
+  private static readonly OWNER_PERMISSIONS: OrganizationPermissions = {
+    canCreateWorkflows: true,
+    canEditWorkflows: true,
+    canDeleteWorkflows: true,
+    canManageUsers: true,
+    canViewAnalytics: true,
+    canManageBilling: true,
+    canAccessApi: true,
+  };
+
+  private static readonly MEMBER_PERMISSIONS: OrganizationPermissions = {
+    canCreateWorkflows: true,
+    canEditWorkflows: true,
+    canDeleteWorkflows: false,
+    canManageUsers: false,
+    canViewAnalytics: true,
+    canManageBilling: false,
+    canAccessApi: true,
+  };
 
   constructor() {
     this.db = db;
     if (!this.db && process.env.NODE_ENV !== 'development') {
       throw new Error('Database connection not available');
     }
+  }
+
+  private static sanitizePermissions(permissions?: OrganizationPermissions | null): OrganizationPermissions {
+    return {
+      canCreateWorkflows: permissions?.canCreateWorkflows ?? false,
+      canEditWorkflows: permissions?.canEditWorkflows ?? false,
+      canDeleteWorkflows: permissions?.canDeleteWorkflows ?? false,
+      canManageUsers: permissions?.canManageUsers ?? false,
+      canViewAnalytics: permissions?.canViewAnalytics ?? false,
+      canManageBilling: permissions?.canManageBilling ?? false,
+      canAccessApi: permissions?.canAccessApi ?? false,
+    };
+  }
+
+  private static getPlanLimits(plan: OrganizationPlan) {
+    return this.PLAN_LIMITS[plan] ?? this.PLAN_LIMITS.starter;
+  }
+
+  private static getPlanFeatures(plan: OrganizationPlan) {
+    return this.PLAN_FEATURES[plan] ?? this.PLAN_FEATURES.starter;
+  }
+
+  private static getDefaultBranding(name: string, domain?: string | null) {
+    return {
+      companyName: name,
+      supportEmail: domain ? `support@${domain}` : undefined,
+    };
+  }
+
+  private static getDefaultPermissionsForRole(role: string): OrganizationPermissions {
+    if (role === 'owner' || role === 'admin') {
+      return this.OWNER_PERMISSIONS;
+    }
+    return this.MEMBER_PERMISSIONS;
+  }
+
+  private static generateSubdomain(companyName: string): string {
+    const base = companyName
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, '')
+      .substring(0, 20);
+
+    const fallback = base || 'org';
+    return `${fallback}-${Math.random().toString(36).substring(2, 8)}`;
+  }
+
+  private static getTrialEndDate(): Date {
+    return new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+  }
+
+  private async getUserOrganizations(userId: string): Promise<OrganizationSummary[]> {
+    if (!this.db) {
+      return [];
+    }
+
+    const rows = await this.db
+      .select({
+        id: organizations.id,
+        name: organizations.name,
+        domain: organizations.domain,
+        plan: organizations.plan,
+        status: organizations.status,
+        usageApiCalls: organizations.usageApiCalls,
+        usageWorkflowExecutions: organizations.usageWorkflowExecutions,
+        usageStorageUsed: organizations.usageStorageUsed,
+        usageUsersActive: organizations.usageUsersActive,
+        limitWorkflows: organizations.limitWorkflows,
+        limitExecutions: organizations.limitExecutions,
+        limitApiCalls: organizations.limitApiCalls,
+        limitUsers: organizations.limitUsers,
+        limitStorage: organizations.limitStorage,
+        role: organizationMembers.role,
+        permissions: organizationMembers.permissions,
+        isDefault: organizationMembers.isDefault,
+      })
+      .from(organizationMembers)
+      .innerJoin(organizations, eq(organizationMembers.organizationId, organizations.id))
+      .where(eq(organizationMembers.userId, userId));
+
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      domain: row.domain,
+      plan: (row.plan as OrganizationPlan) ?? 'starter',
+      status: row.status,
+      role: row.role,
+      isDefault: Boolean(row.isDefault),
+      limits: {
+        workflows: Number(row.limitWorkflows ?? 0),
+        executions: Number(row.limitExecutions ?? 0),
+        apiCalls: Number(row.limitApiCalls ?? 0),
+        users: Number(row.limitUsers ?? 0),
+        storage: Number(row.limitStorage ?? 0),
+      },
+      usage: {
+        apiCalls: Number(row.usageApiCalls ?? 0),
+        workflowExecutions: Number(row.usageWorkflowExecutions ?? 0),
+        storage: Number(row.usageStorageUsed ?? 0),
+        usersActive: Number(row.usageUsersActive ?? 0),
+      },
+      permissions: AuthService.sanitizePermissions(row.permissions as OrganizationPermissions),
+    }));
+  }
+
+  private async ensureDefaultOrganization(
+    userId: string,
+    email: string,
+    displayName?: string | null
+  ): Promise<{ organizations: OrganizationSummary[]; activeOrganizationId: string | null; activeOrganization?: OrganizationSummary }>
+  {
+    let organizations = await this.getUserOrganizations(userId);
+
+    if (organizations.length === 0) {
+      const [localPart, domain] = email.split('@');
+      const workspaceName = displayName
+        ? `${displayName}'s Workspace`
+        : `${localPart || 'workspace'} Team`;
+
+      const creation = await this.createOrganizationForUser(userId, {
+        name: workspaceName,
+        domain: domain || null,
+        plan: 'starter',
+        ownerEmail: email,
+        ownerName: displayName ?? null,
+        setDefault: true,
+      });
+      organizations = creation.organizations;
+    }
+
+    const activeOrganization = organizations.find((org) => org.isDefault) ?? organizations[0];
+
+    return {
+      organizations,
+      activeOrganizationId: activeOrganization ? activeOrganization.id : null,
+      activeOrganization,
+    };
+  }
+
+  private async createOrganizationForUser(
+    userId: string,
+    params: {
+      name: string;
+      domain?: string | null;
+      plan?: OrganizationPlan;
+      ownerEmail: string;
+      ownerName?: string | null;
+      setDefault?: boolean;
+    }
+  ): Promise<{ organizations: OrganizationSummary[]; createdOrganization?: OrganizationSummary }>
+  {
+    if (!this.db) {
+      return { organizations: [] };
+    }
+
+    const plan = params.plan ?? 'starter';
+    const limits = AuthService.getPlanLimits(plan);
+    const features = { ...AuthService.getPlanFeatures(plan) };
+    const security = {
+      ...AuthService.DEFAULT_SECURITY,
+      ipWhitelist: [...AuthService.DEFAULT_SECURITY.ipWhitelist],
+      passwordPolicy: { ...AuthService.DEFAULT_SECURITY.passwordPolicy },
+    };
+    const compliance = { ...AuthService.DEFAULT_COMPLIANCE };
+    const branding = AuthService.getDefaultBranding(params.name, params.domain ?? null);
+    const trialEndsAt = AuthService.getTrialEndDate();
+    const billingPeriodStart = new Date();
+    const billingPeriodEnd = AuthService.getTrialEndDate();
+
+    const [organization] = await this.db
+      .insert(organizations)
+      .values({
+        ownerId: userId,
+        name: params.name,
+        domain: params.domain ?? null,
+        subdomain: AuthService.generateSubdomain(params.name),
+        plan,
+        status: 'trial',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        trialEndsAt,
+        billingCustomerId: '',
+        billingSubscriptionId: '',
+        billingPeriodStart,
+        billingPeriodEnd,
+        usageWorkflowExecutions: 0,
+        usageApiCalls: 0,
+        usageStorageUsed: 0,
+        usageUsersActive: 1,
+        limitWorkflows: limits.workflows,
+        limitExecutions: limits.executions,
+        limitApiCalls: limits.apiCalls,
+        limitUsers: limits.users,
+        limitStorage: limits.storage,
+        features,
+        security,
+        branding,
+        compliance,
+        metadata: {
+          provisionedBy: 'auth_service',
+          createdBy: userId,
+        },
+      })
+      .returning({ id: organizations.id });
+
+    if (!organization) {
+      const organizations = await this.getUserOrganizations(userId);
+      return { organizations };
+    }
+
+    if (params.setDefault !== false) {
+      await this.db
+        .update(organizationMembers)
+        .set({ isDefault: false, updatedAt: new Date() })
+        .where(eq(organizationMembers.userId, userId));
+    }
+
+    const nameParts = (params.ownerName || '').trim().split(/\s+/).filter(Boolean);
+    const [firstName, ...rest] = nameParts;
+    const lastName = rest.length ? rest.join(' ') : null;
+
+    await this.db.insert(organizationMembers).values({
+      organizationId: organization.id,
+      userId,
+      email: params.ownerEmail.toLowerCase(),
+      firstName: firstName || null,
+      lastName: lastName || null,
+      role: 'owner',
+      status: 'active',
+      permissions: AuthService.OWNER_PERMISSIONS,
+      invitedBy: userId,
+      lastLoginAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      mfaEnabled: false,
+      isDefault: params.setDefault !== false,
+    });
+
+    const organizations = await this.getUserOrganizations(userId);
+    const createdOrganization = organizations.find((org) => org.id === organization.id);
+
+    return { organizations, createdOrganization };
+  }
+
+  public async createOrganization(
+    userId: string,
+    payload: { name: string; domain?: string | null; plan?: OrganizationPlan; makeDefault?: boolean }
+  ): Promise<{
+    organizations: OrganizationSummary[];
+    activeOrganizationId: string | null;
+    activeOrganization?: OrganizationSummary;
+    createdOrganization?: OrganizationSummary;
+  }>
+  {
+    const user = await this.getUserById(userId);
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    const name = payload.name?.trim();
+    if (!name) {
+      throw new Error('Organization name is required');
+    }
+
+    const creation = await this.createOrganizationForUser(userId, {
+      name,
+      domain: payload.domain ?? null,
+      plan: payload.plan ?? 'starter',
+      ownerEmail: user.email,
+      ownerName: user.name ?? null,
+      setDefault: payload.makeDefault ?? true,
+    });
+
+    const organizations = creation.organizations;
+
+    const activeOrganization = organizations.find((org) => org.isDefault) ?? organizations[0];
+
+    return {
+      organizations,
+      activeOrganizationId: activeOrganization ? activeOrganization.id : null,
+      activeOrganization,
+      createdOrganization: creation.createdOrganization,
+    };
+  }
+
+  private async getOrganizationMembership(userId: string, organizationId: string) {
+    const [membership] = await this.db
+      .select({
+        id: organizationMembers.id,
+        role: organizationMembers.role,
+        permissions: organizationMembers.permissions,
+        status: organizationMembers.status,
+        isDefault: organizationMembers.isDefault,
+      })
+      .from(organizationMembers)
+      .where(and(
+        eq(organizationMembers.userId, userId),
+        eq(organizationMembers.organizationId, organizationId)
+      ));
+
+    return membership;
+  }
+
+  private async getOrganizationById(organizationId: string) {
+    const [organization] = await this.db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.id, organizationId));
+
+    return organization;
+  }
+
+  public async setActiveOrganization(
+    userId: string,
+    sessionToken: string,
+    organizationId: string
+  ): Promise<{ organizations: OrganizationSummary[]; activeOrganizationId: string | null; activeOrganization?: OrganizationSummary }>
+  {
+    const membership = await this.getOrganizationMembership(userId, organizationId);
+    if (!membership) {
+      throw new Error('Not a member of this organization');
+    }
+
+    await this.db
+      .update(organizationMembers)
+      .set({ isDefault: false, updatedAt: new Date() })
+      .where(eq(organizationMembers.userId, userId));
+
+    await this.db
+      .update(organizationMembers)
+      .set({ isDefault: true, status: 'active', updatedAt: new Date() })
+      .where(and(
+        eq(organizationMembers.userId, userId),
+        eq(organizationMembers.organizationId, organizationId)
+      ));
+
+    await this.db
+      .update(sessions)
+      .set({ organizationId, lastUsed: new Date() })
+      .where(and(
+        eq(sessions.userId, userId),
+        eq(sessions.token, sessionToken),
+        eq(sessions.isActive, true)
+      ));
+
+    const organizations = await this.getUserOrganizations(userId);
+    const activeOrganization = organizations.find((org) => org.id === organizationId) ?? organizations[0];
+
+    return {
+      organizations,
+      activeOrganizationId: activeOrganization ? activeOrganization.id : null,
+      activeOrganization,
+    };
+  }
+
+  public async inviteToOrganization(
+    userId: string,
+    organizationId: string,
+    payload: { email: string; role?: string; expiresInDays?: number; metadata?: Record<string, any> }
+  )
+    : Promise<{ id: string; email: string; role: string; status: string; token: string; expiresAt: Date }>
+  {
+    const membership = await this.getOrganizationMembership(userId, organizationId);
+    if (!membership) {
+      throw new Error('Not a member of this organization');
+    }
+
+    const permissions = AuthService.sanitizePermissions(membership.permissions as OrganizationPermissions);
+    if (!permissions.canManageUsers) {
+      throw new Error('Insufficient permissions to invite members');
+    }
+
+    const organization = await this.getOrganizationById(organizationId);
+    if (!organization) {
+      throw new Error('Organization not found');
+    }
+
+    const [{ memberCount }] = await this.db
+      .select({ memberCount: count() })
+      .from(organizationMembers)
+      .where(eq(organizationMembers.organizationId, organizationId));
+
+    const [{ pendingInvites }] = await this.db
+      .select({ pendingInvites: count() })
+      .from(organizationInvites)
+      .where(and(
+        eq(organizationInvites.organizationId, organizationId),
+        eq(organizationInvites.status, 'pending')
+      ));
+
+    const totalSeats = Number(memberCount ?? 0) + Number(pendingInvites ?? 0);
+    if (totalSeats >= Number(organization.limitUsers ?? 0)) {
+      throw new Error('Organization user limit reached for current plan');
+    }
+
+    const token = EncryptionService.generateSecureId(48);
+    const expiresInDays = payload.expiresInDays ?? 14;
+    const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000);
+
+    const [invite] = await this.db
+      .insert(organizationInvites)
+      .values({
+        organizationId,
+        email: payload.email.toLowerCase(),
+        role: payload.role ?? 'member',
+        status: 'pending',
+        invitedBy: userId,
+        token,
+        expiresAt,
+        metadata: payload.metadata ?? {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .returning({
+        id: organizationInvites.id,
+        email: organizationInvites.email,
+        role: organizationInvites.role,
+        status: organizationInvites.status,
+        token: organizationInvites.token,
+        expiresAt: organizationInvites.expiresAt,
+      });
+
+    return {
+      id: invite.id,
+      email: invite.email,
+      role: invite.role,
+      status: invite.status,
+      token: invite.token,
+      expiresAt: invite.expiresAt,
+    };
+  }
+
+  public async revokeInvite(
+    userId: string,
+    organizationId: string,
+    inviteId: string
+  ): Promise<void>
+  {
+    const membership = await this.getOrganizationMembership(userId, organizationId);
+    if (!membership) {
+      throw new Error('Not a member of this organization');
+    }
+
+    const permissions = AuthService.sanitizePermissions(membership.permissions as OrganizationPermissions);
+    if (!permissions.canManageUsers) {
+      throw new Error('Insufficient permissions to manage invites');
+    }
+
+    await this.db
+      .update(organizationInvites)
+      .set({ status: 'revoked', revokedAt: new Date(), updatedAt: new Date() })
+      .where(and(
+        eq(organizationInvites.organizationId, organizationId),
+        eq(organizationInvites.id, inviteId)
+      ));
+  }
+
+  public async removeMember(
+    userId: string,
+    organizationId: string,
+    membershipId: string
+  ): Promise<void>
+  {
+    const actingMembership = await this.getOrganizationMembership(userId, organizationId);
+    if (!actingMembership) {
+      throw new Error('Not a member of this organization');
+    }
+
+    const permissions = AuthService.sanitizePermissions(actingMembership.permissions as OrganizationPermissions);
+    if (!permissions.canManageUsers) {
+      throw new Error('Insufficient permissions to remove members');
+    }
+
+    const [targetMembership] = await this.db
+      .select({
+        id: organizationMembers.id,
+        userId: organizationMembers.userId,
+        role: organizationMembers.role,
+      })
+      .from(organizationMembers)
+      .where(and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizationMembers.id, membershipId)
+      ));
+
+    if (!targetMembership) {
+      throw new Error('Member not found');
+    }
+
+    // Prevent removing the last owner
+    if (targetMembership.role === 'owner') {
+      const [{ ownerCount }] = await this.db
+        .select({ ownerCount: count() })
+        .from(organizationMembers)
+        .where(and(
+          eq(organizationMembers.organizationId, organizationId),
+          eq(organizationMembers.role, 'owner')
+        ));
+
+      if (Number(ownerCount ?? 0) <= 1) {
+        throw new Error('Cannot remove the last owner from the organization');
+      }
+    }
+
+    await this.db
+      .delete(organizationMembers)
+      .where(and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizationMembers.id, membershipId)
+      ));
   }
 
   /**
@@ -117,14 +784,27 @@ export class AuthService {
         quotaTokens: users.quotaTokens,
       });
 
+      const { organizations, activeOrganizationId, activeOrganization } = await this.ensureDefaultOrganization(
+        newUser.id,
+        newUser.email,
+        newUser.name
+      );
+
       // Generate tokens
-      const { token, refreshToken, expiresAt } = await this.generateTokens(newUser.id);
+      const { token, refreshToken, expiresAt } = await this.generateTokens(newUser.id, activeOrganizationId);
 
       console.log(`✅ User registered successfully: ${newUser.id}`);
 
       return {
         success: true,
-        user: newUser,
+        user: {
+          ...newUser,
+          activeOrganizationId,
+          organizationRole: activeOrganization?.role,
+          organizationPermissions: activeOrganization?.permissions,
+        },
+        organizations,
+        activeOrganizationId,
         token,
         refreshToken,
         expiresAt
@@ -179,8 +859,14 @@ export class AuthService {
       // Update last login
       await this.updateLastLogin(user.id);
 
+      const { organizations, activeOrganizationId, activeOrganization } = await this.ensureDefaultOrganization(
+        user.id,
+        user.email,
+        user.name
+      );
+
       // Generate tokens
-      const { token, refreshToken, expiresAt } = await this.generateTokens(user.id);
+      const { token, refreshToken, expiresAt } = await this.generateTokens(user.id, activeOrganizationId);
 
       console.log(`✅ Login successful: ${user.id}`);
 
@@ -195,7 +881,12 @@ export class AuthService {
           emailVerified: user.emailVerified,
           quotaApiCalls: user.quotaApiCalls,
           quotaTokens: user.quotaTokens,
+          activeOrganizationId,
+          organizationRole: activeOrganization?.role,
+          organizationPermissions: activeOrganization?.permissions,
         },
+        organizations,
+        activeOrganizationId,
         token,
         refreshToken,
         expiresAt
@@ -253,8 +944,14 @@ export class AuthService {
         };
       }
 
+      const { organizations, activeOrganizationId, activeOrganization } = await this.ensureDefaultOrganization(
+        user.id,
+        user.email,
+        user.name
+      );
+
       // Generate new tokens
-      const tokens = await this.generateTokens(user.id);
+      const tokens = await this.generateTokens(user.id, activeOrganizationId);
 
       return {
         success: true,
@@ -267,7 +964,12 @@ export class AuthService {
           emailVerified: user.emailVerified,
           quotaApiCalls: user.quotaApiCalls,
           quotaTokens: user.quotaTokens,
+          activeOrganizationId,
+          organizationRole: activeOrganization?.role,
+          organizationPermissions: activeOrganization?.permissions,
         },
+        organizations,
+        activeOrganizationId,
         token: tokens.token,
         refreshToken: tokens.refreshToken,
         expiresAt: tokens.expiresAt
@@ -302,7 +1004,7 @@ export class AuthService {
     try {
       // Verify JWT
       const payload = EncryptionService.verifyJWT(token);
-      
+
       // Check if session is active
       const [session] = await this.db
         .select()
@@ -328,10 +1030,37 @@ export class AuthService {
         return null;
       }
 
+      const { organizations, activeOrganizationId, activeOrganization } = await this.ensureDefaultOrganization(
+        user.id,
+        user.email,
+        user.name
+      );
+
+      let resolvedOrganizationId = session.organizationId ?? activeOrganizationId;
+      let resolvedOrganization = organizations.find((org) => org.id === resolvedOrganizationId) ?? activeOrganization;
+
+      if (resolvedOrganizationId && !resolvedOrganization) {
+        resolvedOrganization = activeOrganization;
+        resolvedOrganizationId = activeOrganizationId ?? null;
+      }
+
+      if (resolvedOrganizationId !== session.organizationId) {
+        await this.db
+          .update(sessions)
+          .set({ organizationId: resolvedOrganizationId ?? null, lastUsed: new Date() })
+          .where(eq(sessions.id, session.id));
+      }
+
       // Update last used
       await this.updateSessionLastUsed(token);
 
-      return user;
+      return {
+        ...user,
+        activeOrganizationId: resolvedOrganization ? resolvedOrganization.id : null,
+        organizationRole: resolvedOrganization?.role,
+        organizationPermissions: resolvedOrganization?.permissions,
+        organizations,
+      } as AuthUser;
 
     } catch (error) {
       console.error('❌ Token verification error:', error);
@@ -366,7 +1095,7 @@ export class AuthService {
   /**
    * Generate JWT and refresh tokens
    */
-  private async generateTokens(userId: string): Promise<{
+  private async generateTokens(userId: string, organizationId?: string | null): Promise<{
     token: string;
     refreshToken: string;
     expiresAt: Date;
@@ -389,7 +1118,8 @@ export class AuthService {
       userId,
       email: user.email,
       role: user.role,
-      plan: user.plan
+      plan: user.plan,
+      organizationId: organizationId ?? undefined,
     }, '24h');
     const refreshToken = EncryptionService.generateRefreshToken();
     const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days
@@ -397,6 +1127,7 @@ export class AuthService {
     // Store session
     await this.db.insert(sessions).values({
       userId,
+      organizationId: organizationId ?? null,
       token,
       refreshToken,
       expiresAt,
@@ -438,7 +1169,7 @@ export class AuthService {
     await this.db
       .update(sessions)
       .set({
-        lastUsedAt: new Date(),
+        lastUsed: new Date(),
       })
       .where(eq(sessions.token, token));
   }
@@ -477,30 +1208,70 @@ export class AuthService {
   /**
    * Check if user has quota remaining
    */
-  public async checkQuota(userId: string, apiCalls: number = 1, tokens: number = 0): Promise<{
+  public async checkQuota(
+    userId: string,
+    apiCalls: number = 1,
+    tokens: number = 0,
+    organizationId?: string | null
+  ): Promise<{
     hasQuota: boolean;
     quotaExceeded: 'api_calls' | 'tokens' | null;
+    organizationQuotaExceeded: 'api_calls' | 'executions' | null;
   }> {
     const user = await this.getUserById(userId);
     if (!user) {
-      return { hasQuota: false, quotaExceeded: null };
+      return { hasQuota: false, quotaExceeded: null, organizationQuotaExceeded: null };
     }
 
     if (user.monthlyApiCalls + apiCalls > user.quotaApiCalls) {
-      return { hasQuota: false, quotaExceeded: 'api_calls' };
+      return { hasQuota: false, quotaExceeded: 'api_calls', organizationQuotaExceeded: null };
     }
 
     if (user.monthlyTokensUsed + tokens > user.quotaTokens) {
-      return { hasQuota: false, quotaExceeded: 'tokens' };
+      return { hasQuota: false, quotaExceeded: 'tokens', organizationQuotaExceeded: null };
     }
 
-    return { hasQuota: true, quotaExceeded: null };
+    let organizationQuotaExceeded: 'api_calls' | 'executions' | null = null;
+
+    if (organizationId) {
+      const organization = await this.getOrganizationById(organizationId);
+      if (!organization) {
+        return { hasQuota: false, quotaExceeded: null, organizationQuotaExceeded: 'api_calls' };
+      }
+
+      const usageApiCalls = Number(organization.usageApiCalls ?? 0);
+      const limitApiCalls = Number(organization.limitApiCalls ?? 0);
+      const usageExecutions = Number(organization.usageWorkflowExecutions ?? 0);
+      const limitExecutions = Number(organization.limitExecutions ?? 0);
+
+      if (limitApiCalls > 0 && usageApiCalls + apiCalls > limitApiCalls) {
+        organizationQuotaExceeded = 'api_calls';
+      } else if (limitExecutions > 0 && usageExecutions + 1 > limitExecutions) {
+        organizationQuotaExceeded = 'executions';
+      }
+
+      if (organizationQuotaExceeded) {
+        return { hasQuota: false, quotaExceeded: null, organizationQuotaExceeded };
+      }
+    }
+
+    return { hasQuota: true, quotaExceeded: null, organizationQuotaExceeded };
+  }
+
+  public async listUserOrganizations(userId: string): Promise<OrganizationSummary[]> {
+    return this.getUserOrganizations(userId);
   }
 
   /**
    * Update usage metrics
    */
-  public async updateUsage(userId: string, apiCalls: number = 0, tokens: number = 0): Promise<void> {
+  public async updateUsage(
+    userId: string,
+    apiCalls: number = 0,
+    tokens: number = 0,
+    organizationId?: string | null,
+    workflowExecutions: number = 0
+  ): Promise<void> {
     await this.db
       .update(users)
       .set({
@@ -509,6 +1280,17 @@ export class AuthService {
         updatedAt: new Date(),
       })
       .where(eq(users.id, userId));
+
+    if (organizationId) {
+      await this.db
+        .update(organizations)
+        .set({
+          usageApiCalls: organizations.usageApiCalls + apiCalls,
+          usageWorkflowExecutions: organizations.usageWorkflowExecutions + workflowExecutions,
+          updatedAt: new Date(),
+        })
+        .where(eq(organizations.id, organizationId));
+    }
   }
 }
 

--- a/server/workflowAPI.ts
+++ b/server/workflowAPI.ts
@@ -56,7 +56,14 @@ export class WorkflowAPI {
       }
 
       console.log('🤔 Clarifying intent for:', request.prompt);
-      
+
+      if (!request.userId && req.user) {
+        request.userId = req.user.id;
+      }
+      if (!request.organizationId && req.organizationId) {
+        request.organizationId = req.organizationId;
+      }
+
       const response = await this.orchestrator.clarifyIntent(request);
       
       res.json({
@@ -91,7 +98,14 @@ export class WorkflowAPI {
       }
 
       console.log('📋 Planning workflow for:', request.prompt);
-      
+
+      if (!request.userId && req.user) {
+        request.userId = req.user.id;
+      }
+      if (!request.organizationId && req.organizationId) {
+        request.organizationId = req.organizationId;
+      }
+
       const response = await this.orchestrator.planWorkflow(request);
       
       // Validate the generated graph
@@ -144,7 +158,14 @@ export class WorkflowAPI {
       }
 
       console.log('🔧 Fixing workflow errors:', request.errors.length);
-      
+
+      if (!request.userId && req.user) {
+        request.userId = req.user.id;
+      }
+      if (!request.organizationId && req.organizationId) {
+        request.organizationId = req.organizationId;
+      }
+
       const response = await this.orchestrator.fixWorkflow(request);
       
       // Re-validate the fixed graph
@@ -174,12 +195,19 @@ export class WorkflowAPI {
   public generateCode = async (req: Request, res: Response) => {
     try {
       const request: CodegenRequest = req.body;
-      
+
       if (!request.graph) {
         return res.status(400).json({
           success: false,
           error: 'Graph is required'
         });
+      }
+
+      if (!request.userId && req.user) {
+        request.userId = req.user.id;
+      }
+      if (!request.organizationId && req.organizationId) {
+        request.organizationId = req.organizationId;
       }
 
       // Validate graph before compilation

--- a/shared/nodeGraphSchema.ts
+++ b/shared/nodeGraphSchema.ts
@@ -186,6 +186,8 @@ export interface Question {
 export interface ClarifyRequest {
   prompt: string;
   context?: any;
+  userId?: string;
+  organizationId?: string;
 }
 
 export interface ClarifyResponse {
@@ -201,6 +203,8 @@ export interface PlanRequest {
   prompt: string;
   answers?: Record<string, string>;
   capabilities: Capabilities;
+  userId?: string;
+  organizationId?: string;
 }
 
 export interface PlanResponse {
@@ -211,6 +215,8 @@ export interface PlanResponse {
 export interface FixRequest {
   graph: NodeGraph;
   errors: ValidationError[];
+  userId?: string;
+  organizationId?: string;
 }
 
 export interface FixResponse {
@@ -219,6 +225,8 @@ export interface FixResponse {
 
 export interface CodegenRequest {
   graph: NodeGraph;
+  userId?: string;
+  organizationId?: string;
 }
 
 export interface CodegenResponse {


### PR DESCRIPTION
## Summary
- add organization, membership, invite, and usage tables to the Drizzle schema and wire up relations in AuthService
- extend auth, middleware, and production orchestrator flows to track the active organization, enforce plan quotas, and expose organization CRUD routes
- persist workspace state on the client, add a workspace selector experience, and gate workflow tools on an active organization

## Testing
- `npm run check` *(fails: pre-existing TypeScript errors across server and client code)*

------
https://chatgpt.com/codex/tasks/task_e_68de32543c4c8331bc771c5545802b50