### PR TITLE
Support multi-account OAuth relinking

### DIFF
--- a/scripts/generateOAuthProviders.ts
+++ b/scripts/generateOAuthProviders.ts
@@ -372,6 +372,8 @@ export interface OAuthState {
   userId: string;
   provider: string;
   returnUrl?: string;
+  connectionId?: string;
+  label?: string;
   codeVerifier?: string; // For PKCE
   nonce: string;
   createdAt: number;
@@ -396,10 +398,11 @@ ${this.generateProviderInitializations(providers)}
    * Generate authorization URL with state and PKCE
    */
   async generateAuthUrl(
-    providerId: string, 
-    userId: string, 
+    providerId: string,
+    userId: string,
     returnUrl?: string,
-    additionalScopes?: string[]
+    additionalScopes?: string[],
+    options: { connectionId?: string; label?: string } = {}
   ): Promise<{ authUrl: string; state: string }> {
     const provider = this.providers.get(providerId);
     if (!provider) {
@@ -420,10 +423,15 @@ ${this.generateProviderInitializations(providers)}
     }
 
     // Store state
+    const sanitizedLabel = options.label?.trim();
+    const label = sanitizedLabel && sanitizedLabel.length > 0 ? sanitizedLabel : undefined;
+
     this.pendingStates.set(state, {
       userId,
       provider: providerId,
       returnUrl,
+      connectionId: options.connectionId,
+      label,
       codeVerifier,
       nonce,
       createdAt: Date.now()

--- a/server/services/__tests__/ConnectionService.test.ts
+++ b/server/services/__tests__/ConnectionService.test.ts
@@ -74,7 +74,8 @@ try {
     };
     await service.storeConnection(userId, organizationId, providerId, newTokens, undefined, {
       name: 'Gmail Account',
-      type: 'saas'
+      type: 'saas',
+      connectionId: gmailConnectionId
     });
     return newTokens;
   };


### PR DESCRIPTION
## Summary
- carry optional connection identifiers and labels through the OAuth state so callbacks can relink specific records without overwriting other accounts
- update the connection service to target updates by id or by the {organization, user, provider, name} composite key while leaving previously stored connections intact
- refresh the admin UI to surface existing labels, send connection ids during re-authorization, and bubble the metadata back through the OAuth callback flow

## Testing
- npx tsx server/routes/__tests__/oauth-flow.test.ts
- npx tsx server/services/__tests__/ConnectionService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de8dd3dcc08331a10728687e257955