### PR TITLE
feat: persist execution logs and expose history APIs

### DIFF
--- a/migrations/0007_execution_node_logs.ts
+++ b/migrations/0007_execution_node_logs.ts
@@ -1,0 +1,80 @@
+import { sql } from 'drizzle-orm';
+
+type MigrationClient = { execute: (query: any) => Promise<unknown> };
+
+export async function up(db: MigrationClient): Promise<void> {
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "execution_logs" (
+      "execution_id" text PRIMARY KEY,
+      "workflow_id" text NOT NULL,
+      "workflow_name" text,
+      "user_id" text,
+      "status" text NOT NULL,
+      "start_time" timestamptz NOT NULL DEFAULT now(),
+      "end_time" timestamptz,
+      "duration_ms" integer,
+      "trigger_type" text,
+      "trigger_data" jsonb,
+      "final_output" jsonb,
+      "error" text,
+      "total_nodes" integer NOT NULL DEFAULT 0,
+      "completed_nodes" integer NOT NULL DEFAULT 0,
+      "failed_nodes" integer NOT NULL DEFAULT 0,
+      "correlation_id" text,
+      "tags" text[],
+      "metadata" jsonb,
+      "timeline" jsonb,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "updated_at" timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "node_logs" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "execution_id" text NOT NULL REFERENCES "execution_logs"("execution_id") ON DELETE CASCADE,
+      "node_id" text NOT NULL,
+      "node_type" text,
+      "node_label" text,
+      "status" text NOT NULL,
+      "attempt" integer NOT NULL DEFAULT 1,
+      "max_attempts" integer NOT NULL DEFAULT 1,
+      "start_time" timestamptz NOT NULL DEFAULT now(),
+      "end_time" timestamptz,
+      "duration_ms" integer,
+      "input" jsonb,
+      "output" jsonb,
+      "error" text,
+      "correlation_id" text,
+      "retry_history" jsonb,
+      "metadata" jsonb,
+      "timeline" jsonb,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "updated_at" timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS "execution_logs_workflow_idx" ON "execution_logs" ("workflow_id")`);
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS "execution_logs_status_idx" ON "execution_logs" ("status")`);
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS "execution_logs_start_time_idx" ON "execution_logs" ("start_time")`);
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS "execution_logs_correlation_idx" ON "execution_logs" ("correlation_id")`);
+
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS "node_logs_execution_idx" ON "node_logs" ("execution_id")`);
+  await db.execute(sql`CREATE UNIQUE INDEX IF NOT EXISTS "node_logs_execution_node_unique" ON "node_logs" ("execution_id", "node_id")`);
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS "node_logs_status_idx" ON "node_logs" ("status")`);
+  await db.execute(sql`CREATE INDEX IF NOT EXISTS "node_logs_start_time_idx" ON "node_logs" ("start_time")`);
+}
+
+export async function down(db: MigrationClient): Promise<void> {
+  await db.execute(sql`DROP INDEX IF EXISTS "node_logs_start_time_idx"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "node_logs_status_idx"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "node_logs_execution_node_unique"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "node_logs_execution_idx"`);
+  await db.execute(sql`DROP TABLE IF EXISTS "node_logs"`);
+
+  await db.execute(sql`DROP INDEX IF EXISTS "execution_logs_correlation_idx"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "execution_logs_start_time_idx"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "execution_logs_status_idx"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "execution_logs_workflow_idx"`);
+  await db.execute(sql`DROP TABLE IF EXISTS "execution_logs"`);
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1759132944664,
       "tag": "0004_polling_triggers_backoff",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1759132945664,
+      "tag": "0007_execution_node_logs",
+      "breakpoints": true
     }
   ]
 }

--- a/server/core/RunExecutionManager.ts
+++ b/server/core/RunExecutionManager.ts
@@ -1,9 +1,14 @@
 /**
  * RUN EXECUTION MANAGER - Comprehensive execution tracking and observability
- * Tracks workflow executions with detailed timeline, inputs/outputs, and debugging info
+ * Persists workflow executions to the database with secret redaction
  */
 
+import { and, asc, desc, eq, gte, inArray, lt, lte, sql } from 'drizzle-orm';
+
 import { NodeGraph, GraphNode } from '../../shared/nodeGraphSchema';
+import { db, executionLogs, nodeLogs } from '../database/schema.js';
+import { sanitizeLogPayload, appendTimelineEvent } from '../utils/executionLogRedaction';
+import { logAction } from '../utils/actionLog';
 import { retryManager, CircuitBreakerSnapshot } from './RetryManager';
 
 export interface NodeExecution {
@@ -36,6 +41,7 @@ export interface NodeExecution {
     timeoutMs?: number;
     connectorId?: string;
     circuitState?: CircuitBreakerSnapshot;
+    [key: string]: any;
   };
 }
 
@@ -94,23 +100,110 @@ export interface ExecutionQuery {
   sortOrder?: 'asc' | 'desc';
 }
 
