### PR TITLE
Add connector parity lint check

### DIFF
--- a/docs/connectors/parity.md
+++ b/docs/connectors/parity.md
@@ -1,0 +1,52 @@
+# Connector Parity Checklist
+
+The automation platform expects every stable connector definition in
+`server/connector-manifest.json` to have a matching API client under
+`server/integrations` that exports at least one handler. The
+`scripts/check-connector-parity.ts` guard enforces this agreement during
+`npm run lint`.
+
+## Running the check locally
+
+```bash
+npm run lint
+```
+
+The command runs `tsc` followed by the parity script. If mismatches are
+found, the script prints a bulleted list describing what is missing.
+Common messages include:
+
+- `Stable connector "{id}" is missing an API client` – the manifest marks
+the connector as `"stable"`, but there is no corresponding
+`*APIClient.ts` file.
+- `Stable connector "{id}" (...) does not register any handlers` – the
+API client exists but never calls `registerHandler(s)`.
+- `Integration file ... does not have a corresponding entry` – an API
+client exists without a manifest entry.
+
+The script exits with a non-zero status so CI will fail until the issues
+are resolved.
+
+## Remediation steps
+
+1. **Identify the expected connector ID.** The manifest entry’s
+   `normalizedId` must match the API client’s name when converted to
+   canonical form (e.g. `AirtableAPIClient.ts` → `airtable`).
+2. **Create or update the API client.**
+   - If the file is missing, copy an existing client that targets a
+     similar API and implement the required handlers.
+   - Ensure the client calls `registerHandler` or `registerHandlers` for
+     every operation you want to expose.
+3. **Update the manifest if needed.**
+   - Add a manifest entry for any new API client. Point
+     `definitionPath` to the connector JSON under `connectors/`.
+   - Mark connectors as `"stable"` only after their handlers are
+     implemented.
+4. **Add or adjust the connector definition.** Confirm the JSON file
+   referenced by `definitionPath` exists and describes the actions or
+   triggers supplied by the handlers.
+5. **Re-run `npm run lint`.** Continue refining the changes until the
+   parity script reports success.
+
+When in doubt, review similar connectors in the repository to model file
+structure, handler naming, and manifest entries.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check": "tsc",
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
+    "lint": "npm run check && tsx scripts/check-connector-parity.ts",
     "db:push": "drizzle-kit push",
     "test": "tsx server/services/__tests__/ConnectionService.encryption.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-deploy.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/components/workflow/__tests__/NodeConfigurationModal.regression.test.ts && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts && tsx server/integrations/__tests__/BaseAPIClient.helpers.test.ts && tsx server/integrations/__tests__/AwsClients.test.ts && tsx server/integrations/__tests__/MarketingAPIClients.test.ts && tsx server/workflow/__tests__/WorkflowRuntimeService.test.ts && tsx server/core/__tests__/ParameterResolver.llm.test.ts && tsx server/runtime/__tests__/WorkflowRuntime.sandbox.test.ts && tsx server/workflow/__tests__/WorkflowRepository.test.ts && tsx server/workflow/__tests__/WorkflowRepository.fallback.test.ts && tsx server/services/__tests__/TriggerPersistenceService.fallback.test.ts && tsx server/webhooks/__tests__/WebhookManager.persistence.test.ts",
     "trigger-admin": "tsx scripts/trigger-admin.ts",

