### PR TITLE
Implement organization RBAC permissions and role APIs

### DIFF
--- a/configs/rbac.ts
+++ b/configs/rbac.ts
@@ -1,0 +1,99 @@
+export type OrgRole = 'owner' | 'admin' | 'member' | 'viewer';
+
+export type Permission =
+  | 'workflow:create'
+  | 'workflow:view'
+  | 'workflow:edit'
+  | 'workflow:deploy'
+  | 'workflow:delete'
+  | 'workflow:collaborate'
+  | 'connections:read'
+  | 'connections:write'
+  | 'integration:metadata:read'
+  | 'organization:invite_member'
+  | 'organization:remove_member'
+  | 'organization:manage_roles'
+  | 'organization:view_usage'
+  | 'billing:manage';
+
+export interface RolePermissionMatrix {
+  description: string;
+  permissions: Permission[];
+}
+
+const OWNER_PERMISSIONS: Permission[] = [
+  'workflow:create',
+  'workflow:view',
+  'workflow:edit',
+  'workflow:deploy',
+  'workflow:delete',
+  'workflow:collaborate',
+  'connections:read',
+  'connections:write',
+  'integration:metadata:read',
+  'organization:invite_member',
+  'organization:remove_member',
+  'organization:manage_roles',
+  'organization:view_usage',
+  'billing:manage',
+];
+
+const ADMIN_PERMISSIONS: Permission[] = OWNER_PERMISSIONS.filter(
+  (permission) => permission !== 'billing:manage'
+);
+
+const MEMBER_PERMISSIONS: Permission[] = [
+  'workflow:create',
+  'workflow:view',
+  'workflow:edit',
+  'workflow:deploy',
+  'workflow:collaborate',
+  'connections:read',
+  'connections:write',
+  'integration:metadata:read',
+  'organization:view_usage',
+];
+
+const VIEWER_PERMISSIONS: Permission[] = [
+  'workflow:view',
+  'organization:view_usage',
+  'integration:metadata:read',
+];
+
+export const ROLE_PERMISSIONS: Record<OrgRole, RolePermissionMatrix> = {
+  owner: {
+    description: 'Full access to manage organization settings and billing',
+    permissions: OWNER_PERMISSIONS,
+  },
+  admin: {
+    description: 'Manage workflows, connections, and members (excluding billing)',
+    permissions: ADMIN_PERMISSIONS,
+  },
+  member: {
+    description: 'Build and deploy workflows and manage personal connections',
+    permissions: MEMBER_PERMISSIONS,
+  },
+  viewer: {
+    description: 'Read-only access to workflows and analytics',
+    permissions: VIEWER_PERMISSIONS,
+  },
+};
+
+const FALLBACK_PERMISSIONS: Permission[] = ['workflow:view'];
+
+export function getPermissionsForRole(role?: string | null): Permission[] {
+  if (!role) {
+    return FALLBACK_PERMISSIONS;
+  }
+
+  const normalized = role.toLowerCase() as OrgRole;
+  if (normalized in ROLE_PERMISSIONS) {
+    return ROLE_PERMISSIONS[normalized as OrgRole].permissions;
+  }
+
+  return FALLBACK_PERMISSIONS;
+}
+
+export function hasPermission(role: string | undefined | null, permission: Permission): boolean {
+  return getPermissionsForRole(role).includes(permission);
+}

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -192,6 +192,24 @@ export const organizationMembers = pgTable(
   })
 );
 
