### PR TITLE
Enforce organization network allowlists

### DIFF
--- a/configs/rbac.ts
+++ b/configs/rbac.ts
@@ -14,6 +14,8 @@ export type Permission =
   | 'organization:remove_member'
   | 'organization:manage_roles'
   | 'organization:view_usage'
+  | 'organization:manage_security'
+  | 'organization:view_security_audit'
   | 'billing:manage';
 
 export interface RolePermissionMatrix {
@@ -35,6 +37,8 @@ const OWNER_PERMISSIONS: Permission[] = [
   'organization:remove_member',
   'organization:manage_roles',
   'organization:view_usage',
+  'organization:manage_security',
+  'organization:view_security_audit',
   'billing:manage',
 ];
 

--- a/enterprise/multi-tenant-architecture.ts
+++ b/enterprise/multi-tenant-architecture.ts
@@ -50,6 +50,8 @@ export interface Organization {
   // Security settings
   security: {
     ipWhitelist: string[];
+    allowedDomains: string[];
+    allowedIpRanges: string[];
     mfaRequired: boolean;
     sessionTimeout: number; // minutes
     passwordPolicy: {
@@ -146,6 +148,8 @@ export class MultiTenantService {
       
       security: {
         ipWhitelist: [],
+        allowedDomains: [],
+        allowedIpRanges: [],
         mfaRequired: false,
         sessionTimeout: 480, // 8 hours
         passwordPolicy: {

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -47,6 +47,8 @@ export interface OrganizationFeatureFlags {
 
 export interface OrganizationSecuritySettings {
   ipWhitelist: string[];
+  allowedDomains: string[];
+  allowedIpRanges: string[];
   mfaRequired: boolean;
   sessionTimeout: number;
   passwordPolicy: {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -49,6 +49,7 @@ import { WorkflowRepository } from './workflow/WorkflowRepository.js';
 import { registerDeploymentPrerequisiteRoutes } from "./routes/deployment-prerequisites.js";
 import { organizationService } from "./services/OrganizationService";
 import { env } from './env';
+import organizationSecurityRoutes from "./routes/organization-security";
 
 const SUPPORTED_CONNECTION_PROVIDERS = [
   'openai',
@@ -157,6 +158,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Organization role management APIs
   app.use('/api/organizations', organizationRoleRoutes);
+  app.use('/api/organizations', organizationSecurityRoutes);
 
   // (removed duplicate /api/ai/models in favor of aiRouter.get('/models'))
   

--- a/server/routes/organization-security.ts
+++ b/server/routes/organization-security.ts
@@ -1,0 +1,143 @@
+import { Router, type Request } from 'express';
+import { authenticateToken, requirePermission } from '../middleware/auth';
+import { organizationService } from '../services/OrganizationService';
+import { connectionService } from '../services/ConnectionService';
+import { getErrorMessage } from '../types/common';
+
+const router = Router();
+
+const MANAGE_SECURITY_PERMISSION = 'organization:manage_security' as const;
+const VIEW_SECURITY_AUDIT_PERMISSION = 'organization:view_security_audit' as const;
+
+const ensureOrganizationContext = (req: Request, organizationId: string) => {
+  if (!req.organizationId || req.organizationId !== organizationId) {
+    return false;
+  }
+  return true;
+};
+
+router.get(
+  '/:organizationId/security/allowlist',
+  authenticateToken,
+  requirePermission(MANAGE_SECURITY_PERMISSION),
+  async (req, res) => {
+    try {
+      const { organizationId } = req.params;
+
+      if (!ensureOrganizationContext(req, organizationId)) {
+        return res.status(403).json({
+          success: false,
+          error: 'Active organization mismatch',
+        });
+      }
+
+      const security = await organizationService.getSecuritySettings(organizationId);
+
+      return res.json({
+        success: true,
+        organizationId,
+        allowlist: {
+          domains: security.allowedDomains,
+          ipRanges: security.allowedIpRanges,
+        },
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+);
+
+router.put(
+  '/:organizationId/security/allowlist',
+  authenticateToken,
+  requirePermission(MANAGE_SECURITY_PERMISSION),
+  async (req, res) => {
+    try {
+      const { organizationId } = req.params;
+      const { allowedDomains, allowedIpRanges } = req.body ?? {};
+
+      if (!ensureOrganizationContext(req, organizationId)) {
+        return res.status(403).json({
+          success: false,
+          error: 'Active organization mismatch',
+        });
+      }
+
+      if (
+        allowedDomains !== undefined &&
+        !Array.isArray(allowedDomains)
+      ) {
+        return res.status(400).json({ success: false, error: 'allowedDomains must be an array of strings' });
+      }
+
+      if (
+        allowedIpRanges !== undefined &&
+        !Array.isArray(allowedIpRanges)
+      ) {
+        return res.status(400).json({ success: false, error: 'allowedIpRanges must be an array of strings' });
+      }
+
+      const updated = await organizationService.updateNetworkAllowlist(organizationId, {
+        allowedDomains,
+        allowedIpRanges,
+      });
+
+      connectionService.invalidateOrganizationSecurityCache(organizationId);
+
+      return res.json({
+        success: true,
+        organizationId,
+        allowlist: {
+          domains: updated.allowedDomains,
+          ipRanges: updated.allowedIpRanges,
+        },
+      });
+    } catch (error) {
+      return res.status(400).json({
+        success: false,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+);
+
+router.get(
+  '/:organizationId/security/allowlist/audit',
+  authenticateToken,
+  requirePermission(VIEW_SECURITY_AUDIT_PERMISSION),
+  async (req, res) => {
+    try {
+      const { organizationId } = req.params;
+      const limitRaw = req.query.limit;
+      const limit = typeof limitRaw === 'string' ? Number(limitRaw) : undefined;
+
+      if (!ensureOrganizationContext(req, organizationId)) {
+        return res.status(403).json({
+          success: false,
+          error: 'Active organization mismatch',
+        });
+      }
+
+      const entries = connectionService.getDeniedNetworkAccess(
+        organizationId,
+        Number.isFinite(limit) && limit !== undefined ? Math.max(Number(limit), 1) : 50
+      );
+
+      return res.json({
+        success: true,
+        organizationId,
+        entries,
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+);
+
+export default router;

--- a/server/workflow/WorkflowRuntimeService.ts
+++ b/server/workflow/WorkflowRuntimeService.ts
@@ -892,6 +892,16 @@ export class WorkflowRuntimeService {
 
       const credentials = { ...context.credentials };
 
+      if (context.networkAllowlist) {
+        (credentials as APICredentials).__organizationNetworkAllowlist = context.networkAllowlist;
+      }
+
+      (credentials as APICredentials).__organizationId = context.connection.organizationId;
+      (credentials as APICredentials).__connectionId = context.connection.id;
+      if (userId) {
+        (credentials as APICredentials).__userId = userId;
+      }
+
       return {
         success: true,
         credentials,


### PR DESCRIPTION
## Summary
- extend organization security settings with domain and IP allowlist fields and normalize defaults
- validate outbound API client requests against organization network policies and record denied attempts
- add admin routes and RBAC permissions for managing allowlists and reviewing network access audits

## Testing
- npm run check *(fails: missing type definitions for node and vite in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df842466e4833183525bfdc4da8d34