--- a/scripts/check-connector-parity.ts
+++ b/scripts/check-connector-parity.ts
@@ -1,0 +1,307 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+type ConnectorAvailability = 'stable' | 'experimental' | 'disabled' | null;
+
+type ManifestConnector = {
+  id: string;
+  normalizedId: string;
+  definitionPath: string;
+  availability: ConnectorAvailability;
+};
+
+type IntegrationInfo = {
+  canonicalId: string;
+  rawName: string;
+  filePath: string;
+  handlers: Set<string>;
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+const MANIFEST_PATH = path.join(ROOT_DIR, 'server', 'connector-manifest.json');
+const INTEGRATIONS_DIR = path.join(ROOT_DIR, 'server', 'integrations');
+
+const IGNORED_CLIENT_BASENAMES = new Set([
+  'BaseAPIClient',
+  'GenericAPIClient',
+  'GenericExecutor',
+  'IntegrationManager',
+  'LocalCoreAPIClients',
+  'Normalizers',
+  'RateLimiter',
+  'RequestValidator',
+  'SchemaRegistry',
+]);
+
+function canonicalize(value: string): string {
+  return value.replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+async function loadManifestConnectors(): Promise<ManifestConnector[]> {
+  const rawContent = await fs.readFile(MANIFEST_PATH, 'utf8');
+  const manifest = JSON.parse(rawContent) as { connectors?: Array<{ id: string; normalizedId?: string; definitionPath: string }>; };
+
+  if (!manifest.connectors || !Array.isArray(manifest.connectors)) {
+    throw new Error('connector-manifest.json is missing a "connectors" array');
+  }
+
+  const results: ManifestConnector[] = [];
+
+  for (const entry of manifest.connectors) {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error('connector-manifest.json contains an invalid entry');
+    }
+
+    const id = entry.id;
+    const normalizedId = entry.normalizedId ?? entry.id;
+    const definitionPath = path.resolve(ROOT_DIR, entry.definitionPath);
+
+    let availability: ConnectorAvailability = null;
+    try {
+      const definitionRaw = await fs.readFile(definitionPath, 'utf8');
+      const definition = JSON.parse(definitionRaw) as { availability?: string | null };
+      const declared = definition?.availability ?? null;
+      if (declared === 'stable' || declared === 'experimental' || declared === 'disabled') {
+        availability = declared;
+      }
+    } catch (error) {
+      throw new Error(`Failed to load connector definition for ${id} at ${definitionPath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    results.push({
+      id,
+      normalizedId,
+      definitionPath,
+      availability,
+    });
+  }
+
+  return results;
+}
+
+function toScriptKind(filePath: string): ts.ScriptKind {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.ts':
+      return ts.ScriptKind.TS;
+    case '.tsx':
+      return ts.ScriptKind.TSX;
+    case '.mts':
+      return ts.ScriptKind.MTS;
+    case '.cts':
+      return ts.ScriptKind.CTS;
+    case '.js':
+      return ts.ScriptKind.JS;
+    case '.mjs':
+      return ts.ScriptKind.JS;
+    case '.cjs':
+      return ts.ScriptKind.JS;
+    default:
+      return ts.ScriptKind.TS;
+  }
+}
+
+function getCallIdentifier(expression: ts.Expression): string | undefined {
+  if (ts.isIdentifier(expression)) {
+    return expression.text;
+  }
+
+  if (ts.isPropertyAccessExpression(expression)) {
+    return expression.name.text;
+  }
+
+  return undefined;
+}
+
+function recordPropertyName(target: Set<string>, name: ts.PropertyName | ts.Expression | undefined): void {
+  if (!name) {
+    return;
+  }
+
+  if (ts.isIdentifier(name)) {
+    target.add(name.text);
+    return;
+  }
+
+  if (ts.isStringLiteralLike(name)) {
+    target.add(name.text);
+    return;
+  }
+
+  if (ts.isPropertyAccessExpression(name)) {
+    target.add(name.name.text);
+  }
+}
+
+function extractRegisteredHandlers(sourceFile: ts.SourceFile): Set<string> {
+  const handlers = new Set<string>();
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node)) {
+      const callName = getCallIdentifier(node.expression);
+
+      if (callName === 'registerHandler' && node.arguments.length >= 1) {
+        const first = node.arguments[0];
+        if (ts.isStringLiteralLike(first)) {
+          handlers.add(first.text);
+        }
+      }
+
+      if (callName === 'registerHandlers' && node.arguments.length >= 1) {
+        const first = node.arguments[0];
+        if (ts.isObjectLiteralExpression(first)) {
+          for (const prop of first.properties) {
+            if (ts.isPropertyAssignment(prop)) {
+              recordPropertyName(handlers, prop.name);
+            } else if (ts.isShorthandPropertyAssignment(prop) || ts.isMethodDeclaration(prop)) {
+              recordPropertyName(handlers, prop.name);
+            }
+          }
+        } else if (ts.isCallExpression(first)) {
+          for (const arg of first.arguments) {
+            if (ts.isObjectLiteralExpression(arg)) {
+              for (const prop of arg.properties) {
+                if (ts.isPropertyAssignment(prop)) {
+                  recordPropertyName(handlers, prop.name);
+                }
+              }
+            }
+          }
+        }
+      }
+
+      if (callName === 'registerAliasHandlers' && node.arguments.length >= 1) {
+        const first = node.arguments[0];
+        if (ts.isObjectLiteralExpression(first)) {
+          for (const prop of first.properties) {
+            if (ts.isPropertyAssignment(prop)) {
+              recordPropertyName(handlers, prop.name);
+            }
+          }
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return handlers;
+}
+
+async function loadIntegrationHandlers(): Promise<Map<string, IntegrationInfo>> {
+  const dirents = await fs.readdir(INTEGRATIONS_DIR, { withFileTypes: true });
+  const integrations = new Map<string, IntegrationInfo>();
+
+  for (const dirent of dirents) {
+    if (!dirent.isFile()) {
+      continue;
+    }
+
+    const ext = path.extname(dirent.name);
+    if (!ext) {
+      continue;
+    }
+
+    const baseName = path.basename(dirent.name, ext);
+    if (!/(?:API|Api)Client$/.test(baseName)) {
+      continue;
+    }
+
+    if (IGNORED_CLIENT_BASENAMES.has(baseName)) {
+      continue;
+    }
+
+    if (dirent.name.endsWith('.d.ts')) {
+      continue;
+    }
+
+    const rawName = baseName.replace(/(API|Api)Client$/, '');
+    const canonicalId = canonicalize(rawName);
+    const filePath = path.join(INTEGRATIONS_DIR, dirent.name);
+    const content = await fs.readFile(filePath, 'utf8');
+    const sourceFile = ts.createSourceFile(dirent.name, content, ts.ScriptTarget.Latest, true, toScriptKind(filePath));
+    const handlers = extractRegisteredHandlers(sourceFile);
+
+    if (integrations.has(canonicalId)) {
+      // Prefer TypeScript sources over compiled JavaScript when duplicates exist
+      const existing = integrations.get(canonicalId)!;
+      const existingIsTs = existing.filePath.endsWith('.ts') || existing.filePath.endsWith('.tsx');
+      const currentIsTs = filePath.endsWith('.ts') || filePath.endsWith('.tsx');
+      if (!existingIsTs && currentIsTs) {
+        integrations.set(canonicalId, { canonicalId, rawName, filePath, handlers });
+      }
+      continue;
+    }
+
+    integrations.set(canonicalId, { canonicalId, rawName, filePath, handlers });
+  }
+
+  return integrations;
+}
+
+async function main(): Promise<void> {
+  const manifestConnectors = await loadManifestConnectors();
+  const integrationHandlers = await loadIntegrationHandlers();
+
+  const manifestByCanonical = new Map<string, ManifestConnector>();
+  const stableCanonicalIds = new Set<string>();
+
+  for (const connector of manifestConnectors) {
+    const canonical = canonicalize(connector.normalizedId);
+    manifestByCanonical.set(canonical, connector);
+    if (connector.availability === 'stable') {
+      stableCanonicalIds.add(canonical);
+    }
+  }
+
+  const errors: string[] = [];
+
+  for (const canonical of stableCanonicalIds) {
+    const connector = manifestByCanonical.get(canonical);
+    const integration = integrationHandlers.get(canonical);
+
+    if (!connector) {
+      // Should not happen, but guard against inconsistent manifest state
+      errors.push(`Stable connector with canonical id "${canonical}" is missing from the manifest map.`);
+      continue;
+    }
+
+    if (!integration) {
+      errors.push(`Stable connector "${connector.normalizedId}" is missing an API client in server/integrations.`);
+      continue;
+    }
+
+    if (integration.handlers.size === 0) {
+      errors.push(`Stable connector "${connector.normalizedId}" (${path.relative(ROOT_DIR, integration.filePath)}) does not register any handlers.`);
+    }
+  }
+
+  for (const [canonical, integration] of integrationHandlers.entries()) {
+    const connector = manifestByCanonical.get(canonical);
+    if (!connector) {
+      errors.push(`Integration file ${path.relative(ROOT_DIR, integration.filePath)} does not have a corresponding entry in connector-manifest.json.`);
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('\nConnector parity check failed:');
+    for (const message of errors) {
+      console.error(`  • ${message}`);
+    }
+    console.error('\nTo resolve, ensure stable connectors have matching API clients with registered handlers and that manifest entries exist for every integration.');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('✅ Connector manifest and integration handlers are in parity.');
+}
+
+main().catch(error => {
+  console.error('Unexpected error while verifying connector parity:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a TypeScript script that validates connector manifest entries against registered integration handlers
- run the parity check from `npm run lint` so CI fails when connectors or handlers drift
- document how contributors can diagnose and resolve parity failures

## Testing
- `npm run lint` *(fails: missing type definition packages in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df69b735a08331bd8adf8212b8d82f