### PR TITLE
Add polling scheduler worker and next poll tracking

### DIFF
--- a/migrations/0003_polling_triggers_next_poll_at.sql
+++ b/migrations/0003_polling_triggers_next_poll_at.sql
@@ -1,0 +1,11 @@
+ALTER TABLE polling_triggers
+  ADD COLUMN IF NOT EXISTS next_poll_at timestamp NOT NULL DEFAULT NOW();
+
+UPDATE polling_triggers
+SET next_poll_at = COALESCE(next_poll, NOW());
+
+CREATE INDEX IF NOT EXISTS polling_triggers_next_poll_at_idx
+  ON polling_triggers(next_poll_at);
+
+ALTER TABLE polling_triggers
+  ALTER COLUMN next_poll_at DROP DEFAULT;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1759132942664,
       "tag": "0002_workflows_add_organization",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1759132943664,
+      "tag": "0003_polling_triggers_next_poll_at",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -719,6 +719,7 @@ export const pollingTriggers = pgTable(
     interval: integer('interval').notNull(), // seconds
     lastPoll: timestamp('last_poll'),
     nextPoll: timestamp('next_poll').notNull(),
+    nextPollAt: timestamp('next_poll_at').notNull(),
     isActive: boolean('is_active').default(true).notNull(),
     dedupeKey: text('dedupe_key'),
     metadata: json('metadata').$type<Record<string, any>>(),
@@ -729,6 +730,7 @@ export const pollingTriggers = pgTable(
     workflowIdIdx: index('polling_triggers_workflow_id_idx').on(table.workflowId),
     appTriggerIdx: index('polling_triggers_app_trigger_idx').on(table.appId, table.triggerId),
     nextPollIdx: index('polling_triggers_next_poll_idx').on(table.nextPoll),
+    nextPollAtIdx: index('polling_triggers_next_poll_at_idx').on(table.nextPollAt),
     activeIdx: index('polling_triggers_active_idx').on(table.isActive),
   })
 );

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2866,6 +2866,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         workflowId,
         interval,
         nextPoll: new Date(Date.now() + interval * 1000),
+        nextPollAt: new Date(Date.now() + interval * 1000),
         isActive: true,
         dedupeKey,
         metadata: {
@@ -2975,6 +2976,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         interval: intervalSec,
         lastPoll: now,
         nextPoll: new Date(now.getTime() + intervalSec * 1000),
+        nextPollAt: new Date(now.getTime() + intervalSec * 1000),
         isActive: true,
         metadata
       });

--- a/server/services/__tests__/TriggerPersistenceService.fallback.test.ts
+++ b/server/services/__tests__/TriggerPersistenceService.fallback.test.ts
@@ -42,6 +42,7 @@ async function runTriggerPersistenceFallbackIntegration(): Promise<void> {
     triggerId: 'issue.poll',
     interval: 300,
     nextPoll: new Date(Date.now() + 300_000),
+    nextPollAt: new Date(Date.now() + 300_000),
     isActive: true,
     metadata: { interval: '5m' },
   } as const;
@@ -53,10 +54,11 @@ async function runTriggerPersistenceFallbackIntegration(): Promise<void> {
 
   const lastPoll = new Date();
   const nextPoll = new Date(Date.now() + 600_000);
-  await service.updatePollingRuntimeState('poll-1', lastPoll, nextPoll);
+  await service.updatePollingRuntimeState('poll-1', { lastPoll, nextPollAt: nextPoll });
   const updatedPolling = (await service.loadPollingTriggers())[0];
   assert.equal(updatedPolling?.lastPoll?.getTime(), lastPoll.getTime());
   assert.equal(updatedPolling?.nextPoll.getTime(), nextPoll.getTime());
+  assert.equal(updatedPolling?.nextPollAt.getTime(), nextPoll.getTime());
 
   await service.persistDedupeTokens('poll-1', ['token-1', 'token-2']);
   const dedupe = await service.loadDedupeTokens();

--- a/server/webhooks/__tests__/WebhookManager.persistence.test.ts
+++ b/server/webhooks/__tests__/WebhookManager.persistence.test.ts
@@ -37,17 +37,33 @@ class InMemoryTriggerPersistenceDb {
       ...record,
       metadata: record.metadata ?? existing.metadata ?? {},
       isActive: record.isActive ?? existing.isActive ?? true,
+      nextPollAt:
+        record.nextPollAt ??
+        existing.nextPollAt ??
+        (record.nextPoll ? new Date(record.nextPoll) : new Date(Date.now() + (record.interval ?? existing.interval ?? 60) * 1000)),
       updatedAt: new Date(),
       createdAt: existing.createdAt ?? new Date(),
     };
     this.pollingTriggers.set(record.id, next);
   }
 
