### PR TITLE
Add workflow versioning and deployment APIs

### DIFF
--- a/common/workflow-types.ts
+++ b/common/workflow-types.ts
@@ -44,6 +44,54 @@ export type WorkflowGraph = {
   meta?: Record<string, any>;
 };
 
+export type WorkflowEnvironment = 'dev' | 'stage' | 'prod';
+export type WorkflowVersionState = 'draft' | 'published';
+
+export interface WorkflowVersionSummary {
+  id: string;
+  workflowId: string;
+  organizationId: string;
+  versionNumber: number;
+  state: WorkflowVersionState;
+  graph: WorkflowGraph;
+  metadata?: Record<string, any> | null;
+  name?: string | null;
+  description?: string | null;
+  createdAt: string;
+  createdBy?: string | null;
+  publishedAt?: string | null;
+  publishedBy?: string | null;
+}
+
+export interface WorkflowDeploymentSummary {
+  id: string;
+  workflowId: string;
+  organizationId: string;
+  versionId: string;
+  environment: WorkflowEnvironment;
+  deployedAt: string;
+  deployedBy?: string | null;
+  metadata?: Record<string, any> | null;
+  rollbackOf?: string | null;
+}
+
+export interface WorkflowDiffSummary {
+  hasChanges: boolean;
+  addedNodes: string[];
+  removedNodes: string[];
+  modifiedNodes: string[];
+  addedEdges: string[];
+  removedEdges: string[];
+  metadataChanged: boolean;
+}
+
+export interface WorkflowDiffResponse {
+  draftVersion?: WorkflowVersionSummary | null;
+  deployedVersion?: WorkflowVersionSummary | null;
+  deployment?: WorkflowDeploymentSummary | null;
+  summary: WorkflowDiffSummary;
+}
+
 export type CompileResult = {
   workflowId?: string;
   graph: WorkflowGraph;

--- a/migrations/0006_workflow_versions_deployments.ts
+++ b/migrations/0006_workflow_versions_deployments.ts
@@ -1,0 +1,66 @@
+import { sql } from 'drizzle-orm';
+
+type MigrationClient = { execute: (query: any) => Promise<unknown> };
+
+export async function up(db: MigrationClient): Promise<void> {
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "workflow_versions" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "workflow_id" uuid NOT NULL REFERENCES "workflows"("id") ON DELETE CASCADE,
+      "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+      "version_number" integer NOT NULL,
+      "state" text NOT NULL DEFAULT 'draft',
+      "graph" jsonb NOT NULL,
+      "metadata" jsonb,
+      "name" text,
+      "description" text,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "created_by" uuid REFERENCES "users"("id") ON DELETE SET NULL,
+      "published_at" timestamptz,
+      "published_by" uuid REFERENCES "users"("id") ON DELETE SET NULL
+    )
+  `);
+
+  await db.execute(
+    sql`CREATE UNIQUE INDEX IF NOT EXISTS "workflow_versions_unique_version" ON "workflow_versions" ("workflow_id", "version_number")`
+  );
+  await db.execute(
+    sql`CREATE INDEX IF NOT EXISTS "workflow_versions_workflow_state_idx" ON "workflow_versions" ("workflow_id", "state")`
+  );
+
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "workflow_deployments" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "workflow_id" uuid NOT NULL REFERENCES "workflows"("id") ON DELETE CASCADE,
+      "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+      "version_id" uuid NOT NULL REFERENCES "workflow_versions"("id") ON DELETE CASCADE,
+      "environment" text NOT NULL,
+      "is_active" boolean NOT NULL DEFAULT true,
+      "deployed_at" timestamptz NOT NULL DEFAULT now(),
+      "deployed_by" uuid REFERENCES "users"("id") ON DELETE SET NULL,
+      "metadata" jsonb,
+      "rollback_of" uuid REFERENCES "workflow_deployments"("id") ON DELETE SET NULL
+    )
+  `);
+
+  await db.execute(
+    sql`CREATE INDEX IF NOT EXISTS "workflow_deployments_workflow_idx" ON "workflow_deployments" ("workflow_id")`
+  );
+  await db.execute(
+    sql`CREATE INDEX IF NOT EXISTS "workflow_deployments_environment_idx" ON "workflow_deployments" ("workflow_id", "environment")`
+  );
+  await db.execute(
+    sql`CREATE UNIQUE INDEX IF NOT EXISTS "workflow_deployments_active_environment" ON "workflow_deployments" ("workflow_id", "environment") WHERE "is_active" = true`
+  );
+}
+
+export async function down(db: MigrationClient): Promise<void> {
+  await db.execute(sql`DROP INDEX IF EXISTS "workflow_deployments_active_environment"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "workflow_deployments_environment_idx"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "workflow_deployments_workflow_idx"`);
+  await db.execute(sql`DROP TABLE IF EXISTS "workflow_deployments"`);
+
+  await db.execute(sql`DROP INDEX IF EXISTS "workflow_versions_workflow_state_idx"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "workflow_versions_unique_version"`);
+  await db.execute(sql`DROP TABLE IF EXISTS "workflow_versions"`);
+}

