### PR TITLE
Add AWS CloudFormation and CodePipeline integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "db:push": "drizzle-kit push",
-    "test": "tsx server/services/__tests__/ConnectionService.encryption.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-deploy.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/components/workflow/__tests__/NodeConfigurationModal.regression.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts && tsx server/integrations/__tests__/BaseAPIClient.helpers.test.ts && tsx server/workflow/__tests__/WorkflowRuntimeService.test.ts && tsx server/core/__tests__/ParameterResolver.llm.test.ts && tsx server/workflow/__tests__/WorkflowRepository.test.ts && tsx server/workflow/__tests__/WorkflowRepository.fallback.test.ts && tsx server/services/__tests__/TriggerPersistenceService.fallback.test.ts && tsx server/webhooks/__tests__/WebhookManager.persistence.test.ts",
+    "test": "tsx server/services/__tests__/ConnectionService.encryption.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-deploy.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/components/workflow/__tests__/NodeConfigurationModal.regression.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts && tsx server/integrations/__tests__/BaseAPIClient.helpers.test.ts && tsx server/integrations/__tests__/AwsClients.test.ts && tsx server/workflow/__tests__/WorkflowRuntimeService.test.ts && tsx server/core/__tests__/ParameterResolver.llm.test.ts && tsx server/workflow/__tests__/WorkflowRepository.test.ts && tsx server/workflow/__tests__/WorkflowRepository.fallback.test.ts && tsx server/services/__tests__/TriggerPersistenceService.fallback.test.ts && tsx server/webhooks/__tests__/WebhookManager.persistence.test.ts",
     "trigger-admin": "tsx scripts/trigger-admin.ts",
     "inventory:connectors": "node scripts/inventory-connectors.js",
     "audit:connectors": "tsx scripts/connector-audit.ts",
@@ -29,6 +29,8 @@
     "smoke:connectors": "tsx scripts/connector-smoke.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudformation": "^3.676.0",
+    "@aws-sdk/client-codepipeline": "^3.676.0",
     "@google/clasp": "^3.0.6-alpha",
     "@google/generative-ai": "0.24.1",
     "@hookform/resolvers": "^3.10.0",

--- a/server/ConnectorRegistry.ts
+++ b/server/ConnectorRegistry.ts
@@ -67,6 +67,8 @@ import { TerraformCloudAPIClient } from './integrations/TerraformCloudAPIClient'
 import { HashicorpVaultAPIClient } from './integrations/HashicorpVaultAPIClient';
 import { HelmAPIClient } from './integrations/HelmAPIClient';
 import { AnsibleAPIClient } from './integrations/AnsibleAPIClient';
