### PR TITLE
Add OAuth router endpoints and adjust tests

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -17,6 +17,7 @@ import aiNormalizerRoutes from "./routes/ai-normalizer.js";
 import workflowReadRoutes from "./routes/workflow-read.js";
 import productionHealthRoutes from "./routes/production-health.js";
 import flowRoutes from "./routes/flows.js";
+import oauthRoutes from "./routes/oauth";
 import { RealAIService, ConversationManager } from "./realAIService";
 
 // Production services
@@ -121,6 +122,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   // P1-7: AI assist functionality routes
   app.use('/api/ai-assist', aiAssistRoutes);
+
+  // OAuth routes for third-party providers
+  app.use('/api/oauth', oauthRoutes);
   
   // P2-1: Workflow templates routes
   app.use('/api/workflow-templates', templateRoutes);

--- a/server/routes/__tests__/oauth-flow.test.ts
+++ b/server/routes/__tests__/oauth-flow.test.ts
@@ -175,13 +175,13 @@ try {
   const address = server.address() as AddressInfo;
   const baseUrl = `http://127.0.0.1:${address.port}`;
 
-  const authResponse = await fetch(`${baseUrl}/api/oauth/authorize`, {
+  const authResponse = await fetch(`${baseUrl}/api/oauth/authorize/gmail`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
       authorization: 'Bearer test-token',
     },
-    body: JSON.stringify({ provider: 'gmail' })
+    body: JSON.stringify({})
   });
 
   const authBody = await authResponse.json();
@@ -203,13 +203,10 @@ try {
   const redirectLocation = callbackResponse.headers.get('location');
   assert.ok(redirectLocation, 'callback should return a redirect location');
   const redirectUrl = new URL(redirectLocation!);
-  assert.equal(
-    `${redirectUrl.origin}${redirectUrl.pathname}`,
-    `${process.env.BASE_URL}/oauth/callback/gmail`,
-    'callback should redirect to the React callback route'
-  );
+  assert.equal(`${redirectUrl.origin}${redirectUrl.pathname}`, `${process.env.BASE_URL}/oauth/callback/gmail`, 'callback should redirect to the React callback route');
   assert.equal(redirectUrl.searchParams.get('code'), 'test-code', 'redirect should preserve OAuth code');
   assert.equal(redirectUrl.searchParams.get('state'), state, 'redirect should preserve OAuth state');
+  assert.equal(redirectUrl.searchParams.get('provider'), 'gmail', 'redirect should include provider identifier');
   assert.equal(
     redirectUrl.searchParams.get('connectionId'),
     'test-connection-id',
@@ -219,6 +216,11 @@ try {
     redirectUrl.searchParams.get('label'),
     userInfoResponse.email,
     'redirect should include the resolved connection label'
+  );
+  assert.equal(
+    redirectUrl.searchParams.get('email'),
+    userInfoResponse.email,
+    'redirect should include the user email when available'
   );
 
   assert.equal(storedConnections.length, 1, 'ConnectionService.storeConnection should be called once');

--- a/server/routes/oauth.ts
+++ b/server/routes/oauth.ts
@@ -1,0 +1,126 @@
+import { Router } from 'express';
+import { oauthManager } from '../oauth/OAuthManager';
+import { authenticateToken } from '../middleware/auth';
+import { getErrorMessage } from '../types/common';
+
+const oauthRouter = Router();
+
+function normalizeRedirectUrl(url: string, providerId: string): URL {
+  const target = new URL(url);
+  if (target.pathname.startsWith('/api/oauth/callback')) {
+    target.pathname = target.pathname.replace('/api/oauth/callback', '/oauth/callback');
+  }
+  if (target.pathname === '/oauth/callback') {
+    target.pathname = `/oauth/callback/${providerId}`;
+  }
+  return target;
+}
+
+oauthRouter.post('/authorize/:provider', authenticateToken, async (req, res) => {
+  try {
+    const providerId = String(req.params.provider || '').toLowerCase();
+    if (!providerId) {
+      return res.status(400).json({ success: false, error: 'Provider is required' });
+    }
+
+    if (!oauthManager.supportsOAuth(providerId)) {
+      return res.status(404).json({ success: false, error: `Unsupported OAuth provider: ${providerId}` });
+    }
+
+    const user = req.user;
+    const organizationId = req.organizationId || user?.organizationId;
+
+    if (!user?.id || !organizationId) {
+      return res.status(400).json({ success: false, error: 'Missing authentication context' });
+    }
+
+    const { returnUrl, scopes, connectionId, label } = req.body || {};
+
+    const additionalScopes = Array.isArray(scopes)
+      ? scopes.filter((scope): scope is string => typeof scope === 'string')
+      : undefined;
+
+    const { authUrl, state } = await oauthManager.generateAuthUrl(
+      providerId,
+      user.id,
+      organizationId,
+      typeof returnUrl === 'string' && returnUrl.length > 0 ? returnUrl : undefined,
+      additionalScopes,
+      {
+        connectionId: typeof connectionId === 'string' ? connectionId : undefined,
+        label: typeof label === 'string' ? label : undefined,
+      }
+    );
+
+    return res.json({
+      success: true,
+      data: {
+        provider: providerId,
+        authUrl,
+        state,
+      },
+    });
+  } catch (error) {
+    console.error('OAuth authorize error:', error);
+    return res.status(500).json({ success: false, error: getErrorMessage(error) });
+  }
+});
+
+oauthRouter.get('/callback/:provider', async (req, res) => {
+  try {
+    const providerId = String(req.params.provider || '').toLowerCase();
+    const code = typeof req.query.code === 'string' ? req.query.code : undefined;
+    const state = typeof req.query.state === 'string' ? req.query.state : undefined;
+
+    if (!providerId) {
+      throw new Error('Provider is required');
+    }
+
+    if (!code || !state) {
+      throw new Error('Missing OAuth code or state');
+    }
+
+    if (!oauthManager.supportsOAuth(providerId)) {
+      throw new Error(`Unsupported OAuth provider: ${providerId}`);
+    }
+
+    const { tokens, userInfo, returnUrl, connectionId, label, userInfoError } = await oauthManager.handleCallback(
+      code,
+      state,
+      providerId
+    );
+
+    if (!tokens?.accessToken) {
+      throw new Error('OAuth token exchange failed');
+    }
+
+    const redirectUrl = normalizeRedirectUrl(returnUrl, providerId);
+    redirectUrl.searchParams.set('code', code);
+    redirectUrl.searchParams.set('state', state);
+    redirectUrl.searchParams.set('provider', providerId);
+    if (connectionId) {
+      redirectUrl.searchParams.set('connectionId', connectionId);
+    }
+    if (label) {
+      redirectUrl.searchParams.set('label', label);
+    }
+    if (userInfo?.email) {
+      redirectUrl.searchParams.set('email', userInfo.email);
+    }
+    if (userInfoError) {
+      redirectUrl.searchParams.set('userInfoError', userInfoError);
+    }
+
+    return res.redirect(302, redirectUrl.toString());
+  } catch (error) {
+    console.error('OAuth callback error:', error);
+    const providerId = String(req.params.provider || '');
+    const fallbackUrl = new URL(
+      `${process.env.BASE_URL || process.env.SERVER_PUBLIC_URL || 'http://localhost:5000'}/oauth/callback/${providerId}`
+    );
+    fallbackUrl.searchParams.set('error', getErrorMessage(error));
+    return res.redirect(302, fallbackUrl.toString());
+  }
+});
+
+export default oauthRouter;


### PR DESCRIPTION
## Summary
- add an Express OAuth router that exposes `/api/oauth/authorize/:provider` and `/api/oauth/callback/:provider` using `OAuthManager`
- normalize callback redirects and register the OAuth router with the main server route configuration
- update the OAuth flow integration test to use the new parameterized endpoints and assert the additional redirect metadata

## Testing
- ⚠️ `npx tsx server/routes/__tests__/oauth-flow.test.ts` *(fails: npm registry access forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df553e4654833182b69748ded77707