### PR TITLE
Enforce organization scoping across connection workflows

### DIFF
--- a/server/routes/google-sheets.ts
+++ b/server/routes/google-sheets.ts
@@ -12,8 +12,13 @@ router.get(
   authenticateToken,
   async (req, res) => {
     const userId = (req as any)?.user?.id;
+    const organizationId = (req as any)?.organizationId;
     if (!userId) {
       return res.status(401).json({ success: false, error: "UNAUTHORIZED" });
+    }
+
+    if (!organizationId) {
+      return res.status(400).json({ success: false, error: "ORGANIZATION_REQUIRED" });
     }
 
     const rawParam = String(req.params.spreadsheetId || "").trim();
@@ -26,7 +31,7 @@ router.get(
     }
 
     try {
-      const connections = await connectionService.getUserConnections(userId);
+      const connections = await connectionService.getUserConnections(userId, organizationId);
       const sheetsConnection = connections.find((conn) => {
         const provider = (conn.provider || "").toLowerCase();
         return provider.includes("sheet");

--- a/server/routes/metadata.ts
+++ b/server/routes/metadata.ts
@@ -8,8 +8,13 @@ const router = Router();
 
 router.post('/resolve', authenticateToken, async (req, res) => {
   const userId = (req as any)?.user?.id;
+  const organizationId = (req as any)?.organizationId;
   if (!userId) {
     return res.status(401).json({ success: false, error: 'UNAUTHORIZED' });
+  }
+
+  if (!organizationId) {
+    return res.status(400).json({ success: false, error: 'ORGANIZATION_REQUIRED' });
   }
 
   const { connector, connectionId, credentials: inlineCredentials = {}, params = {}, options = {} } = req.body || {};
@@ -22,7 +27,7 @@ router.post('/resolve', authenticateToken, async (req, res) => {
     let credentials: Record<string, any> = { ...inlineCredentials };
 
     if (connectionId) {
-      const connection = await connectionService.getConnection(String(connectionId), userId);
+      const connection = await connectionService.getConnection(String(connectionId), userId, organizationId);
       if (!connection) {
         return res.status(404).json({ success: false, error: 'CONNECTION_NOT_FOUND' });
       }

--- a/server/routes/workflow-read.ts
+++ b/server/routes/workflow-read.ts
@@ -446,6 +446,7 @@ workflowReadRouter.post('/workflows/:id/execute', async (req, res) => {
       workflowId: id,
       executionId,
       userId: (req as any)?.user?.id,
+      organizationId: (req as any)?.organizationId,
       timezone: req.body?.timezone || 'UTC',
       nodeOutputs,
       edges

--- a/server/services/HealthMonitoringService.ts
+++ b/server/services/HealthMonitoringService.ts
@@ -353,7 +353,7 @@ export class HealthMonitoringService {
     
     try {
       // Test if we can create connections (this would test the service)
-      const testResult = await connectionService.getUserConnections('health-check-user');
+      const testResult = await connectionService.getUserConnections('health-check-user', 'health-check-org');
       
       const responseTime = Date.now() - startTime;
       

--- a/server/services/ProductionLLMOrchestrator.ts
+++ b/server/services/ProductionLLMOrchestrator.ts
@@ -112,7 +112,7 @@ export class ProductionLLMOrchestrator {
       console.log(`🤔 Clarifying intent for user: ${request.userId}`);
 
       // Get user's LLM connection
-      const connection = await this.getLLMConnection(request.userId);
+      const connection = await this.getLLMConnection(request.userId, request.organizationId);
       if (!connection) {
         return {
           success: false,
@@ -188,7 +188,7 @@ export class ProductionLLMOrchestrator {
     try {
       console.log(`📋 Planning workflow for user: ${request.userId}`);
 
-      const connection = await this.getLLMConnection(request.userId);
+      const connection = await this.getLLMConnection(request.userId, request.organizationId);
       if (!connection) {
         return {
           success: false,
@@ -279,7 +279,7 @@ export class ProductionLLMOrchestrator {
     try {
       console.log(`🔧 Fixing workflow for user: ${request.userId}`);
 
-      const connection = await this.getLLMConnection(request.userId);
+      const connection = await this.getLLMConnection(request.userId, request.organizationId);
       if (!connection) {
         return {
           success: false,
@@ -350,12 +350,16 @@ export class ProductionLLMOrchestrator {
   /**
    * Get user's LLM connection (tries multiple providers)
    */
-  private async getLLMConnection(userId: string): Promise<any> {
+  private async getLLMConnection(userId: string, organizationId?: string): Promise<any> {
+    if (!organizationId) {
+      console.warn('⚠️ ProductionLLMOrchestrator: Missing organizationId when resolving LLM connection');
+      return null;
+    }
     // Try providers in order of preference
     const providers = ['gemini', 'openai', 'claude'];
-    
+
     for (const provider of providers) {
-      const connection = await connectionService.getLLMConnection(userId, provider);
+      const connection = await connectionService.getLLMConnection(userId, organizationId, provider);
       if (connection) {
         return connection;
       }

--- a/server/services/__tests__/ConnectionService.encryption.test.ts
+++ b/server/services/__tests__/ConnectionService.encryption.test.ts
@@ -23,6 +23,7 @@ const originalCredentials = {
 
 const connectionId = await service.createConnection({
   userId: 'user-123',
+  organizationId: 'org-123',
   name: 'Test Connection',
   provider: 'OpenAI',
   type: 'llm',
@@ -36,17 +37,17 @@ assert.equal(storedRecords.length, 1, 'a single connection record should be stor
 assert.ok(storedRecords[0].iv, 'stored connection should include an iv field');
 assert.equal('credentialsIv' in storedRecords[0], false, 'legacy credentialsIv field should not be present');
 
-const fetched = await service.getConnection(connectionId, 'user-123');
+const fetched = await service.getConnection(connectionId, 'user-123', 'org-123');
 assert.ok(fetched, 'connection should be retrievable');
 assert.equal(fetched?.iv, storedRecords[0].iv, 'fetched connection exposes iv');
 assert.deepEqual(fetched?.credentials, originalCredentials, 'credentials should decrypt to original payload');
 
-const byProvider = await service.getConnectionByProvider('user-123', 'openai');
+const byProvider = await service.getConnectionByProvider('user-123', 'org-123', 'openai');
 assert.ok(byProvider, 'connection should be retrievable by provider');
 assert.equal(byProvider?.iv, storedRecords[0].iv, 'provider lookup exposes iv');
 assert.deepEqual(byProvider?.credentials, originalCredentials, 'provider lookup decrypts credentials');
 
-const allConnections = await service.getUserConnections('user-123', 'openai');
+const allConnections = await service.getUserConnections('user-123', 'org-123', 'openai');
 assert.equal(allConnections.length, 1, 'user should have one connection after creation');
 assert.equal(allConnections[0].iv, storedRecords[0].iv, 'list entries expose iv');
 assert.deepEqual(allConnections[0].credentials, originalCredentials, 'list entries decrypt credentials');

--- a/server/services/__tests__/ConnectionService.test.ts
+++ b/server/services/__tests__/ConnectionService.test.ts
@@ -20,6 +20,7 @@ const service = new ConnectionService();
 
 const request = {
   userId: 'user-123',
+  organizationId: 'org-123',
   name: 'Test Connection',
   provider: 'custom-service',
   type: 'saas' as const,
@@ -34,11 +35,11 @@ const request = {
 const connectionId = await service.createConnection(request);
 assert.ok(connectionId, 'should return a connection id');
 
-const testResult = await service.testConnection(connectionId, request.userId);
+const testResult = await service.testConnection(connectionId, request.userId, request.organizationId);
 assert.equal(testResult.provider, request.provider, 'test returns provider name');
 assert.equal(testResult.success, false, 'unknown providers fall back to not implemented');
 
-const userConnections = await service.getUserConnections(request.userId);
+const userConnections = await service.getUserConnections(request.userId, request.organizationId);
 assert.equal(userConnections.length, 1, 'user should have exactly one connection');
 const [connection] = userConnections;
 
@@ -51,7 +52,7 @@ assert.equal(
   'test error message captured during failed test'
 );
 
-const fetched = await service.getConnection(connectionId, request.userId);
+const fetched = await service.getConnection(connectionId, request.userId, request.organizationId);
 assert.ok(fetched, 'connection can be fetched by id');
 assert.equal(fetched?.type, request.type, 'fetched connection preserves type');
 assert.equal(fetched?.testStatus, 'failed', 'fetched connection includes test status');

--- a/server/testing/EndToEndTester.ts
+++ b/server/testing/EndToEndTester.ts
@@ -97,7 +97,7 @@ export class EndToEndTester {
     // Test OAuth URL generation
     await this.runTest('OAuth URL Generation', async () => {
       try {
-        const { authUrl, state } = await oauthManager.generateAuthUrl('gmail', this.testUserId);
+        const { authUrl, state } = await oauthManager.generateAuthUrl('gmail', this.testUserId, 'org-test');
         return authUrl.includes('accounts.google.com') && state.length > 0;
       } catch (error) {
         console.log('OAuth URL generation failed (expected in test environment)');

--- a/server/webhooks/WebhookManager.ts
+++ b/server/webhooks/WebhookManager.ts
@@ -607,13 +607,22 @@ export class WebhookManager {
       const service = await this.getConnectionService();
       if (service) {
         try {
-          const connection = await service.getConnection(metadata.connectionId, metadata.userId);
-          if (connection) {
-            return {
-              credentials: (connection.credentials as APICredentials),
-              additionalConfig: { ...(connection.metadata ?? {}), ...(metadata.additionalConfig ?? {}) },
-              parameters,
-            };
+          const organizationId = (metadata as any).organizationId;
+          if (!organizationId) {
+            console.warn('⚠️ Missing organizationId for polling trigger connection resolution');
+          } else {
+            const connection = await service.getConnection(
+              metadata.connectionId,
+              metadata.userId,
+              organizationId
+            );
+            if (connection) {
+              return {
+                credentials: (connection.credentials as APICredentials),
+                additionalConfig: { ...(connection.metadata ?? {}), ...(metadata.additionalConfig ?? {}) },
+                parameters,
+              };
+            }
           }
         } catch (error) {
           console.warn('⚠️ Failed to load connection for polling trigger:', getErrorMessage(error));

--- a/server/workflow/__tests__/WorkflowRuntimeService.test.ts
+++ b/server/workflow/__tests__/WorkflowRuntimeService.test.ts
@@ -11,7 +11,8 @@ async function runSheetsAndTimeRegression(): Promise<void> {
     workflowId: 'workflow-sheets-time',
     executionId: 'exec-1',
     nodeOutputs: {},
-    timezone: 'UTC'
+    timezone: 'UTC',
+    organizationId: 'org-inline'
   };
 
   const sheetsNode = {
@@ -81,16 +82,19 @@ async function runConnectionIdAuthRegression(): Promise<void> {
     executionId: 'exec-2',
     nodeOutputs: {},
     timezone: 'UTC',
-    userId: 'user-auth'
+    userId: 'user-auth',
+    organizationId: 'org-auth'
   };
 
   const mockConnectionService = {
-    async getConnection(connectionId: string, userId: string) {
+    async getConnection(connectionId: string, userId: string, organizationId: string) {
       assert.equal(connectionId, 'conn-auth-1', 'Runtime should request the configured connection id');
       assert.equal(userId, 'user-auth', 'Runtime should request connection for current user');
+      assert.equal(organizationId, 'org-auth', 'Runtime should include organization when resolving connection');
       return {
         id: connectionId,
         userId,
+        organizationId,
         name: 'Auth Connection',
         provider: 'sheets',
         type: 'saas',


### PR DESCRIPTION
## Summary
- require an organization identifier for all connection persistence and retrieval in the ConnectionService
- propagate organization context through API routes, OAuth flows, and workflow execution helpers that touch connections
- update supporting tests and utilities to exercise the new organization-aware signatures

## Testing
- `node server/services/__tests__/ConnectionService.test.ts` *(fails: missing compiled JS dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de5d65021c833193d7d0bd5cf09f50