### PR TITLE
Add BullMQ factory and Redis queue configuration

### DIFF
--- a/docs/operations/queue.md
+++ b/docs/operations/queue.md
@@ -1,0 +1,68 @@
+# Queue & Worker Infrastructure
+
+This service uses [BullMQ](https://docs.bullmq.io/) backed by Redis for all background job processing. The utilities in `server/queue/BullMQFactory.ts` centralize queue configuration so that every queue, worker, and queue-events instance shares the same connection parameters, telemetry, and defaults.
+
+## Environment variables
+
+Set the following variables to configure the Redis connection that BullMQ should use:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `QUEUE_REDIS_HOST` | Redis host name or IP address. | `127.0.0.1` |
+| `QUEUE_REDIS_PORT` | Redis TCP port. | `6379` |
+| `QUEUE_REDIS_DB` | Logical Redis database index. | `0` |
+| `QUEUE_REDIS_USERNAME` | Optional Redis username when ACLs are enabled. | _empty_ |
+| `QUEUE_REDIS_PASSWORD` | Optional Redis password. | _empty_ |
+| `QUEUE_REDIS_TLS` | Set to `true` to enable TLS connections. | `false` |
+| `QUEUE_METRICS_INTERVAL_MS` | Interval (ms) for periodic queue metrics collection/logging. | `60000` |
+
+All queues created via the factory automatically honour these settings.
+
+## Local development with Docker Compose
+
+A minimal Redis instance suitable for local queue development can be started with Docker Compose:
+
+```yaml
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+```
+
+Export the environment variables before starting the API or workers:
+
+```bash
+export QUEUE_REDIS_HOST=127.0.0.1
+export QUEUE_REDIS_PORT=6379
+export QUEUE_REDIS_DB=0
+```
+
+When TLS or authentication is required, set `QUEUE_REDIS_USERNAME`, `QUEUE_REDIS_PASSWORD`, and `QUEUE_REDIS_TLS=true` accordingly.
+
+## Telemetry & metrics helpers
+
+Use `registerQueueTelemetry` to attach logging and periodic metrics collection to any queue. The helper wires standard BullMQ events (`completed`, `failed`, `stalled`, `waiting`, and `error`) to console logging by default. You can supply custom handlers or a metrics callback to push queue statistics into your observability stack.
+
+Example:
+
+```ts
+import { createQueue, createQueueEvents, registerQueueTelemetry } from '../queue/BullMQFactory';
+
+const executionQueue = createQueue('workflow.execute');
+const executionEvents = createQueueEvents('workflow.execute');
+
+const detach = registerQueueTelemetry(executionQueue, executionEvents, {
+  onMetrics: (counts) => metricsClient.gauge('queue.workflow_execute', counts),
+});
+
+// Call detach() during shutdown to remove listeners and timers.
+```
+
+The factory exports typed job payloads (e.g. `workflow.execute`) so that enqueueing and worker processors receive type-safe payloads throughout the codebase.

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@radix-ui/react-toggle-group": "^1.1.3",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.85.5",
+    "bullmq": "^5.27.2",
     "@types/crypto-js": "^4.2.2",
     "@types/jsonwebtoken": "^9.0.10",
     "ajv": "8.17.1",

--- a/server/env.ts
+++ b/server/env.ts
@@ -44,6 +44,13 @@ export const env = {
   SERVER_PUBLIC_URL: process.env.SERVER_PUBLIC_URL || '',
   ENABLE_LLM_FEATURES: process.env.ENABLE_LLM_FEATURES === 'true',
   GENERIC_EXECUTOR_ENABLED: process.env.GENERIC_EXECUTOR_ENABLED === 'true',
+  QUEUE_REDIS_HOST: process.env.QUEUE_REDIS_HOST || '127.0.0.1',
+  QUEUE_REDIS_PORT: Number.parseInt(process.env.QUEUE_REDIS_PORT ?? '6379', 10),
+  QUEUE_REDIS_DB: Number.parseInt(process.env.QUEUE_REDIS_DB ?? '0', 10),
+  QUEUE_REDIS_USERNAME: process.env.QUEUE_REDIS_USERNAME,
+  QUEUE_REDIS_PASSWORD: process.env.QUEUE_REDIS_PASSWORD,
+  QUEUE_REDIS_TLS: process.env.QUEUE_REDIS_TLS === 'true',
+  QUEUE_METRICS_INTERVAL_MS: Number.parseInt(process.env.QUEUE_METRICS_INTERVAL_MS ?? '60000', 10),
 } as const;
 
 export const FLAGS = {

--- a/server/queue/BullMQFactory.ts
+++ b/server/queue/BullMQFactory.ts
@@ -1,0 +1,216 @@
+import {
+  Queue,
+  QueueEvents,
+  Worker,
+  type Processor,
+  type QueueEventsOptions,
+  type QueueOptions,
+  type WorkerOptions,
+  type RedisOptions,
+} from 'bullmq';
+
+import { env } from '../env';
+
+export type WorkflowExecuteJobPayload = {
+  workflowId: string;
+  executionId: string;
+  organizationId: string;
+  userId?: string;
+  triggerType: string;
+  triggerData?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown>;
+};
+
+export interface JobPayloads {
+  'workflow.execute': WorkflowExecuteJobPayload;
+}
+
+export type QueueName = keyof JobPayloads;
+
+type JobPayload<Name extends QueueName> = JobPayloads[Name];
+
+export type QueueJobCounts<Name extends QueueName> = Awaited<
+  ReturnType<Queue<JobPayload<Name>, unknown, Name>['getJobCounts']>
+>;
+
+export interface QueueTelemetryHandlers<Name extends QueueName> {
+  onCompleted?: (payload: { jobId: string; returnValue: unknown }) => void;
+  onFailed?: (payload: { jobId: string; failedReason: string; attemptsMade: number }) => void;
+  onStalled?: (payload: { jobId: string }) => void;
+  onWaiting?: (payload: { jobId: string }) => void;
+  onError?: (error: Error) => void;
+}
+
+export interface QueueTelemetryOptions<Name extends QueueName> {
+  logger?: Pick<Console, 'info' | 'warn' | 'error'>;
+  handlers?: QueueTelemetryHandlers<Name>;
+  metricsIntervalMs?: number;
+  onMetrics?: (counts: QueueJobCounts<Name>) => void;
+}
+
+const defaultLogger: Pick<Console, 'info' | 'warn' | 'error'> = console;
+
+export function getRedisConnectionOptions(): RedisOptions {
+  const baseOptions: RedisOptions = {
+    host: env.QUEUE_REDIS_HOST,
+    port: env.QUEUE_REDIS_PORT,
+    db: env.QUEUE_REDIS_DB,
+  };
+
+  if (env.QUEUE_REDIS_USERNAME) {
+    baseOptions.username = env.QUEUE_REDIS_USERNAME;
+  }
+  if (env.QUEUE_REDIS_PASSWORD) {
+    baseOptions.password = env.QUEUE_REDIS_PASSWORD;
+  }
+  if (env.QUEUE_REDIS_TLS) {
+    baseOptions.tls = {};
+  }
+
+  return baseOptions;
+}
+
+export function createQueue<Name extends QueueName, ResultType = unknown>(
+  name: Name,
+  options?: QueueOptions<JobPayload<Name>, ResultType, Name>
+): Queue<JobPayload<Name>, ResultType, Name> {
+  const connection = { ...getRedisConnectionOptions(), ...options?.connection };
+  const defaultJobOptions = {
+    removeOnComplete: true,
+    removeOnFail: false,
+    ...options?.defaultJobOptions,
+  };
+  const merged: QueueOptions<JobPayload<Name>, ResultType, Name> = {
+    ...options,
+    connection,
+    defaultJobOptions,
+    prefix: options?.prefix ?? `bull:${String(name)}`,
+  };
+
+  return new Queue<JobPayload<Name>, ResultType, Name>(name, merged);
+}
+
+export function createWorker<Name extends QueueName, ResultType = unknown>(
+  name: Name,
+  processor: Processor<JobPayload<Name>, ResultType, Name>,
+  options?: WorkerOptions<JobPayload<Name>, ResultType, Name>
+): Worker<JobPayload<Name>, ResultType, Name> {
+  const merged: WorkerOptions<JobPayload<Name>, ResultType, Name> = {
+    connection: { ...getRedisConnectionOptions(), ...options?.connection },
+    autorun: options?.autorun ?? true,
+    ...options,
+  };
+
+  return new Worker<JobPayload<Name>, ResultType, Name>(name, processor, merged);
+}
+
+export function createQueueEvents<Name extends QueueName>(
+  name: Name,
+  options?: QueueEventsOptions
+): QueueEvents {
+  const merged: QueueEventsOptions = {
+    connection: { ...getRedisConnectionOptions(), ...options?.connection },
+    autorun: options?.autorun ?? true,
+    ...options,
+  };
+
+  return new QueueEvents(name, merged);
+}
+
+export function registerQueueTelemetry<Name extends QueueName>(
+  queue: Queue<JobPayload<Name>, unknown, Name>,
+  queueEvents: QueueEvents,
+  options: QueueTelemetryOptions<Name> = {}
+): () => void {
+  const logger = options.logger ?? defaultLogger;
+  const handlers = options.handlers ?? {};
+  const metricsIntervalMs = options.metricsIntervalMs ?? env.QUEUE_METRICS_INTERVAL_MS;
+
+  const completedHandler = ({ jobId, returnvalue }: { jobId: string; returnvalue: unknown }) => {
+    handlers.onCompleted?.({ jobId, returnValue: returnvalue });
+    if (!handlers.onCompleted) {
+      logger.info(`[queue:${queue.name}] Job ${jobId} completed`);
+    }
+  };
+
+  const failedHandler = ({
+    jobId,
+    failedReason,
+    attemptsMade,
+  }: {
+    jobId: string;
+    failedReason: string;
+    attemptsMade: number;
+  }) => {
+    handlers.onFailed?.({ jobId, failedReason, attemptsMade });
+    if (!handlers.onFailed) {
+      logger.error(
+        `[queue:${queue.name}] Job ${jobId} failed after ${attemptsMade} attempts: ${failedReason}`
+      );
+    }
+  };
+
+  const stalledHandler = ({ jobId }: { jobId: string }) => {
+    handlers.onStalled?.({ jobId });
+    if (!handlers.onStalled) {
+      logger.warn(`[queue:${queue.name}] Job ${jobId} stalled`);
+    }
+  };
+
+  const waitingHandler = ({ jobId }: { jobId: string }) => {
+    handlers.onWaiting?.({ jobId });
+    if (!handlers.onWaiting) {
+      logger.info(`[queue:${queue.name}] Job ${jobId} enqueued`);
+    }
+  };
+
+  const errorHandler = (error: Error) => {
+    handlers.onError?.(error);
+    if (!handlers.onError) {
+      logger.error(`[queue:${queue.name}] Queue error`, error);
+    }
+  };
+
+  queueEvents.on('completed', completedHandler as unknown as (...args: unknown[]) => void);
+  queueEvents.on('failed', failedHandler as unknown as (...args: unknown[]) => void);
+  queueEvents.on('stalled', stalledHandler as unknown as (...args: unknown[]) => void);
+  queueEvents.on('waiting', waitingHandler as unknown as (...args: unknown[]) => void);
+  queueEvents.on('error', errorHandler);
+
+  let metricsTimer: NodeJS.Timeout | undefined;
+  if (metricsIntervalMs > 0) {
+    const collectMetrics = async () => {
+      try {
+        const counts = await queue.getJobCounts(
+          'waiting',
+          'active',
+          'completed',
+          'failed',
+          'delayed',
+          'paused'
+        );
+        options.onMetrics?.(counts as QueueJobCounts<Name>);
+        if (!options.onMetrics) {
+          logger.info(`[queue:${queue.name}] counts`, counts);
+        }
+      } catch (error) {
+        logger.error(`[queue:${queue.name}] Failed to collect metrics`, error);
+      }
+    };
+
+    metricsTimer = setInterval(collectMetrics, metricsIntervalMs);
+    metricsTimer.unref?.();
+    void collectMetrics();
+  }
+
+  return () => {
+    queueEvents.off('completed', completedHandler as unknown as (...args: unknown[]) => void);
+    queueEvents.off('failed', failedHandler as unknown as (...args: unknown[]) => void);
+    queueEvents.off('stalled', stalledHandler as unknown as (...args: unknown[]) => void);
+    queueEvents.off('waiting', waitingHandler as unknown as (...args: unknown[]) => void);
+    queueEvents.off('error', errorHandler);
+    if (metricsTimer) {
+      clearInterval(metricsTimer);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add a BullMQ factory to centralize queue, worker, and telemetry configuration with typed payloads
- extend the environment configuration with Redis/BullMQ settings for queue connectivity and metrics
- document Redis queue setup, including environment variables and a Docker Compose example

## Testing
- npm install --package-lock-only *(fails: 403 Forbidden fetching @tailwindcss/oxide-wasm32-wasi)*

------
https://chatgpt.com/codex/tasks/task_e_68df517466308331b8e41bd366439117