--- a/server/database/status.ts
+++ b/server/database/status.ts
@@ -4,6 +4,8 @@ const REQUIRED_TABLES = [
   'users',
   'workflows',
   'workflow_executions',
+  'workflow_versions',
+  'workflow_deployments',
   'workflow_triggers',
   'polling_triggers',
   'webhook_logs',

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,6 +15,7 @@ import analyticsRoutes from "./routes/analytics.js";
 import aiPlannerRoutes from "./routes/ai-planner.js";
 import aiNormalizerRoutes from "./routes/ai-normalizer.js";
 import workflowReadRoutes from "./routes/workflow-read.js";
+import workflowDeploymentRoutes from "./routes/workflow-deployments.js";
 import productionHealthRoutes from "./routes/production-health.js";
 import flowRoutes from "./routes/flows.js";
 import oauthRoutes from "./routes/oauth";
@@ -143,6 +144,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   // CRITICAL FIX: Workflow read routes for Graph Editor handoff
   app.use('/api', workflowReadRoutes);
+  app.use('/api/workflows', workflowDeploymentRoutes);
   
   // PRODUCTION: Health monitoring and metrics routes
   app.use('/api', productionHealthRoutes);

--- a/server/routes/workflow-deployments.ts
+++ b/server/routes/workflow-deployments.ts
@@ -1,0 +1,107 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+
+import { WorkflowRepository } from '../workflow/WorkflowRepository.js';
+
+const router = Router();
+
+const requireOrganizationContext = (req: Request, res: Response): string | null => {
+  const organizationId = (req as any)?.organizationId;
+  const organizationStatus = (req as any)?.organizationStatus;
+
+  if (!organizationId) {
+    res.status(403).json({ success: false, error: 'Organization context is required' });
+    return null;
+  }
+
+  if (organizationStatus && organizationStatus !== 'active') {
+    res.status(403).json({ success: false, error: 'Organization is not active' });
+    return null;
+  }
+
+  return organizationId;
+};
+
+router.post('/:workflowId/publish', async (req, res) => {
+  try {
+    const organizationId = requireOrganizationContext(req, res);
+    if (!organizationId) {
+      return;
+    }
+
+    const environment = typeof req.body?.environment === 'string' ? req.body.environment : 'prod';
+    const versionId = typeof req.body?.versionId === 'string' ? req.body.versionId : undefined;
+    const metadata = req.body?.metadata && typeof req.body.metadata === 'object' ? req.body.metadata : null;
+
+    const result = await WorkflowRepository.publishWorkflowVersion({
+      workflowId: req.params.workflowId,
+      organizationId,
+      environment,
+      versionId,
+      userId: (req as any)?.user?.id,
+      metadata,
+    });
+
+    res.json({ success: true, deployment: result.deployment, version: result.version });
+  } catch (error: any) {
+    console.error('❌ Failed to publish workflow version:', error);
+    res.status(400).json({ success: false, error: error?.message || 'Failed to publish workflow version' });
+  }
+});
+
+router.get('/:workflowId/diff/:environment', async (req, res) => {
+  try {
+    const organizationId = requireOrganizationContext(req, res);
+    if (!organizationId) {
+      return;
+    }
+
+    const diff = await WorkflowRepository.getWorkflowDiff({
+      workflowId: req.params.workflowId,
+      organizationId,
+      environment: req.params.environment,
+    });
+
+    res.json({ success: true, diff });
+  } catch (error: any) {
+    console.error('❌ Failed to compute workflow diff:', error);
+    res.status(400).json({ success: false, error: error?.message || 'Failed to compute workflow diff' });
+  }
+});
+
+router.post('/:workflowId/rollback', async (req, res) => {
+  try {
+    const organizationId = requireOrganizationContext(req, res);
+    if (!organizationId) {
+      return;
+    }
+
+    const environment = typeof req.body?.environment === 'string' ? req.body.environment : undefined;
+    if (!environment) {
+      return res.status(400).json({ success: false, error: 'Environment is required for rollback' });
+    }
+
+    const deploymentId = typeof req.body?.deploymentId === 'string' ? req.body.deploymentId : undefined;
+    const metadata = req.body?.metadata && typeof req.body.metadata === 'object' ? req.body.metadata : null;
+
+    const result = await WorkflowRepository.rollbackDeployment({
+      workflowId: req.params.workflowId,
+      organizationId,
+      environment,
+      userId: (req as any)?.user?.id,
+      deploymentId,
+      metadata,
+    });
+
+    if (!result) {
+      return res.status(404).json({ success: false, error: 'No deployment history available to rollback' });
+    }
+
+    res.json({ success: true, deployment: result.deployment, version: result.version });
+  } catch (error: any) {
+    console.error('❌ Failed to rollback workflow deployment:', error);
+    res.status(400).json({ success: false, error: error?.message || 'Failed to rollback workflow deployment' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- introduce workflow_versions and workflow_deployments tables to store graph history and environment-specific releases
- extend WorkflowRepository with version tracking, diff helpers, and publish/rollback flows while keeping in-memory fallback support
- expose publish, diff, and rollback workflow endpoints and update shared workflow contract types plus route wiring

## Testing
- npm run lint *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68df77efef088331b10fe1841de4f094