### PR TITLE
Add Azure DevOps, CircleCI, and Jenkins API clients

### DIFF
--- a/server/ConnectorRegistry.ts
+++ b/server/ConnectorRegistry.ts
@@ -45,14 +45,15 @@ import { GitlabAPIClient } from './integrations/GitlabAPIClient';
 import { BitbucketAPIClient } from './integrations/BitbucketAPIClient';
 import { ConfluenceAPIClient } from './integrations/ConfluenceAPIClient';
 import { JiraServiceManagementAPIClient } from './integrations/JiraServiceManagementAPIClient';
-import { MailchimpAPIClient } from './integrations/MailchimpAPIClient';
 import { QuickbooksAPIClient } from './integrations/QuickbooksAPIClient';
 import { AdyenAPIClient } from './integrations/AdyenAPIClient';
 import { BamboohrAPIClient } from './integrations/BamboohrAPIClient';
 import { PagerdutyAPIClient } from './integrations/PagerdutyAPIClient';
 import { SalesforceAPIClient } from './integrations/SalesforceAPIClient';
-import { GenericAPIClient } from './integrations/GenericAPIClient';
 import { getCompilerOpMap } from './workflow/compiler/op-map.js';
+import { AzureDevopsAPIClient } from './integrations/AzureDevopsAPIClient';
+import { CircleCIApiClient } from './integrations/CircleCIApiClient';
+import { JenkinsAPIClient } from './integrations/JenkinsAPIClient';
 
 interface ConnectorFunction {
   id: string;
@@ -266,6 +267,9 @@ export class ConnectorRegistry {
     this.registerAPIClient('confluence', ConfluenceAPIClient);
     this.registerAPIClient('jira-service-management', JiraServiceManagementAPIClient);
     this.registerAPIClient('pagerduty', PagerdutyAPIClient);
+    this.registerAPIClient('azure-devops', AzureDevopsAPIClient);
+    this.registerAPIClient('circleci', CircleCIApiClient);
+    this.registerAPIClient('jenkins', JenkinsAPIClient);
   }
 
   /**

--- a/server/integrations/AzureDevopsAPIClient.ts
+++ b/server/integrations/AzureDevopsAPIClient.ts
@@ -1,0 +1,160 @@
+import { Buffer } from 'buffer';
+import { APICredentials, APIResponse, BaseAPIClient } from './BaseAPIClient';
+
+interface AzureDevOpsCredentials extends APICredentials {
+  organization: string;
+  personal_access_token?: string;
+  personalAccessToken?: string;
+  project?: string;
+}
+
+interface WorkItemParams {
+  type: string;
+  title: string;
+  description?: string;
+  assigned_to?: string;
+  area_path?: string;
+  iteration_path?: string;
+  priority?: number;
+}
+
+interface TriggerBuildParams {
+  definition_id: string;
+  source_branch?: string;
+  parameters?: Record<string, any>;
+}
+
+interface CreateReleaseParams {
+  definition_id: string;
+  description?: string;
+  artifacts?: Array<Record<string, any>>;
+}
+
+interface GetBuildStatusParams {
+  build_id: string;
+}
+
+export class AzureDevopsAPIClient extends BaseAPIClient {
+  private readonly project?: string;
+  private readonly apiVersion = '7.0';
+  private readonly personalAccessToken: string;
+
+  constructor(credentials: AzureDevOpsCredentials) {
+    const organization = credentials.organization || credentials.org;
+    const personalAccessToken = credentials.personal_access_token || credentials.personalAccessToken;
+    if (!organization) {
+      throw new Error('Azure DevOps integration requires an organization');
+    }
+    if (!personalAccessToken) {
+      throw new Error('Azure DevOps integration requires a personal access token');
+    }
+
+    const baseURL = `https://dev.azure.com/${encodeURIComponent(organization)}`;
+    super(baseURL, credentials);
+
+    this.personalAccessToken = personalAccessToken;
+    this.project = credentials.project;
+
+    this.registerHandlers({
+      'test_connection': this.testConnection.bind(this) as any,
+      'create_work_item': this.createWorkItem.bind(this) as any,
+      'trigger_build': this.triggerBuild.bind(this) as any,
+      'create_release': this.createRelease.bind(this) as any,
+      'get_build_status': this.getBuildStatus.bind(this) as any,
+    });
+  }
+
+  protected getAuthHeaders(): Record<string, string> {
+    const token = Buffer.from(`:${this.personalAccessToken}`).toString('base64');
+    return {
+      Authorization: `Basic ${token}`,
+      Accept: 'application/json',
+    };
+  }
+
+  public async testConnection(): Promise<APIResponse<any>> {
+    return this.get(`/_apis/projects?api-version=${this.apiVersion}`);
+  }
+
+  public async createWorkItem(params: WorkItemParams): Promise<APIResponse<any>> {
+    this.ensureProject();
+    this.validateRequiredParams(params as any, ['type', 'title']);
+
+    const operations: Array<{ op: string; path: string; value: any }> = [
+      { op: 'add', path: '/fields/System.Title', value: params.title }
+    ];
+
+    if (params.description) {
+      operations.push({ op: 'add', path: '/fields/System.Description', value: params.description });
+    }
+    if (params.assigned_to) {
+      operations.push({ op: 'add', path: '/fields/System.AssignedTo', value: params.assigned_to });
+    }
+    if (params.area_path) {
+      operations.push({ op: 'add', path: '/fields/System.AreaPath', value: params.area_path });
+    }
+    if (params.iteration_path) {
+      operations.push({ op: 'add', path: '/fields/System.IterationPath', value: params.iteration_path });
+    }
+    if (typeof params.priority === 'number') {
+      operations.push({ op: 'add', path: '/fields/Microsoft.VSTS.Common.Priority', value: params.priority });
+    }
+
+    const endpoint = `/${encodeURIComponent(this.project!)}/_apis/wit/workitems/$${encodeURIComponent(params.type)}?api-version=${this.apiVersion}`;
+    return this.patch(endpoint, operations, {
+      'Content-Type': 'application/json-patch+json',
+    });
+  }
+
+  public async triggerBuild(params: TriggerBuildParams): Promise<APIResponse<any>> {
+    this.ensureProject();
+    this.validateRequiredParams(params as any, ['definition_id']);
+
+    const payload: Record<string, any> = {
+      definition: { id: params.definition_id },
+    };
+    if (params.source_branch) {
+      payload.sourceBranch = params.source_branch;
+    }
+    if (params.parameters) {
+      payload.parameters = JSON.stringify(params.parameters);
+    }
+
+    const endpoint = `/${encodeURIComponent(this.project!)}/_apis/build/builds?api-version=${this.apiVersion}`;
+    return this.post(endpoint, payload);
+  }
+
+  public async createRelease(params: CreateReleaseParams): Promise<APIResponse<any>> {
+    this.ensureProject();
+    this.validateRequiredParams(params as any, ['definition_id']);
+
+    const payload: Record<string, any> = {
+      definitionId: params.definition_id,
+    };
+
+    if (params.description) {
+      payload.description = params.description;
+    }
+
+    if (params.artifacts) {
+      payload.artifacts = params.artifacts;
+    }
+
+    const endpoint = `/${encodeURIComponent(this.project!)}/_apis/release/releases?api-version=${this.apiVersion}`;
+    return this.post(endpoint, payload);
+  }
+
+  public async getBuildStatus(params: GetBuildStatusParams): Promise<APIResponse<any>> {
+    this.ensureProject();
+    this.validateRequiredParams(params as any, ['build_id']);
+
+    const endpoint = `/${encodeURIComponent(this.project!)}/_apis/build/builds/${encodeURIComponent(params.build_id)}?api-version=${this.apiVersion}`;
+    return this.get(endpoint);
+  }
+
+  private ensureProject(): void {
+    if (!this.project) {
+      throw new Error('Azure DevOps integration requires a project');
+    }
+  }
+}

--- a/server/integrations/CircleCIApiClient.ts
+++ b/server/integrations/CircleCIApiClient.ts
@@ -1,0 +1,121 @@
+import { APICredentials, APIResponse, BaseAPIClient } from './BaseAPIClient';
+
+type TriggerPipelineParams = {
+  project_slug: string;
+  branch?: string;
+  tag?: string;
+  parameters?: Record<string, any>;
+};
+
+type ProjectScopedParams = {
+  project_slug: string;
+  branch?: string;
+  page_token?: string;
+};
+
+type PipelineLookupParams = {
+  pipeline_id: string;
+  page_token?: string;
+};
+
+type WorkflowLookupParams = {
+  workflow_id: string;
+  page_token?: string;
+};
+
+type RerunWorkflowParams = {
+  workflow_id: string;
+  enable_ssh?: boolean;
+  from_failed?: boolean;
+  sparse_tree?: boolean;
+};
+
+export class CircleCIApiClient extends BaseAPIClient {
+  private readonly token: string;
+
+  constructor(credentials: APICredentials) {
+    const token = credentials.apiKey || credentials.token || credentials.accessToken;
+    if (!token) {
+      throw new Error('CircleCI integration requires an API token');
+    }
+
+    super('https://circleci.com/api/v2', credentials);
+    this.token = token;
+
+    this.registerHandlers({
+      'test_connection': this.testConnection.bind(this) as any,
+      'trigger_pipeline': this.triggerPipeline.bind(this) as any,
+      'get_pipelines': this.getPipelines.bind(this) as any,
+      'get_pipeline': this.getPipeline.bind(this) as any,
+      'get_workflows': this.getWorkflows.bind(this) as any,
+      'get_jobs': this.getJobs.bind(this) as any,
+      'cancel_workflow': this.cancelWorkflow.bind(this) as any,
+      'rerun_workflow': this.rerunWorkflow.bind(this) as any,
+    });
+  }
+
+  protected getAuthHeaders(): Record<string, string> {
+    return {
+      'Circle-Token': this.token,
+      Accept: 'application/json',
+    };
+  }
+
+  private encodeProjectSlug(slug: string): string {
+    return slug
+      .split('/')
+      .map(segment => encodeURIComponent(segment))
+      .join('/');
+  }
+
+  public async testConnection(): Promise<APIResponse<any>> {
+    return this.get('/me');
+  }
+
+  public async triggerPipeline(params: TriggerPipelineParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['project_slug']);
+    const payload: Record<string, any> = {};
+    if (params.branch) payload.branch = params.branch;
+    if (params.tag) payload.tag = params.tag;
+    if (params.parameters) payload.parameters = params.parameters;
+
+    return this.post(`/project/${this.encodeProjectSlug(params.project_slug)}/pipeline`, payload);
+  }
+
+  public async getPipelines(params: ProjectScopedParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['project_slug']);
+    const query = this.buildQueryString({ branch: params.branch, 'page-token': params.page_token });
+    return this.get(`/project/${this.encodeProjectSlug(params.project_slug)}/pipeline${query}`);
+  }
+
+  public async getPipeline(params: PipelineLookupParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['pipeline_id']);
+    return this.get(`/pipeline/${encodeURIComponent(params.pipeline_id)}`);
+  }
+
+  public async getWorkflows(params: PipelineLookupParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['pipeline_id']);
+    const query = this.buildQueryString({ 'page-token': params.page_token });
+    return this.get(`/pipeline/${encodeURIComponent(params.pipeline_id)}/workflow${query}`);
+  }
+
+  public async getJobs(params: WorkflowLookupParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['workflow_id']);
+    const query = this.buildQueryString({ 'page-token': params.page_token });
+    return this.get(`/workflow/${encodeURIComponent(params.workflow_id)}/job${query}`);
+  }
+
+  public async cancelWorkflow(params: { workflow_id: string }): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['workflow_id']);
+    return this.post(`/workflow/${encodeURIComponent(params.workflow_id)}/cancel`, {});
+  }
+
+  public async rerunWorkflow(params: RerunWorkflowParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['workflow_id']);
+    const payload: Record<string, any> = {};
+    if (typeof params.enable_ssh === 'boolean') payload.enable_ssh = params.enable_ssh;
+    if (typeof params.from_failed === 'boolean') payload.from_failed = params.from_failed;
+    if (typeof params.sparse_tree === 'boolean') payload.sparse_tree = params.sparse_tree;
+    return this.post(`/workflow/${encodeURIComponent(params.workflow_id)}/rerun`, payload);
+  }
+}

--- a/server/integrations/IntegrationManager.ts
+++ b/server/integrations/IntegrationManager.ts
@@ -112,6 +112,12 @@ export class IntegrationManager {
       'confluence': 'confluence',
       'confluence-enhanced': 'confluence',
       'jira-service-management-enhanced': 'jira-service-management',
+      'azure_devops': 'azure-devops',
+      'azuredevops': 'azure-devops',
+      'circle-ci': 'circleci',
+      'circle_ci': 'circleci',
+      'jenkins-ci': 'jenkins',
+      'jenkins_ci': 'jenkins',
     };
     return map[v] || v;
   }

--- a/server/integrations/JenkinsAPIClient.ts
+++ b/server/integrations/JenkinsAPIClient.ts
@@ -1,0 +1,265 @@
+import { Buffer } from 'buffer';
+import { APICredentials, APIResponse, BaseAPIClient } from './BaseAPIClient';
+import { getErrorMessage } from '../types/common';
+
+type JenkinsCredentials = APICredentials & {
+  instanceUrl?: string;
+  instance_url?: string;
+  username?: string;
+  api_token?: string;
+  apiToken?: string;
+};
+
+type BuildParams = {
+  job_name: string;
+  parameters?: Record<string, any>;
+  token?: string;
+  cause?: string;
+};
+
+type BuildLookup = {
+  job_name: string;
+  build_number: number;
+};
+
+type JobMutation = {
+  job_name: string;
+  config_xml: string;
+  folder?: string;
+};
+
+type JobCopyParams = {
+  from_job: string;
+  to_job: string;
+  folder?: string;
+};
+
+type QueueItemParams = {
+  queue_id: number;
+};
+
+export class JenkinsAPIClient extends BaseAPIClient {
+  private readonly username: string;
+  private readonly apiToken: string;
+
+  constructor(credentials: JenkinsCredentials) {
+    const instanceUrl = (credentials.instanceUrl || credentials.instance_url || '').replace(/\/$/, '');
+    if (!instanceUrl) {
+      throw new Error('Jenkins integration requires an instance URL');
+    }
+
+    const username = credentials.username;
+    const apiToken = credentials.api_token || credentials.apiToken || credentials.password || credentials.token;
+    if (!username || !apiToken) {
+      throw new Error('Jenkins integration requires username and API token');
+    }
+
+    super(instanceUrl, credentials);
+
+    this.username = username;
+    this.apiToken = apiToken;
+
+    this.registerHandlers({
+      'test_connection': this.testConnection.bind(this) as any,
+      'trigger_build': this.triggerBuild.bind(this) as any,
+      'get_build_status': this.getBuildStatus.bind(this) as any,
+      'get_last_build': this.getLastBuild.bind(this) as any,
+      'get_build_console': this.getBuildConsole.bind(this) as any,
+      'list_jobs': this.listJobs.bind(this) as any,
+      'get_job_info': this.getJobInfo.bind(this) as any,
+      'create_job': this.createJob.bind(this) as any,
+      'update_job': this.updateJob.bind(this) as any,
+      'delete_job': this.deleteJob.bind(this) as any,
+      'enable_job': this.enableJob.bind(this) as any,
+      'disable_job': this.disableJob.bind(this) as any,
+      'copy_job': this.copyJob.bind(this) as any,
+      'stop_build': this.stopBuild.bind(this) as any,
+      'get_queue': this.getQueue.bind(this) as any,
+      'cancel_queue_item': this.cancelQueueItem.bind(this) as any,
+    });
+  }
+
+  protected getAuthHeaders(): Record<string, string> {
+    const token = Buffer.from(`${this.username}:${this.apiToken}`).toString('base64');
+    return {
+      Authorization: `Basic ${token}`,
+      Accept: 'application/json',
+    };
+  }
+
+  public async testConnection(): Promise<APIResponse<any>> {
+    return this.get('/api/json');
+  }
+
+  public async triggerBuild(params: BuildParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['job_name']);
+    const jobPath = this.buildJobPath(params.job_name);
+    const hasParameters = params.parameters && Object.keys(params.parameters).length > 0;
+    const endpointBase = `/${jobPath}/${hasParameters ? 'buildWithParameters' : 'build'}`;
+    const query = this.buildQueryString({ token: params.token, cause: params.cause });
+    const endpoint = `${endpointBase}${query}`;
+
+    if (hasParameters) {
+      const form = new URLSearchParams();
+      for (const [key, value] of Object.entries(params.parameters ?? {})) {
+        form.append(key, String(value));
+      }
+      return this.rawRequest('POST', endpoint, {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: form.toString(),
+      });
+    }
+
+    return this.rawRequest('POST', endpoint);
+  }
+
+  public async getBuildStatus(params: BuildLookup): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['job_name', 'build_number']);
+    const jobPath = this.buildJobPath(params.job_name);
+    return this.get(`/${jobPath}/${params.build_number}/api/json`);
+  }
+
+  public async getLastBuild(params: { job_name: string }): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['job_name']);
+    const jobPath = this.buildJobPath(params.job_name);
+    return this.get(`/${jobPath}/lastBuild/api/json`);
+  }
+
+  public async getBuildConsole(params: BuildLookup & { start?: number }): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['job_name', 'build_number']);
+    const jobPath = this.buildJobPath(params.job_name);
+    const query = this.buildQueryString({ start: params.start ?? 0 });
+    return this.get(`/${jobPath}/${params.build_number}/logText/progressiveText${query}`);
+  }
+
+  public async listJobs(params: { folder?: string; depth?: number } = {}): Promise<APIResponse<any>> {
+    const folderPrefix = params.folder ? `${this.buildJobPath(params.folder)}/` : '';
+    const query = this.buildQueryString({ depth: params.depth ?? 1, tree: 'jobs[name,color,url]' });
+    return this.get(`/${folderPrefix}api/json${query}`);
+  }
+
+  public async getJobInfo(params: { job_name: string }): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['job_name']);
+    const jobPath = this.buildJobPath(params.job_name);
+    return this.get(`/${jobPath}/api/json`);
+  }
+
+  public async createJob(params: JobMutation): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['job_name', 'config_xml']);
+    const folderPrefix = params.folder ? `${this.buildJobPath(params.folder)}/` : '';
+    const endpoint = `/${folderPrefix}createItem?name=${encodeURIComponent(params.job_name)}`;
+    return this.rawRequest('POST', endpoint, {
+      headers: { 'Content-Type': 'application/xml' },
+      body: params.config_xml,
+    });
+  }
+
+  public async updateJob(params: JobMutation): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['job_name', 'config_xml']);
+    const jobPath = this.buildJobPath(params.job_name);
+    return this.rawRequest('POST', `/${jobPath}/config.xml`, {
+      headers: { 'Content-Type': 'application/xml' },
+      body: params.config_xml,
+    });
+  }
+
+  public async deleteJob(params: { job_name: string }): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['job_name']);
+    const jobPath = this.buildJobPath(params.job_name);
+    return this.rawRequest('POST', `/${jobPath}/doDelete`);
+  }
+
+  public async enableJob(params: { job_name: string }): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['job_name']);
+    const jobPath = this.buildJobPath(params.job_name);
+    return this.rawRequest('POST', `/${jobPath}/enable`);
+  }
+
+  public async disableJob(params: { job_name: string }): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['job_name']);
+    const jobPath = this.buildJobPath(params.job_name);
+    return this.rawRequest('POST', `/${jobPath}/disable`);
+  }
+
+  public async copyJob(params: JobCopyParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['from_job', 'to_job']);
+    const folderPrefix = params.folder ? `${this.buildJobPath(params.folder)}/` : '';
+    const query = new URLSearchParams({ from: params.from_job, mode: 'copy' });
+    const endpoint = `/${folderPrefix}createItem?name=${encodeURIComponent(params.to_job)}&${query.toString()}`;
+    return this.rawRequest('POST', endpoint);
+  }
+
+  public async stopBuild(params: BuildLookup): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['job_name', 'build_number']);
+    const jobPath = this.buildJobPath(params.job_name);
+    return this.rawRequest('POST', `/${jobPath}/${params.build_number}/stop`);
+  }
+
+  public async getQueue(): Promise<APIResponse<any>> {
+    return this.get('/queue/api/json');
+  }
+
+  public async cancelQueueItem(params: QueueItemParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as any, ['queue_id']);
+    return this.rawRequest('POST', `/queue/cancelItem?id=${params.queue_id}`);
+  }
+
+  private buildJobPath(job: string): string {
+    return job
+      .split('/')
+      .map(segment => segment.trim())
+      .filter(Boolean)
+      .map(segment => `job/${encodeURIComponent(segment)}`)
+      .join('/');
+  }
+
+  private async rawRequest(
+    method: 'POST' | 'PUT',
+    endpoint: string,
+    options: { headers?: Record<string, string>; body?: string } = {}
+  ): Promise<APIResponse<any>> {
+    try {
+      const url = `${this.baseURL}${endpoint}`;
+      const response = await fetch(url, {
+        method,
+        headers: {
+          ...this.getAuthHeaders(),
+          ...(options.headers ?? {}),
+        },
+        body: options.body,
+      });
+
+      const text = await response.text();
+      let data: any = undefined;
+      if (text) {
+        try {
+          data = JSON.parse(text);
+        } catch {
+          data = text;
+        }
+      }
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: `HTTP ${response.status}: ${response.statusText}`,
+          statusCode: response.status,
+          data,
+        };
+      }
+
+      return {
+        success: true,
+        data,
+        statusCode: response.status,
+        headers: Object.fromEntries(response.headers.entries()),
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: getErrorMessage(error),
+        statusCode: 0,
+      };
+    }
+  }
+}

--- a/server/integrations/__tests__/DevOpsClients.test.ts
+++ b/server/integrations/__tests__/DevOpsClients.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+
+import { AzureDevopsAPIClient } from '../AzureDevopsAPIClient.js';
+import { CircleCIApiClient } from '../CircleCIApiClient.js';
+import { JenkinsAPIClient } from '../JenkinsAPIClient.js';
+
+const originalFetch = globalThis.fetch;
+
+type FetchAssertion = (input: RequestInfo | URL, init?: RequestInit) => void;
+
+type MockResponseOptions = {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: any;
+};
+
+function headersToObject(init?: RequestInit): Record<string, string> {
+  const headers = new Headers(init?.headers as HeadersInit | undefined);
+  const result: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}
+
+function mockFetch(assertion: FetchAssertion, options: MockResponseOptions = {}): void {
+  const { status = 200, headers = { 'content-type': 'application/json' }, body = {} } = options;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    assertion(input, init);
+    const payload = typeof body === 'string' ? body : JSON.stringify(body);
+    return new Response(payload, { status, headers });
+  }) as typeof fetch;
+}
+
+async function testAzureDevopsClient(): Promise<void> {
+  const client = new AzureDevopsAPIClient({
+    organization: 'contoso',
+    personal_access_token: 'secret-token',
+    project: 'payments'
+  });
+
+  mockFetch((url, init) => {
+    assert.equal(String(url), 'https://dev.azure.com/contoso/_apis/projects?api-version=7.0');
+    const headers = headersToObject(init);
+    assert.ok(headers['authorization']?.startsWith('Basic '));
+  });
+  const ping = await client.testConnection();
+  assert.equal(ping.success, true, 'Azure DevOps test connection should succeed');
+
+  mockFetch((url, init) => {
+    assert.equal(
+      String(url),
+      'https://dev.azure.com/contoso/payments/_apis/wit/workitems/$Bug?api-version=7.0'
+    );
+    const headers = headersToObject(init);
+    assert.equal(headers['content-type'], 'application/json-patch+json');
+    const payload = JSON.parse(String(init?.body || '[]')) as Array<{ path: string; value: unknown }>;
+    assert.ok(payload.some(entry => entry.path === '/fields/System.Title' && entry.value === 'Portal bug'));
+    assert.ok(payload.some(entry => entry.path === '/fields/System.AssignedTo' && entry.value === 'dev@example.com'));
+  });
+  const workItem = await client.createWorkItem({
+    type: 'Bug',
+    title: 'Portal bug',
+    assigned_to: 'dev@example.com'
+  });
+  assert.equal(workItem.success, true, 'Work item creation should succeed');
+
+  mockFetch((url, init) => {
+    assert.equal(
+      String(url),
+      'https://dev.azure.com/contoso/payments/_apis/build/builds?api-version=7.0'
+    );
+    const payload = JSON.parse(String(init?.body || '{}'));
+    assert.deepEqual(payload.definition, { id: '123' });
+    assert.equal(payload.sourceBranch, 'refs/heads/main');
+  });
+  const build = await client.triggerBuild({ definition_id: '123', source_branch: 'refs/heads/main' });
+  assert.equal(build.success, true, 'Build trigger should succeed');
+}
+
+async function testCircleCIClient(): Promise<void> {
+  const client = new CircleCIApiClient({ apiKey: 'circleci-token' });
+
+  mockFetch((url, init) => {
+    assert.equal(String(url), 'https://circleci.com/api/v2/me');
+    const headers = headersToObject(init);
+    assert.equal(headers['circle-token'], 'circleci-token');
+  });
+  const ping = await client.testConnection();
+  assert.equal(ping.success, true, 'CircleCI test connection should succeed');
+
+  mockFetch((url, init) => {
+    assert.equal(
+      String(url),
+      'https://circleci.com/api/v2/project/github/org/repo/pipeline'
+    );
+    const payload = JSON.parse(String(init?.body || '{}'));
+    assert.equal(payload.branch, 'main');
+    assert.deepEqual(payload.parameters, { deploy: true });
+  });
+  const trigger = await client.triggerPipeline({
+    project_slug: 'github/org/repo',
+    branch: 'main',
+    parameters: { deploy: true }
+  });
+  assert.equal(trigger.success, true, 'CircleCI pipeline trigger should succeed');
+
+  mockFetch((url) => {
+    assert.equal(
+      String(url),
+      'https://circleci.com/api/v2/pipeline/abc123/workflow?page-token=next'
+    );
+  });
+  const workflows = await client.getWorkflows({ pipeline_id: 'abc123', page_token: 'next' });
+  assert.equal(workflows.success, true, 'CircleCI workflows retrieval should succeed');
+}
+
+async function testJenkinsClient(): Promise<void> {
+  const client = new JenkinsAPIClient({
+    instanceUrl: 'https://jenkins.example.com',
+    username: 'ci-bot',
+    api_token: 'jenkins-secret'
+  });
+
+  mockFetch((url) => {
+    assert.equal(String(url), 'https://jenkins.example.com/api/json');
+  });
+  const ping = await client.testConnection();
+  assert.equal(ping.success, true, 'Jenkins test connection should succeed');
+
+  mockFetch((url, init) => {
+    assert.equal(
+      String(url),
+      'https://jenkins.example.com/job/backend/job/build/buildWithParameters'
+    );
+    const headers = headersToObject(init);
+    assert.equal(headers['content-type'], 'application/x-www-form-urlencoded');
+    assert.equal(String(init?.body), 'env=prod');
+  }, { headers: { 'content-type': 'application/json' } });
+  const build = await client.triggerBuild({
+    job_name: 'backend/build',
+    parameters: { env: 'prod' }
+  });
+  assert.equal(build.success, true, 'Jenkins build trigger should succeed');
+
+  mockFetch((url, init) => {
+    assert.equal(
+      String(url),
+      'https://jenkins.example.com/createItem?name=new-job&from=seed&mode=copy'
+    );
+    assert.equal(init?.method, 'POST');
+  }, { headers: { 'content-type': 'application/json' } });
+  const copy = await client.copyJob({ from_job: 'seed', to_job: 'new-job' });
+  assert.equal(copy.success, true, 'Jenkins copy job should succeed');
+
+  mockFetch((url) => {
+    assert.equal(String(url), 'https://jenkins.example.com/queue/api/json');
+  });
+  const queue = await client.getQueue();
+  assert.equal(queue.success, true, 'Jenkins queue retrieval should succeed');
+}
+
+await testAzureDevopsClient();
+await testCircleCIClient();
+await testJenkinsClient();
+
+globalThis.fetch = originalFetch;
+
+console.log('DevOps API clients integration smoke tests passed.');

--- a/server/integrations/__tests__/IntegrationManager.test.ts
+++ b/server/integrations/__tests__/IntegrationManager.test.ts
@@ -25,6 +25,13 @@ const credentialFixtures: Record<string, { credentials: APICredentials; addition
   bamboohr: {
     credentials: { apiKey: 'test-bamboohr-key', companyDomain: 'example' }
   },
+  'azure-devops': {
+    credentials: {
+      organization: 'example-org',
+      personal_access_token: 'azure-devops-pat',
+      project: 'sample-project'
+    }
+  },
   bitbucket: {
     credentials: { accessToken: 'bitbucket-access-token' }
   },
@@ -45,6 +52,9 @@ const credentialFixtures: Record<string, { credentials: APICredentials; addition
   },
   freshdesk: {
     credentials: { apiKey: 'freshdesk-api-key', domain: 'example' }
+  },
+  circleci: {
+    credentials: { apiKey: 'circleci-api-token' }
   },
   github: {
     credentials: { accessToken: 'github-personal-token' }
@@ -78,6 +88,13 @@ const credentialFixtures: Record<string, { credentials: APICredentials; addition
   },
   intercom: {
     credentials: { accessToken: 'intercom-access-token' }
+  },
+  jenkins: {
+    credentials: {
+      instanceUrl: 'https://jenkins.example.com',
+      username: 'automation',
+      api_token: 'jenkins-api-token'
+    }
   },
   'jira-service-management': {
     credentials: {

--- a/server/workflow/compiler/op-map.ts
+++ b/server/workflow/compiler/op-map.ts
@@ -6,6 +6,10 @@
  */
 
 import { REAL_OPS } from '../compile-to-appsscript.js';
+import type { APIResponse, BaseAPIClient } from '../../integrations/BaseAPIClient.js';
+import { AzureDevopsAPIClient } from '../../integrations/AzureDevopsAPIClient.js';
+import { CircleCIApiClient } from '../../integrations/CircleCIApiClient.js';
+import { JenkinsAPIClient } from '../../integrations/JenkinsAPIClient.js';
 
 /**
  * Get the compiler operation map
@@ -14,6 +18,74 @@ import { REAL_OPS } from '../compile-to-appsscript.js';
 export function getCompilerOpMap(): Record<string, any> {
   return REAL_OPS;
 }
+
+type RuntimeHandler = (client: BaseAPIClient, params?: Record<string, any>) => Promise<APIResponse<any>>;
+
+function assertClientInstance<T extends BaseAPIClient>(client: BaseAPIClient, ctor: new (...args: any[]) => T): T {
+  if (!(client instanceof ctor)) {
+    throw new Error(`${ctor.name} handler invoked with incompatible client instance.`);
+  }
+  return client;
+}
+
+const RUNTIME_OPS: Record<string, RuntimeHandler> = {
+  'action.azure-devops:test_connection': client => assertClientInstance(client, AzureDevopsAPIClient).testConnection(),
+  'action.azure-devops:create_work_item': (client, params = {}) =>
+    assertClientInstance(client, AzureDevopsAPIClient).createWorkItem(params),
+  'action.azure-devops:trigger_build': (client, params = {}) =>
+    assertClientInstance(client, AzureDevopsAPIClient).triggerBuild(params),
+  'action.azure-devops:create_release': (client, params = {}) =>
+    assertClientInstance(client, AzureDevopsAPIClient).createRelease(params),
+  'action.azure-devops:get_build_status': (client, params = {}) =>
+    assertClientInstance(client, AzureDevopsAPIClient).getBuildStatus(params),
+
+  'action.circleci:test_connection': client => assertClientInstance(client, CircleCIApiClient).testConnection(),
+  'action.circleci:trigger_pipeline': (client, params = {}) =>
+    assertClientInstance(client, CircleCIApiClient).triggerPipeline(params),
+  'action.circleci:get_pipelines': (client, params = {}) =>
+    assertClientInstance(client, CircleCIApiClient).getPipelines(params),
+  'action.circleci:get_pipeline': (client, params = {}) =>
+    assertClientInstance(client, CircleCIApiClient).getPipeline(params),
+  'action.circleci:get_workflows': (client, params = {}) =>
+    assertClientInstance(client, CircleCIApiClient).getWorkflows(params),
+  'action.circleci:get_jobs': (client, params = {}) =>
+    assertClientInstance(client, CircleCIApiClient).getJobs(params),
+  'action.circleci:cancel_workflow': (client, params = {}) =>
+    assertClientInstance(client, CircleCIApiClient).cancelWorkflow(params),
+  'action.circleci:rerun_workflow': (client, params = {}) =>
+    assertClientInstance(client, CircleCIApiClient).rerunWorkflow(params),
+
+  'action.jenkins:test_connection': client => assertClientInstance(client, JenkinsAPIClient).testConnection(),
+  'action.jenkins:trigger_build': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).triggerBuild(params),
+  'action.jenkins:get_build_status': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).getBuildStatus(params),
+  'action.jenkins:get_last_build': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).getLastBuild(params),
+  'action.jenkins:get_build_console': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).getBuildConsole(params),
+  'action.jenkins:list_jobs': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).listJobs(params),
+  'action.jenkins:get_job_info': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).getJobInfo(params),
+  'action.jenkins:create_job': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).createJob(params),
+  'action.jenkins:update_job': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).updateJob(params),
+  'action.jenkins:delete_job': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).deleteJob(params),
+  'action.jenkins:enable_job': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).enableJob(params),
+  'action.jenkins:disable_job': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).disableJob(params),
+  'action.jenkins:copy_job': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).copyJob(params),
+  'action.jenkins:stop_build': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).stopBuild(params),
+  'action.jenkins:get_queue': client => assertClientInstance(client, JenkinsAPIClient).getQueue(),
+  'action.jenkins:cancel_queue_item': (client, params = {}) =>
+    assertClientInstance(client, JenkinsAPIClient).cancelQueueItem(params),
+};
 
 /**
  * Check if a specific operation is implemented
@@ -38,7 +110,7 @@ export function getAllImplementedOperations(): string[] {
  */
 export function getImplementedOperationsByApp(): Record<string, string[]> {
   const byApp: Record<string, string[]> = {};
-  
+
   for (const opKey of Object.keys(REAL_OPS)) {
     // Parse operation key (e.g., "action.gmail:sendEmail" -> app: "gmail", op: "sendEmail")
     const match = opKey.match(/^(action|trigger)\.([^:]+):(.+)$/) || opKey.match(/^([^.]+)\.(.+)$/);
@@ -52,6 +124,14 @@ export function getImplementedOperationsByApp(): Record<string, string[]> {
       byApp[app].push(operation);
     }
   }
-  
+
   return byApp;
+}
+
+export function getRuntimeOpHandlers(): Record<string, RuntimeHandler> {
+  return RUNTIME_OPS;
+}
+
+export function getRuntimeOpHandler(key: string): RuntimeHandler | undefined {
+  return RUNTIME_OPS[key];
 }


### PR DESCRIPTION
## Summary
- implement production-ready Azure DevOps, CircleCI, and Jenkins API clients covering their catalog actions
- register the new clients with the connector registry, runtime op map, and integration manager id aliases
- add regression tests for the new clients and update integration manager fixtures

## Testing
- `npx tsx server/integrations/__tests__/DevOpsClients.test.ts`
- `npx tsx server/integrations/__tests__/IntegrationManager.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68de9020eea48331bf8d308330913549