### PR TITLE
Refactor execution queue to worker-backed processing

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -14,3 +14,8 @@
   - Secrets redacted server-side; avoid printing credentials in app logs.
 - Rollout
   - Flip connectors to Stable by registering API clients in ConnectorRegistry.
+- Process topology
+  - Run the web API/UI: `NODE_ENV=production node dist/index.js` (or `tsx server/index.ts` during development).
+  - Run at least one execution worker: `NODE_ENV=production tsx server/workers/execution.ts` (scale horizontally for more throughput).
+  - Use a process supervisor (systemd, PM2, etc.) to restart the web and worker processes and to forward `SIGTERM` for graceful shutdowns.
+  - Both processes require the same environment (DATABASE_URL, API keys). Workers will drain in-flight jobs before exiting.

--- a/server/index.ts
+++ b/server/index.ts
@@ -75,9 +75,8 @@ app.use((req, res, next) => {
     const { executionQueueService } = await import('./services/ExecutionQueueService.js');
     const { WebhookManager } = await import('./webhooks/WebhookManager.js');
     WebhookManager.configureQueueService(executionQueueService);
-    executionQueueService.start();
   } catch (e) {
-    console.warn('⚠️ Failed to start execution queue:', (e as any)?.message || e);
+    console.warn('⚠️ Failed to configure execution queue:', (e as any)?.message || e);
   }
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {

--- a/server/workers/execution.ts
+++ b/server/workers/execution.ts
@@ -1,0 +1,54 @@
+import { env } from '../env';
+import { executionQueueService } from '../services/ExecutionQueueService.js';
+import { WebhookManager } from '../webhooks/WebhookManager.js';
+
+async function main(): Promise<void> {
+  console.log('🚀 Starting execution worker');
+  console.log('🌍 Worker environment:', env.NODE_ENV);
+
+  WebhookManager.configureQueueService(executionQueueService);
+  executionQueueService.start();
+
+  let shuttingDown = false;
+  let resolveWait: (() => void) | null = null;
+  const waitForExit = new Promise<void>((resolve) => {
+    resolveWait = resolve;
+  });
+
+  const shutdown = async (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+
+    console.log(`⚙️ Received ${signal}. Shutting down execution worker...`);
+    try {
+      await executionQueueService.shutdown();
+      console.log('✅ Execution queue drained successfully.');
+    } catch (error) {
+      console.error('❌ Error during execution worker shutdown:', error);
+    } finally {
+      resolveWait?.();
+    }
+  };
+
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+
+  process.on('unhandledRejection', (reason) => {
+    console.error('❌ Unhandled rejection in execution worker:', reason);
+  });
+
+  process.on('uncaughtException', (error) => {
+    console.error('❌ Uncaught exception in execution worker:', error);
+  });
+
+  console.log('🧵 Execution worker is running.');
+  await waitForExit;
+  console.log('👋 Execution worker has stopped.');
+}
+
+void main().catch((error) => {
+  console.error('Failed to start execution worker:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- refactor `ExecutionQueueService` to run database-backed worker loops with shared signaling and graceful shutdown
- add a transactional claim helper in `WorkflowRepository` using `FOR UPDATE SKIP LOCKED` semantics for safe polling
- move queue startup into a dedicated `server/workers/execution.ts` entry point and document running web/worker processes separately

## Testing
- `npm run check` *(fails: repository has existing TypeScript errors across client and server packages)*

------
https://chatgpt.com/codex/tasks/task_e_68de4491b7c48331a0cab53335a2947b