-  async updatePollingRuntimeState({ id, lastPoll, nextPoll }: { id: string; lastPoll?: Date; nextPoll: Date }) {
+  async updatePollingRuntimeState({
+    id,
+    lastPoll,
+    nextPoll,
+    nextPollAt,
+  }: {
+    id: string;
+    lastPoll?: Date;
+    nextPoll?: Date;
+    nextPollAt?: Date;
+  }) {
     const existing = this.pollingTriggers.get(id);
     if (existing) {
       existing.lastPoll = lastPoll ?? null;
-      existing.nextPoll = nextPoll;
+      const resolvedNext = nextPollAt ?? nextPoll ?? existing.nextPollAt ?? existing.nextPoll ?? null;
+      existing.nextPoll = resolvedNext;
+      existing.nextPollAt = resolvedNext;
       existing.updatedAt = new Date();
       this.pollingTriggers.set(id, existing);
     }

--- a/server/webhooks/types.ts
+++ b/server/webhooks/types.ts
@@ -37,6 +37,7 @@ export interface PollingTrigger {
   interval: number;
   lastPoll?: Date;
   nextPoll: Date;
+  nextPollAt: Date;
   isActive: boolean;
   dedupeKey?: string;
   metadata: Record<string, any>;

--- a/server/workers/scheduler.ts
+++ b/server/workers/scheduler.ts
@@ -1,0 +1,136 @@
+import { env } from '../env';
+import { executionQueueService } from '../services/ExecutionQueueService.js';
+import { triggerPersistenceService } from '../services/TriggerPersistenceService.js';
+import { WebhookManager } from '../webhooks/WebhookManager.js';
+
+const DEFAULT_INTERVAL_MS = 5000;
+const DEFAULT_BATCH_SIZE = 25;
+
+async function runSchedulerCycle(batchSize: number): Promise<void> {
+  const now = new Date();
+  const dueTriggers = await triggerPersistenceService.claimDuePollingTriggers({
+    limit: batchSize,
+    now,
+  });
+
+  if (dueTriggers.length === 0) {
+    return;
+  }
+
+  console.log(`⏱️ Scheduler claimed ${dueTriggers.length} polling trigger(s) at ${now.toISOString()}`);
+
+  const manager = WebhookManager.getInstance();
+  for (const trigger of dueTriggers) {
+    try {
+      await manager.runPollingTrigger(trigger);
+    } catch (error) {
+      console.error(
+        `❌ Scheduler failed to run polling trigger ${trigger.id}:`,
+        error instanceof Error ? error.message : error
+      );
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  console.log('🕒 Starting polling scheduler worker');
+  console.log('🌍 Worker environment:', env.NODE_ENV);
+
+  WebhookManager.configureQueueService(executionQueueService);
+
+  const intervalMs = Math.max(1000, Number.parseInt(process.env.TRIGGER_SCHEDULER_INTERVAL_MS ?? `${DEFAULT_INTERVAL_MS}`, 10));
+  const batchSize = Math.max(1, Number.parseInt(process.env.TRIGGER_SCHEDULER_BATCH_SIZE ?? `${DEFAULT_BATCH_SIZE}`, 10));
+
+  if (!triggerPersistenceService.isDatabaseEnabled()) {
+    console.warn('⚠️ Trigger scheduler requires database persistence; falling back to in-memory scheduling.');
+  }
+
+  let timer: NodeJS.Timeout | null = null;
+  let shuttingDown = false;
+  let runningCycle: Promise<void> | null = null;
+  let resolveShutdown: (() => void) | null = null;
+
+  const waitForShutdown = new Promise<void>((resolve) => {
+    resolveShutdown = resolve;
+  });
+
+  const scheduleNext = () => {
+    if (shuttingDown) {
+      return;
+    }
+    timer = setTimeout(async () => {
+      if (runningCycle) {
+        try {
+          await runningCycle;
+        } catch (error) {
+          console.error('❌ Scheduler cycle error:', error);
+        }
+      }
+
+      runningCycle = runSchedulerCycle(batchSize).catch((error) => {
+        console.error('❌ Scheduler cycle execution error:', error);
+      });
+
+      try {
+        await runningCycle;
+      } finally {
+        runningCycle = null;
+        scheduleNext();
+      }
+    }, intervalMs);
+  };
+
+  runningCycle = runSchedulerCycle(batchSize).catch((error) => {
+    console.error('❌ Initial scheduler cycle failed:', error);
+  });
+
+  await runningCycle;
+  runningCycle = null;
+  scheduleNext();
+
+  const shutdown = async (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+
+    console.log(`⚙️ Received ${signal}. Shutting down scheduler worker...`);
+
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+
+    if (runningCycle) {
+      try {
+        await runningCycle;
+      } catch (error) {
+        console.error('❌ Scheduler cycle error during shutdown:', error);
+      } finally {
+        runningCycle = null;
+      }
+    }
+
+    resolveShutdown?.();
+  };
+
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+
+  process.on('unhandledRejection', (reason) => {
+    console.error('❌ Unhandled rejection in scheduler worker:', reason);
+  });
+
+  process.on('uncaughtException', (error) => {
+    console.error('❌ Uncaught exception in scheduler worker:', error);
+  });
+
+  console.log('🗓️ Polling scheduler worker is running.');
+  await waitForShutdown;
+  console.log('👋 Scheduler worker has stopped.');
+}
+
+void main().catch((error) => {
+  console.error('Failed to start scheduler worker:', error);
+  process.exit(1);
+});

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -41,6 +41,7 @@ export const pollingTriggers = pgTable("polling_triggers", {
   interval: integer("interval").notNull(),
   lastPoll: timestamp("last_poll"),
   nextPoll: timestamp("next_poll").notNull(),
+  nextPollAt: timestamp("next_poll_at").notNull(),
   isActive: boolean("is_active").notNull().default(true),
   dedupeKey: text("dedupe_key"),
   metadata: json("metadata"),


### PR DESCRIPTION
## Summary
- add a dedicated scheduler worker that periodically claims due polling triggers and invokes the webhook manager through the shared queue
- persist and manage next poll timestamps via the new `next_poll_at` column with atomic claims in the trigger persistence service
- remove in-process interval scheduling from the webhook manager so polling relies on the scheduler infrastructure

## Testing
- npm run check *(fails: missing Node/Vite type definitions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df5190596c83319a11e8b4b036fa8b