### PR TITLE
feat: add dynamic connector options support

### DIFF
--- a/common/connectorDynamicOptions.ts
+++ b/common/connectorDynamicOptions.ts
@@ -1,0 +1,161 @@
+export const DYNAMIC_OPTIONS_EXTENSION_KEY = 'x-dynamicOptions';
+
+export type DynamicOptionOperationType = 'action' | 'trigger';
+
+export interface ConnectorDynamicOptionExtension {
+  handler: string;
+  labelField?: string;
+  valueField?: string;
+  searchParam?: string;
+  dependsOn?: string[];
+  cache?: {
+    ttlMs?: number;
+    scope?: 'connection' | 'user' | 'organization';
+  };
+  [key: string]: any;
+}
+
+export interface ConnectorDynamicOptionConfig {
+  operationType: DynamicOptionOperationType;
+  operationId: string;
+  parameterPath: string;
+  schemaType?: string | string[];
+  handler: string;
+  labelField?: string;
+  valueField?: string;
+  searchParam?: string;
+  dependsOn?: string[];
+  cacheTtlMs?: number;
+  extension: ConnectorDynamicOptionExtension;
+}
+
+type SchemaNode = Record<string, any> | undefined | null;
+
+type TraverseCallback = (
+  parameterPath: string,
+  schema: Record<string, any>,
+  extension: ConnectorDynamicOptionExtension
+) => void;
+
+function traverseSchema(schema: SchemaNode, basePath: string, callback: TraverseCallback): void {
+  if (!schema || typeof schema !== 'object') {
+    return;
+  }
+
+  const extension = schema[DYNAMIC_OPTIONS_EXTENSION_KEY];
+  if (extension && typeof extension === 'object') {
+    callback(basePath, schema as Record<string, any>, extension as ConnectorDynamicOptionExtension);
+  }
+
+  const properties = schema.properties;
+  if (properties && typeof properties === 'object') {
+    for (const [key, value] of Object.entries(properties)) {
+      const nextPath = basePath ? `${basePath}.${key}` : key;
+      traverseSchema(value as SchemaNode, nextPath, callback);
+    }
+  }
+
+  const patternProperties = schema.patternProperties;
+  if (patternProperties && typeof patternProperties === 'object') {
+    for (const [pattern, value] of Object.entries(patternProperties)) {
+      const nextPath = basePath ? `${basePath}.{${pattern}}` : `{${pattern}}`;
+      traverseSchema(value as SchemaNode, nextPath, callback);
+    }
+  }
+
+  const items = schema.items;
+  if (Array.isArray(items)) {
+    items.forEach((item, index) => {
+      const nextPath = basePath ? `${basePath}[${index}]` : `[${index}]`;
+      traverseSchema(item as SchemaNode, nextPath, callback);
+    });
+  } else if (items && typeof items === 'object') {
+    const nextPath = basePath ? `${basePath}[]` : '[]';
+    traverseSchema(items as SchemaNode, nextPath, callback);
+  }
+
+  const composites = ['oneOf', 'anyOf', 'allOf', 'then', 'else'];
+  for (const composite of composites) {
+    const value = (schema as Record<string, any>)[composite];
+    if (Array.isArray(value)) {
+      value.forEach((node, index) => {
+        const nextPath = basePath ? `${basePath}<${composite}#${index}>` : `<${composite}#${index}>`;
+        traverseSchema(node as SchemaNode, nextPath, callback);
+      });
+    } else if (value && typeof value === 'object') {
+      const nextPath = basePath ? `${basePath}<${composite}>` : `<${composite}>`;
+      traverseSchema(value as SchemaNode, nextPath, callback);
+    }
+  }
+}
+
+export function normalizeDynamicOptionPath(path: string): string {
+  return path
+    .replace(/\.<[^>]+>/g, '')
+    .replace(/\[\d+\]/g, '[]')
+    .replace(/\{([^}]+)\}/g, '{$1}')
+    .replace(/\.+/g, '.');
+}
+
+export function extractDynamicOptionsFromConnector(definition: Record<string, any>): ConnectorDynamicOptionConfig[] {
+  const results: ConnectorDynamicOptionConfig[] = [];
+  if (!definition || typeof definition !== 'object') {
+    return results;
+  }
+
+  const processCollection = (collection: any[], operationType: DynamicOptionOperationType) => {
+    if (!Array.isArray(collection)) {
+      return;
+    }
+
+    for (const entry of collection) {
+      if (!entry || typeof entry !== 'object') {
+        continue;
+      }
+
+      const operationId = entry.id;
+      if (typeof operationId !== 'string' || operationId.trim() === '') {
+        continue;
+      }
+
+      const schema = entry.parameters || entry.params || null;
+      if (!schema || typeof schema !== 'object') {
+        continue;
+      }
+
+      traverseSchema(schema, '', (parameterPath, nodeSchema, extension) => {
+        if (!extension || typeof extension.handler !== 'string') {
+          return;
+        }
+
+        const normalizedPath = normalizeDynamicOptionPath(parameterPath);
+        const dependsOn = Array.isArray(extension.dependsOn)
+          ? extension.dependsOn.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+          : undefined;
+
+        const cacheTtlMs = typeof extension.cache?.ttlMs === 'number' && Number.isFinite(extension.cache.ttlMs)
+          ? Math.max(0, extension.cache.ttlMs)
+          : undefined;
+
+        results.push({
+          operationType,
+          operationId,
+          parameterPath: normalizedPath,
+          schemaType: nodeSchema.type,
+          handler: extension.handler,
+          labelField: typeof extension.labelField === 'string' ? extension.labelField : undefined,
+          valueField: typeof extension.valueField === 'string' ? extension.valueField : undefined,
+          searchParam: typeof extension.searchParam === 'string' ? extension.searchParam : undefined,
+          dependsOn,
+          cacheTtlMs,
+          extension,
+        });
+      });
+    }
+  };
+
+  processCollection(definition.actions, 'action');
+  processCollection(definition.triggers, 'trigger');
+
+  return results;
+}

