### PR TITLE
Add multi-tenant organization support to backend and workspace UI

### DIFF
--- a/client/src/components/workspaces/WorkspaceGate.tsx
+++ b/client/src/components/workspaces/WorkspaceGate.tsx
@@ -1,0 +1,273 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useAuthStore } from '@/store/authStore';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
+import { Loader2, Plus, Building2 } from 'lucide-react';
+
+interface WorkspaceGateProps {
+  children: React.ReactNode;
+}
+
+const WorkspaceGate = ({ children }: WorkspaceGateProps) => {
+  const {
+    user,
+    organizations,
+    activeOrganization,
+    activeOrganizationId,
+    refreshOrganizations,
+    selectOrganization,
+    createOrganization,
+  } = useAuthStore((state) => ({
+    user: state.user,
+    organizations: state.organizations,
+    activeOrganization: state.activeOrganization,
+    activeOrganizationId: state.activeOrganizationId,
+    refreshOrganizations: state.refreshOrganizations,
+    selectOrganization: state.selectOrganization,
+    createOrganization: state.createOrganization,
+  }));
+
+  const [loading, setLoading] = useState(false);
+  const [showCreate, setShowCreate] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newDomain, setNewDomain] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasOrganizations = useMemo(() => (organizations?.length || 0) > 0, [organizations]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!user) return;
+      try {
+        setLoading(true);
+        setError(null);
+        await refreshOrganizations();
+      } catch (err: any) {
+        setError(err?.message || 'Unable to load workspaces');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (user && !organizations) {
+      load();
+    }
+  }, [user, organizations, refreshOrganizations]);
+
+  if (!user) {
+    return (
+      <div className="flex h-full items-center justify-center bg-muted/30">
+        <Card className="w-full max-w-md shadow-sm">
+          <CardHeader>
+            <CardTitle>Sign in required</CardTitle>
+            <CardDescription>
+              You need to sign in to access workspaces and workflows.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+        <Loader2 className="h-6 w-6 animate-spin" />
+        <p>Loading workspaces…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle>Unable to load workspaces</CardTitle>
+            <CardDescription>{error}</CardDescription>
+          </CardHeader>
+          <CardFooter>
+            <Button onClick={() => { setError(null); refreshOrganizations().catch(() => null); }}>
+              Retry
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!hasOrganizations || !activeOrganizationId) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center bg-muted/30 p-4">
+        <Card className="w-full max-w-lg">
+          <CardHeader>
+            <CardTitle>{hasOrganizations ? 'Select a workspace' : 'Create your first workspace'}</CardTitle>
+            <CardDescription>
+              Workspaces let you organize workflows and manage usage with your team.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {hasOrganizations ? (
+              <div className="space-y-2">
+                {organizations?.map((org) => (
+                  <Card key={org.id} className="border border-dashed">
+                    <CardContent className="flex items-center justify-between gap-2 py-4">
+                      <div>
+                        <p className="font-medium">{org.name}</p>
+                        <p className="text-sm text-muted-foreground">{org.plan.toUpperCase()} • {org.role}</p>
+                      </div>
+                      <Button
+                        variant="outline"
+                        onClick={async () => {
+                          const result = await selectOrganization(org.id);
+                          if (!result.success) {
+                            setError(result.error);
+                          } else {
+                            setError(null);
+                          }
+                        }}
+                      >
+                        Switch
+                      </Button>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div>
+                  <label className="mb-1 block text-sm font-medium">Workspace name</label>
+                  <Input
+                    placeholder="Acme Corp"
+                    value={newName}
+                    onChange={(event) => setNewName(event.target.value)}
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-medium">Company domain (optional)</label>
+                  <Input
+                    placeholder="acme.com"
+                    value={newDomain}
+                    onChange={(event) => setNewDomain(event.target.value)}
+                  />
+                </div>
+              </div>
+            )}
+          </CardContent>
+          <CardFooter className="flex items-center justify-between">
+            <Button
+              variant={hasOrganizations ? 'ghost' : 'outline'}
+              onClick={() => setShowCreate((prev) => !prev)}
+            >
+              {showCreate ? 'Back to workspaces' : 'Create new workspace'}
+            </Button>
+            <div className="flex items-center gap-2">
+              {showCreate || !hasOrganizations ? (
+                <Button
+                  onClick={async () => {
+                    if (!newName.trim()) {
+                      setError('Workspace name is required');
+                      return;
+                    }
+                    setCreating(true);
+                    const result = await createOrganization({ name: newName.trim(), domain: newDomain.trim() || undefined });
+                    setCreating(false);
+                    if (!result.success) {
+                      setError(result.error);
+                    } else {
+                      setError(null);
+                      setNewName('');
+                      setNewDomain('');
+                    }
+                  }}
+                  disabled={creating}
+                >
+                  {creating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Create workspace
+                </Button>
+              ) : null}
+            </div>
+          </CardFooter>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b bg-muted/40 px-6 py-3 text-sm">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Building2 className="h-4 w-4" />
+          <span className="font-medium text-foreground">{activeOrganization?.name}</span>
+          <span className="text-xs uppercase">{activeOrganization?.plan}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={() => setShowCreate((prev) => !prev)}>
+            <Plus className="mr-2 h-4 w-4" /> New workspace
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => refreshOrganizations().catch(() => null)}>
+            Refresh
+          </Button>
+        </div>
+      </div>
+      {showCreate && (
+        <div className="border-b bg-muted/20 px-6 py-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="flex-1">
+              <label className="mb-1 block text-sm font-medium">Workspace name</label>
+              <Input
+                placeholder="New workspace"
+                value={newName}
+                onChange={(event) => setNewName(event.target.value)}
+              />
+            </div>
+            <div className="flex-1">
+              <label className="mb-1 block text-sm font-medium">Company domain (optional)</label>
+              <Input
+                placeholder="workspace.com"
+                value={newDomain}
+                onChange={(event) => setNewDomain(event.target.value)}
+              />
+            </div>
+            <Button
+              onClick={async () => {
+                if (!newName.trim()) {
+                  setError('Workspace name is required');
+                  return;
+                }
+                setCreating(true);
+                const result = await createOrganization({ name: newName.trim(), domain: newDomain.trim() || undefined });
+                setCreating(false);
+                if (!result.success) {
+                  setError(result.error);
+                } else {
+                  setError(null);
+                  setShowCreate(false);
+                  setNewName('');
+                  setNewDomain('');
+                }
+              }}
+              disabled={creating}
+              className="whitespace-nowrap"
+            >
+              {creating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Create
+            </Button>
+          </div>
+        </div>
+      )}
+      {error && (
+        <div className="border-b bg-red-50 px-6 py-2 text-sm text-red-600">
+          {error}
+        </div>
+      )}
+      <div className="flex-1 overflow-hidden">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default WorkspaceGate;

--- a/client/src/pages/GraphEditor.tsx
+++ b/client/src/pages/GraphEditor.tsx
@@ -1,5 +1,6 @@
 import { Helmet } from "react-helmet-async";
 import ProfessionalGraphEditor from "@/components/workflow/ProfessionalGraphEditor";
+import WorkspaceGate from "@/components/workspaces/WorkspaceGate";
 
 export default function GraphEditor() {
   return (
@@ -9,7 +10,9 @@ export default function GraphEditor() {
         <meta name="description" content="Design and build automation workflows with our professional n8n-style visual editor. Drag, drop, and connect nodes to create powerful automations." />
       </Helmet>
       
-      <ProfessionalGraphEditor />
+      <WorkspaceGate>
+        <ProfessionalGraphEditor />
+      </WorkspaceGate>
     </>
   );
 }

--- a/client/src/pages/WorkflowBuilder.tsx
+++ b/client/src/pages/WorkflowBuilder.tsx
@@ -1,5 +1,6 @@
 import { Helmet } from "react-helmet-async";
 import { N8NStyleWorkflowBuilder } from "@/components/ai/N8NStyleWorkflowBuilder";
+import WorkspaceGate from "@/components/workspaces/WorkspaceGate";
 
 export default function WorkflowBuilder() {
   return (
@@ -10,7 +11,9 @@ export default function WorkflowBuilder() {
       </Helmet>
       
       <div className="h-screen overflow-hidden">
-        <N8NStyleWorkflowBuilder />
+        <WorkspaceGate>
+          <N8NStyleWorkflowBuilder />
+        </WorkspaceGate>
       </div>
     </>
   );

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -10,6 +10,20 @@ type AuthUser = {
   emailVerified?: boolean;
   quotaApiCalls?: number;
   quotaTokens?: number;
+  organizationId?: string;
+  organizationRole?: string;
+};
+
+type OrganizationSummary = {
+  id: string;
+  name: string;
+  domain?: string | null;
+  plan: string;
+  status: string;
+  role: string;
+  isDefault: boolean;
+  limits?: Record<string, any>;
+  usage?: Record<string, any>;
 };
 
 type AuthStatus = 'idle' | 'loading';
@@ -20,6 +34,9 @@ type StoredAuthState = {
   token?: string;
   refreshToken?: string;
   user?: AuthUser;
+  organizations?: OrganizationSummary[];
+  activeOrganization?: OrganizationSummary;
+  activeOrganizationId?: string;
 };
 
 type AuthState = StoredAuthState & {
@@ -31,6 +48,9 @@ type AuthState = StoredAuthState & {
   register: (payload: { name?: string; email: string; password: string }) => Promise<AuthResult>;
   logout: (silent?: boolean) => Promise<void>;
   authFetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+  refreshOrganizations: () => Promise<void>;
+  selectOrganization: (organizationId: string) => Promise<AuthResult>;
+  createOrganization: (payload: { name: string; domain?: string; plan?: string }) => Promise<AuthResult>;
 };
 
 const STORAGE_KEY = 'automation.auth.v1';
@@ -84,7 +104,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const nextState: StoredAuthState = {
         token: result.token,
         refreshToken: result.refreshToken,
-        user: result.user
+        user: result.user,
+        organizations: result.organizations,
+        activeOrganization: result.activeOrganization,
+        activeOrganizationId: result.activeOrganization?.id,
       };
       persistState(nextState);
       set({ ...nextState, status: 'idle', error: undefined });
@@ -114,7 +137,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const nextState: StoredAuthState = {
         token: result.token,
         refreshToken: result.refreshToken,
-        user: result.user
+        user: result.user,
+        organizations: result.organizations,
+        activeOrganization: result.activeOrganization,
+        activeOrganizationId: result.activeOrganization?.id,
       };
       persistState(nextState);
       set({ ...nextState, status: 'idle', error: undefined });
@@ -141,7 +167,16 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       }
     } finally {
       persistState({});
-      set({ token: undefined, refreshToken: undefined, user: undefined, status: 'idle', error: undefined });
+      set({
+        token: undefined,
+        refreshToken: undefined,
+        user: undefined,
+        organizations: undefined,
+        activeOrganization: undefined,
+        activeOrganizationId: undefined,
+        status: 'idle',
+        error: undefined,
+      });
       if (!silent) {
         toast.success('Signed out');
       }
@@ -149,6 +184,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
   authFetch: async (input, init) => {
     const token = get().token;
+    const organizationId = get().activeOrganizationId;
     const headers = new Headers(init?.headers);
     if (!headers.has('Content-Type') && init?.body && !(init.body instanceof FormData)) {
       headers.set('Content-Type', 'application/json');
@@ -156,12 +192,86 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     if (token) {
       headers.set('Authorization', `Bearer ${token}`);
     }
+    if (organizationId) {
+      headers.set('X-Organization-Id', organizationId);
+    }
 
     const response = await fetch(input, { ...init, headers });
     if (response.status === 401) {
       await get().logout(true);
     }
     return response;
+  },
+  refreshOrganizations: async () => {
+    if (!get().token) return;
+    const response = await get().authFetch('/api/organizations');
+    const data = await response.json();
+    if (!response.ok || !data.success) {
+      throw new Error(data?.error || 'Failed to load workspaces');
+    }
+    const nextState: StoredAuthState = {
+      token: get().token,
+      refreshToken: get().refreshToken,
+      user: get().user,
+      organizations: data.organizations,
+      activeOrganization: data.activeOrganization,
+      activeOrganizationId: data.activeOrganizationId,
+    };
+    persistState(nextState);
+    set((state) => ({ ...state, ...nextState }));
+  },
+  selectOrganization: async (organizationId) => {
+    try {
+      const response = await get().authFetch(`/api/organizations/${organizationId}/select`, {
+        method: 'POST'
+      });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        const error = data?.error || 'Failed to switch workspace';
+        return { success: false, error };
+      }
+      const nextState: StoredAuthState = {
+        token: get().token,
+        refreshToken: get().refreshToken,
+        user: get().user,
+        organizations: data.organizations,
+        activeOrganization: data.activeOrganization,
+        activeOrganizationId: data.activeOrganization?.id,
+      };
+      persistState(nextState);
+      set((state) => ({ ...state, ...nextState }));
+      toast.success('Workspace switched');
+      return { success: true };
+    } catch (error: any) {
+      return { success: false, error: error?.message || 'Failed to switch workspace' };
+    }
+  },
+  createOrganization: async (payload) => {
+    try {
+      const response = await get().authFetch('/api/organizations', {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        const error = data?.error || 'Failed to create workspace';
+        return { success: false, error };
+      }
+      const nextState: StoredAuthState = {
+        token: get().token,
+        refreshToken: get().refreshToken,
+        user: get().user,
+        organizations: data.organizations,
+        activeOrganization: data.activeOrganization,
+        activeOrganizationId: data.activeOrganization?.id,
+      };
+      persistState(nextState);
+      set((state) => ({ ...state, ...nextState }));
+      toast.success('Workspace created');
+      return { success: true };
+    } catch (error: any) {
+      return { success: false, error: error?.message || 'Failed to create workspace' };
+    }
   }
 }));
 

--- a/server/services/OrganizationService.ts
+++ b/server/services/OrganizationService.ts
@@ -1,0 +1,467 @@
+import { and, eq } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import {
+  db,
+  organizations,
+  organizationMembers,
+  organizationInvites,
+  organizationQuotas,
+  tenantIsolations,
+  OrganizationPlan,
+  OrganizationStatus,
+  OrganizationLimits,
+  OrganizationUsageMetrics,
+  OrganizationFeatureFlags,
+  OrganizationSecuritySettings,
+  OrganizationBranding,
+  OrganizationComplianceSettings,
+} from '../database/schema';
+
+export interface OrganizationSummary {
+  id: string;
+  name: string;
+  domain: string | null;
+  plan: OrganizationPlan;
+  status: OrganizationStatus;
+  role: string;
+  isDefault: boolean;
+  limits: OrganizationLimits;
+  usage: OrganizationUsageMetrics;
+  membershipId: string;
+  joinedAt?: Date | null;
+  lastActiveAt?: Date | null;
+}
+
+export interface OrganizationContext extends OrganizationSummary {
+  subdomain: string;
+  features: OrganizationFeatureFlags;
+  security: OrganizationSecuritySettings;
+  branding: OrganizationBranding;
+  compliance: OrganizationComplianceSettings;
+}
+
+export interface CreateOrganizationOptions {
+  name?: string;
+  domain?: string | null;
+  plan?: OrganizationPlan;
+}
+
+export interface InviteMemberInput {
+  organizationId: string;
+  email: string;
+  role: 'owner' | 'admin' | 'member' | 'viewer';
+  invitedBy: string;
+}
+
+export interface RemoveMemberInput {
+  organizationId: string;
+  memberId: string;
+  requestedBy: string;
+}
+
+export class OrganizationService {
+  private readonly PLAN_LIMITS: Record<OrganizationPlan, OrganizationLimits> = {
+    starter: { maxWorkflows: 25, maxExecutions: 5000, maxUsers: 5, maxStorage: 5 * 1024 },
+    professional: { maxWorkflows: 100, maxExecutions: 50000, maxUsers: 25, maxStorage: 25 * 1024 },
+    enterprise: { maxWorkflows: 500, maxExecutions: 250000, maxUsers: 250, maxStorage: 100 * 1024 },
+    enterprise_plus: { maxWorkflows: 1000, maxExecutions: 1000000, maxUsers: 1000, maxStorage: 500 * 1024 },
+  };
+
+  private readonly PLAN_FEATURES: Record<OrganizationPlan, OrganizationFeatureFlags> = {
+    starter: {
+      ssoEnabled: false,
+      auditLogging: false,
+      customBranding: false,
+      advancedAnalytics: false,
+      prioritySupport: false,
+      customIntegrations: false,
+      onPremiseDeployment: false,
+      dedicatedInfrastructure: false,
+    },
+    professional: {
+      ssoEnabled: true,
+      auditLogging: true,
+      customBranding: true,
+      advancedAnalytics: true,
+      prioritySupport: true,
+      customIntegrations: false,
+      onPremiseDeployment: false,
+      dedicatedInfrastructure: false,
+    },
+    enterprise: {
+      ssoEnabled: true,
+      auditLogging: true,
+      customBranding: true,
+      advancedAnalytics: true,
+      prioritySupport: true,
+      customIntegrations: true,
+      onPremiseDeployment: false,
+      dedicatedInfrastructure: false,
+    },
+    enterprise_plus: {
+      ssoEnabled: true,
+      auditLogging: true,
+      customBranding: true,
+      advancedAnalytics: true,
+      prioritySupport: true,
+      customIntegrations: true,
+      onPremiseDeployment: true,
+      dedicatedInfrastructure: true,
+    },
+  };
+
+  private readonly DEFAULT_SECURITY: OrganizationSecuritySettings = {
+    ipWhitelist: [],
+    mfaRequired: false,
+    sessionTimeout: 480,
+    passwordPolicy: {
+      minLength: 8,
+      requireSpecialChars: true,
+      requireNumbers: true,
+      requireUppercase: true,
+    },
+    apiKeyRotationDays: 90,
+  };
+
+  private readonly DEFAULT_COMPLIANCE: OrganizationComplianceSettings = {
+    gdprEnabled: true,
+    hipaaCompliant: false,
+    soc2Type2: false,
+    dataResidency: 'us',
+    retentionPolicyDays: 2555,
+  };
+
+  public async createOrganizationForUser(
+    user: { id: string; email: string; name?: string | null },
+    options: CreateOrganizationOptions = {}
+  ): Promise<OrganizationContext> {
+    if (!db) {
+      throw new Error('Database connection not available');
+    }
+
+    const plan: OrganizationPlan = options.plan ?? 'starter';
+    const limits = this.PLAN_LIMITS[plan];
+    const features = this.PLAN_FEATURES[plan];
+
+    const now = new Date();
+    const domain = options.domain ?? user.email.split('@')[1] ?? null;
+    const name = options.name ?? (user.name || user.email.split('@')[0] || 'Workspace');
+
+    const billingPeriodEnd = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    const [organization] = await db
+      .insert(organizations)
+      .values({
+        name,
+        domain,
+        subdomain: this.generateSubdomain(name),
+        plan,
+        status: 'trial',
+        trialEndsAt: billingPeriodEnd,
+        billing: {
+          customerId: '',
+          subscriptionId: '',
+          currentPeriodStart: now.toISOString(),
+          currentPeriodEnd: billingPeriodEnd.toISOString(),
+          usage: {
+            workflowExecutions: 0,
+            apiCalls: 0,
+            storageUsed: 0,
+            usersActive: 1,
+          },
+          limits,
+        },
+        features,
+        security: this.DEFAULT_SECURITY,
+        branding: {
+          companyName: name,
+          supportEmail: domain ? `support@${domain}` : 'support@example.com',
+        },
+        compliance: this.DEFAULT_COMPLIANCE,
+      })
+      .returning();
+
+    const [membership] = await db
+      .insert(organizationMembers)
+      .values({
+        organizationId: organization.id,
+        userId: user.id,
+        email: user.email.toLowerCase(),
+        role: 'owner',
+        status: 'active',
+        permissions: {
+          canCreateWorkflows: true,
+          canEditWorkflows: true,
+          canDeleteWorkflows: true,
+          canManageUsers: true,
+          canViewAnalytics: true,
+          canManageBilling: true,
+          canAccessApi: true,
+        },
+        isDefault: true,
+        invitedBy: user.id,
+        invitedAt: now,
+        joinedAt: now,
+        lastActiveAt: now,
+      })
+      .returning();
+
+    await db.insert(tenantIsolations).values({
+      organizationId: organization.id,
+      dataNamespace: `org_${organization.id.replace(/-/g, '')}`,
+      storagePrefix: `org_${organization.id}`,
+      cachePrefix: `org:${organization.id}`,
+      logPrefix: `org.${organization.id}`,
+      metricsPrefix: `org.${organization.id}`,
+    });
+
+    await db.insert(organizationQuotas).values({
+      organizationId: organization.id,
+      billingPeriodStart: now,
+      billingPeriodEnd,
+      limits,
+      usage: {
+        workflowExecutions: 0,
+        apiCalls: 0,
+        storageUsed: 0,
+        usersActive: 1,
+      },
+    });
+
+    return {
+      id: organization.id,
+      name: organization.name,
+      domain: organization.domain,
+      plan: organization.plan as OrganizationPlan,
+      status: organization.status as OrganizationStatus,
+      role: membership.role,
+      isDefault: membership.isDefault,
+      limits,
+      usage: {
+        workflowExecutions: 0,
+        apiCalls: 0,
+        storageUsed: 0,
+        usersActive: 1,
+      },
+      membershipId: membership.id,
+      joinedAt: membership.joinedAt,
+      lastActiveAt: membership.lastActiveAt,
+      subdomain: organization.subdomain,
+      features,
+      security: this.DEFAULT_SECURITY,
+      branding: organization.branding,
+      compliance: organization.compliance,
+    };
+  }
+
+  public async listUserOrganizations(userId: string): Promise<OrganizationContext[]> {
+    if (!db) {
+      return [];
+    }
+
+    const rows = await db
+      .select({
+        organization: organizations,
+        membership: organizationMembers,
+        quota: organizationQuotas,
+      })
+      .from(organizationMembers)
+      .innerJoin(organizations, eq(organizationMembers.organizationId, organizations.id))
+      .leftJoin(organizationQuotas, eq(organizationQuotas.organizationId, organizations.id))
+      .where(eq(organizationMembers.userId, userId));
+
+    return rows.map((row) => this.mapRowToContext(row.organization, row.membership, row.quota));
+  }
+
+  public async getActiveMembership(
+    userId: string,
+    requestedOrganizationId?: string
+  ): Promise<OrganizationContext | null> {
+    const organizations = await this.listUserOrganizations(userId);
+    if (organizations.length === 0) {
+      return null;
+    }
+
+    if (requestedOrganizationId) {
+      const requested = organizations.find((org) => org.id === requestedOrganizationId);
+      if (requested) {
+        return requested;
+      }
+    }
+
+    const defaultOrg = organizations.find((org) => org.isDefault);
+    return defaultOrg ?? organizations[0];
+  }
+
+  public async setActiveOrganization(userId: string, organizationId: string): Promise<OrganizationContext | null> {
+    if (!db) {
+      return null;
+    }
+
+    const organization = await this.getActiveMembership(userId, organizationId);
+    if (!organization) {
+      return null;
+    }
+
+    const now = new Date();
+    await db
+      .update(organizationMembers)
+      .set({ isDefault: false, updatedAt: now })
+      .where(eq(organizationMembers.userId, userId));
+
+    await db
+      .update(organizationMembers)
+      .set({ isDefault: true, status: 'active', lastActiveAt: now })
+      .where(
+        and(
+          eq(organizationMembers.userId, userId),
+          eq(organizationMembers.organizationId, organizationId)
+        )
+      );
+
+    return this.getActiveMembership(userId, organizationId);
+  }
+
+  public async inviteMember(input: InviteMemberInput) {
+    if (!db) {
+      throw new Error('Database connection not available');
+    }
+
+    const token = randomUUID();
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+    const [invite] = await db
+      .insert(organizationInvites)
+      .values({
+        organizationId: input.organizationId,
+        email: input.email.toLowerCase(),
+        role: input.role,
+        status: 'pending',
+        token,
+        invitedBy: input.invitedBy,
+        expiresAt,
+      })
+      .returning();
+
+    return invite;
+  }
+
+  public async removeMember(input: RemoveMemberInput) {
+    if (!db) {
+      throw new Error('Database connection not available');
+    }
+
+    const memberships = await db
+      .select()
+      .from(organizationMembers)
+      .where(
+        and(
+          eq(organizationMembers.organizationId, input.organizationId),
+          eq(organizationMembers.userId, input.memberId)
+        )
+      );
+
+    if (memberships.length === 0) {
+      return false;
+    }
+
+    if (memberships[0].role === 'owner' && memberships[0].userId === input.requestedBy) {
+      throw new Error('Owners cannot remove themselves from their active organization. Transfer ownership first.');
+    }
+
+    await db
+      .delete(organizationMembers)
+      .where(
+        and(
+          eq(organizationMembers.organizationId, input.organizationId),
+          eq(organizationMembers.userId, input.memberId)
+        )
+      );
+
+    return true;
+  }
+
+  public async recordUsage(
+    organizationId: string,
+    usage: Partial<OrganizationUsageMetrics>
+  ): Promise<void> {
+    if (!db) {
+      return;
+    }
+
+    const [quota] = await db
+      .select()
+      .from(organizationQuotas)
+      .where(eq(organizationQuotas.organizationId, organizationId))
+      .limit(1);
+
+    if (!quota) {
+      return;
+    }
+
+    const nextUsage: OrganizationUsageMetrics = {
+      workflowExecutions: quota.usage.workflowExecutions + (usage.workflowExecutions ?? 0),
+      apiCalls: quota.usage.apiCalls + (usage.apiCalls ?? 0),
+      storageUsed: quota.usage.storageUsed + (usage.storageUsed ?? 0),
+      usersActive: Math.max(quota.usage.usersActive, usage.usersActive ?? quota.usage.usersActive),
+    };
+
+    await db
+      .update(organizationQuotas)
+      .set({ usage: nextUsage, updatedAt: new Date() })
+      .where(eq(organizationQuotas.id, quota.id));
+  }
+
+  public getPlanLimits(plan: OrganizationPlan): OrganizationLimits {
+    return this.PLAN_LIMITS[plan];
+  }
+
+  public getPlanFeatures(plan: OrganizationPlan): OrganizationFeatureFlags {
+    return this.PLAN_FEATURES[plan];
+  }
+
+  private generateSubdomain(name: string): string {
+    const base = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, '')
+      .substring(0, 20);
+
+    return `${base || 'workspace'}-${Math.random().toString(36).substring(2, 8)}`;
+  }
+
+  private mapRowToContext(
+    organization: typeof organizations.$inferSelect,
+    membership: typeof organizationMembers.$inferSelect,
+    quota?: typeof organizationQuotas.$inferSelect
+  ): OrganizationContext {
+    const limits = quota?.limits ?? this.PLAN_LIMITS[organization.plan as OrganizationPlan];
+    const usage = quota?.usage ?? {
+      workflowExecutions: 0,
+      apiCalls: 0,
+      storageUsed: 0,
+      usersActive: 0,
+    };
+
+    return {
+      id: organization.id,
+      name: organization.name,
+      domain: organization.domain,
+      plan: organization.plan as OrganizationPlan,
+      status: organization.status as OrganizationStatus,
+      role: membership.role,
+      isDefault: membership.isDefault,
+      limits,
+      usage,
+      membershipId: membership.id,
+      joinedAt: membership.joinedAt,
+      lastActiveAt: membership.lastActiveAt,
+      subdomain: organization.subdomain,
+      features: organization.features as OrganizationFeatureFlags,
+      security: organization.security as OrganizationSecuritySettings,
+      branding: organization.branding as OrganizationBranding,
+      compliance: organization.compliance as OrganizationComplianceSettings,
+    };
+  }
+}
+
+export const organizationService = new OrganizationService();

--- a/server/services/ProductionLLMOrchestrator.ts
+++ b/server/services/ProductionLLMOrchestrator.ts
@@ -6,6 +6,7 @@ export interface ClarifyRequest {
   prompt: string;
   userId: string;
   context?: Record<string, any>;
+  organizationId?: string;
 }
 
 export interface ClarifyResponse {
@@ -38,6 +39,7 @@ export interface PlanRequest {
   answers: Record<string, string>;
   userId: string;
   context?: Record<string, any>;
+  organizationId?: string;
 }
 
 export interface PlanResponse {
@@ -61,6 +63,7 @@ export interface FixRequest {
     code: string;
   }>;
   userId: string;
+  organizationId?: string;
 }
 
 export interface FixResponse {
@@ -81,6 +84,7 @@ export interface CodegenRequest {
     includeLogging?: boolean;
     includeErrorHandling?: boolean;
   };
+  organizationId?: string;
 }
 
 export interface CodegenResponse {
@@ -120,7 +124,7 @@ export class ProductionLLMOrchestrator {
       }
 
       // Check quota
-      const quotaCheck = await authService.checkQuota(request.userId, 1, 500);
+      const quotaCheck = await authService.checkQuota(request.userId, 1, 500, request.organizationId);
       if (!quotaCheck.hasQuota) {
         return {
           success: false,
@@ -139,7 +143,8 @@ export class ProductionLLMOrchestrator {
         connection,
         systemPrompt,
         userPrompt,
-        request.userId
+        request.userId,
+        request.organizationId
       );
 
       if (!llmResponse.success) {
@@ -197,7 +202,7 @@ export class ProductionLLMOrchestrator {
       }
 
       // Check quota (planning uses more tokens)
-      const quotaCheck = await authService.checkQuota(request.userId, 1, 1500);
+      const quotaCheck = await authService.checkQuota(request.userId, 1, 1500, request.organizationId);
       if (!quotaCheck.hasQuota) {
         return {
           success: false,
@@ -217,7 +222,8 @@ export class ProductionLLMOrchestrator {
         connection,
         systemPrompt,
         userPrompt,
-        request.userId
+        request.userId,
+        request.organizationId
       );
 
       if (!llmResponse.success) {
@@ -284,7 +290,7 @@ export class ProductionLLMOrchestrator {
         };
       }
 
-      const quotaCheck = await authService.checkQuota(request.userId, 1, 800);
+      const quotaCheck = await authService.checkQuota(request.userId, 1, 800, request.organizationId);
       if (!quotaCheck.hasQuota) {
         return {
           success: false,
@@ -302,7 +308,8 @@ export class ProductionLLMOrchestrator {
         connection,
         systemPrompt,
         userPrompt,
-        request.userId
+        request.userId,
+        request.organizationId
       );
 
       if (!llmResponse.success) {
@@ -389,7 +396,8 @@ export class ProductionLLMOrchestrator {
     connection: any,
     systemPrompt: string,
     userPrompt: string,
-    userId: string
+    userId: string,
+    organizationId?: string
   ): Promise<{
     success: boolean;
     response?: string;
@@ -426,7 +434,7 @@ export class ProductionLLMOrchestrator {
       }
 
       // Update usage metrics
-      await authService.updateUsage(userId, 1, tokensUsed);
+      await authService.updateUsage(userId, 1, tokensUsed, organizationId);
 
       return {
         success: true,

--- a/server/services/UsageMeteringService.ts
+++ b/server/services/UsageMeteringService.ts
@@ -1,5 +1,6 @@
 import { eq, and, gte, lte, sum, count } from 'drizzle-orm';
 import { users, usageTracking, workflowExecutions, workflows, db } from '../database/schema';
+import { organizationService } from './OrganizationService';
 
 export interface UsageMetrics {
   userId: string;
@@ -132,7 +133,8 @@ export class UsageMeteringService {
     userId: string,
     apiCalls: number = 1,
     tokensUsed: number = 0,
-    cost: number = 0
+    cost: number = 0,
+    organizationId?: string
   ): Promise<void> {
     const period = this.getCurrentBillingPeriod();
     
@@ -189,6 +191,10 @@ export class UsageMeteringService {
 
       // Clear cache for this user
       this.clearUserCache(userId);
+
+      if (organizationId) {
+        await organizationService.recordUsage(organizationId, { apiCalls });
+      }
 
       // Check for quota alerts
       await this.checkQuotaAlerts(userId);

--- a/server/services/__tests__/UsageMeteringService.metering.test.ts
+++ b/server/services/__tests__/UsageMeteringService.metering.test.ts
@@ -92,7 +92,7 @@ test('usage metering updates the usage_tracking.updated_at column when recording
   const service = new UsageMeteringService();
   (service as any).db = mockDb;
 
-  await service.recordApiUsage(userId, 3, 150, 1.23);
+  await service.recordApiUsage(userId, 3, 150, 1.23, 'org-1');
   await service.recordWorkflowExecution(userId, 'workflow-1', true, 10, 4);
 
   const usageUpdates = mockDb.getUpdatesForTable(usageTracking);

--- a/server/types/common.ts
+++ b/server/types/common.ts
@@ -63,6 +63,7 @@ export interface JWTPayload {
   email: string;
   role: string;
   plan: string;
+  organizationId?: string | null;
   iat?: number;
   exp?: number;
 }


### PR DESCRIPTION
## Summary
- add organization, membership, quota, and isolation tables plus supporting service for multi-tenant state management
- propagate active organization context through auth flows, middleware, LLM orchestration, usage metering, and new organization CRUD routes
- gate workflow builders behind workspace selection and expose client-side organization switching/creation flows

## Testing
- not run (missing DATABASE_URL / ENCRYPTION_MASTER_KEY / JWT_SECRET env vars)


------
https://chatgpt.com/codex/tasks/task_e_68de3dac4e808331bcd00a8b9577c6d2