+export const organizationRoleAssignments = pgTable(
+  'organization_role_assignments',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    organizationId: uuid('organization_id').references(() => organizations.id, { onDelete: 'cascade' }).notNull(),
+    userId: uuid('user_id').references(() => users.id, { onDelete: 'cascade' }).notNull(),
+    role: text('role').notNull(),
+    grantedBy: uuid('granted_by').references(() => users.id, { onDelete: 'set null' }),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    organizationUserIdx: uniqueIndex('organization_role_assignments_org_user_idx').on(table.organizationId, table.userId),
+    organizationIdx: index('organization_role_assignments_org_idx').on(table.organizationId),
+    userIdx: index('organization_role_assignments_user_idx').on(table.userId),
+  })
+);
+
 export const organizationInvites = pgTable(
   'organization_invites',
   {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21,6 +21,7 @@ import flowRoutes from "./routes/flows.js";
 import oauthRoutes from "./routes/oauth";
 import executionRoutes from "./routes/executions.js";
 import { RealAIService, ConversationManager } from "./realAIService";
+import organizationRoleRoutes from "./routes/organization-roles";
 
 // Production services
 import { authService } from "./services/AuthService";
@@ -153,7 +154,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   // ChatGPT Fix: Flow storage routes for AI Builder → Graph Editor handoff
   app.use('/api/flows', flowRoutes);
-  
+
+  // Organization role management APIs
+  app.use('/api/organizations', organizationRoleRoutes);
+
   // (removed duplicate /api/ai/models in favor of aiRouter.get('/models'))
   
   // (removed duplicate /api/registry/connectors in favor of the consolidated version below)

--- a/server/routes/app-schemas.ts
+++ b/server/routes/app-schemas.ts
@@ -5,7 +5,7 @@
 import { Router } from 'express';
 import { resolveAppSchemaKey, resolveSchemaOperationKey } from '@shared/appSchemaAlias';
 import { APP_PARAMETER_SCHEMAS, getParameterSchema, validateParameters } from '../schemas/app-parameter-schemas.js';
-import { authenticateToken } from '../middleware/auth';
+import { authenticateToken, requirePermission } from '../middleware/auth';
 import { connectionService } from '../services/ConnectionService';
 import { connectorRegistry } from '../ConnectorRegistry';
 import { getErrorMessage } from '../types/common';
@@ -156,6 +156,7 @@ router.get('/supported-apps', (req, res) => {
 router.post(
   '/schemas/:app/:operation/options/:parameter',
   authenticateToken,
+  requirePermission('workflow:edit'),
   async (req, res) => {
     try {
       const userId = (req as any)?.user?.id;

--- a/server/routes/deployment-prerequisites.ts
+++ b/server/routes/deployment-prerequisites.ts
@@ -1,11 +1,13 @@
 import type { Express, Request, Response } from 'express';
 
 import { productionDeployer } from '../core/ProductionDeployer';
-import { authenticateToken, optionalAuth } from '../middleware/auth';
+import { authenticateToken, optionalAuth, requirePermission } from '../middleware/auth';
 import { getErrorMessage } from '../types/common';
 
 export function registerDeploymentPrerequisiteRoutes(app: Express) {
-  const deploymentPrerequisiteAuth = process.env.NODE_ENV === 'development' ? optionalAuth : authenticateToken;
+  const deploymentPrerequisiteMiddleware = process.env.NODE_ENV === 'development'
+    ? [optionalAuth]
+    : [authenticateToken, requirePermission('workflow:deploy')];
 
   const deploymentPrerequisiteHandler = async (req: Request, res: Response) => {
     try {
@@ -16,6 +18,6 @@ export function registerDeploymentPrerequisiteRoutes(app: Express) {
     }
   };
 
-  app.get('/api/deployment/prerequisites', deploymentPrerequisiteAuth, deploymentPrerequisiteHandler);
-  app.get('/api/ai/deployment/prerequisites', deploymentPrerequisiteAuth, deploymentPrerequisiteHandler);
+  app.get('/api/deployment/prerequisites', ...deploymentPrerequisiteMiddleware, deploymentPrerequisiteHandler);
+  app.get('/api/ai/deployment/prerequisites', ...deploymentPrerequisiteMiddleware, deploymentPrerequisiteHandler);
 }

--- a/server/routes/google-sheets.ts
+++ b/server/routes/google-sheets.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { authenticateToken } from "../middleware/auth";
+import { authenticateToken, requirePermission } from "../middleware/auth";
 import { connectionService } from "../services/ConnectionService";
 import { getErrorMessage } from "../types/common";
 import { connectorMetadataService } from "../services/metadata/ConnectorMetadataService";
@@ -10,6 +10,7 @@ const SHEET_ID_RE = /^[a-zA-Z0-9-_]+$/;
 router.get(
   "/sheets/:spreadsheetId/metadata",
   authenticateToken,
+  requirePermission("integration:metadata:read"),
   async (req, res) => {
     const userId = (req as any)?.user?.id;
     const organizationId = (req as any)?.organizationId;

--- a/server/routes/metadata.ts
+++ b/server/routes/metadata.ts
@@ -1,12 +1,12 @@
 import { Router } from 'express';
-import { authenticateToken } from '../middleware/auth';
+import { authenticateToken, requirePermission } from '../middleware/auth';
 import { connectionService } from '../services/ConnectionService';
 import { connectorMetadataService } from '../services/metadata/ConnectorMetadataService';
 import { getErrorMessage } from '../types/common';
 
 const router = Router();
 
-router.post('/resolve', authenticateToken, async (req, res) => {
+router.post('/resolve', authenticateToken, requirePermission('integration:metadata:read'), async (req, res) => {
   const userId = (req as any)?.user?.id;
   const organizationId = (req as any)?.organizationId;
   if (!userId) {

--- a/server/routes/oauth.ts
+++ b/server/routes/oauth.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { oauthManager } from '../oauth/OAuthManager';
-import { authenticateToken } from '../middleware/auth';
+import { authenticateToken, requirePermission } from '../middleware/auth';
 import { getErrorMessage } from '../types/common';
 
 const oauthRouter = Router();
@@ -16,7 +16,7 @@ function normalizeRedirectUrl(url: string, providerId: string): URL {
   return target;
 }
 
-oauthRouter.post('/authorize/:provider', authenticateToken, async (req, res) => {
+oauthRouter.post('/authorize/:provider', authenticateToken, requirePermission('connections:write'), async (req, res) => {
   try {
     const providerId = String(req.params.provider || '').toLowerCase();
     if (!providerId) {

--- a/server/routes/organization-roles.ts
+++ b/server/routes/organization-roles.ts
@@ -1,0 +1,124 @@
+import { Router } from 'express';
+import { authenticateToken, requirePermission } from '../middleware/auth';
+import { organizationService } from '../services/OrganizationService';
+import { getErrorMessage } from '../types/common';
+import { OrgRole } from '../../configs/rbac';
+
+const router = Router();
+const MANAGE_ROLE_PERMISSION = 'organization:manage_roles' as const;
+const ASSIGNABLE_ROLES: OrgRole[] = ['owner', 'admin', 'member', 'viewer'];
+
+router.get(
+  '/:organizationId/roles',
+  authenticateToken,
+  requirePermission(MANAGE_ROLE_PERMISSION),
+  async (req, res) => {
+    try {
+      const organizationId = req.params.organizationId;
+
+      if (!req.organizationId || req.organizationId !== organizationId) {
+        return res.status(403).json({
+          success: false,
+          error: 'Active organization mismatch',
+        });
+      }
+
+      const roles = await organizationService.listRoleAssignments(organizationId);
+
+      return res.json({
+        success: true,
+        organizationId,
+        roles,
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+);
+
+router.post(
+  '/:organizationId/roles',
+  authenticateToken,
+  requirePermission(MANAGE_ROLE_PERMISSION),
+  async (req, res) => {
+    try {
+      const organizationId = req.params.organizationId;
+      const { userId, role } = req.body ?? {};
+
+      if (!req.organizationId || req.organizationId !== organizationId) {
+        return res.status(403).json({
+          success: false,
+          error: 'Active organization mismatch',
+        });
+      }
+
+      if (typeof userId !== 'string' || userId.length === 0) {
+        return res.status(400).json({ success: false, error: 'userId is required' });
+      }
+
+      if (typeof role !== 'string' || !ASSIGNABLE_ROLES.includes(role as OrgRole)) {
+        return res.status(400).json({ success: false, error: 'Invalid role' });
+      }
+
+      const assignment = await organizationService.updateMemberRole({
+        organizationId,
+        memberId: userId,
+        role: role as OrgRole,
+        requestedBy: req.user!.id,
+      });
+
+      return res.status(200).json({
+        success: true,
+        role: assignment,
+      });
+    } catch (error) {
+      return res.status(400).json({
+        success: false,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+);
+
+router.delete(
+  '/:organizationId/roles/:userId',
+  authenticateToken,
+  requirePermission(MANAGE_ROLE_PERMISSION),
+  async (req, res) => {
+    try {
+      const { organizationId, userId } = req.params;
+      const fallbackRoleRaw = typeof req.query.fallbackRole === 'string' ? req.query.fallbackRole : undefined;
+      const fallbackRole = fallbackRoleRaw && ASSIGNABLE_ROLES.includes(fallbackRoleRaw as OrgRole)
+        ? (fallbackRoleRaw as OrgRole)
+        : undefined;
+
+      if (!req.organizationId || req.organizationId !== organizationId) {
+        return res.status(403).json({
+          success: false,
+          error: 'Active organization mismatch',
+        });
+      }
+
+      const removed = await organizationService.removeRoleAssignment({
+        organizationId,
+        memberId: userId,
+        requestedBy: req.user!.id,
+        fallbackRole,
+      });
+
+      return res.json({
+        success: removed,
+      });
+    } catch (error) {
+      return res.status(400).json({
+        success: false,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+);
+
+export default router;

--- a/server/services/AuthService.ts
+++ b/server/services/AuthService.ts
@@ -11,6 +11,7 @@ import {
 import { EncryptionService } from './EncryptionService';
 import { JWTPayload } from '../types/common';
 import { organizationService, OrganizationContext } from './OrganizationService';
+import { getPermissionsForRole, Permission } from '../../configs/rbac';
 
 type UserRecord = typeof users.$inferSelect;
 
@@ -58,6 +59,7 @@ export interface AuthUser {
   organizationUsage?: OrganizationUsageMetrics;
   activeOrganization?: AuthOrganization;
   organizations?: AuthOrganization[];
+  permissions?: Permission[];
 }
 
 export interface AuthOrganization {
@@ -549,6 +551,7 @@ export class AuthService {
     const activeOrganization = activeContext ? this.mapOrganizationForResponse(activeContext) : undefined;
 
     const legacyPlanType = this.mapPlanToLegacy(activeContext?.plan ?? userRecord.planType);
+    const organizationPermissions = getPermissionsForRole(activeOrganization?.role);
 
     const authUser: AuthUser = {
       id: userRecord.id,
@@ -571,6 +574,7 @@ export class AuthService {
       organizationUsage: activeOrganization?.usage,
       activeOrganization,
       organizations: organizationSummaries,
+      permissions: organizationPermissions,
     };
 
     return {


### PR DESCRIPTION
## Summary
- add central RBAC configuration with role-based permission matrices and expose helpers in auth middleware
- persist organization role assignments and expose admin endpoints for listing, updating, and removing roles
- gate sensitive metadata, workflow, OAuth, and deployment routes behind the new permission middleware

## Testing
- `npm run check` *(fails: missing type definition packages for node and vite/client in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df815d662483318041aea430b794f8