### PR TITLE
Add auto-refresh handling for connections and proactive refresh worker

### DIFF
--- a/server/integrations/AdobesignAPIClient.ts
+++ b/server/integrations/AdobesignAPIClient.ts
@@ -104,21 +104,14 @@ export class AdobesignAPIClient extends BaseAPIClient {
         }
 
         const payload = await response.json();
-        this.credentials.accessToken = payload.access_token;
-        if (payload.refresh_token) {
-          this.credentials.refreshToken = payload.refresh_token;
-        }
-        if (payload.expires_in) {
-          this.credentials.expiresAt = Date.now() + Number(payload.expires_in) * 1000;
-        }
-
-        if (typeof this.credentials.onTokenRefreshed === 'function') {
-          await this.credentials.onTokenRefreshed({
-            accessToken: this.credentials.accessToken!,
-            refreshToken: this.credentials.refreshToken,
-            expiresAt: parseExpiryTimestamp(this.credentials.expiresAt),
-          });
-        }
+        const expiresAt = payload.expires_in ? Date.now() + Number(payload.expires_in) * 1000 : undefined;
+        await this.applyTokenRefresh({
+          accessToken: payload.access_token,
+          refreshToken: payload.refresh_token,
+          expiresAt,
+          tokenType: payload.token_type,
+          scope: payload.scope,
+        });
 
         this.refreshPromise = undefined;
       })().catch(error => {

--- a/server/integrations/DocusignAPIClient.ts
+++ b/server/integrations/DocusignAPIClient.ts
@@ -152,21 +152,14 @@ export class DocusignAPIClient extends BaseAPIClient {
         }
 
         const payload = await response.json();
-        this.credentials.accessToken = payload.access_token;
-        if (payload.refresh_token) {
-          this.credentials.refreshToken = payload.refresh_token;
-        }
-        if (payload.expires_in) {
-          this.credentials.expiresAt = Date.now() + Number(payload.expires_in) * 1000;
-        }
-
-        if (typeof this.credentials.onTokenRefreshed === 'function') {
-          await this.credentials.onTokenRefreshed({
-            accessToken: this.credentials.accessToken!,
-            refreshToken: this.credentials.refreshToken,
-            expiresAt: parseExpiryTimestamp(this.credentials.expiresAt),
-          });
-        }
+        const expiresAt = payload.expires_in ? Date.now() + Number(payload.expires_in) * 1000 : undefined;
+        await this.applyTokenRefresh({
+          accessToken: payload.access_token,
+          refreshToken: payload.refresh_token,
+          expiresAt,
+          tokenType: payload.token_type,
+          scope: payload.scope,
+        });
 
         this.refreshPromise = undefined;
       })().catch(error => {

--- a/server/integrations/EgnyteAPIClient.ts
+++ b/server/integrations/EgnyteAPIClient.ts
@@ -151,21 +151,14 @@ export class EgnyteAPIClient extends BaseAPIClient {
         }
 
         const payload = await response.json();
-        this.credentials.accessToken = payload.access_token;
-        if (payload.refresh_token) {
-          this.credentials.refreshToken = payload.refresh_token;
-        }
-        if (payload.expires_in) {
-          this.credentials.expiresAt = Date.now() + Number(payload.expires_in) * 1000;
-        }
-
-        if (typeof this.credentials.onTokenRefreshed === 'function') {
-          await this.credentials.onTokenRefreshed({
-            accessToken: this.credentials.accessToken!,
-            refreshToken: this.credentials.refreshToken,
-            expiresAt: parseExpiryTimestamp(this.credentials.expiresAt),
-          });
-        }
+        const expiresAt = payload.expires_in ? Date.now() + Number(payload.expires_in) * 1000 : undefined;
+        await this.applyTokenRefresh({
+          accessToken: payload.access_token,
+          refreshToken: payload.refresh_token,
+          expiresAt,
+          tokenType: payload.token_type,
+          scope: payload.scope,
+        });
 
         this.refreshPromise = undefined;
       })().catch(error => {

--- a/server/integrations/GoogleAdminAPIClient.ts
+++ b/server/integrations/GoogleAdminAPIClient.ts
@@ -140,21 +140,14 @@ export class GoogleAdminAPIClient extends BaseAPIClient {
         }
 
         const payload = await response.json();
-        this.credentials.accessToken = payload.access_token;
-        if (payload.refresh_token) {
-          this.credentials.refreshToken = payload.refresh_token;
-        }
-        if (payload.expires_in) {
-          this.credentials.expiresAt = Date.now() + Number(payload.expires_in) * 1000;
-        }
-
-        if (typeof this.credentials.onTokenRefreshed === 'function') {
-          await this.credentials.onTokenRefreshed({
-            accessToken: this.credentials.accessToken!,
-            refreshToken: this.credentials.refreshToken,
-            expiresAt: parseExpiryTimestamp(this.credentials.expiresAt),
-          });
-        }
+        const expiresAt = payload.expires_in ? Date.now() + Number(payload.expires_in) * 1000 : undefined;
+        await this.applyTokenRefresh({
+          accessToken: payload.access_token,
+          refreshToken: payload.refresh_token,
+          expiresAt,
+          tokenType: payload.token_type,
+          scope: payload.scope,
+        });
 
         this.refreshPromise = undefined;
       })().catch(error => {

--- a/server/integrations/MarketoAPIClient.ts
+++ b/server/integrations/MarketoAPIClient.ts
@@ -154,13 +154,14 @@ export class MarketoAPIClient extends BaseAPIClient {
         }
 
         const payload = await response.json();
-        this.credentials.accessToken = payload.access_token;
-        if (payload.refresh_token) {
-          this.credentials.refreshToken = payload.refresh_token;
-        }
-        if (payload.expires_in) {
-          (this.credentials as MarketoCredentials).expiresAt = Date.now() + Number(payload.expires_in) * 1000;
-        }
+        const expiresAt = payload.expires_in ? Date.now() + Number(payload.expires_in) * 1000 : undefined;
+        await this.applyTokenRefresh({
+          accessToken: payload.access_token,
+          refreshToken: payload.refresh_token,
+          expiresAt,
+          tokenType: payload.token_type,
+          scope: payload.scope,
+        });
         this.refreshPromise = undefined;
       })().catch(error => {
         this.refreshPromise = undefined;

--- a/server/integrations/PardotAPIClient.ts
+++ b/server/integrations/PardotAPIClient.ts
@@ -129,13 +129,14 @@ export class PardotAPIClient extends BaseAPIClient {
         }
 
         const payload = await response.json();
-        this.credentials.accessToken = payload.access_token;
-        if (payload.refresh_token) {
-          this.credentials.refreshToken = payload.refresh_token;
-        }
-        if (payload.expires_in) {
-          (this.credentials as PardotCredentials).expiresAt = Date.now() + Number(payload.expires_in) * 1000;
-        }
+        const expiresAt = payload.expires_in ? Date.now() + Number(payload.expires_in) * 1000 : undefined;
+        await this.applyTokenRefresh({
+          accessToken: payload.access_token,
+          refreshToken: payload.refresh_token,
+          expiresAt,
+          tokenType: payload.token_type,
+          scope: payload.scope,
+        });
         this.refreshPromise = undefined;
       })().catch(error => {
         this.refreshPromise = undefined;

--- a/server/workers/connection-refresh.ts
+++ b/server/workers/connection-refresh.ts
@@ -1,0 +1,119 @@
+import { env } from '../env';
+import { connectionService } from '../services/ConnectionService.js';
+import { getErrorMessage } from '../types/common.js';
+
+const DEFAULT_INTERVAL_MS = 60_000;
+const DEFAULT_LOOKAHEAD_MS = 10 * 60 * 1000;
+const DEFAULT_BATCH_SIZE = 25;
+
+async function runRefreshCycle(lookaheadMs: number, limit: number): Promise<void> {
+  const summary = await connectionService.refreshConnectionsExpiringSoon({
+    lookaheadMs,
+    limit,
+  });
+
+  if (summary.refreshed > 0 || summary.errors > 0) {
+    console.log(
+      `🔄 Connection refresh cycle: scanned=${summary.scanned} refreshed=${summary.refreshed} skipped=${summary.skipped} errors=${summary.errors}`
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  console.log('🕒 Starting connection refresh worker');
+  console.log('🌍 Worker environment:', env.NODE_ENV);
+
+  const intervalMs = Math.max(5_000, Number.parseInt(process.env.CONNECTION_REFRESH_INTERVAL_MS ?? `${DEFAULT_INTERVAL_MS}`, 10));
+  const lookaheadMs = Math.max(0, Number.parseInt(process.env.CONNECTION_REFRESH_LOOKAHEAD_MS ?? `${DEFAULT_LOOKAHEAD_MS}`, 10));
+  const batchSize = Math.max(1, Number.parseInt(process.env.CONNECTION_REFRESH_BATCH_SIZE ?? `${DEFAULT_BATCH_SIZE}`, 10));
+
+  let shuttingDown = false;
+  let timer: NodeJS.Timeout | null = null;
+  let inflight: Promise<void> | null = null;
+  let resolveShutdown: (() => void) | null = null;
+
+  const waitForShutdown = new Promise<void>((resolve) => {
+    resolveShutdown = resolve;
+  });
+
+  const scheduleNext = () => {
+    if (shuttingDown) {
+      return;
+    }
+
+    timer = setTimeout(async () => {
+      if (inflight) {
+        try {
+          await inflight;
+        } catch (error) {
+          console.error('❌ Connection refresh cycle error:', getErrorMessage(error));
+        }
+      }
+
+      inflight = runRefreshCycle(lookaheadMs, batchSize).catch((error) => {
+        console.error('❌ Connection refresh execution error:', getErrorMessage(error));
+      });
+
+      try {
+        await inflight;
+      } finally {
+        inflight = null;
+        scheduleNext();
+      }
+    }, intervalMs);
+  };
+
+  inflight = runRefreshCycle(lookaheadMs, batchSize).catch((error) => {
+    console.error('❌ Initial connection refresh cycle failed:', getErrorMessage(error));
+  });
+
+  await inflight;
+  inflight = null;
+  scheduleNext();
+
+  const shutdown = async (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    console.log(`⚙️ Received ${signal}. Shutting down connection refresh worker...`);
+
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+
+    if (inflight) {
+      try {
+        await inflight;
+      } catch (error) {
+        console.error('❌ Connection refresh cycle error during shutdown:', getErrorMessage(error));
+      } finally {
+        inflight = null;
+      }
+    }
+
+    resolveShutdown?.();
+  };
+
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+
+  process.on('unhandledRejection', (reason) => {
+    console.error('❌ Unhandled rejection in connection refresh worker:', reason);
+  });
+
+  process.on('uncaughtException', (error) => {
+    console.error('❌ Uncaught exception in connection refresh worker:', error);
+  });
+
+  console.log('🔁 Connection refresh worker is running.');
+  await waitForShutdown;
+  console.log('👋 Connection refresh worker has stopped.');
+}
+
+void main().catch((error) => {
+  console.error('Failed to start connection refresh worker:', error);
+  process.exit(1);
+});

--- a/server/workflow/WorkflowRuntimeService.ts
+++ b/server/workflow/WorkflowRuntimeService.ts
@@ -876,12 +876,12 @@ export class WorkflowRuntimeService {
         };
       }
 
-      const connection = await service.getConnectionWithFreshTokens(
+      const context = await service.prepareConnectionForClient({
         connectionId,
         userId,
-        organizationId
-      );
-      if (!connection) {
+        organizationId,
+      });
+      if (!context) {
         return {
           success: false,
           error: `Connection not found: ${connectionId}`,
@@ -890,12 +890,14 @@ export class WorkflowRuntimeService {
         };
       }
 
+      const credentials = { ...context.credentials };
+
       return {
         success: true,
-        credentials: this.clone(connection.credentials),
+        credentials,
         source: 'connection',
         connectionId,
-        additionalConfig: this.extractAdditionalConfig(node, connection.metadata || {})
+        additionalConfig: this.extractAdditionalConfig(node, context.connection.metadata || {})
       };
     } catch (error: any) {
       const message = getErrorMessage(error);


### PR DESCRIPTION
## Summary
- add ConnectionService helpers for auto-refresh, token persistence, and proactive refresh scheduling
- ensure BaseAPIClient propagates refreshed tokens to credential callbacks and update OAuth clients to use it
- update routes, workflow runtime, and tests to use the new helper and add a connection refresh worker

## Testing
- npx tsx server/services/__tests__/ConnectionService.test.ts *(fails: npm 403 fetching tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68df56e5f95c833185809a21b8b81ac1