### PR TITLE
Refresh OAuth tokens before connector execution

### DIFF
--- a/server/core/ParameterResolver.ts
+++ b/server/core/ParameterResolver.ts
@@ -159,7 +159,7 @@ async function resolveLLMValue(
       const availableAdapters = llmRegistry.getAvailableProviders();
       const message = `LLM provider adapter "${provider}" is not registered. Available adapters: ${availableAdapters.join(', ') || 'none'}.`;
       console.warn(message);
-      return message;
+      throw new Error(message);
     }
 
     // Interpolate prompt with context

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1134,9 +1134,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
           const userId = req.user!.id;
           let conn = null as any;
           if (connectionId) {
-            conn = await connectionService.getConnection(String(connectionId), userId, req.organizationId);
+            conn = await connectionService.getConnectionWithFreshTokens(
+              String(connectionId),
+              userId,
+              req.organizationId
+            );
           } else if (provider) {
-            conn = await connectionService.getConnectionByProvider(userId, req.organizationId, String(provider));
+            conn = await connectionService.getConnectionByProviderWithFreshTokens(
+              userId,
+              req.organizationId,
+              String(provider)
+            );
           }
           if (!conn) {
             results.push({ success: false, error: 'Connection not found', appName, functionId });
@@ -1772,9 +1780,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const userId = req.user!.id;
         let conn = null as any;
         if (connectionId) {
-          conn = await connectionService.getConnection(String(connectionId), userId, req.organizationId);
+          conn = await connectionService.getConnectionWithFreshTokens(
+            String(connectionId),
+            userId,
+            req.organizationId
+          );
         } else if (provider) {
-          conn = await connectionService.getConnectionByProvider(userId, req.organizationId, String(provider));
+          conn = await connectionService.getConnectionByProviderWithFreshTokens(
+            userId,
+            req.organizationId,
+            String(provider)
+          );
         }
         if (!conn) {
           return res.status(404).json({ success: false, error: 'Connection not found' });
@@ -1843,9 +1859,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const userId = req.user!.id;
         let conn = null as any;
         if (connectionId) {
-          conn = await connectionService.getConnection(String(connectionId), userId, req.organizationId);
+          conn = await connectionService.getConnectionWithFreshTokens(
+            String(connectionId),
+            userId,
+            req.organizationId
+          );
         } else if (provider) {
-          conn = await connectionService.getConnectionByProvider(userId, req.organizationId, String(provider));
+          conn = await connectionService.getConnectionByProviderWithFreshTokens(
+            userId,
+            req.organizationId,
+            String(provider)
+          );
         }
         if (!conn) {
           return res.status(404).json({ success: false, error: 'Connection not found' });
@@ -1902,8 +1926,19 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if ((!credentials) && (connectionId || provider)) {
         const userId = req.user!.id;
         let conn = null as any;
-        if (connectionId) conn = await connectionService.getConnection(String(connectionId), userId, req.organizationId);
-        else if (provider) conn = await connectionService.getConnectionByProvider(userId, req.organizationId, String(provider));
+        if (connectionId) {
+          conn = await connectionService.getConnectionWithFreshTokens(
+            String(connectionId),
+            userId,
+            req.organizationId
+          );
+        } else if (provider) {
+          conn = await connectionService.getConnectionByProviderWithFreshTokens(
+            userId,
+            req.organizationId,
+            String(provider)
+          );
+        }
         if (!conn) return res.status(404).json({ success: false, error: 'Connection not found' });
         credentials = conn.credentials;
         appName = appName || conn.provider;
@@ -3644,33 +3679,40 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       // Get all user connections
       const connections = await connectionService.getUserConnections(userId, req.organizationId);
-      
+
       const healthChecks: Record<string, any> = {};
       let totalConnections = 0;
       let healthyConnections = 0;
       let failedConnections = 0;
-      
+
       // Test each connection
       for (const connection of connections) {
         totalConnections++;
-        
+
         try {
+          const hydrated = await connectionService.getConnectionWithFreshTokens(
+            connection.id,
+            userId,
+            req.organizationId
+          );
+          const activeConnection = hydrated ?? connection;
+
           // Use the integrationManager to test the connection
           const testResult = await integrationManager.executeFunction({
-            appName: connection.provider,
+            appName: activeConnection.provider,
             functionId: 'test_connection',
             parameters: {},
-            credentials: connection.credentials || {},
-            connectionId: connection.id
+            credentials: activeConnection.credentials || {},
+            connectionId: activeConnection.id
           });
-          
-          healthChecks[connection.provider] = {
+
+          healthChecks[activeConnection.provider] = {
             status: testResult.success ? 'healthy' : 'error',
             lastChecked: new Date().toISOString(),
-            connectedAt: connection.createdAt,
+            connectedAt: activeConnection.createdAt,
             error: testResult.success ? null : testResult.error
           };
-          
+
           if (testResult.success) {
             healthyConnections++;
           } else {
@@ -3679,7 +3721,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
           
         } catch (error) {
           failedConnections++;
-          healthChecks[connection.provider] = {
+          const provider = connection.provider;
+          healthChecks[provider] = {
             status: 'error',
             lastChecked: new Date().toISOString(),
             connectedAt: connection.createdAt,
@@ -3730,7 +3773,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Check if user has this connection
       const connections = await connectionService.getUserConnections(userId, req.organizationId);
       const connection = connections.find(conn => conn.provider === provider);
-      
+
       if (!connection) {
         return res.status(404).json({
           success: false,
@@ -3738,30 +3781,39 @@ export async function registerRoutes(app: Express): Promise<Server> {
           responseTime: Date.now() - startTime
         });
       }
-      
+
+      let activeConnection = connection;
+
       try {
+        const hydrated = await connectionService.getConnectionWithFreshTokens(
+          connection.id,
+          userId,
+          req.organizationId
+        );
+        activeConnection = hydrated ?? connection;
+
         // Test the specific connection
         const testResult = await integrationManager.executeFunction({
           appName: provider,
           functionId: 'test_connection',
           parameters: {},
-          credentials: connection.credentials || {},
-          connectionId: connection.id
+          credentials: activeConnection.credentials || {},
+          connectionId: activeConnection.id
         });
-        
+
         res.json({
           success: true,
           health: {
             provider,
             status: testResult.success ? 'healthy' : 'error',
             lastChecked: new Date().toISOString(),
-            connectedAt: connection.createdAt,
+            connectedAt: activeConnection.createdAt,
             error: testResult.success ? null : testResult.error,
             details: testResult
           },
           responseTime: Date.now() - startTime
         });
-        
+
       } catch (error) {
         res.json({
           success: true,
@@ -3769,7 +3821,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
             provider,
             status: 'error',
             lastChecked: new Date().toISOString(),
-            connectedAt: connection.createdAt,
+            connectedAt: activeConnection.createdAt,
             error: getErrorMessage(error)
           },
           responseTime: Date.now() - startTime

--- a/server/routes/__tests__/workflow-deploy.test.ts
+++ b/server/routes/__tests__/workflow-deploy.test.ts
@@ -5,6 +5,8 @@ import type { AddressInfo } from 'node:net';
 
 const originalNodeEnv = process.env.NODE_ENV;
 process.env.NODE_ENV = 'development';
+const originalAllowFileStore = process.env.ALLOW_FILE_CONNECTION_STORE;
+process.env.ALLOW_FILE_CONNECTION_STORE = 'true';
 
 const stubApp = {
   post: () => stubApp,
@@ -105,6 +107,12 @@ try {
     process.env.NODE_ENV = originalNodeEnv;
   } else {
     delete process.env.NODE_ENV;
+  }
+
+  if (originalAllowFileStore) {
+    process.env.ALLOW_FILE_CONNECTION_STORE = originalAllowFileStore;
+  } else {
+    delete process.env.ALLOW_FILE_CONNECTION_STORE;
   }
 
   process.exit(exitCode);

--- a/server/workflow/WorkflowRuntimeService.ts
+++ b/server/workflow/WorkflowRuntimeService.ts
@@ -876,7 +876,11 @@ export class WorkflowRuntimeService {
         };
       }
 
-      const connection = await service.getConnection(connectionId, userId, organizationId);
+      const connection = await service.getConnectionWithFreshTokens(
+        connectionId,
+        userId,
+        organizationId
+      );
       if (!connection) {
         return {
           success: false,


### PR DESCRIPTION
## Summary
- add token refresh orchestration to `ConnectionService`, including cached OAuth manager access and helpers that return fresh credentials
- update workflow runtime, integration routes, and health checks to resolve connections with refreshed credentials before invoking connectors
- harden LLM parameter error handling and extend tests to cover token refresh, runtime behavior, and route setup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de894846f88331b84e14c1d96f28ae