--- a/connectors/slack-enhanced.json
+++ b/connectors/slack-enhanced.json
@@ -53,7 +53,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID or name"
+            "description": "Channel ID or name",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "text": {
             "type": "string",
@@ -222,11 +231,29 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID"
+            "description": "Channel ID",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "user": {
             "type": "string",
-            "description": "User ID"
+            "description": "User ID",
+            "x-dynamicOptions": {
+              "handler": "list_users",
+              "labelField": "real_name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           }
         },
         "required": ["channel", "user"],
@@ -242,7 +269,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID"
+            "description": "Channel ID",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "cursor": {
             "type": "string",
@@ -325,7 +361,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel where the message to add reaction to was posted"
+            "description": "Channel where the message to add reaction to was posted",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "name": {
             "type": "string",
@@ -405,7 +450,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID"
+            "description": "Channel ID",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "topic": {
             "type": "string",
@@ -425,7 +479,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID"
+            "description": "Channel ID",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           }
         },
         "required": ["channel"],
@@ -441,7 +504,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID"
+            "description": "Channel ID",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "timestamp": {
             "type": "string",
@@ -461,7 +533,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID or name"
+            "description": "Channel ID or name",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "text": {
             "type": "string",
@@ -539,7 +620,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID to monitor"
+            "description": "Channel ID to monitor",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "user": {
             "type": "string",
@@ -648,7 +738,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID to monitor for file uploads"
+            "description": "Channel ID to monitor for file uploads",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "user": {
             "type": "string",
@@ -714,7 +813,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID to monitor"
+            "description": "Channel ID to monitor",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "reaction": {
             "type": "string",

--- a/connectors/slack.json
+++ b/connectors/slack.json
@@ -57,7 +57,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID or user ID to send message to"
+            "description": "Channel ID or user ID to send message to",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "text": {
             "type": "string",
@@ -125,11 +134,29 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID to invite users to"
+            "description": "Channel ID to invite users to",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "users": {
             "type": "string",
-            "description": "Comma-separated list of user IDs"
+            "description": "Comma-separated list of user IDs",
+            "x-dynamicOptions": {
+              "handler": "list_users",
+              "labelField": "real_name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           }
         },
         "required": ["channel", "users"],
@@ -185,7 +212,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID to get info for"
+            "description": "Channel ID to get info for",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           }
         },
         "required": ["channel"],
@@ -264,7 +300,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel containing the message"
+            "description": "Channel containing the message",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "timestamp": {
             "type": "string",
@@ -290,7 +335,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID to send message to"
+            "description": "Channel ID to send message to",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "text": {
             "type": "string",
@@ -357,7 +411,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID to monitor (optional, monitors all if empty)"
+            "description": "Channel ID to monitor (optional, monitors all if empty)",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "user": {
             "type": "string",
@@ -392,7 +455,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID to monitor"
+            "description": "Channel ID to monitor",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           },
           "emoji": {
             "type": "string",
@@ -422,7 +494,16 @@
         "properties": {
           "channel": {
             "type": "string",
-            "description": "Channel ID to monitor"
+            "description": "Channel ID to monitor",
+            "x-dynamicOptions": {
+              "handler": "list_channels",
+              "labelField": "name",
+              "valueField": "id",
+              "searchParam": "search",
+              "cache": {
+                "ttlMs": 300000
+              }
+            }
           }
         },
         "required": ["channel"],

--- a/scripts/generateConnectorManifest.ts
+++ b/scripts/generateConnectorManifest.ts
@@ -1,10 +1,13 @@
 import { promises as fs } from 'fs';
 import { join, relative, resolve } from 'path';
+import type { ConnectorDynamicOptionConfig } from '../common/connectorDynamicOptions.js';
+import { extractDynamicOptionsFromConnector } from '../common/connectorDynamicOptions.js';
 
 interface ConnectorManifestEntry {
   id: string;
   normalizedId: string;
   definitionPath: string;
+  dynamicOptions?: ConnectorDynamicOptionConfig[];
 }
 
 interface ConnectorManifest {
@@ -52,10 +55,13 @@ async function main(): Promise<void> {
       console.warn(`Normalizing connector id from "${rawId}" to "${normalizedId}" for ${file}`);
     }
 
+    const dynamicOptions = extractDynamicOptionsFromConnector(parsed);
+
     entries.push({
       id: parsed.id,
       normalizedId,
       definitionPath: relative(process.cwd(), fullPath).replace(/\\/g, '/'),
+      dynamicOptions: dynamicOptions.length > 0 ? dynamicOptions : undefined,
     });
   }
 

--- a/server/connector-manifest.json
+++ b/server/connector-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-03T06:04:27.956Z",
+  "generatedAt": "2025-10-03T07:06:56.119Z",
   "connectors": [
     {
       "id": "adobesign",
@@ -599,12 +599,436 @@
     {
       "id": "slack",
       "normalizedId": "slack",
-      "definitionPath": "connectors/slack.json"
+      "definitionPath": "connectors/slack.json",
+      "dynamicOptions": [
+        {
+          "operationType": "action",
+          "operationId": "send_message",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "invite_to_channel",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "invite_to_channel",
+          "parameterPath": "users",
+          "schemaType": "string",
+          "handler": "list_users",
+          "labelField": "real_name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_users",
+            "labelField": "real_name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "get_channel_info",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "add_reaction",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "schedule_message",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "trigger",
+          "operationId": "message_received",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "trigger",
+          "operationId": "reaction_added",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "trigger",
+          "operationId": "user_joined_channel",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        }
+      ]
     },
     {
       "id": "slack-enhanced",
       "normalizedId": "slack-enhanced",
-      "definitionPath": "connectors/slack-enhanced.json"
+      "definitionPath": "connectors/slack-enhanced.json",
+      "dynamicOptions": [
+        {
+          "operationType": "action",
+          "operationId": "send_message",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "invite_user_to_channel",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "invite_user_to_channel",
+          "parameterPath": "user",
+          "schemaType": "string",
+          "handler": "list_users",
+          "labelField": "real_name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_users",
+            "labelField": "real_name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "get_channel_history",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "add_reaction",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "set_channel_topic",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "archive_channel",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "pin_message",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "action",
+          "operationId": "schedule_message",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "trigger",
+          "operationId": "new_message",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "trigger",
+          "operationId": "new_file",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        },
+        {
+          "operationType": "trigger",
+          "operationId": "reaction_added",
+          "parameterPath": "channel",
+          "schemaType": "string",
+          "handler": "list_channels",
+          "labelField": "name",
+          "valueField": "id",
+          "searchParam": "search",
+          "cacheTtlMs": 300000,
+          "extension": {
+            "handler": "list_channels",
+            "labelField": "name",
+            "valueField": "id",
+            "searchParam": "search",
+            "cache": {
+              "ttlMs": 300000
+            }
+          }
+        }
+      ]
     },
     {
       "id": "smartsheet",

--- a/server/routes/app-schemas.ts
+++ b/server/routes/app-schemas.ts
@@ -5,6 +5,10 @@
 import { Router } from 'express';
 import { resolveAppSchemaKey, resolveSchemaOperationKey } from '@shared/appSchemaAlias';
 import { APP_PARAMETER_SCHEMAS, getParameterSchema, validateParameters } from '../schemas/app-parameter-schemas.js';
+import { authenticateToken } from '../middleware/auth';
+import { connectionService } from '../services/ConnectionService';
+import { connectorRegistry } from '../ConnectorRegistry';
+import { getErrorMessage } from '../types/common';
 
 const router = Router();
 
@@ -148,5 +152,146 @@ router.get('/supported-apps', (req, res) => {
     });
   }
 });
+
+router.post(
+  '/schemas/:app/:operation/options/:parameter',
+  authenticateToken,
+  async (req, res) => {
+    try {
+      const userId = (req as any)?.user?.id;
+      const organizationId = (req as any)?.organizationId;
+
+      if (!userId) {
+        return res.status(401).json({ success: false, error: 'UNAUTHORIZED' });
+      }
+
+      if (!organizationId) {
+        return res.status(400).json({ success: false, error: 'ORGANIZATION_REQUIRED' });
+      }
+
+      const { app, operation, parameter } = req.params;
+      const resolvedApp = resolveAppSchemaKey(app) ?? app;
+      const resolvedOperation = resolveSchemaOperationKey(operation);
+
+      const requestedTypeRaw = typeof req.body?.type === 'string' ? String(req.body.type).toLowerCase() : undefined;
+      const candidateTypes: Array<'action' | 'trigger'> =
+        requestedTypeRaw === 'trigger'
+          ? ['trigger']
+          : requestedTypeRaw === 'action'
+            ? ['action']
+            : ['action', 'trigger'];
+
+      let matchedConfig = undefined;
+      let resolvedType: 'action' | 'trigger' = 'action';
+      for (const type of candidateTypes) {
+        const config = connectorRegistry.getDynamicOptionConfig(resolvedApp, type, resolvedOperation, parameter);
+        if (config) {
+          matchedConfig = config;
+          resolvedType = type;
+          break;
+        }
+      }
+
+      if (!matchedConfig) {
+        return res.status(404).json({
+          success: false,
+          error: `Dynamic options not defined for ${resolvedApp}:${resolvedOperation}.${parameter}`,
+        });
+      }
+
+      const connectionId = typeof req.body?.connectionId === 'string' ? req.body.connectionId.trim() : undefined;
+      if (!connectionId) {
+        return res.status(400).json({ success: false, error: 'CONNECTION_ID_REQUIRED' });
+      }
+
+      const dependenciesInput = req.body?.dependencies;
+      const dependencies =
+        dependenciesInput && typeof dependenciesInput === 'object' ? { ...dependenciesInput } : {} as Record<string, any>;
+
+      if (matchedConfig.dependsOn?.length) {
+        const missingDeps = matchedConfig.dependsOn.filter(key => {
+          const value = dependencies[key];
+          return value === undefined || value === null || value === '';
+        });
+
+        if (missingDeps.length > 0) {
+          return res.status(400).json({
+            success: false,
+            error: `Missing dependent values: ${missingDeps.join(', ')}`,
+            missing: missingDeps,
+          });
+        }
+      }
+
+      const search = typeof req.body?.search === 'string' ? req.body.search : undefined;
+      const cursor = typeof req.body?.cursor === 'string' ? req.body.cursor : undefined;
+      const limitRaw = req.body?.limit;
+      const limit = Number.isFinite(limitRaw) ? Number(limitRaw) : undefined;
+      const additionalContext = req.body?.context;
+      const forceRefresh = Boolean(req.body?.forceRefresh);
+      const includeRaw = Boolean(req.body?.includeRaw);
+
+      const handlerContext: DynamicOptionHandlerContext = {
+        ...(additionalContext && typeof additionalContext === 'object' ? additionalContext : {}),
+        dependencies,
+      };
+
+      if (search !== undefined) handlerContext.search = search;
+      if (cursor !== undefined) handlerContext.cursor = cursor;
+      if (limit !== undefined) handlerContext.limit = limit;
+
+      const result = await connectionService.fetchDynamicOptions({
+        connectionId,
+        userId,
+        organizationId,
+        appId: resolvedApp,
+        handlerId: matchedConfig.handler,
+        operationType: resolvedType,
+        operationId: resolvedOperation,
+        parameterPath: matchedConfig.parameterPath,
+        context: handlerContext,
+        cacheTtlMs: matchedConfig.cacheTtlMs,
+        forceRefresh,
+        additionalConfig: req.body?.additionalConfig,
+      });
+
+      const status = result.success ? 200 : 502;
+
+      return res.status(status).json({
+        success: result.success,
+        cached: result.cached,
+        cacheKey: result.cacheKey,
+        cacheExpiresAt: result.cacheExpiresAt ?? null,
+        options: result.options,
+        nextCursor: result.nextCursor ?? null,
+        totalCount: result.totalCount ?? null,
+        error: result.success ? undefined : result.error,
+        raw: includeRaw ? result.raw : undefined,
+        metadata: {
+          app: resolvedApp,
+          requestedApp: app,
+          operation: resolvedOperation,
+          requestedOperation: operation,
+          operationType: resolvedType,
+          parameter: matchedConfig.parameterPath,
+          requestedParameter: parameter,
+          handler: matchedConfig.handler,
+          labelField: matchedConfig.labelField,
+          valueField: matchedConfig.valueField,
+          searchParam: matchedConfig.searchParam,
+          dependsOn: matchedConfig.dependsOn ?? [],
+          cacheTtlMs: matchedConfig.cacheTtlMs ?? null,
+        },
+      });
+    } catch (error) {
+      const statusCode = typeof (error as any)?.statusCode === 'number' ? (error as any).statusCode : 500;
+      console.error('Error fetching dynamic options:', error);
+      return res.status(statusCode).json({
+        success: false,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- add an extractor for connector dynamic option metadata and surface it in the generated manifest and registry
- annotate Slack channel/user parameters with the new x-dynamicOptions convention and expose it through the regenerated manifest
- implement dynamic option handler plumbing across the integration manager, Slack API client, connection service cache, and app schema route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df71ec38888331a07325c79d642ae2