+import { AwsCloudFormationAPIClient } from './integrations/AwsCloudFormationAPIClient';
+import { AwsCodePipelineAPIClient } from './integrations/AwsCodePipelineAPIClient';
 
 interface ConnectorFunction {
   id: string;
@@ -293,6 +295,8 @@ export class ConnectorRegistry {
     this.registerAPIClient('kubernetes', KubernetesAPIClient);
     this.registerAPIClient('argocd', ArgocdAPIClient);
     this.registerAPIClient('terraform-cloud', TerraformCloudAPIClient);
+    this.registerAPIClient('aws-cloudformation', AwsCloudFormationAPIClient);
+    this.registerAPIClient('aws-codepipeline', AwsCodePipelineAPIClient);
     this.registerAPIClient('hashicorp-vault', HashicorpVaultAPIClient);
     this.registerAPIClient('helm', HelmAPIClient);
     this.registerAPIClient('ansible', AnsibleAPIClient);

--- a/server/integrations/AwsCloudFormationAPIClient.ts
+++ b/server/integrations/AwsCloudFormationAPIClient.ts
@@ -1,0 +1,278 @@
+import {
+  CloudFormationClient,
+  CreateStackCommand,
+  DeleteStackCommand,
+  DescribeStacksCommand,
+  ListStacksCommand,
+  UpdateStackCommand,
+  type CloudFormationClientConfig
+} from '@aws-sdk/client-cloudformation';
+
+import { APICredentials, APIResponse, BaseAPIClient } from './BaseAPIClient';
+import { getErrorMessage } from '../types/common';
+
+interface AwsCloudFormationCredentials extends APICredentials {
+  access_key_id?: string;
+  accessKeyId?: string;
+  secret_access_key?: string;
+  secretAccessKey?: string;
+  session_token?: string;
+  sessionToken?: string;
+  aws_session_token?: string;
+  awsSessionToken?: string;
+  region?: string;
+  aws_region?: string;
+  awsRegion?: string;
+  cloudFormationClient?: CloudFormationClient;
+}
+
+interface StackParameters {
+  ParameterKey: string;
+  ParameterValue: string;
+}
+
+interface StackTag {
+  Key: string;
+  Value: string;
+}
+
+interface CreateOrUpdateStackParams {
+  stack_name: string;
+  template_body?: string;
+  template_url?: string;
+  parameters?: StackParameters[];
+  capabilities?: string[];
+  tags?: StackTag[];
+}
+
+interface DeleteStackParams {
+  stack_name: string;
+}
+
+interface GetStackStatusParams {
+  stack_name: string;
+}
+
+function sanitizeRegion(credentials: AwsCloudFormationCredentials): string {
+  return (
+    credentials.region ||
+    credentials.aws_region ||
+    credentials.awsRegion ||
+    'us-east-1'
+  );
+}
+
+function sanitizeAccessKeyId(credentials: AwsCloudFormationCredentials): string | undefined {
+  return credentials.access_key_id || credentials.accessKeyId || credentials.apiKey;
+}
+
+function sanitizeSecretAccessKey(credentials: AwsCloudFormationCredentials): string | undefined {
+  return credentials.secret_access_key || credentials.secretAccessKey || credentials.clientSecret;
+}
+
+function sanitizeSessionToken(credentials: AwsCloudFormationCredentials): string | undefined {
+  return (
+    credentials.session_token ||
+    credentials.sessionToken ||
+    credentials.aws_session_token ||
+    credentials.awsSessionToken ||
+    credentials.accessToken
+  );
+}
+
+export class AwsCloudFormationAPIClient extends BaseAPIClient {
+  private readonly client: CloudFormationClient;
+  private readonly region: string;
+
+  constructor(credentials: AwsCloudFormationCredentials) {
+    const {
+      cloudFormationClient,
+      ...rest
+    } = credentials;
+
+    const accessKeyId = sanitizeAccessKeyId(credentials);
+    const secretAccessKey = sanitizeSecretAccessKey(credentials);
+    const sessionToken = sanitizeSessionToken(credentials);
+    const region = sanitizeRegion(credentials);
+
+    if (!accessKeyId) {
+      throw new Error('AWS CloudFormation integration requires an access key ID');
+    }
+    if (!secretAccessKey) {
+      throw new Error('AWS CloudFormation integration requires a secret access key');
+    }
+
+    super(`https://cloudformation.${region}.amazonaws.com`, rest);
+
+    const config: CloudFormationClientConfig = {
+      region,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+        sessionToken
+      }
+    };
+
+    this.client = cloudFormationClient ?? new CloudFormationClient(config);
+    this.region = region;
+
+    this.registerHandlers({
+      'test_connection': this.testConnection.bind(this) as any,
+      'create_stack': this.createStack.bind(this) as any,
+      'update_stack': this.updateStack.bind(this) as any,
+      'delete_stack': this.deleteStack.bind(this) as any,
+      'get_stack_status': this.getStackStatus.bind(this) as any
+    });
+  }
+
+  protected getAuthHeaders(): Record<string, string> {
+    return {};
+  }
+
+  public async testConnection(): Promise<APIResponse<any>> {
+    try {
+      const response = await this.client.send(new ListStacksCommand({ MaxResults: 1 }));
+      return {
+        success: true,
+        data: {
+          stackCount: response.StackSummaries?.length ?? 0,
+          nextToken: response.NextToken
+        }
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: this.formatAwsError(error)
+      };
+    }
+  }
+
+  public async createStack(params: CreateOrUpdateStackParams): Promise<APIResponse<any>> {
+    try {
+      this.validateRequiredParams(params as Record<string, any>, ['stack_name']);
+
+      const input = this.buildStackCommandInput(params);
+      const response = await this.client.send(new CreateStackCommand(input));
+      return {
+        success: true,
+        data: response
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: this.formatAwsError(error)
+      };
+    }
+  }
+
+  public async updateStack(params: CreateOrUpdateStackParams): Promise<APIResponse<any>> {
+    try {
+      this.validateRequiredParams(params as Record<string, any>, ['stack_name']);
+
+      const input = this.buildStackCommandInput(params);
+      const response = await this.client.send(new UpdateStackCommand(input));
+      return {
+        success: true,
+        data: response
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: this.formatAwsError(error)
+      };
+    }
+  }
+
+  public async deleteStack(params: DeleteStackParams): Promise<APIResponse<any>> {
+    try {
+      this.validateRequiredParams(params as Record<string, any>, ['stack_name']);
+
+      const response = await this.client.send(new DeleteStackCommand({
+        StackName: params.stack_name
+      }));
+      return {
+        success: true,
+        data: response
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: this.formatAwsError(error)
+      };
+    }
+  }
+
+  public async getStackStatus(params: GetStackStatusParams): Promise<APIResponse<any>> {
+    try {
+      this.validateRequiredParams(params as Record<string, any>, ['stack_name']);
+
+      const response = await this.client.send(new DescribeStacksCommand({
+        StackName: params.stack_name
+      }));
+
+      const stack = response.Stacks?.[0];
+      return {
+        success: true,
+        data: stack
+          ? {
+              stackId: stack.StackId,
+              stackName: stack.StackName,
+              stackStatus: stack.StackStatus,
+              stackStatusReason: stack.StackStatusReason,
+              lastUpdatedTime: stack.LastUpdatedTime,
+              creationTime: stack.CreationTime
+            }
+          : undefined
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: this.formatAwsError(error)
+      };
+    }
+  }
+
+  private buildStackCommandInput(params: CreateOrUpdateStackParams): Record<string, any> {
+    const input: Record<string, any> = {
+      StackName: params.stack_name,
+      Parameters: params.parameters,
+      Capabilities: params.capabilities,
+      Tags: params.tags
+    };
+
+    if (params.template_body) {
+      input.TemplateBody = params.template_body;
+    }
+    if (params.template_url) {
+      input.TemplateURL = params.template_url;
+    }
+
+    if (!input.TemplateBody && !input.TemplateURL) {
+      throw new Error('Either template_body or template_url must be provided');
+    }
+
+    return input;
+  }
+
+  private formatAwsError(error: unknown): string {
+    const message = getErrorMessage(error);
+
+    if (typeof error === 'object' && error !== null && '$metadata' in error) {
+      const metadata = (error as { $metadata?: { httpStatusCode?: number } }).$metadata;
+      if (metadata?.httpStatusCode) {
+        return `${message} (status ${metadata.httpStatusCode})`;
+      }
+    }
+
+    if (message.includes('Could not connect to the endpoint URL')) {
+      return `${message} (verify region: ${this.region})`;
+    }
+
+    const name = (error as { name?: string }).name;
+    if (name === 'UnknownEndpoint' || name === 'EndpointError') {
+      return `${message} (verify region: ${this.region})`;
+    }
+
+    return message;
+  }
+}

--- a/server/integrations/AwsCodePipelineAPIClient.ts
+++ b/server/integrations/AwsCodePipelineAPIClient.ts
@@ -1,0 +1,345 @@
+import {
+  CodePipelineClient,
+  CreatePipelineCommand,
+  GetPipelineStateCommand,
+  ListPipelinesCommand,
+  StartPipelineExecutionCommand,
+  StopPipelineExecutionCommand,
+  type CodePipelineClientConfig,
+  type ActionTypeId,
+  type StageDeclaration
+} from '@aws-sdk/client-codepipeline';
+
+import { APICredentials, APIResponse, BaseAPIClient } from './BaseAPIClient';
+import { getErrorMessage } from '../types/common';
+
+interface AwsCodePipelineCredentials extends APICredentials {
+  access_key_id?: string;
+  accessKeyId?: string;
+  secret_access_key?: string;
+  secretAccessKey?: string;
+  session_token?: string;
+  sessionToken?: string;
+  aws_session_token?: string;
+  awsSessionToken?: string;
+  region?: string;
+  aws_region?: string;
+  awsRegion?: string;
+  codePipelineClient?: CodePipelineClient;
+}
+
+interface CreatePipelineParams {
+  name: string;
+  role_arn: string;
+  source_provider: 'GitHub' | 'CodeCommit' | 'S3';
+  repository: string;
+  branch?: string;
+  artifact_bucket?: string;
+  artifactBucket?: string;
+  oauth_token?: string;
+  oauthToken?: string;
+}
+
+interface PipelineNameParams {
+  name: string;
+}
+
+interface StopPipelineParams extends PipelineNameParams {
+  execution_id: string;
+}
+
+function sanitizeRegion(credentials: AwsCodePipelineCredentials): string {
+  return (
+    credentials.region ||
+    credentials.aws_region ||
+    credentials.awsRegion ||
+    'us-east-1'
+  );
+}
+
+function sanitizeAccessKeyId(credentials: AwsCodePipelineCredentials): string | undefined {
+  return credentials.access_key_id || credentials.accessKeyId || credentials.apiKey;
+}
+
+function sanitizeSecretAccessKey(credentials: AwsCodePipelineCredentials): string | undefined {
+  return credentials.secret_access_key || credentials.secretAccessKey || credentials.clientSecret;
+}
+
+function sanitizeSessionToken(credentials: AwsCodePipelineCredentials): string | undefined {
+  return (
+    credentials.session_token ||
+    credentials.sessionToken ||
+    credentials.aws_session_token ||
+    credentials.awsSessionToken ||
+    credentials.accessToken
+  );
+}
+
+export class AwsCodePipelineAPIClient extends BaseAPIClient {
+  private readonly client: CodePipelineClient;
+  private readonly region: string;
+
+  constructor(credentials: AwsCodePipelineCredentials) {
+    const {
+      codePipelineClient,
+      ...rest
+    } = credentials;
+
+    const accessKeyId = sanitizeAccessKeyId(credentials);
+    const secretAccessKey = sanitizeSecretAccessKey(credentials);
+    const sessionToken = sanitizeSessionToken(credentials);
+    const region = sanitizeRegion(credentials);
+
+    if (!accessKeyId) {
+      throw new Error('AWS CodePipeline integration requires an access key ID');
+    }
+    if (!secretAccessKey) {
+      throw new Error('AWS CodePipeline integration requires a secret access key');
+    }
+
+    super(`https://codepipeline.${region}.amazonaws.com`, rest);
+
+    const config: CodePipelineClientConfig = {
+      region,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+        sessionToken
+      }
+    };
+
+    this.client = codePipelineClient ?? new CodePipelineClient(config);
+    this.region = region;
+
+    this.registerHandlers({
+      'test_connection': this.testConnection.bind(this) as any,
+      'create_pipeline': this.createPipeline.bind(this) as any,
+      'start_pipeline': this.startPipeline.bind(this) as any,
+      'get_pipeline_state': this.getPipelineState.bind(this) as any,
+      'stop_pipeline': this.stopPipeline.bind(this) as any
+    });
+  }
+
+  protected getAuthHeaders(): Record<string, string> {
+    return {};
+  }
+
+  public async testConnection(): Promise<APIResponse<any>> {
+    try {
+      const response = await this.client.send(new ListPipelinesCommand({ MaxResults: 1 }));
+      return {
+        success: true,
+        data: {
+          pipelineCount: response.pipelines?.length ?? 0,
+          nextToken: response.nextToken
+        }
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: this.formatAwsError(error)
+      };
+    }
+  }
+
+  public async createPipeline(params: CreatePipelineParams): Promise<APIResponse<any>> {
+    try {
+      this.validateRequiredParams(params as Record<string, any>, ['name', 'role_arn', 'source_provider', 'repository']);
+
+      const pipeline = this.buildPipelineDefinition(params);
+      const response = await this.client.send(new CreatePipelineCommand({ pipeline }));
+      return {
+        success: true,
+        data: response
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: this.formatAwsError(error)
+      };
+    }
+  }
+
+  public async startPipeline(params: PipelineNameParams): Promise<APIResponse<any>> {
+    try {
+      this.validateRequiredParams(params as Record<string, any>, ['name']);
+
+      const response = await this.client.send(new StartPipelineExecutionCommand({
+        name: params.name
+      }));
+      return {
+        success: true,
+        data: response
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: this.formatAwsError(error)
+      };
+    }
+  }
+
+  public async getPipelineState(params: PipelineNameParams): Promise<APIResponse<any>> {
+    try {
+      this.validateRequiredParams(params as Record<string, any>, ['name']);
+
+      const response = await this.client.send(new GetPipelineStateCommand({
+        name: params.name
+      }));
+      return {
+        success: true,
+        data: response
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: this.formatAwsError(error)
+      };
+    }
+  }
+
+  public async stopPipeline(params: StopPipelineParams): Promise<APIResponse<any>> {
+    try {
+      this.validateRequiredParams(params as Record<string, any>, ['name', 'execution_id']);
+
+      const response = await this.client.send(new StopPipelineExecutionCommand({
+        name: params.name,
+        pipelineExecutionId: params.execution_id
+      }));
+      return {
+        success: true,
+        data: response
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: this.formatAwsError(error)
+      };
+    }
+  }
+
+  private buildPipelineDefinition(
+    params: CreatePipelineParams
+  ): { name: string; roleArn: string; artifactStore: { type: string; location: string }; stages: StageDeclaration[] } {
+    const artifactBucket =
+      params.artifact_bucket ||
+      params.artifactBucket ||
+      (params.source_provider === 'S3' ? params.repository : `${params.name}-artifacts`);
+
+    const sourceStage: StageDeclaration = {
+      name: 'Source',
+      actions: [
+        {
+          name: 'Source',
+          actionTypeId: this.getSourceActionType(params.source_provider),
+          configuration: this.getSourceConfiguration(params),
+          outputArtifacts: [{ name: 'SourceOutput' }]
+        }
+      ]
+    };
+
+    const buildStage: StageDeclaration = {
+      name: 'Build',
+      actions: [
+        {
+          name: 'Build',
+          actionTypeId: {
+            category: 'Build',
+            owner: 'AWS',
+            provider: 'CodeBuild',
+            version: '1'
+          } as ActionTypeId,
+          inputArtifacts: [{ name: 'SourceOutput' }],
+          outputArtifacts: [{ name: 'BuildOutput' }]
+        }
+      ]
+    };
+
+    const deployStage: StageDeclaration = {
+      name: 'Deploy',
+      actions: [
+        {
+          name: 'Deploy',
+          actionTypeId: {
+            category: 'Deploy',
+            owner: 'AWS',
+            provider: 'CodeDeploy',
+            version: '1'
+          } as ActionTypeId,
+          inputArtifacts: [{ name: 'BuildOutput' }]
+        }
+      ]
+    };
+
+    return {
+      name: params.name,
+      roleArn: params.role_arn,
+      artifactStore: {
+        type: 'S3',
+        location: artifactBucket
+      },
+      stages: [sourceStage, buildStage, deployStage]
+    };
+  }
+
+  private getSourceActionType(provider: CreatePipelineParams['source_provider']): ActionTypeId {
+    switch (provider) {
+      case 'GitHub':
+        return { category: 'Source', owner: 'ThirdParty', provider: 'GitHub', version: '1' };
+      case 'CodeCommit':
+        return { category: 'Source', owner: 'AWS', provider: 'CodeCommit', version: '1' };
+      case 'S3':
+        return { category: 'Source', owner: 'AWS', provider: 'S3', version: '1' };
+      default:
+        throw new Error(`Unsupported source provider: ${provider}`);
+    }
+  }
+
+  private getSourceConfiguration(params: CreatePipelineParams): Record<string, string> {
+    switch (params.source_provider) {
+      case 'GitHub':
+        return {
+          Owner: params.repository.split('/')[0] ?? '',
+          Repo: params.repository.split('/')[1] ?? '',
+          Branch: params.branch ?? 'main',
+          ...(params.oauth_token || params.oauthToken || this.credentials.accessToken
+            ? { OAuthToken: params.oauth_token || params.oauthToken || String(this.credentials.accessToken || '') }
+            : {})
+        };
+      case 'CodeCommit':
+        return {
+          RepositoryName: params.repository,
+          BranchName: params.branch ?? 'main'
+        };
+      case 'S3':
+        return {
+          S3Bucket: params.repository,
+          S3ObjectKey: params.branch ?? 'latest'
+        };
+      default:
+        return {};
+    }
+  }
+
+  private formatAwsError(error: unknown): string {
+    const message = getErrorMessage(error);
+
+    if (typeof error === 'object' && error !== null && '$metadata' in error) {
+      const metadata = (error as { $metadata?: { httpStatusCode?: number } }).$metadata;
+      if (metadata?.httpStatusCode) {
+        return `${message} (status ${metadata.httpStatusCode})`;
+      }
+    }
+
+    if (message.includes('Could not connect to the endpoint URL')) {
+      return `${message} (verify region: ${this.region})`;
+    }
+
+    const name = (error as { name?: string }).name;
+    if (name === 'UnknownEndpoint' || name === 'EndpointError') {
+      return `${message} (verify region: ${this.region})`;
+    }
+
+    return message;
+  }
+}

