### PR TITLE
Persist webhook dedupe state with replay tolerance

### DIFF
--- a/migrations/0005_webhook_dedupe.ts
+++ b/migrations/0005_webhook_dedupe.ts
@@ -1,0 +1,28 @@
+import { sql } from 'drizzle-orm';
+
+type MigrationClient = { execute: (query: any) => Promise<unknown> };
+
+export async function up(db: MigrationClient): Promise<void> {
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "webhook_dedupe" (
+      "trigger_id" text NOT NULL,
+      "token" text NOT NULL,
+      "created_at" timestamp NOT NULL DEFAULT now(),
+      CONSTRAINT "webhook_dedupe_pk" PRIMARY KEY ("trigger_id", "token")
+    )
+  `);
+
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "webhook_dedupe_trigger_idx" ON "webhook_dedupe" ("trigger_id")
+  `);
+
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "webhook_dedupe_created_idx" ON "webhook_dedupe" ("created_at")
+  `);
+}
+
+export async function down(db: MigrationClient): Promise<void> {
+  await db.execute(sql`DROP INDEX IF EXISTS "webhook_dedupe_created_idx"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "webhook_dedupe_trigger_idx"`);
+  await db.execute(sql`DROP TABLE IF EXISTS "webhook_dedupe"`);
+}

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -11,7 +11,8 @@ import {
   uuid,
   index,
   uniqueIndex,
-  serial
+  serial,
+  primaryKey,
 } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 import type { WorkflowTimerPayload } from '../types/workflowTimers';
@@ -757,6 +758,20 @@ export const webhookLogs = pgTable(
     workflowIdx: index('webhook_logs_workflow_idx').on(table.workflowId),
     sourceIdx: index('webhook_logs_source_idx').on(table.source),
     dedupeIdx: index('webhook_logs_dedupe_idx').on(table.dedupeToken),
+  })
+);
+
+export const webhookDedupe = pgTable(
+  'webhook_dedupe',
+  {
+    triggerId: text('trigger_id').notNull(),
+    token: text('token').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.triggerId, table.token], name: 'webhook_dedupe_pk' }),
+    triggerIdx: index('webhook_dedupe_trigger_idx').on(table.triggerId),
+    createdIdx: index('webhook_dedupe_created_idx').on(table.createdAt),
   })
 );
 

--- a/server/database/status.ts
+++ b/server/database/status.ts
@@ -7,6 +7,7 @@ const REQUIRED_TABLES = [
   'workflow_triggers',
   'polling_triggers',
   'webhook_logs',
+  'webhook_dedupe',
 ];
 
 let dbAvailable = Boolean(db);


### PR DESCRIPTION
## Summary
- add a dedicated `webhook_dedupe` table and migration to track dedupe tokens with timestamps
- update trigger persistence to write/read timestamped dedupe entries with TTL cleanup and per-trigger limits
- enforce replay tolerance for webhook events and cover stale-event rejection in persistence tests

## Testing
- ⚠️ `npx tsx server/services/__tests__/TriggerPersistenceService.test.ts` *(fails: npm registry access blocked)*
- ⚠️ `npx tsx server/services/__tests__/TriggerPersistenceService.fallback.test.ts` *(not run: npm registry access blocked)*
- ⚠️ `npx tsx server/webhooks/__tests__/WebhookManager.persistence.test.ts` *(not run: npm registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68df71e5c640833199b60e2c6a692eb4