### PR TITLE
Add AWS SDK fallbacks for offline environments

### DIFF
--- a/server/integrations/AwsCloudFormationAPIClient.ts
+++ b/server/integrations/AwsCloudFormationAPIClient.ts
@@ -1,12 +1,6 @@
-import {
-  CloudFormationClient,
-  CreateStackCommand,
-  DeleteStackCommand,
-  DescribeStacksCommand,
-  ListStacksCommand,
-  UpdateStackCommand,
-  type CloudFormationClientConfig
-} from '@aws-sdk/client-cloudformation';
+import type { CloudFormationClientConfig } from './aws/stubs/cloudformation';
+
+import { loadCloudFormationSdk } from './aws/sdk-loader';
 
 import { APICredentials, APIResponse, BaseAPIClient } from './BaseAPIClient';
 import { getErrorMessage } from '../types/common';
@@ -79,6 +73,15 @@ function sanitizeSessionToken(credentials: AwsCloudFormationCredentials): string
     credentials.accessToken
   );
 }
+
+const {
+  CloudFormationClient,
+  CreateStackCommand,
+  DeleteStackCommand,
+  DescribeStacksCommand,
+  ListStacksCommand,
+  UpdateStackCommand
+} = await loadCloudFormationSdk();
 
 export class AwsCloudFormationAPIClient extends BaseAPIClient {
   private readonly client: CloudFormationClient;

--- a/server/integrations/AwsCodePipelineAPIClient.ts
+++ b/server/integrations/AwsCodePipelineAPIClient.ts
@@ -1,14 +1,10 @@
-import {
-  CodePipelineClient,
-  CreatePipelineCommand,
-  GetPipelineStateCommand,
-  ListPipelinesCommand,
-  StartPipelineExecutionCommand,
-  StopPipelineExecutionCommand,
-  type CodePipelineClientConfig,
-  type ActionTypeId,
-  type StageDeclaration
-} from '@aws-sdk/client-codepipeline';
+import type {
+  ActionTypeId,
+  CodePipelineClientConfig,
+  StageDeclaration
+} from './aws/stubs/codepipeline';
+
+import { loadCodePipelineSdk } from './aws/sdk-loader';
 
 import { APICredentials, APIResponse, BaseAPIClient } from './BaseAPIClient';
 import { getErrorMessage } from '../types/common';
@@ -74,6 +70,15 @@ function sanitizeSessionToken(credentials: AwsCodePipelineCredentials): string |
     credentials.accessToken
   );
 }