--- a/server/integrations/IntegrationManager.ts
+++ b/server/integrations/IntegrationManager.ts
@@ -132,6 +132,12 @@ export class IntegrationManager {
       'helmfile': 'helm',
       'ansible-tower': 'ansible',
       'awx': 'ansible',
+      'cloudformation': 'aws-cloudformation',
+      'aws_cloudformation': 'aws-cloudformation',
+      'awscloudformation': 'aws-cloudformation',
+      'codepipeline': 'aws-codepipeline',
+      'aws_codepipeline': 'aws-codepipeline',
+      'aws-code-pipeline': 'aws-codepipeline',
     };
     return map[v] || v;
   }

--- a/server/integrations/__tests__/AwsClients.test.ts
+++ b/server/integrations/__tests__/AwsClients.test.ts
@@ -1,0 +1,261 @@
+import assert from 'node:assert/strict';
+
+import {
+  CreateStackCommand,
+  DeleteStackCommand,
+  DescribeStacksCommand,
+  ListStacksCommand,
+  UpdateStackCommand
+} from '@aws-sdk/client-cloudformation';
+import {
+  CreatePipelineCommand,
+  GetPipelineStateCommand,
+  ListPipelinesCommand,
+  StartPipelineExecutionCommand,
+  StopPipelineExecutionCommand
+} from '@aws-sdk/client-codepipeline';
+
+import { AwsCloudFormationAPIClient } from '../AwsCloudFormationAPIClient.js';
+import { AwsCodePipelineAPIClient } from '../AwsCodePipelineAPIClient.js';
+import { getRuntimeOpHandler } from '../../workflow/compiler/op-map.js';
+
+class StubAwsClient<TCommand = any> {
+  public readonly sent: TCommand[] = [];
+  private readonly responses: Array<any>;
+
+  constructor(responses: Array<any>) {
+    this.responses = [...responses];
+  }
+
+  async send(command: TCommand): Promise<any> {
+    this.sent.push(command);
+    if (this.responses.length === 0) {
+      return {};
+    }
+    const next = this.responses.shift();
+    if (typeof next === 'function') {
+      return next(command);
+    }
+    if (next instanceof Error) {
+      throw next;
+    }
+    if (next && typeof next === 'object' && 'error' in next) {
+      throw (next as { error: Error }).error;
+    }
+    return next;
+  }
+}
+
+async function testCloudFormationClient(): Promise<void> {
+  const stub = new StubAwsClient([
+    (command: unknown) => {
+      assert.ok(command instanceof ListStacksCommand, 'First command should be ListStacksCommand');
+      return { StackSummaries: [{ StackId: '1' }] };
+    },
+    (command: unknown) => {
+      assert.ok(command instanceof CreateStackCommand, 'Second command should be CreateStackCommand');
+      const input = (command as CreateStackCommand).input;
+      assert.equal(input.StackName, 'demo-stack');
+      assert.equal(input.TemplateBody, '{"Resources":{}}');
+      assert.deepEqual(input.Capabilities, ['CAPABILITY_IAM']);
+      return { StackId: 'stack/123' };
+    },
+    (command: unknown) => {
+      assert.ok(command instanceof UpdateStackCommand, 'Third command should be UpdateStackCommand');
+      const input = (command as UpdateStackCommand).input;
+      assert.equal(input.StackName, 'demo-stack');
+      assert.equal(input.TemplateURL, 'https://example.com/template.yaml');
+      return { StackId: 'stack/123' };
+    },
+    (command: unknown) => {
+      assert.ok(command instanceof DescribeStacksCommand, 'Fourth command should be DescribeStacksCommand');
+      const input = (command as DescribeStacksCommand).input;
+      assert.equal(input.StackName, 'demo-stack');
+      return {
+        Stacks: [
+          {
+            StackId: 'stack/123',
+            StackName: 'demo-stack',
+            StackStatus: 'CREATE_COMPLETE',
+            StackStatusReason: 'OK',
+            LastUpdatedTime: new Date('2024-01-02T00:00:00.000Z'),
+            CreationTime: new Date('2024-01-01T00:00:00.000Z')
+          }
+        ]
+      };
+    },
+    (command: unknown) => {
+      assert.ok(command instanceof DeleteStackCommand, 'Fifth command should be DeleteStackCommand');
+      const input = (command as DeleteStackCommand).input;
+      assert.equal(input.StackName, 'demo-stack');
+      return {};
+    },
+    new Proxy(new Error('Could not connect to the endpoint URL: "https://cloudformation.us-west-2.amazonaws.com"'), {
+      get(target, prop) {
+        if (prop === 'name') return 'UnknownEndpoint';
+        return Reflect.get(target, prop);
+      }
+    })
+  ]);
+
+  const client = new AwsCloudFormationAPIClient({
+    access_key_id: 'AKIA123',
+    secret_access_key: 'secret',
+    region: 'us-west-2',
+    cloudFormationClient: stub as unknown as any
+  });
+
+  const ping = await client.testConnection();
+  assert.equal(ping.success, true, 'CloudFormation test connection should succeed');
+  assert.equal(ping.data?.stackCount, 1);
+
+  const createResult = await client.createStack({
+    stack_name: 'demo-stack',
+    template_body: '{"Resources":{}}',
+    capabilities: ['CAPABILITY_IAM']
+  });
+  assert.equal(createResult.success, true, 'CloudFormation create stack should succeed');
+
+  const updateResult = await client.updateStack({
+    stack_name: 'demo-stack',
+    template_url: 'https://example.com/template.yaml'
+  });
+  assert.equal(updateResult.success, true, 'CloudFormation update stack should succeed');
+
+  const status = await client.getStackStatus({ stack_name: 'demo-stack' });
+  assert.equal(status.success, true, 'CloudFormation get stack status should succeed');
+  assert.equal(status.data?.stackStatus, 'CREATE_COMPLETE');
+
+  const deletion = await client.deleteStack({ stack_name: 'demo-stack' });
+  assert.equal(deletion.success, true, 'CloudFormation delete stack should succeed');
+
+  const regionError = await client.testConnection();
+  assert.equal(regionError.success, false, 'Region failure should surface as error');
+  assert.ok(
+    regionError.error?.includes('verify region: us-west-2'),
+    'Error should include region guidance'
+  );
+
+  const runtimeHandler = getRuntimeOpHandler('action.aws-cloudformation:create_stack');
+  assert.ok(runtimeHandler, 'Runtime handler for CloudFormation create should exist');
+  const runtimeStub = new StubAwsClient([
+    () => ({ StackId: 'stack/456' })
+  ]);
+  const runtimeClient = new AwsCloudFormationAPIClient({
+    access_key_id: 'AKIA456',
+    secret_access_key: 'secret',
+    region: 'us-west-2',
+    cloudFormationClient: runtimeStub as unknown as any
+  });
+  const runtimeResult = await runtimeHandler!(runtimeClient, {
+    stack_name: 'runtime-stack',
+    template_body: '{"Resources":{}}'
+  });
+  assert.equal(runtimeResult.success, true, 'Runtime handler should delegate to client');
+  assert.equal(runtimeStub.sent.length, 1, 'Runtime handler should trigger AWS call');
+}
+
+async function testCodePipelineClient(): Promise<void> {
+  const stub = new StubAwsClient([
+    (command: unknown) => {
+      assert.ok(command instanceof ListPipelinesCommand, 'First command should be ListPipelinesCommand');
+      return { pipelines: [{ name: 'existing' }] };
+    },
+    (command: unknown) => {
+      assert.ok(command instanceof CreatePipelineCommand, 'Second command should be CreatePipelineCommand');
+      const input = (command as CreatePipelineCommand).input;
+      assert.equal(input.pipeline?.name, 'deploy');
+      assert.equal(input.pipeline?.roleArn, 'arn:aws:iam::123:role/pipeline');
+      assert.equal(input.pipeline?.artifactStore?.location, 'deployment-artifacts');
+      assert.equal(
+        input.pipeline?.stages?.[0]?.actions?.[0]?.configuration?.OAuthToken,
+        'ghp_test'
+      );
+      return { pipeline: { name: 'deploy' } };
+    },
+    (command: unknown) => {
+      assert.ok(command instanceof StartPipelineExecutionCommand, 'Third command should be StartPipelineExecutionCommand');
+      const input = (command as StartPipelineExecutionCommand).input;
+      assert.equal(input.name, 'deploy');
+      return { pipelineExecutionId: 'exe-1' };
+    },
+    (command: unknown) => {
+      assert.ok(command instanceof GetPipelineStateCommand, 'Fourth command should be GetPipelineStateCommand');
+      const input = (command as GetPipelineStateCommand).input;
+      assert.equal(input.name, 'deploy');
+      return { pipelineName: 'deploy', stageStates: [] };
+    },
+    (command: unknown) => {
+      assert.ok(command instanceof StopPipelineExecutionCommand, 'Fifth command should be StopPipelineExecutionCommand');
+      const input = (command as StopPipelineExecutionCommand).input;
+      assert.equal(input.name, 'deploy');
+      assert.equal(input.pipelineExecutionId, 'exe-1');
+      return {};
+    },
+    new Proxy(new Error('Could not connect to the endpoint URL: "https://codepipeline.us-west-2.amazonaws.com"'), {
+      get(target, prop) {
+        if (prop === 'name') return 'EndpointError';
+        return Reflect.get(target, prop);
+      }
+    })
+  ]);
+
+  const client = new AwsCodePipelineAPIClient({
+    access_key_id: 'AKIA789',
+    secret_access_key: 'secret',
+    region: 'us-west-2',
+    accessToken: 'gh-token',
+    codePipelineClient: stub as unknown as any
+  });
+
+  const ping = await client.testConnection();
+  assert.equal(ping.success, true, 'CodePipeline test connection should succeed');
+  assert.equal(ping.data?.pipelineCount, 1);
+
+  const createResult = await client.createPipeline({
+    name: 'deploy',
+    role_arn: 'arn:aws:iam::123:role/pipeline',
+    source_provider: 'GitHub',
+    repository: 'octo/repo',
+    branch: 'main',
+    artifact_bucket: 'deployment-artifacts',
+    oauth_token: 'ghp_test'
+  });
+  assert.equal(createResult.success, true, 'CodePipeline create should succeed');
+
+  const start = await client.startPipeline({ name: 'deploy' });
+  assert.equal(start.success, true, 'Start pipeline should succeed');
+
+  const state = await client.getPipelineState({ name: 'deploy' });
+  assert.equal(state.success, true, 'Get pipeline state should succeed');
+
+  const stop = await client.stopPipeline({ name: 'deploy', execution_id: 'exe-1' });
+  assert.equal(stop.success, true, 'Stop pipeline should succeed');
+
+  const regionError = await client.testConnection();
+  assert.equal(regionError.success, false, 'Region failure should surface as error');
+  assert.ok(
+    regionError.error?.includes('verify region: us-west-2'),
+    'CodePipeline error should include region guidance'
+  );
+
+  const runtimeHandler = getRuntimeOpHandler('action.aws-codepipeline:start_pipeline');
+  assert.ok(runtimeHandler, 'Runtime handler for start pipeline should exist');
+  const runtimeStub = new StubAwsClient([
+    () => ({ pipelineExecutionId: 'exe-2' })
+  ]);
+  const runtimeClient = new AwsCodePipelineAPIClient({
+    access_key_id: 'AKIA000',
+    secret_access_key: 'secret',
+    region: 'us-west-2',
+    codePipelineClient: runtimeStub as unknown as any
+  });
+  const runtimeResult = await runtimeHandler!(runtimeClient, { name: 'deploy' });
+  assert.equal(runtimeResult.success, true, 'Runtime handler should delegate to CodePipeline client');
+  assert.equal(runtimeStub.sent.length, 1, 'Runtime handler should trigger AWS call');
+}
+
+await testCloudFormationClient();
+await testCodePipelineClient();
+
+console.log('AWS CloudFormation and CodePipeline client tests passed.');