-class RunExecutionManager {
-  private executions = new Map<string, WorkflowExecution>();
-  private nodeExecutions = new Map<string, NodeExecution[]>(); // executionId -> NodeExecution[]
-  private correlationIndex = new Map<string, string[]>(); // correlationId -> executionIds[]
+export interface NodeExecutionQueryOptions {
+  limit?: number;
+  offset?: number;
+}
 
-  /**
-   * Start tracking a new workflow execution
-   */
+interface ExecutionQueryResult {
+  executions: WorkflowExecution[];
+  total: number;
+  hasMore: boolean;
+  limit: number;
+  offset: number;
+}
+
+interface NodeExecutionQueryResult {
+  nodes: NodeExecution[];
+  total: number;
+  hasMore: boolean;
+  limit: number;
+  offset: number;
+}
+
+type ExecutionLogRow = typeof executionLogs.$inferSelect;
+type NodeLogRow = typeof nodeLogs.$inferSelect;
+
+type ExecutionLogInsert = typeof executionLogs.$inferInsert;
+type NodeLogInsert = typeof nodeLogs.$inferInsert;
+
+interface ExecutionLogStore {
   startExecution(
     executionId: string,
     workflow: NodeGraph,
     userId?: string,
     triggerType?: string,
     triggerData?: any
-  ): WorkflowExecution {
-    const correlationId = this.generateCorrelationId();
-    
+  ): Promise<WorkflowExecution>;
+  startNodeExecution(
+    executionId: string,
+    node: GraphNode,
+    input?: any,
+    options?: { timeoutMs?: number; connectorId?: string }
+  ): Promise<NodeExecution>;
+  completeNodeExecution(
+    executionId: string,
+    nodeId: string,
+    output: any,
+    metadata?: Partial<NodeExecution['metadata']>
+  ): Promise<void>;
+  failNodeExecution(
+    executionId: string,
+    nodeId: string,
+    error: string,
+    metadata?: Partial<NodeExecution['metadata']>
+  ): Promise<void>;
+  completeExecution(executionId: string, finalOutput?: any, error?: string): Promise<void>;
+  markExecutionWaiting(executionId: string, reason?: string, resumeAt?: Date): Promise<void>;
+  getExecution(executionId: string): Promise<WorkflowExecution | undefined>;
+  queryExecutions(query?: ExecutionQuery): Promise<ExecutionQueryResult>;
+  getNodeExecutions(executionId: string, options?: NodeExecutionQueryOptions): Promise<NodeExecutionQueryResult>;
+  getExecutionsByCorrelation(correlationId: string): Promise<WorkflowExecution[]>;
+  getExecutionStats(timeframe?: 'hour' | 'day' | 'week'): Promise<{
+    totalExecutions: number;
+    successfulExecutions: number;
+    failedExecutions: number;
+    averageDuration: number;
+    successRate: number;
+    totalCost: number;
+    popularWorkflows: Array<{ workflowId: string; count: number }>;
+  }>;
+  cleanup(maxAge?: number): Promise<void>;
+}
+
+const DEFAULT_METADATA_BASE: WorkflowExecution['metadata'] = {
+  retryCount: 0,
+  totalCostUSD: 0,
+  totalTokensUsed: 0,
+  cacheHitRate: 0,
+  averageNodeDuration: 0,
+  openCircuitBreakers: [],
+};
+
+function createDefaultMetadata(): WorkflowExecution['metadata'] {
+  return {
+    ...DEFAULT_METADATA_BASE,
+    openCircuitBreakers: [],
+  };
+}
+
+function generateCorrelationId(): string {
+  return `corr_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+}
+
+class InMemoryExecutionLogStore implements ExecutionLogStore {
+  private readonly executions = new Map<string, WorkflowExecution>();
+  private readonly nodeExecutions = new Map<string, NodeExecution[]>();
+  private readonly correlationIndex = new Map<string, string[]>();
+
+  async startExecution(
+    executionId: string,
+    workflow: NodeGraph,
+    userId?: string,
+    triggerType?: string,
+    triggerData?: any
+  ): Promise<WorkflowExecution> {
+    const correlationId = generateCorrelationId();
     const execution: WorkflowExecution = {
       executionId,
       workflowId: workflow.id,
@@ -126,38 +219,27 @@ class RunExecutionManager {
       nodeExecutions: [],
       correlationId,
       tags: workflow.tags || [],
-      metadata: {
-        retryCount: 0,
-        totalCostUSD: 0,
-        totalTokensUsed: 0,
-        cacheHitRate: 0,
-        averageNodeDuration: 0,
-        openCircuitBreakers: []
-      }
+      metadata: createDefaultMetadata(),
     };
 
     this.executions.set(executionId, execution);
     this.nodeExecutions.set(executionId, []);
-    
-    // Index by correlation ID
+
     if (!this.correlationIndex.has(correlationId)) {
       this.correlationIndex.set(correlationId, []);
     }
     this.correlationIndex.get(correlationId)!.push(executionId);
 
-    console.log(`📊 Started tracking execution ${executionId} with correlation ${correlationId}`);
+    logAction({ type: 'execution_start', executionId, workflowId: workflow.id, correlationId });
     return execution;
   }
 
-  /**
-   * Start tracking a node execution
-   */
-  startNodeExecution(
+  async startNodeExecution(
     executionId: string,
     node: GraphNode,
     input?: any,
     options: { timeoutMs?: number; connectorId?: string } = {}
-  ): NodeExecution {
+  ): Promise<NodeExecution> {
     const execution = this.executions.get(executionId);
     if (!execution) {
       throw new Error(`Execution ${executionId} not found`);
@@ -173,52 +255,44 @@ class RunExecutionManager {
       status: 'running',
       startTime: new Date(),
       attempt: 1,
-      maxAttempts: 3, // Will be updated based on retry policy
+      maxAttempts: 3,
       input,
       correlationId: execution.correlationId,
       retryHistory: [],
       metadata: {
         timeoutMs: options.timeoutMs,
         connectorId,
-        circuitState
-      }
+        circuitState,
+      },
     };
 
-    // Get retry info from retry manager
     const retryStatus = retryManager.getRetryStatus(executionId, node.id);
     if (retryStatus) {
       nodeExecution.attempt = retryStatus.attempts.length + 1;
       nodeExecution.maxAttempts = retryStatus.policy.maxAttempts;
       nodeExecution.metadata.idempotencyKey = retryStatus.idempotencyKey;
-      
-      // Build retry history
-      nodeExecution.retryHistory = retryStatus.attempts.map(attempt => ({
+      nodeExecution.retryHistory = retryStatus.attempts.map((attempt) => ({
         attempt: attempt.attempt,
         timestamp: attempt.timestamp,
         error: attempt.error,
-        duration: 0 // We don't track individual attempt duration yet
+        duration: 0,
       }));
     }
 
     const nodeExecutions = this.nodeExecutions.get(executionId)!;
     nodeExecutions.push(nodeExecution);
 
-    // Update workflow status
     execution.status = 'running';
 
-    console.log(`🔍 Started node execution: ${node.id} (${node.type})`);
     return nodeExecution;
   }
 
-  /**
-   * Complete a node execution successfully
-   */
-  completeNodeExecution(
+  async completeNodeExecution(
     executionId: string,
     nodeId: string,
     output: any,
     metadata: Partial<NodeExecution['metadata']> = {}
-  ): void {
+  ): Promise<void> {
     const nodeExecution = this.findNodeExecution(executionId, nodeId);
     if (!nodeExecution) return;
 
@@ -228,25 +302,17 @@ class RunExecutionManager {
     nodeExecution.output = output;
     nodeExecution.metadata = { ...nodeExecution.metadata, ...metadata };
 
-    // Update workflow progress
     const execution = this.executions.get(executionId)!;
     execution.completedNodes++;
-    
-    // Update workflow metadata
     this.updateWorkflowMetadata(execution);
-
-    console.log(`✅ Completed node execution: ${nodeId} in ${nodeExecution.duration}ms`);
   }
 
-  /**
-   * Fail a node execution
-   */
-  failNodeExecution(
+  async failNodeExecution(
     executionId: string,
     nodeId: string,
     error: string,
     metadata: Partial<NodeExecution['metadata']> = {}
-  ): void {
+  ): Promise<void> {
     const nodeExecution = this.findNodeExecution(executionId, nodeId);
     if (!nodeExecution) return;
 
@@ -256,17 +322,11 @@ class RunExecutionManager {
     nodeExecution.error = error;
     nodeExecution.metadata = { ...nodeExecution.metadata, ...metadata };
 
-    // Update workflow progress
     const execution = this.executions.get(executionId)!;
     execution.failedNodes++;
-    
-    console.error(`❌ Failed node execution: ${nodeId} - ${error}`);
   }
 
-  /**
-   * Complete a workflow execution
-   */
-  completeExecution(executionId: string, finalOutput?: any, error?: string): void {
+  async completeExecution(executionId: string, finalOutput?: any, error?: string): Promise<void> {
     const execution = this.executions.get(executionId);
     if (!execution) return;
 
@@ -283,20 +343,13 @@ class RunExecutionManager {
       execution.status = 'succeeded';
     }
 
-    // Final metadata update
     this.updateWorkflowMetadata(execution);
-
-    console.log(`🏁 Completed execution ${executionId}: ${execution.status} in ${execution.duration}ms`);
+    logAction({ type: 'execution_complete', executionId, status: execution.status });
   }
 
-  /**
-   * Mark execution as waiting for external signal
-   */
-  markExecutionWaiting(executionId: string, reason?: string, resumeAt?: Date): void {
+  async markExecutionWaiting(executionId: string, reason?: string, resumeAt?: Date): Promise<void> {
     const execution = this.executions.get(executionId);
-    if (!execution) {
-      return;
-    }
+    if (!execution) return;
 
     execution.status = 'waiting';
     if (resumeAt) {
@@ -305,70 +358,46 @@ class RunExecutionManager {
     if (reason) {
       execution.metadata.waitReason = reason;
     }
-
-    console.log(
-      `⏸️ Execution ${executionId} paused${resumeAt ? ` until ${resumeAt.toISOString()}` : ''}${reason ? ` (${reason})` : ''}`
-    );
   }
 
-  /**
-   * Get execution by ID with full details
-   */
-  getExecution(executionId: string): WorkflowExecution | undefined {
+  async getExecution(executionId: string): Promise<WorkflowExecution | undefined> {
     const execution = this.executions.get(executionId);
     if (!execution) return undefined;
-
-    // Attach node executions
     execution.nodeExecutions = this.nodeExecutions.get(executionId) || [];
-    
     return execution;
   }
 
-  /**
-   * Query executions with filtering and pagination
-   */
-  queryExecutions(query: ExecutionQuery = {}): {
-    executions: WorkflowExecution[];
-    total: number;
-    hasMore: boolean;
-  } {
+  async queryExecutions(query: ExecutionQuery = {}): Promise<ExecutionQueryResult> {
     let executions = Array.from(this.executions.values());
 
-    // Apply filters
     if (query.executionId) {
-      executions = executions.filter(e => e.executionId === query.executionId);
+      executions = executions.filter((e) => e.executionId === query.executionId);
     }
     if (query.workflowId) {
-      executions = executions.filter(e => e.workflowId === query.workflowId);
+      executions = executions.filter((e) => e.workflowId === query.workflowId);
     }
     if (query.userId) {
-      executions = executions.filter(e => e.userId === query.userId);
+      executions = executions.filter((e) => e.userId === query.userId);
     }
     if (query.status && query.status.length > 0) {
-      executions = executions.filter(e => query.status!.includes(e.status));
+      executions = executions.filter((e) => query.status!.includes(e.status));
     }
     if (query.dateFrom) {
-      executions = executions.filter(e => e.startTime >= query.dateFrom!);
+      executions = executions.filter((e) => e.startTime >= query.dateFrom!);
     }
     if (query.dateTo) {
-      executions = executions.filter(e => e.startTime <= query.dateTo!);
+      executions = executions.filter((e) => e.startTime <= query.dateTo!);
     }
     if (query.tags && query.tags.length > 0) {
-      executions = executions.filter(e => 
-        query.tags!.some(tag => e.tags.includes(tag))
-      );
+      executions = executions.filter((e) => query.tags!.some((tag) => e.tags.includes(tag)));
     }
 
-    // Sort
     const sortBy = query.sortBy || 'startTime';
     const sortOrder = query.sortOrder || 'desc';
     executions.sort((a, b) => {
-      let aVal: any, bVal: any;
+      let aVal: any;
+      let bVal: any;
       switch (sortBy) {
-        case 'startTime':
-          aVal = a.startTime.getTime();
-          bVal = b.startTime.getTime();
-          break;
         case 'duration':
           aVal = a.duration || 0;
           bVal = b.duration || 0;
@@ -377,49 +406,56 @@ class RunExecutionManager {
           aVal = a.status;
           bVal = b.status;
           break;
+        case 'startTime':
         default:
           aVal = a.startTime.getTime();
           bVal = b.startTime.getTime();
       }
-      
+
       if (sortOrder === 'asc') {
         return aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
-      } else {
-        return aVal > bVal ? -1 : aVal < bVal ? 1 : 0;
       }
+      return aVal > bVal ? -1 : aVal < bVal ? 1 : 0;
     });
 
     const total = executions.length;
     const limit = query.limit || 50;
     const offset = query.offset || 0;
-    
-    // Paginate
     const paginatedExecutions = executions.slice(offset, offset + limit);
-    
-    // Attach node executions to each
-    paginatedExecutions.forEach(execution => {
+
+    paginatedExecutions.forEach((execution) => {
       execution.nodeExecutions = this.nodeExecutions.get(execution.executionId) || [];
     });
 
     return {
       executions: paginatedExecutions,
       total,
-      hasMore: offset + limit < total
+      hasMore: offset + limit < total,
+      limit,
+      offset,
     };
   }
 
-  /**
-   * Get executions by correlation ID
-   */
-  getExecutionsByCorrelation(correlationId: string): WorkflowExecution[] {
-    const executionIds = this.correlationIndex.get(correlationId) || [];
-    return executionIds.map(id => this.getExecution(id)).filter(Boolean) as WorkflowExecution[];
+  async getNodeExecutions(executionId: string, options: NodeExecutionQueryOptions = {}): Promise<NodeExecutionQueryResult> {
+    const nodes = this.nodeExecutions.get(executionId) || [];
+    const limit = options.limit ?? 50;
+    const offset = options.offset ?? 0;
+    const slice = nodes.slice(offset, offset + limit);
+    return {
+      nodes: slice,
+      total: nodes.length,
+      hasMore: offset + limit < nodes.length,
+      limit,
+      offset,
+    };
   }
 
-  /**
-   * Get execution statistics
-   */
-  getExecutionStats(timeframe: 'hour' | 'day' | 'week' = 'day'): {
+  async getExecutionsByCorrelation(correlationId: string): Promise<WorkflowExecution[]> {
+    const executionIds = this.correlationIndex.get(correlationId) || [];
+    return executionIds.map((id) => this.executions.get(id)).filter(Boolean) as WorkflowExecution[];
+  }
+
+  async getExecutionStats(timeframe: 'hour' | 'day' | 'week' = 'day'): Promise<{
     totalExecutions: number;
     successfulExecutions: number;
     failedExecutions: number;
@@ -427,33 +463,31 @@ class RunExecutionManager {
     successRate: number;
     totalCost: number;
     popularWorkflows: Array<{ workflowId: string; count: number }>;
-  } {
+  }> {
     const now = new Date();
     const timeframeMs = {
       hour: 60 * 60 * 1000,
       day: 24 * 60 * 60 * 1000,
-      week: 7 * 24 * 60 * 60 * 1000
+      week: 7 * 24 * 60 * 60 * 1000,
     }[timeframe];
-    
+
     const cutoff = new Date(now.getTime() - timeframeMs);
-    const recentExecutions = Array.from(this.executions.values())
-      .filter(e => e.startTime >= cutoff);
+    const recentExecutions = Array.from(this.executions.values()).filter((e) => e.startTime >= cutoff);
 
-    const successful = recentExecutions.filter(e => e.status === 'succeeded');
-    const failed = recentExecutions.filter(e => e.status === 'failed');
-    
+    const successful = recentExecutions.filter((e) => e.status === 'succeeded');
+    const failed = recentExecutions.filter((e) => e.status === 'failed');
+
     const totalDuration = recentExecutions
-      .filter(e => e.duration)
+      .filter((e) => e.duration)
       .reduce((sum, e) => sum + e.duration!, 0);
-    
-    const totalCost = recentExecutions
-      .reduce((sum, e) => sum + e.metadata.totalCostUSD, 0);
 
-    // Popular workflows
+    const totalCost = recentExecutions.reduce((sum, e) => sum + (e.metadata.totalCostUSD || 0), 0);
+
     const workflowCounts = new Map<string, number>();
-    recentExecutions.forEach(e => {
+    recentExecutions.forEach((e) => {
       workflowCounts.set(e.workflowId, (workflowCounts.get(e.workflowId) || 0) + 1);
     });
+
     const popularWorkflows = Array.from(workflowCounts.entries())
       .map(([workflowId, count]) => ({ workflowId, count }))
       .sort((a, b) => b.count - a.count)
@@ -466,23 +500,17 @@ class RunExecutionManager {
       averageDuration: recentExecutions.length > 0 ? totalDuration / recentExecutions.length : 0,
       successRate: recentExecutions.length > 0 ? successful.length / recentExecutions.length : 0,
       totalCost,
-      popularWorkflows
+      popularWorkflows,
     };
   }
 
-  /**
-   * Clean up old executions
-   */
-  cleanup(maxAge: number = 30 * 24 * 60 * 60 * 1000): void { // 30 days default
+  async cleanup(maxAge: number = 30 * 24 * 60 * 60 * 1000): Promise<void> {
     const cutoff = new Date(Date.now() - maxAge);
-    let cleanedCount = 0;
-
     for (const [executionId, execution] of this.executions.entries()) {
       if (execution.startTime < cutoff) {
         this.executions.delete(executionId);
         this.nodeExecutions.delete(executionId);
-        
-        // Clean up correlation index
+
         const correlationExecutions = this.correlationIndex.get(execution.correlationId);
         if (correlationExecutions) {
           const index = correlationExecutions.indexOf(executionId);
@@ -493,18 +521,13 @@ class RunExecutionManager {
             this.correlationIndex.delete(execution.correlationId);
           }
         }
-        
-        cleanedCount++;
       }
     }
-
-    console.log(`🧹 Cleaned up ${cleanedCount} old executions`);
   }
 
-  // Private helper methods
   private findNodeExecution(executionId: string, nodeId: string): NodeExecution | undefined {
     const nodeExecutions = this.nodeExecutions.get(executionId);
-    return nodeExecutions?.find(ne => ne.nodeId === nodeId);
+    return nodeExecutions?.find((ne) => ne.nodeId === nodeId);
   }
 
   private resolveConnectorId(node: GraphNode): string | undefined {
@@ -518,7 +541,7 @@ class RunExecutionManager {
       (data as any)?.app,
       node.app,
       node.connectionId,
-      (data as any)?.connectionId
+      (data as any)?.connectionId,
     ];
 
     for (const candidate of candidates) {
@@ -543,26 +566,21 @@ class RunExecutionManager {
   private updateWorkflowMetadata(execution: WorkflowExecution): void {
     const nodeExecutions = this.nodeExecutions.get(execution.executionId) || [];
 
-    // Calculate retry count
     execution.metadata.retryCount = nodeExecutions.reduce((sum, ne) => sum + ne.retryHistory.length, 0);
-    
-    // Calculate total cost and tokens
     execution.metadata.totalCostUSD = nodeExecutions.reduce((sum, ne) => sum + (ne.metadata.costUSD || 0), 0);
     execution.metadata.totalTokensUsed = nodeExecutions.reduce((sum, ne) => sum + (ne.metadata.tokensUsed || 0), 0);
-    
-    // Calculate cache hit rate
-    const cacheableNodes = nodeExecutions.filter(ne => ne.metadata.idempotencyKey);
-    const cacheHits = cacheableNodes.filter(ne => ne.metadata.cacheHit);
+
+    const cacheableNodes = nodeExecutions.filter((ne) => ne.metadata.idempotencyKey);
+    const cacheHits = cacheableNodes.filter((ne) => ne.metadata.cacheHit);
     execution.metadata.cacheHitRate = cacheableNodes.length > 0 ? cacheHits.length / cacheableNodes.length : 0;
-    
-    // Calculate average node duration
-    const completedNodes = nodeExecutions.filter(ne => ne.duration);
+
+    const completedNodes = nodeExecutions.filter((ne) => ne.duration);
     execution.metadata.averageNodeDuration = completedNodes.length > 0
       ? completedNodes.reduce((sum, ne) => sum + ne.duration!, 0) / completedNodes.length
       : 0;
 
     const breakerDetails = nodeExecutions
-      .map(ne => {
+      .map((ne) => {
         const state = ne.metadata.circuitState;
         if (!state) {
           return null;
@@ -577,7 +595,7 @@ class RunExecutionManager {
             openedAt: state.openedAt,
             lastFailureAt: state.lastFailureAt,
             cooldownMs: state.cooldownMs,
-            failureThreshold: state.failureThreshold
+            failureThreshold: state.failureThreshold,
           };
         }
         return null;
@@ -586,15 +604,962 @@ class RunExecutionManager {
 
     execution.metadata.openCircuitBreakers = breakerDetails;
   }
+}
 
-  private generateCorrelationId(): string {
-    return `corr_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+class DatabaseExecutionLogStore implements ExecutionLogStore {
+  constructor(private readonly dbProvider: () => typeof db) {}
+
+  isAvailable(): boolean {
+    return Boolean(this.dbProvider());
+  }
+
+  private getDb() {
+    return this.dbProvider();
+  }
+
+  async startExecution(
+    executionId: string,
+    workflow: NodeGraph,
+    userId?: string,
+    triggerType?: string,
+    triggerData?: any
+  ): Promise<WorkflowExecution> {
+    const correlationId = generateCorrelationId();
+    const now = new Date();
+
+    const execution: WorkflowExecution = {
+      executionId,
+      workflowId: workflow.id,
+      workflowName: workflow.name,
+      userId,
+      status: 'pending',
+      startTime: now,
+      triggerType,
+      triggerData: sanitizeLogPayload(triggerData),
+      totalNodes: workflow.nodes.length,
+      completedNodes: 0,
+      failedNodes: 0,
+      nodeExecutions: [],
+      correlationId,
+      tags: workflow.tags || [],
+      metadata: createDefaultMetadata(),
+    };
+
+    const row: ExecutionLogInsert = {
+      executionId,
+      workflowId: workflow.id,
+      workflowName: workflow.name,
+      userId,
+      status: 'pending',
+      startTime: now,
+      triggerType,
+      triggerData: sanitizeLogPayload(triggerData),
+      totalNodes: workflow.nodes.length,
+      completedNodes: 0,
+      failedNodes: 0,
+      correlationId,
+      tags: workflow.tags || [],
+      metadata: this.serializeExecutionMetadata(execution.metadata),
+      timeline: appendTimelineEvent([], {
+        type: 'execution.start',
+        timestamp: now.toISOString(),
+      }),
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const database = this.getDb();
+    if (database) {
+      await database
+        .insert(executionLogs)
+        .values(row)
+        .onConflictDoUpdate({
+          target: executionLogs.executionId,
+          set: {
+            workflowId: row.workflowId,
+            workflowName: row.workflowName,
+            userId: row.userId,
+            status: row.status,
+            startTime: row.startTime,
+            triggerType: row.triggerType,
+            triggerData: row.triggerData,
+            totalNodes: row.totalNodes,
+            completedNodes: row.completedNodes,
+            failedNodes: row.failedNodes,
+            correlationId: row.correlationId,
+            tags: row.tags,
+            metadata: row.metadata,
+            timeline: row.timeline,
+            updatedAt: now,
+          },
+        });
+    }
+
+    logAction({ type: 'execution_start', executionId, workflowId: workflow.id, correlationId });
+    return execution;
+  }
+
+  async startNodeExecution(
+    executionId: string,
+    node: GraphNode,
+    input?: any,
+    options: { timeoutMs?: number; connectorId?: string } = {}
+  ): Promise<NodeExecution> {
+    const database = this.getDb();
+    if (!database) {
+      throw new Error('Database client not available');
+    }
+
+    const executionRow = await this.getExecutionRow(executionId);
+    if (!executionRow) {
+      throw new Error(`Execution ${executionId} not found`);
+    }
+
+    const connectorId = options.connectorId ?? this.resolveConnectorId(node);
+    const circuitState = connectorId ? retryManager.getCircuitState(connectorId, node.id) : undefined;
+
+    const nodeExecution: NodeExecution = {
+      nodeId: node.id,
+      nodeType: node.type,
+      nodeLabel: node.data.label || node.id,
+      status: 'running',
+      startTime: new Date(),
+      attempt: 1,
+      maxAttempts: 3,
+      input,
+      correlationId: executionRow.correlationId || generateCorrelationId(),
+      retryHistory: [],
+      metadata: {
+        timeoutMs: options.timeoutMs,
+        connectorId,
+        circuitState,
+      },
+    };
+
+    const retryStatus = retryManager.getRetryStatus(executionId, node.id);
+    if (retryStatus) {
+      nodeExecution.attempt = retryStatus.attempts.length + 1;
+      nodeExecution.maxAttempts = retryStatus.policy.maxAttempts;
+      nodeExecution.metadata.idempotencyKey = retryStatus.idempotencyKey;
+      nodeExecution.retryHistory = retryStatus.attempts.map((attempt) => ({
+        attempt: attempt.attempt,
+        timestamp: attempt.timestamp,
+        error: attempt.error,
+        duration: 0,
+      }));
+    }
+
+    const existing = await this.getNodeRow(executionId, node.id);
+    const now = nodeExecution.startTime;
+
+    const timelineEvent = {
+      type: existing ? 'node.restart' : 'node.start',
+      timestamp: now.toISOString(),
+      status: 'running',
+      attempt: nodeExecution.attempt,
+    };
+
+    const sanitizedMetadata = sanitizeLogPayload({
+      timeoutMs: nodeExecution.metadata.timeoutMs,
+      connectorId: nodeExecution.metadata.connectorId,
+      circuitState: nodeExecution.metadata.circuitState,
+      idempotencyKey: nodeExecution.metadata.idempotencyKey,
+    });
+
+    if (!existing) {
+      const row: NodeLogInsert = {
+        executionId,
+        nodeId: node.id,
+        nodeType: node.type,
+        nodeLabel: node.data.label || node.id,
+        status: 'running',
+        attempt: nodeExecution.attempt,
+        maxAttempts: nodeExecution.maxAttempts,
+        startTime: now,
+        input: sanitizeLogPayload(input),
+        correlationId: nodeExecution.correlationId,
+        retryHistory: sanitizeLogPayload(nodeExecution.retryHistory),
+        metadata: sanitizedMetadata,
+        timeline: appendTimelineEvent([], timelineEvent),
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      await database.insert(nodeLogs).values(row);
+    } else {
+      const mergedMetadata = sanitizeLogPayload({
+        ...(existing.metadata || {}),
+        ...sanitizedMetadata,
+      });
+
+      const mergedTimeline = appendTimelineEvent(existing.timeline, timelineEvent);
+
+      await database
+        .update(nodeLogs)
+        .set({
+          status: 'running',
+          attempt: nodeExecution.attempt,
+          maxAttempts: nodeExecution.maxAttempts,
+          startTime: now,
+          endTime: null,
+          durationMs: null,
+          input: sanitizeLogPayload(input),
+          output: null,
+          error: null,
+          metadata: mergedMetadata,
+          retryHistory: sanitizeLogPayload(nodeExecution.retryHistory),
+          timeline: mergedTimeline,
+          updatedAt: now,
+        })
+        .where(and(eq(nodeLogs.executionId, executionId), eq(nodeLogs.nodeId, node.id)));
+    }
+
+    await database
+      .update(executionLogs)
+      .set({ status: 'running', updatedAt: now })
+      .where(eq(executionLogs.executionId, executionId));
+
+    await this.updateExecutionAggregates(executionId);
+
+    return nodeExecution;
+  }
+
+  async completeNodeExecution(
+    executionId: string,
+    nodeId: string,
+    output: any,
+    metadata: Partial<NodeExecution['metadata']> = {}
+  ): Promise<void> {
+    const database = this.getDb();
+    if (!database) return;
+
+    const existing = await this.getNodeRow(executionId, nodeId);
+    if (!existing) return;
+
+    const endTime = new Date();
+    const durationMs = existing.startTime ? endTime.getTime() - existing.startTime.getTime() : null;
+
+    const mergedMetadata = sanitizeLogPayload({
+      ...(existing.metadata || {}),
+      ...metadata,
+    });
+
+    const timeline = appendTimelineEvent(existing.timeline, {
+      type: 'node.complete',
+      timestamp: endTime.toISOString(),
+      status: 'succeeded',
+      durationMs,
+    });
+
+    await database
+      .update(nodeLogs)
+      .set({
+        status: 'succeeded',
+        endTime,
+        durationMs: durationMs ?? undefined,
+        output: sanitizeLogPayload(output),
+        metadata: mergedMetadata,
+        timeline,
+        updatedAt: endTime,
+      })
+      .where(and(eq(nodeLogs.executionId, executionId), eq(nodeLogs.nodeId, nodeId)));
+
+    await this.updateExecutionAggregates(executionId);
+  }
+
+  async failNodeExecution(
+    executionId: string,
+    nodeId: string,
+    error: string,
+    metadata: Partial<NodeExecution['metadata']> = {}
+  ): Promise<void> {
+    const database = this.getDb();
+    if (!database) return;
+
+    const existing = await this.getNodeRow(executionId, nodeId);
+    if (!existing) return;
+
+    const endTime = new Date();
+    const durationMs = existing.startTime ? endTime.getTime() - existing.startTime.getTime() : null;
+
+    const mergedMetadata = sanitizeLogPayload({
+      ...(existing.metadata || {}),
+      ...metadata,
+    });
+
+    const timeline = appendTimelineEvent(existing.timeline, {
+      type: 'node.fail',
+      timestamp: endTime.toISOString(),
+      status: 'failed',
+      durationMs,
+      error,
+    });
+
+    await database
+      .update(nodeLogs)
+      .set({
+        status: 'failed',
+        endTime,
+        durationMs: durationMs ?? undefined,
+        error,
+        metadata: mergedMetadata,
+        timeline,
+        updatedAt: endTime,
+      })
+      .where(and(eq(nodeLogs.executionId, executionId), eq(nodeLogs.nodeId, nodeId)));
+
+    await this.updateExecutionAggregates(executionId);
+  }
+
+  async completeExecution(executionId: string, finalOutput?: any, error?: string): Promise<void> {
+    const database = this.getDb();
+    if (!database) return;
+
+    const nodes = await this.fetchNodeExecutions(executionId);
+    const executionRow = await this.getExecutionRow(executionId);
+    if (!executionRow) return;
+
+    const now = new Date();
+    const completedNodes = nodes.filter((node) => node.status === 'succeeded').length;
+    const failedNodes = nodes.filter((node) => node.status === 'failed').length;
+    const status = error ? 'failed' : failedNodes > 0 ? 'partial' : 'succeeded';
+    const durationMs = executionRow.startTime
+      ? now.getTime() - executionRow.startTime.getTime()
+      : executionRow.durationMs ?? undefined;
+
+    const metadata = this.buildExecutionMetadata(nodes, executionRow.metadata);
+
+    const timeline = appendTimelineEvent(executionRow.timeline, {
+      type: 'execution.complete',
+      timestamp: now.toISOString(),
+      status,
+    });
+
+    await database
+      .update(executionLogs)
+      .set({
+        status,
+        endTime: now,
+        durationMs,
+        finalOutput: sanitizeLogPayload(finalOutput),
+        error: error ? String(error) : null,
+        completedNodes,
+        failedNodes,
+        metadata: this.serializeExecutionMetadata(metadata),
+        timeline,
+        updatedAt: now,
+      })
+      .where(eq(executionLogs.executionId, executionId));
+  }
+
+  async markExecutionWaiting(executionId: string, reason?: string, resumeAt?: Date): Promise<void> {
+    const database = this.getDb();
+    if (!database) return;
+
+    const executionRow = await this.getExecutionRow(executionId);
+    if (!executionRow) return;
+
+    const now = new Date();
+    const existingMetadata = this.normalizeExecutionMetadata(executionRow.metadata);
+
+    const metadata = {
+      ...existingMetadata,
+      nextResumeAt: resumeAt ?? existingMetadata.nextResumeAt,
+      waitReason: reason ?? existingMetadata.waitReason,
+    };
+
+    const timeline = appendTimelineEvent(executionRow.timeline, {
+      type: 'execution.wait',
+      timestamp: now.toISOString(),
+      reason,
+      resumeAt: resumeAt ? resumeAt.toISOString() : undefined,
+    });
+
+    await database
+      .update(executionLogs)
+      .set({
+        status: 'waiting',
+        metadata: this.serializeExecutionMetadata(metadata),
+        timeline,
+        updatedAt: now,
+      })
+      .where(eq(executionLogs.executionId, executionId));
+
+    await this.updateExecutionAggregates(executionId);
+  }
+
+  async getExecution(executionId: string): Promise<WorkflowExecution | undefined> {
+    const database = this.getDb();
+    if (!database) return undefined;
+
+    const executionRow = await this.getExecutionRow(executionId);
+    if (!executionRow) return undefined;
+
+    const nodes = await this.fetchNodeExecutions(executionId);
+    return this.mapExecutionRow(executionRow, nodes);
+  }
+
+  async queryExecutions(query: ExecutionQuery = {}): Promise<ExecutionQueryResult> {
+    const database = this.getDb();
+    if (!database) {
+      return { executions: [], total: 0, hasMore: false, limit: query.limit ?? 50, offset: query.offset ?? 0 };
+    }
+
+    const conditions = [] as any[];
+    if (query.executionId) {
+      conditions.push(eq(executionLogs.executionId, query.executionId));
+    }
+    if (query.workflowId) {
+      conditions.push(eq(executionLogs.workflowId, query.workflowId));
+    }
+    if (query.userId) {
+      conditions.push(eq(executionLogs.userId, query.userId));
+    }
+    if (query.status && query.status.length > 0) {
+      conditions.push(inArray(executionLogs.status, query.status));
+    }
+    if (query.dateFrom) {
+      conditions.push(gte(executionLogs.startTime, query.dateFrom));
+    }
+    if (query.dateTo) {
+      conditions.push(lte(executionLogs.startTime, query.dateTo));
+    }
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const sortBy = query.sortBy || 'startTime';
+    const sortOrder = query.sortOrder || 'desc';
+    const sortColumn =
+      sortBy === 'duration'
+        ? executionLogs.durationMs
+        : sortBy === 'status'
+        ? executionLogs.status
+        : executionLogs.startTime;
+
+    const limit = query.limit ?? 50;
+    const offset = query.offset ?? 0;
+
+    const rows = await database
+      .select()
+      .from(executionLogs)
+      .where(whereClause)
+      .orderBy(sortOrder === 'asc' ? asc(sortColumn) : desc(sortColumn))
+      .limit(limit)
+      .offset(offset);
+
+    const [{ value: total = 0 } = { value: 0 }] = await database
+      .select({ value: sql<number>`count(*)` })
+      .from(executionLogs)
+      .where(whereClause)
+      .limit(1);
+
+    const executionIds = rows.map((row) => row.executionId);
+    const nodeRows = executionIds.length
+      ? await database
+          .select()
+          .from(nodeLogs)
+          .where(inArray(nodeLogs.executionId, executionIds))
+          .orderBy(asc(nodeLogs.startTime))
+      : [];
+
+    const nodeMap = new Map<string, NodeExecution[]>();
+    for (const row of nodeRows) {
+      const executionNodes = nodeMap.get(row.executionId) ?? [];
+      executionNodes.push(this.mapNodeRow(row));
+      nodeMap.set(row.executionId, executionNodes);
+    }
+
+    const executions = rows.map((row) => this.mapExecutionRow(row, nodeMap.get(row.executionId) ?? []));
+
+    return {
+      executions,
+      total,
+      hasMore: offset + limit < total,
+      limit,
+      offset,
+    };
+  }
+
+  async getNodeExecutions(
+    executionId: string,
+    options: NodeExecutionQueryOptions = {}
+  ): Promise<NodeExecutionQueryResult> {
+    const database = this.getDb();
+    if (!database) {
+      return { nodes: [], total: 0, hasMore: false, limit: options.limit ?? 50, offset: options.offset ?? 0 };
+    }
+
+    const limit = options.limit ?? 50;
+    const offset = options.offset ?? 0;
+
+    const [{ value: total = 0 } = { value: 0 }] = await database
+      .select({ value: sql<number>`count(*)` })
+      .from(nodeLogs)
+      .where(eq(nodeLogs.executionId, executionId))
+      .limit(1);
+
+    const rows = await database
+      .select()
+      .from(nodeLogs)
+      .where(eq(nodeLogs.executionId, executionId))
+      .orderBy(asc(nodeLogs.startTime))
+      .limit(limit)
+      .offset(offset);
+
+    const nodes = rows.map((row) => this.mapNodeRow(row));
+
+    return {
+      nodes,
+      total,
+      hasMore: offset + limit < total,
+      limit,
+      offset,
+    };
+  }
+
+  async getExecutionsByCorrelation(correlationId: string): Promise<WorkflowExecution[]> {
+    const database = this.getDb();
+    if (!database) return [];
+
+    const rows = await database
+      .select()
+      .from(executionLogs)
+      .where(eq(executionLogs.correlationId, correlationId))
+      .orderBy(desc(executionLogs.startTime));
+
+    const executionIds = rows.map((row) => row.executionId);
+    const nodeRows = executionIds.length
+      ? await database
+          .select()
+          .from(nodeLogs)
+          .where(inArray(nodeLogs.executionId, executionIds))
+          .orderBy(asc(nodeLogs.startTime))
+      : [];
+
+    const nodeMap = new Map<string, NodeExecution[]>();
+    for (const row of nodeRows) {
+      const executionNodes = nodeMap.get(row.executionId) ?? [];
+      executionNodes.push(this.mapNodeRow(row));
+      nodeMap.set(row.executionId, executionNodes);
+    }
+
+    return rows.map((row) => this.mapExecutionRow(row, nodeMap.get(row.executionId) ?? []));
+  }
+
+  async getExecutionStats(timeframe: 'hour' | 'day' | 'week' = 'day'): Promise<{
+    totalExecutions: number;
+    successfulExecutions: number;
+    failedExecutions: number;
+    averageDuration: number;
+    successRate: number;
+    totalCost: number;
+    popularWorkflows: Array<{ workflowId: string; count: number }>;
+  }> {
+    const database = this.getDb();
+    if (!database) {
+      return {
+        totalExecutions: 0,
+        successfulExecutions: 0,
+        failedExecutions: 0,
+        averageDuration: 0,
+        successRate: 0,
+        totalCost: 0,
+        popularWorkflows: [],
+      };
+    }
+
+    const timeframeMs = {
+      hour: 60 * 60 * 1000,
+      day: 24 * 60 * 60 * 1000,
+      week: 7 * 24 * 60 * 60 * 1000,
+    }[timeframe];
+
+    const cutoff = new Date(Date.now() - timeframeMs);
+
+    const rows = await database
+      .select()
+      .from(executionLogs)
+      .where(gte(executionLogs.startTime, cutoff));
+
+    const totalExecutions = rows.length;
+    const successfulExecutions = rows.filter((row) => row.status === 'succeeded').length;
+    const failedExecutions = rows.filter((row) => row.status === 'failed').length;
+
+    const totalDuration = rows.reduce((sum, row) => sum + (row.durationMs ?? 0), 0);
+
+    const totalCost = rows.reduce((sum, row) => {
+      const metadata = this.normalizeExecutionMetadata(row.metadata);
+      return sum + (metadata.totalCostUSD || 0);
+    }, 0);
+
+    const workflowCounts = new Map<string, number>();
+    rows.forEach((row) => {
+      workflowCounts.set(row.workflowId, (workflowCounts.get(row.workflowId) || 0) + 1);
+    });
+
+    const popularWorkflows = Array.from(workflowCounts.entries())
+      .map(([workflowId, count]) => ({ workflowId, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
+
+    return {
+      totalExecutions,
+      successfulExecutions,
+      failedExecutions,
+      averageDuration: totalExecutions > 0 ? totalDuration / totalExecutions : 0,
+      successRate: totalExecutions > 0 ? successfulExecutions / totalExecutions : 0,
+      totalCost,
+      popularWorkflows,
+    };
+  }
+
+  async cleanup(maxAge: number = 30 * 24 * 60 * 60 * 1000): Promise<void> {
+    const database = this.getDb();
+    if (!database) return;
+
+    const cutoff = new Date(Date.now() - maxAge);
+    await database.delete(executionLogs).where(lt(executionLogs.startTime, cutoff));
+  }
+
+  private async updateExecutionAggregates(executionId: string): Promise<void> {
+    const database = this.getDb();
+    if (!database) return;
+
+    const executionRow = await this.getExecutionRow(executionId);
+    if (!executionRow) return;
+
+    const nodes = await this.fetchNodeExecutions(executionId);
+
+    const completedNodes = nodes.filter((node) => node.status === 'succeeded').length;
+    const failedNodes = nodes.filter((node) => node.status === 'failed').length;
+    const metadata = this.buildExecutionMetadata(nodes, executionRow.metadata);
+
+    await database
+      .update(executionLogs)
+      .set({
+        completedNodes,
+        failedNodes,
+        metadata: this.serializeExecutionMetadata(metadata),
+        updatedAt: new Date(),
+      })
+      .where(eq(executionLogs.executionId, executionId));
+  }
+
+  private buildExecutionMetadata(
+    nodes: NodeExecution[],
+    existingMetadata: ExecutionLogRow['metadata']
+  ): WorkflowExecution['metadata'] {
+    const base = this.normalizeExecutionMetadata(existingMetadata);
+
+    const retryCount = nodes.reduce((sum, node) => sum + node.retryHistory.length, 0);
+    const totalCostUSD = nodes.reduce((sum, node) => sum + (node.metadata.costUSD || 0), 0);
+    const totalTokensUsed = nodes.reduce((sum, node) => sum + (node.metadata.tokensUsed || 0), 0);
+
+    const cacheableNodes = nodes.filter((node) => node.metadata.idempotencyKey);
+    const cacheHits = cacheableNodes.filter((node) => node.metadata.cacheHit);
+    const cacheHitRate = cacheableNodes.length > 0 ? cacheHits.length / cacheableNodes.length : 0;
+
+    const durationValues = nodes.filter((node) => typeof node.duration === 'number');
+    const averageNodeDuration =
+      durationValues.length > 0
+        ? durationValues.reduce((sum, node) => sum + (node.duration || 0), 0) / durationValues.length
+        : 0;
+
+    const openCircuitBreakers = nodes
+      .map((node) => {
+        const state = node.metadata.circuitState;
+        if (!state) return null;
+        if (state.state === 'open' || state.state === 'half_open') {
+          return {
+            nodeId: node.nodeId,
+            nodeLabel: node.nodeLabel,
+            connectorId: node.metadata.connectorId,
+            state: state.state,
+            consecutiveFailures: state.consecutiveFailures,
+            openedAt: state.openedAt ? new Date(state.openedAt) : undefined,
+            lastFailureAt: state.lastFailureAt ? new Date(state.lastFailureAt) : undefined,
+            cooldownMs: state.cooldownMs,
+            failureThreshold: state.failureThreshold,
+          };
+        }
+        return null;
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+
+    return {
+      ...base,
+      retryCount,
+      totalCostUSD,
+      totalTokensUsed,
+      cacheHitRate,
+      averageNodeDuration,
+      openCircuitBreakers,
+    };
+  }
+
+  private serializeExecutionMetadata(metadata: WorkflowExecution['metadata']): any {
+    const serialized = {
+      ...metadata,
+      nextResumeAt: metadata.nextResumeAt ? metadata.nextResumeAt.toISOString() : undefined,
+      openCircuitBreakers: metadata.openCircuitBreakers.map((breaker) => ({
+        ...breaker,
+        openedAt: breaker.openedAt ? breaker.openedAt.toISOString() : undefined,
+        lastFailureAt: breaker.lastFailureAt ? breaker.lastFailureAt.toISOString() : undefined,
+      })),
+    };
+
+    return sanitizeLogPayload(serialized);
+  }
+
+  private normalizeExecutionMetadata(metadata: ExecutionLogRow['metadata']): WorkflowExecution['metadata'] {
+    if (!metadata || typeof metadata !== 'object') {
+      return createDefaultMetadata();
+    }
+
+    const nextResumeAt = metadata.nextResumeAt ? new Date(metadata.nextResumeAt as string) : undefined;
+    const waitReason = metadata.waitReason as string | undefined;
+
+    const openCircuitBreakers = Array.isArray(metadata.openCircuitBreakers)
+      ? metadata.openCircuitBreakers.map((breaker: any) => ({
+          nodeId: breaker.nodeId,
+          nodeLabel: breaker.nodeLabel,
+          connectorId: breaker.connectorId,
+          state: breaker.state,
+          consecutiveFailures: breaker.consecutiveFailures ?? 0,
+          openedAt: breaker.openedAt ? new Date(breaker.openedAt) : undefined,
+          lastFailureAt: breaker.lastFailureAt ? new Date(breaker.lastFailureAt) : undefined,
+          cooldownMs: breaker.cooldownMs ?? 0,
+          failureThreshold: breaker.failureThreshold ?? 0,
+        }))
+      : [];
+
+    return {
+      retryCount: metadata.retryCount ?? 0,
+      totalCostUSD: metadata.totalCostUSD ?? 0,
+      totalTokensUsed: metadata.totalTokensUsed ?? 0,
+      cacheHitRate: metadata.cacheHitRate ?? 0,
+      averageNodeDuration: metadata.averageNodeDuration ?? 0,
+      openCircuitBreakers,
+      nextResumeAt,
+      waitReason,
+    };
+  }
+
+  private async getExecutionRow(executionId: string): Promise<ExecutionLogRow | undefined> {
+    const database = this.getDb();
+    if (!database) return undefined;
+
+    const rows = await database
+      .select()
+      .from(executionLogs)
+      .where(eq(executionLogs.executionId, executionId))
+      .limit(1);
+
+    return rows[0];
+  }
+
+  private async getNodeRow(executionId: string, nodeId: string): Promise<NodeLogRow | undefined> {
+    const database = this.getDb();
+    if (!database) return undefined;
+
+    const rows = await database
+      .select()
+      .from(nodeLogs)
+      .where(and(eq(nodeLogs.executionId, executionId), eq(nodeLogs.nodeId, nodeId)))
+      .limit(1);
+
+    return rows[0];
+  }
+
+  private async fetchNodeExecutions(executionId: string): Promise<NodeExecution[]> {
+    const database = this.getDb();
+    if (!database) return [];
+
+    const rows = await database
+      .select()
+      .from(nodeLogs)
+      .where(eq(nodeLogs.executionId, executionId))
+      .orderBy(asc(nodeLogs.startTime));
+
+    return rows.map((row) => this.mapNodeRow(row));
+  }
+
+  private mapExecutionRow(row: ExecutionLogRow, nodes: NodeExecution[]): WorkflowExecution {
+    const metadata = this.normalizeExecutionMetadata(row.metadata);
+
+    return {
+      executionId: row.executionId,
+      workflowId: row.workflowId,
+      workflowName: row.workflowName ?? row.workflowId,
+      userId: row.userId ?? undefined,
+      status: row.status as WorkflowExecution['status'],
+      startTime: row.startTime ?? new Date(),
+      endTime: row.endTime ?? undefined,
+      duration: row.durationMs ?? undefined,
+      triggerType: row.triggerType ?? undefined,
+      triggerData: row.triggerData ?? undefined,
+      totalNodes: row.totalNodes ?? nodes.length,
+      completedNodes: row.completedNodes ?? nodes.filter((node) => node.status === 'succeeded').length,
+      failedNodes: row.failedNodes ?? nodes.filter((node) => node.status === 'failed').length,
+      nodeExecutions: nodes,
+      finalOutput: row.finalOutput ?? undefined,
+      error: row.error ?? undefined,
+      correlationId: row.correlationId ?? '',
+      tags: row.tags ?? [],
+      metadata,
+    };
+  }
+
+  private mapNodeRow(row: NodeLogRow): NodeExecution {
+    const retryHistory = Array.isArray(row.retryHistory)
+      ? row.retryHistory.map((attempt: any) => ({
+          attempt: attempt.attempt ?? 0,
+          timestamp: attempt.timestamp ? new Date(attempt.timestamp) : row.startTime,
+          error: attempt.error ?? undefined,
+          duration: attempt.duration ?? 0,
+        }))
+      : [];
+
+    return {
+      nodeId: row.nodeId,
+      nodeType: row.nodeType ?? '',
+      nodeLabel: row.nodeLabel ?? row.nodeId,
+      status: row.status as NodeExecution['status'],
+      startTime: row.startTime ?? new Date(),
+      endTime: row.endTime ?? undefined,
+      duration: row.durationMs ?? undefined,
+      attempt: row.attempt ?? 1,
+      maxAttempts: row.maxAttempts ?? 1,
+      input: row.input ?? undefined,
+      output: row.output ?? undefined,
+      error: row.error ?? undefined,
+      correlationId: row.correlationId ?? '',
+      retryHistory,
+      metadata: {
+        ...(row.metadata || {}),
+      },
+    };
+  }
+
+  private resolveConnectorId(node: GraphNode): string | undefined {
+    const data = node.data || {};
+    const metadata = node.metadata || {};
+    const candidates = [
+      (data as any)?.connectorId,
+      (metadata as any)?.connectorId,
+      (data as any)?.provider,
+      (data as any)?.appKey,
+      (data as any)?.app,
+      node.app,
+      node.connectionId,
+      (data as any)?.connectionId,
+    ];
+
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        return candidate.trim();
+      }
+    }
+
+    if (typeof node.type === 'string') {
+      const parts = node.type.split('.');
+      if (parts.length >= 2) {
+        const [category, connector] = parts;
+        if (category === 'action' || category === 'trigger') {
+          return connector;
+        }
+      }
+    }
+
+    return undefined;
+  }
+}
+
+class RunExecutionManager {
+  private readonly databaseStore = new DatabaseExecutionLogStore(() => db);
+  private readonly memoryStore = new InMemoryExecutionLogStore();
+
+  private get store(): ExecutionLogStore {
+    return this.databaseStore.isAvailable() ? this.databaseStore : this.memoryStore;
+  }
+
+  async startExecution(
+    executionId: string,
+    workflow: NodeGraph,
+    userId?: string,
+    triggerType?: string,
+    triggerData?: any
+  ): Promise<WorkflowExecution> {
+    return this.store.startExecution(executionId, workflow, userId, triggerType, triggerData);
+  }
+
+  async startNodeExecution(
+    executionId: string,
+    node: GraphNode,
+    input?: any,
+    options: { timeoutMs?: number; connectorId?: string } = {}
+  ): Promise<NodeExecution> {
+    return this.store.startNodeExecution(executionId, node, input, options);
+  }
+
+  async completeNodeExecution(
+    executionId: string,
+    nodeId: string,
+    output: any,
+    metadata: Partial<NodeExecution['metadata']> = {}
+  ): Promise<void> {
+    await this.store.completeNodeExecution(executionId, nodeId, output, metadata);
+  }
+
+  async failNodeExecution(
+    executionId: string,
+    nodeId: string,
+    error: string,
+    metadata: Partial<NodeExecution['metadata']> = {}
+  ): Promise<void> {
+    await this.store.failNodeExecution(executionId, nodeId, error, metadata);
+  }
+
+  async completeExecution(executionId: string, finalOutput?: any, error?: string): Promise<void> {
+    await this.store.completeExecution(executionId, finalOutput, error);
+  }
+
+  async markExecutionWaiting(executionId: string, reason?: string, resumeAt?: Date): Promise<void> {
+    await this.store.markExecutionWaiting(executionId, reason, resumeAt);
+  }
+
+  async getExecution(executionId: string): Promise<WorkflowExecution | undefined> {
+    return this.store.getExecution(executionId);
+  }
+
+  async queryExecutions(query: ExecutionQuery = {}): Promise<ExecutionQueryResult> {
+    return this.store.queryExecutions(query);
+  }
+
+  async getNodeExecutions(
+    executionId: string,
+    options: NodeExecutionQueryOptions = {}
+  ): Promise<NodeExecutionQueryResult> {
+    return this.store.getNodeExecutions(executionId, options);
+  }
+
+  async getExecutionsByCorrelation(correlationId: string): Promise<WorkflowExecution[]> {
+    return this.store.getExecutionsByCorrelation(correlationId);
+  }
+
+  async getExecutionStats(timeframe: 'hour' | 'day' | 'week' = 'day') {
+    return this.store.getExecutionStats(timeframe);
+  }
+
+  async cleanup(maxAge?: number): Promise<void> {
+    await this.store.cleanup(maxAge);
   }
 }
 
 export const runExecutionManager = new RunExecutionManager();
 
-// Start cleanup interval
 setInterval(() => {
-  runExecutionManager.cleanup();
-}, 2 * 60 * 60 * 1000); // Every 2 hours
+  runExecutionManager.cleanup().catch((error) => {
+    console.error('Failed to cleanup execution logs', error);
+  });
+}, 2 * 60 * 60 * 1000);

--- a/server/core/WorkflowRuntime.ts
+++ b/server/core/WorkflowRuntime.ts
@@ -119,7 +119,7 @@ export class WorkflowRuntime {
     }
 
     // Start execution tracking
-    runExecutionManager.startExecution(executionId, graph, userId, triggerType, initialData);
+    await runExecutionManager.startExecution(executionId, graph, userId, triggerType, initialData);
 
     console.log(`🚀 Starting server-side execution of workflow: ${graph.name}`);
 
@@ -138,7 +138,7 @@ export class WorkflowRuntime {
         const configuredTimeout = this.resolveConfiguredTimeout(node.id, runtimeOptions);
 
         // Start node execution tracking
-        runExecutionManager.startNodeExecution(context.executionId, node, context.prevOutput, {
+        await runExecutionManager.startNodeExecution(context.executionId, node, context.prevOutput, {
           timeoutMs: configuredTimeout,
           connectorId
         });
@@ -167,7 +167,7 @@ export class WorkflowRuntime {
           // Track successful completion
           const metadata = this.consumeNodeMetadata(context.executionId, node.id);
           const circuitState = connectorId ? retryManager.getCircuitState(connectorId, node.id) : undefined;
-          runExecutionManager.completeNodeExecution(context.executionId, node.id, nodeOutput, {
+          await runExecutionManager.completeNodeExecution(context.executionId, node.id, nodeOutput, {
             ...metadata,
             circuitState
           });
@@ -187,7 +187,7 @@ export class WorkflowRuntime {
                   (nodeOutput as Record<string, any>).scheduled = true;
                   (nodeOutput as Record<string, any>).resumeAt = scheduleResult.resumeAt.toISOString();
                 }
-                runExecutionManager.markExecutionWaiting(
+                await runExecutionManager.markExecutionWaiting(
                   context.executionId,
                   `Timer scheduled for node ${node.label}`,
                   scheduleResult.resumeAt
@@ -213,7 +213,7 @@ export class WorkflowRuntime {
           const message = (error as Error)?.message ?? 'Unknown error';
           const metadata = this.consumeNodeMetadata(context.executionId, node.id);
           const circuitState = connectorId ? retryManager.getCircuitState(connectorId, node.id) : undefined;
-          runExecutionManager.failNodeExecution(context.executionId, node.id, message, {
+          await runExecutionManager.failNodeExecution(context.executionId, node.id, message, {
             ...metadata,
             circuitState
           });
@@ -227,7 +227,7 @@ export class WorkflowRuntime {
       const executionTime = Date.now() - startTime.getTime();
       
       // Track successful completion
-      runExecutionManager.completeExecution(context.executionId, context.prevOutput);
+      await runExecutionManager.completeExecution(context.executionId, context.prevOutput);
 
       console.log(`🎉 Workflow execution completed in ${executionTime}ms`);
 
@@ -243,7 +243,7 @@ export class WorkflowRuntime {
       const errorMessage = (error as Error)?.message ?? 'Unknown error';
 
       // Track failed completion
-      runExecutionManager.completeExecution(context.executionId, undefined, errorMessage);
+      await runExecutionManager.completeExecution(context.executionId, undefined, errorMessage);
 
       console.error(`💥 Workflow execution failed after ${executionTime}ms:`, error);
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -19,6 +19,7 @@ import workflowDeploymentRoutes from "./routes/workflow-deployments.js";
 import productionHealthRoutes from "./routes/production-health.js";
 import flowRoutes from "./routes/flows.js";
 import oauthRoutes from "./routes/oauth";
+import executionRoutes from "./routes/executions.js";
 import { RealAIService, ConversationManager } from "./realAIService";
 
 // Production services
@@ -117,6 +118,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   // P1-6: App parameter schema routes
   app.use('/api/app-schemas', appSchemaRoutes);
+  app.use('/api/executions', executionRoutes);
 
   app.use('/api/google', googleSheetsRoutes);
   app.use('/api/metadata', metadataRoutes);
@@ -4325,96 +4327,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  // ===== RUN EXECUTION & OBSERVABILITY API =====
-  
-  // Get workflow executions with filtering and pagination
-  app.get('/api/executions', async (req, res) => {
-    try {
-      const { runExecutionManager } = await import('./core/RunExecutionManager');
-      
-      const query = {
-        executionId: req.query.executionId as string,
-        workflowId: req.query.workflowId as string,
-        userId: req.query.userId as string,
-        status: req.query.status ? [req.query.status as string] : undefined,
-        limit: req.query.limit ? parseInt(req.query.limit as string) : undefined,
-        offset: req.query.offset ? parseInt(req.query.offset as string) : undefined,
-        sortBy: req.query.sortBy as 'startTime' | 'duration' | 'status',
-        sortOrder: req.query.sortOrder as 'asc' | 'desc'
-      };
-      
-      const result = runExecutionManager.queryExecutions(query);
-      res.json(result);
-    } catch (error) {
-      console.error('Failed to query executions:', error);
-      res.status(500).json({ error: 'Failed to query executions' });
-    }
-  });
-  
-  // Get specific execution details
-  app.get('/api/executions/:executionId', async (req, res) => {
-    try {
-      const { runExecutionManager } = await import('./core/RunExecutionManager');
-      const execution = runExecutionManager.getExecution(req.params.executionId);
-      
-      if (!execution) {
-        return res.status(404).json({ error: 'Execution not found' });
-      }
-      
-      res.json(execution);
-    } catch (error) {
-      console.error('Failed to get execution:', error);
-      res.status(500).json({ error: 'Failed to get execution' });
-    }
-  });
-  
-  // Retry entire execution
-  app.post('/api/executions/:executionId/retry', async (req, res) => {
-    try {
-      const { workflowRuntime } = await import('./core/WorkflowRuntime');
-      const { runExecutionManager } = await import('./core/RunExecutionManager');
-      
-      const execution = runExecutionManager.getExecution(req.params.executionId);
-      if (!execution) {
-        return res.status(404).json({ error: 'Execution not found' });
-      }
-      
-      // TODO: Implement retry logic by re-running the workflow
-      // For now, just return success
-      res.json({ success: true, message: 'Retry scheduled' });
-    } catch (error) {
-      console.error('Failed to retry execution:', error);
-      res.status(500).json({ error: 'Failed to retry execution' });
-    }
-  });
-  
-  // Retry specific node
-  app.post('/api/executions/:executionId/nodes/:nodeId/retry', async (req, res) => {
-    try {
-      const { retryManager } = await import('./core/RetryManager');
-      
-      await retryManager.replayFromDLQ(req.params.executionId, req.params.nodeId);
-      res.json({ success: true, message: 'Node retry scheduled' });
-    } catch (error) {
-      console.error('Failed to retry node:', error);
-      res.status(500).json({ error: 'Failed to retry node' });
-    }
-  });
-  
-  // Get execution statistics
-  app.get('/api/executions/stats/:timeframe', async (req, res) => {
-    try {
-      const { runExecutionManager } = await import('./core/RunExecutionManager');
-      const timeframe = req.params.timeframe as 'hour' | 'day' | 'week';
-      
-      const stats = runExecutionManager.getExecutionStats(timeframe);
-      res.json(stats);
-    } catch (error) {
-      console.error('Failed to get execution stats:', error);
-      res.status(500).json({ error: 'Failed to get execution stats' });
-    }
-  });
-  
   // Get DLQ items
   app.get('/api/dlq', async (req, res) => {
     try {

--- a/server/routes/executions.ts
+++ b/server/routes/executions.ts
@@ -1,0 +1,125 @@
+import { Router } from 'express';
+
+import { runExecutionManager } from '../core/RunExecutionManager.js';
+import { retryManager } from '../core/RetryManager.js';
+
+const router = Router();
+
+router.get('/', async (req, res) => {
+  try {
+    const statusParam = req.query.status;
+    const status = Array.isArray(statusParam)
+      ? statusParam.map((value) => String(value))
+      : statusParam
+      ? [String(statusParam)]
+      : undefined;
+
+    const tagsParam = req.query.tags;
+    const tags = Array.isArray(tagsParam)
+      ? tagsParam.map((value) => String(value))
+      : typeof tagsParam === 'string'
+      ? tagsParam.split(',').map((value) => value.trim()).filter(Boolean)
+      : undefined;
+
+    const limit = req.query.limit ? parseInt(String(req.query.limit), 10) : undefined;
+    const offset = req.query.offset ? parseInt(String(req.query.offset), 10) : undefined;
+    const dateFrom = req.query.dateFrom ? new Date(String(req.query.dateFrom)) : undefined;
+    const dateTo = req.query.dateTo ? new Date(String(req.query.dateTo)) : undefined;
+
+    const result = await runExecutionManager.queryExecutions({
+      executionId: req.query.executionId ? String(req.query.executionId) : undefined,
+      workflowId: req.query.workflowId ? String(req.query.workflowId) : undefined,
+      userId: req.query.userId ? String(req.query.userId) : undefined,
+      status,
+      tags,
+      dateFrom: dateFrom && !isNaN(dateFrom.getTime()) ? dateFrom : undefined,
+      dateTo: dateTo && !isNaN(dateTo.getTime()) ? dateTo : undefined,
+      limit,
+      offset,
+      sortBy: req.query.sortBy ? (String(req.query.sortBy) as 'startTime' | 'duration' | 'status') : undefined,
+      sortOrder: req.query.sortOrder ? (String(req.query.sortOrder) as 'asc' | 'desc') : undefined,
+    });
+
+    res.json({
+      success: true,
+      executions: result.executions,
+      pagination: {
+        total: result.total,
+        limit: result.limit,
+        offset: result.offset,
+        hasMore: result.hasMore,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to query executions', error);
+    res.status(500).json({ success: false, error: 'Failed to query executions' });
+  }
+});
+
+router.get('/stats/:timeframe', async (req, res) => {
+  try {
+    const timeframe = req.params.timeframe as 'hour' | 'day' | 'week';
+    const stats = await runExecutionManager.getExecutionStats(timeframe);
+    res.json({ success: true, stats });
+  } catch (error) {
+    console.error('Failed to get execution stats', error);
+    res.status(500).json({ success: false, error: 'Failed to get execution stats' });
+  }
+});
+
+router.get('/correlation/:correlationId', async (req, res) => {
+  try {
+    const executions = await runExecutionManager.getExecutionsByCorrelation(req.params.correlationId);
+    res.json({ success: true, executions });
+  } catch (error) {
+    console.error('Failed to fetch executions by correlation', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch executions by correlation' });
+  }
+});
+
+router.get('/:executionId/nodes', async (req, res) => {
+  try {
+    const limit = req.query.limit ? parseInt(String(req.query.limit), 10) : undefined;
+    const offset = req.query.offset ? parseInt(String(req.query.offset), 10) : undefined;
+    const result = await runExecutionManager.getNodeExecutions(req.params.executionId, { limit, offset });
+    res.json({ success: true, ...result });
+  } catch (error) {
+    console.error('Failed to fetch node executions', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch node executions' });
+  }
+});
+
+router.get('/:executionId', async (req, res) => {
+  try {
+    const execution = await runExecutionManager.getExecution(req.params.executionId);
+    if (!execution) {
+      return res.status(404).json({ success: false, error: 'Execution not found' });
+    }
+    res.json({ success: true, execution });
+  } catch (error) {
+    console.error('Failed to get execution', error);
+    res.status(500).json({ success: false, error: 'Failed to get execution' });
+  }
+});
+
+router.post('/:executionId/retry', async (req, res) => {
+  try {
+    // TODO: wire to workflow runtime when retry orchestration is implemented
+    res.json({ success: true, message: 'Retry scheduled' });
+  } catch (error) {
+    console.error('Failed to schedule execution retry', error);
+    res.status(500).json({ success: false, error: 'Failed to schedule execution retry' });
+  }
+});
+
+router.post('/:executionId/nodes/:nodeId/retry', async (req, res) => {
+  try {
+    await retryManager.replayFromDLQ(req.params.executionId, req.params.nodeId);
+    res.json({ success: true, message: 'Node retry scheduled' });
+  } catch (error) {
+    console.error('Failed to retry node execution', error);
+    res.status(500).json({ success: false, error: 'Failed to retry node execution' });
+  }
+});
+
+export default router;

--- a/server/utils/executionLogRedaction.ts
+++ b/server/utils/executionLogRedaction.ts
@@ -1,0 +1,58 @@
+import { redactSecrets } from './redact';
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+type ReplacerValue = JsonValue | Record<string, unknown> | undefined;
+
+function toSerializable(value: unknown): ReplacerValue {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+  if (value instanceof Map) {
+    return Object.fromEntries(value);
+  }
+  if (value instanceof Set) {
+    return Array.from(value);
+  }
+  return value as ReplacerValue;
+}
+
+/**
+ * Prepare arbitrary data for logging by making it JSON-serializable and redacting secrets.
+ */
+export function sanitizeLogPayload<T>(payload: T): T {
+  if (payload === undefined) {
+    return payload;
+  }
+
+  try {
+    const json = JSON.stringify(payload, (_key, value) => toSerializable(value));
+    if (!json) {
+      return payload;
+    }
+    const parsed = JSON.parse(json) as JsonValue;
+    return redactSecrets(parsed) as T;
+  } catch (error) {
+    // If serialization fails, attempt to redact directly
+    try {
+      return redactSecrets(payload) as T;
+    } catch {
+      return payload;
+    }
+  }
+}
+
+export function appendTimelineEvent<T extends Record<string, any>>(timeline: unknown, event: T): T[] {
+  const existing = Array.isArray(timeline) ? [...timeline] : [];
+  const sanitizedEvent = sanitizeLogPayload(event);
+  existing.push(sanitizedEvent);
+  return existing as T[];
+}
+
+export function coerceTimeline(timeline: unknown): any[] {
+  return Array.isArray(timeline) ? timeline : [];
+}


### PR DESCRIPTION
## Summary
- add a migration and schema definitions for execution and node log tables used for workflow observability
- persist RunExecutionManager state to the database with sanitized payloads and aggregate metadata updates
- expose dedicated /api/executions routes for querying run history, node timelines, and execution statistics

## Testing
- npm run check *(fails: missing type definitions for `node` and `vite/client` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df7c1f072c8331ab17d3403e072657