+
+const {
+  CodePipelineClient,
+  CreatePipelineCommand,
+  GetPipelineStateCommand,
+  ListPipelinesCommand,
+  StartPipelineExecutionCommand,
+  StopPipelineExecutionCommand
+} = await loadCodePipelineSdk();
 
 export class AwsCodePipelineAPIClient extends BaseAPIClient {
   private readonly client: CodePipelineClient;

--- a/server/integrations/__tests__/AwsClients.test.ts
+++ b/server/integrations/__tests__/AwsClients.test.ts
@@ -1,23 +1,26 @@
 import assert from 'node:assert/strict';
 
-import {
+import { loadCloudFormationSdk, loadCodePipelineSdk } from '../aws/sdk-loader.js';
+
+import { AwsCloudFormationAPIClient } from '../AwsCloudFormationAPIClient.js';
+import { AwsCodePipelineAPIClient } from '../AwsCodePipelineAPIClient.js';
+import { getRuntimeOpHandler } from '../../workflow/compiler/op-map.js';
+
+const {
   CreateStackCommand,
   DeleteStackCommand,
   DescribeStacksCommand,
   ListStacksCommand,
   UpdateStackCommand
-} from '@aws-sdk/client-cloudformation';
-import {
+} = await loadCloudFormationSdk();
+
+const {
   CreatePipelineCommand,
   GetPipelineStateCommand,
   ListPipelinesCommand,
   StartPipelineExecutionCommand,
   StopPipelineExecutionCommand
-} from '@aws-sdk/client-codepipeline';
-
-import { AwsCloudFormationAPIClient } from '../AwsCloudFormationAPIClient.js';
-import { AwsCodePipelineAPIClient } from '../AwsCodePipelineAPIClient.js';
-import { getRuntimeOpHandler } from '../../workflow/compiler/op-map.js';
+} = await loadCodePipelineSdk();
 
 class StubAwsClient<TCommand = any> {
   public readonly sent: TCommand[] = [];

--- a/server/integrations/aws/sdk-loader.ts
+++ b/server/integrations/aws/sdk-loader.ts
@@ -1,0 +1,39 @@
+const moduleWarnings = new Set<string>();
+
+const isModuleNotFoundError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  return 'code' in error && (error as { code?: string }).code === 'ERR_MODULE_NOT_FOUND';
+};
+
+const resolveModule = async <TModule>(
+  specifier: string,
+  fallback: () => Promise<TModule>,
+  warning: string
+): Promise<TModule> => {
+  return import(specifier).catch(async (error: unknown) => {
+    if (!isModuleNotFoundError(error)) {
+      throw error;
+    }
+    if (!moduleWarnings.has(specifier)) {
+      console.warn(warning);
+      moduleWarnings.add(specifier);
+    }
+    return fallback();
+  }) as Promise<TModule>;
+};
+
+export const loadCloudFormationSdk = (): Promise<typeof import('./stubs/cloudformation.js')> =>
+  resolveModule(
+    '@aws-sdk/client-cloudformation',
+    () => import('./stubs/cloudformation.js'),
+    '[aws-sdk] Falling back to internal stub for @aws-sdk/client-cloudformation. Install the official AWS SDK client to enable live CloudFormation calls.'
+  );
+
+export const loadCodePipelineSdk = (): Promise<typeof import('./stubs/codepipeline.js')> =>
+  resolveModule(
+    '@aws-sdk/client-codepipeline',
+    () => import('./stubs/codepipeline.js'),
+    '[aws-sdk] Falling back to internal stub for @aws-sdk/client-codepipeline. Install the official AWS SDK client to enable live CodePipeline calls.'
+  );

--- a/server/integrations/aws/stubs/cloudformation.ts
+++ b/server/integrations/aws/stubs/cloudformation.ts
@@ -1,0 +1,36 @@
+export interface CloudFormationClientConfig {
+  region?: string;
+  credentials?: {
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+  };
+}
+
+class BaseCommand<TInput = Record<string, any>> {
+  public readonly input: TInput;
+
+  constructor(input: TInput) {
+    this.input = input;
+  }
+}
+
+export class CloudFormationClient {
+  public readonly config: CloudFormationClientConfig;
+
+  constructor(config: CloudFormationClientConfig = {}) {
+    this.config = config;
+  }
+
+  async send(): Promise<never> {
+    throw new Error(
+      'CloudFormationClient stub cannot execute commands. Install @aws-sdk/client-cloudformation to enable live operations.'
+    );
+  }
+}
+
+export class CreateStackCommand<TInput = Record<string, any>> extends BaseCommand<TInput> {}
+export class UpdateStackCommand<TInput = Record<string, any>> extends BaseCommand<TInput> {}
+export class DeleteStackCommand<TInput = Record<string, any>> extends BaseCommand<TInput> {}
+export class DescribeStacksCommand<TInput = Record<string, any>> extends BaseCommand<TInput> {}
+export class ListStacksCommand<TInput = Record<string, any>> extends BaseCommand<TInput> {}

--- a/server/integrations/aws/stubs/codepipeline.ts
+++ b/server/integrations/aws/stubs/codepipeline.ts
@@ -1,0 +1,60 @@
+export interface CodePipelineClientConfig {
+  region?: string;
+  credentials?: {
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+  };
+}
+
+export interface ActionTypeId {
+  category: string;
+  owner: string;
+  provider: string;
+  version: string;
+}
+
+export interface ArtifactDeclaration {
+  name: string;
+}
+
+export interface ActionDeclaration {
+  name: string;
+  actionTypeId: ActionTypeId;
+  configuration?: Record<string, any>;
+  inputArtifacts?: ArtifactDeclaration[];
+  outputArtifacts?: ArtifactDeclaration[];
+}
+
+export interface StageDeclaration {
+  name: string;
+  actions: ActionDeclaration[];
+}
+
+class BaseCommand<TInput = Record<string, any>> {
+  public readonly input: TInput;
+
+  constructor(input: TInput) {
+    this.input = input;
+  }
+}
+
+export class CodePipelineClient {
+  public readonly config: CodePipelineClientConfig;
+
+  constructor(config: CodePipelineClientConfig = {}) {
+    this.config = config;
+  }
+
+  async send(): Promise<never> {
+    throw new Error(
+      'CodePipelineClient stub cannot execute commands. Install @aws-sdk/client-codepipeline to enable live operations.'
+    );
+  }
+}
+
+export class CreatePipelineCommand<TInput = Record<string, any>> extends BaseCommand<TInput> {}
+export class GetPipelineStateCommand<TInput = Record<string, any>> extends BaseCommand<TInput> {}
+export class ListPipelinesCommand<TInput = Record<string, any>> extends BaseCommand<TInput> {}
+export class StartPipelineExecutionCommand<TInput = Record<string, any>> extends BaseCommand<TInput> {}
+export class StopPipelineExecutionCommand<TInput = Record<string, any>> extends BaseCommand<TInput> {}


### PR DESCRIPTION
## Summary
- add a reusable loader that falls back to local AWS stubs when the official SDK packages are unavailable
- supply CloudFormation and CodePipeline stub implementations compatible with existing clients and tests
- update the AWS integration clients and regression tests to consume the loader, enabling development without installing the SDKs

## Testing
- npm test -- --runTestsByPath server/integrations/__tests__/AwsClients.test.ts *(fails: Transform failed with 1 error: compile-to-appsscript.ts expected ';' but found '$')*

------
https://chatgpt.com/codex/tasks/task_e_68de30c9928083318105eeb25d00dd90