--- a/server/workflow/compiler/op-map.ts
+++ b/server/workflow/compiler/op-map.ts
@@ -16,6 +16,8 @@ import { TerraformCloudAPIClient } from '../../integrations/TerraformCloudAPICli
 import { HashicorpVaultAPIClient } from '../../integrations/HashicorpVaultAPIClient.js';
 import { HelmAPIClient } from '../../integrations/HelmAPIClient.js';
 import { AnsibleAPIClient } from '../../integrations/AnsibleAPIClient.js';
+import { AwsCloudFormationAPIClient } from '../../integrations/AwsCloudFormationAPIClient.js';
+import { AwsCodePipelineAPIClient } from '../../integrations/AwsCodePipelineAPIClient.js';
 
 /**
  * Get the compiler operation map
@@ -60,6 +62,28 @@ const RUNTIME_OPS: Record<string, RuntimeHandler> = {
     assertClientInstance(client, CircleCIApiClient).cancelWorkflow(params),
   'action.circleci:rerun_workflow': (client, params = {}) =>
     assertClientInstance(client, CircleCIApiClient).rerunWorkflow(params),
+
+  'action.aws-cloudformation:test_connection': client =>
+    assertClientInstance(client, AwsCloudFormationAPIClient).testConnection(),
+  'action.aws-cloudformation:create_stack': (client, params = {}) =>
+    assertClientInstance(client, AwsCloudFormationAPIClient).createStack(params),
+  'action.aws-cloudformation:update_stack': (client, params = {}) =>
+    assertClientInstance(client, AwsCloudFormationAPIClient).updateStack(params),
+  'action.aws-cloudformation:delete_stack': (client, params = {}) =>
+    assertClientInstance(client, AwsCloudFormationAPIClient).deleteStack(params),
+  'action.aws-cloudformation:get_stack_status': (client, params = {}) =>
+    assertClientInstance(client, AwsCloudFormationAPIClient).getStackStatus(params),
+
+  'action.aws-codepipeline:test_connection': client =>
+    assertClientInstance(client, AwsCodePipelineAPIClient).testConnection(),
+  'action.aws-codepipeline:create_pipeline': (client, params = {}) =>
+    assertClientInstance(client, AwsCodePipelineAPIClient).createPipeline(params),
+  'action.aws-codepipeline:start_pipeline': (client, params = {}) =>
+    assertClientInstance(client, AwsCodePipelineAPIClient).startPipeline(params),
+  'action.aws-codepipeline:get_pipeline_state': (client, params = {}) =>
+    assertClientInstance(client, AwsCodePipelineAPIClient).getPipelineState(params),
+  'action.aws-codepipeline:stop_pipeline': (client, params = {}) =>
+    assertClientInstance(client, AwsCodePipelineAPIClient).stopPipeline(params),
 
   'action.kubernetes:test_connection': client => assertClientInstance(client, KubernetesAPIClient).testConnection(),
   'action.kubernetes:create_deployment': (client, params = {}) =>


### PR DESCRIPTION
## Summary
- add dedicated AWS CloudFormation and CodePipeline API clients backed by the AWS SDK
- register both clients with the connector registry and compiler runtime handlers
- add integration tests that exercise stack lifecycle and pipeline trigger flows with region error handling

## Testing
- npm test *(fails: cannot download @aws-sdk packages in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68de9d7d767483318dab081710822296