### PR TITLE
Add OpenID scopes to Gmail OAuth providers

### DIFF
--- a/connectors/gmail-enhanced.json
+++ b/connectors/gmail-enhanced.json
@@ -11,7 +11,13 @@
     "config": {
       "authUrl": "https://accounts.google.com/o/oauth2/v2/auth",
       "tokenUrl": "https://oauth2.googleapis.com/token",
-      "scopes": ["https://www.googleapis.com/auth/gmail.modify", "https://www.googleapis.com/auth/gmail.labels"]
+      "scopes": [
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.labels",
+        "openid",
+        "email",
+        "profile"
+      ]
     }
   },
   "baseUrl": "https://gmail.googleapis.com/gmail/v1",

--- a/connectors/gmail.json
+++ b/connectors/gmail.json
@@ -16,7 +16,10 @@
         "https://www.googleapis.com/auth/gmail.readonly",
         "https://www.googleapis.com/auth/gmail.send",
         "https://www.googleapis.com/auth/gmail.compose",
-        "https://www.googleapis.com/auth/gmail.modify"
+        "https://www.googleapis.com/auth/gmail.modify",
+        "openid",
+        "email",
+        "profile"
       ]
     }
   },

--- a/scripts/generate30MoreApps.ts
+++ b/scripts/generate30MoreApps.ts
@@ -408,7 +408,10 @@ export class ThirtyMoreAppsGenerator {
           scopes: [
             "https://www.googleapis.com/auth/gmail.modify",
             "https://www.googleapis.com/auth/gmail.compose",
-            "https://www.googleapis.com/auth/gmail.labels"
+            "https://www.googleapis.com/auth/gmail.labels",
+            "openid",
+            "email",
+            "profile"
           ]
         }
       },

--- a/server/connectors/ConnectorFramework.ts
+++ b/server/connectors/ConnectorFramework.ts
@@ -689,7 +689,13 @@ export class ConnectorFramework {
           oauth2: {
             authUrl: 'https://accounts.google.com/o/oauth2/auth',
             tokenUrl: 'https://oauth2.googleapis.com/token',
-            scopes: ['https://www.googleapis.com/auth/gmail.send', 'https://www.googleapis.com/auth/gmail.readonly'],
+            scopes: [
+              'https://www.googleapis.com/auth/gmail.send',
+              'https://www.googleapis.com/auth/gmail.readonly',
+              'openid',
+              'email',
+              'profile'
+            ],
             clientIdRequired: true
           }
         },

--- a/server/oauth/OAuthManager.ts
+++ b/server/oauth/OAuthManager.ts
@@ -321,7 +321,10 @@ export class OAuthManager {
         scopes: [
           'https://www.googleapis.com/auth/gmail.readonly',
           'https://www.googleapis.com/auth/gmail.modify',
-          'https://www.googleapis.com/auth/gmail.send'
+          'https://www.googleapis.com/auth/gmail.send',
+          'openid',
+          'email',
+          'profile'
         ],
         authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
         tokenUrl: 'https://oauth2.googleapis.com/token',
@@ -341,7 +344,10 @@ export class OAuthManager {
         scopes: [
           'https://www.googleapis.com/auth/gmail.readonly',
           'https://www.googleapis.com/auth/gmail.modify',
-          'https://www.googleapis.com/auth/gmail.send'
+          'https://www.googleapis.com/auth/gmail.send',
+          'openid',
+          'email',
+          'profile'
         ],
         authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
         tokenUrl: 'https://oauth2.googleapis.com/token',


### PR DESCRIPTION
## Summary
- append the OpenID Connect scopes to the Gmail and Gmail Enhanced OAuth provider definitions
- mirror the expanded Gmail scope list in connector configs and generation scripts to keep metadata aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9b80dc7c8331bfc6cf2c36a945ca