### PR TITLE
Add deterministic OAuth manager mock for tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  moduleNameMapper: {
+    '^(?:\.\./)+oauth/OAuthManager$': '<rootDir>/server/oauth/__mocks__/OAuthManager.ts',
+    '^server/oauth/OAuthManager$': '<rootDir>/server/oauth/__mocks__/OAuthManager.ts',
+  },
+};

--- a/server/oauth/__mocks__/OAuthManager.ts
+++ b/server/oauth/__mocks__/OAuthManager.ts
@@ -1,0 +1,265 @@
+import { connectionService } from '../../services/ConnectionService';
+import { env } from '../../env';
+import type {
+  OAuthConfig,
+  OAuthProvider,
+  OAuthTokens,
+  OAuthUserInfo,
+} from '../OAuthManager';
+
+export type { OAuthConfig, OAuthProvider, OAuthTokens, OAuthUserInfo } from '../OAuthManager';
+
+interface PendingState {
+  userId: string;
+  organizationId: string;
+  provider: string;
+  returnUrl: string;
+  connectionId?: string;
+  label?: string;
+  scopes?: string[];
+  createdAt: number;
+}
+
+interface ProviderMetadata {
+  provider: OAuthProvider;
+  tokens?: Partial<OAuthTokens>;
+  userInfo?: OAuthUserInfo;
+}
+
+const DEFAULT_RETURN_BASE = () => env.SERVER_PUBLIC_URL || process.env.BASE_URL || 'http://localhost:5000';
+const DEFAULT_EXPIRES_AT = 1_700_000_000_000;
+
+function normalizeReturnUrl(providerId: string, returnUrl?: string): string {
+  if (returnUrl) {
+    return returnUrl;
+  }
+
+  const base = DEFAULT_RETURN_BASE();
+  const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  return `${normalizedBase}/oauth/callback/${providerId}`;
+}
+
+export class MockOAuthManager {
+  private providers = new Map<string, ProviderMetadata>();
+  private pendingStates = new Map<string, PendingState>();
+  private stateCounter = 0;
+
+  reset() {
+    this.providers.clear();
+    this.pendingStates.clear();
+    this.stateCounter = 0;
+  }
+
+  registerProvider(
+    providerId: string,
+    options: {
+      displayName?: string;
+      config?: Partial<OAuthConfig>;
+      tokens?: Partial<OAuthTokens>;
+      userInfo?: OAuthUserInfo;
+    } = {}
+  ) {
+    const normalizedId = providerId.toLowerCase();
+    const defaultConfig: OAuthConfig = {
+      clientId: `${normalizedId}-client-id`,
+      clientSecret: `${normalizedId}-client-secret`,
+      redirectUri: normalizeReturnUrl(normalizedId),
+      scopes: options.config?.scopes ?? ['read'],
+      authUrl: options.config?.authUrl ?? `https://example.test/oauth/${normalizedId}`,
+      tokenUrl: options.config?.tokenUrl ?? `https://example.test/token/${normalizedId}`,
+      userInfoUrl: options.config?.userInfoUrl,
+      additionalParams: options.config?.additionalParams,
+    };
+
+    const provider: OAuthProvider = {
+      name: normalizedId,
+      displayName: options.displayName ?? providerId,
+      config: {
+        ...defaultConfig,
+        ...options.config,
+        scopes: options.config?.scopes ?? defaultConfig.scopes,
+      },
+    };
+
+    this.providers.set(normalizedId, {
+      provider,
+      tokens: options.tokens,
+      userInfo: options.userInfo,
+    });
+  }
+
+  supportsOAuth(providerId: string): boolean {
+    return this.providers.has(providerId.toLowerCase());
+  }
+
+  listProviders(): OAuthProvider[] {
+    return Array.from(this.providers.values()).map(({ provider }) => provider);
+  }
+
+  listDisabledProviders(): Array<{ provider: OAuthProvider; reason: string }> {
+    return [];
+  }
+
+  getProvider(providerId: string): OAuthProvider | undefined {
+    return this.providers.get(providerId.toLowerCase())?.provider;
+  }
+
+  getSupportedProviders(): string[] {
+    return Array.from(this.providers.keys());
+  }
+
+  isProviderConfigured(providerId: string): boolean {
+    return this.supportsOAuth(providerId);
+  }
+
+  resolveReturnUrl(providerId: string, state?: string): string {
+    if (state) {
+      const stored = this.pendingStates.get(state);
+      if (stored && stored.provider === providerId.toLowerCase()) {
+        return stored.returnUrl;
+      }
+    }
+    return normalizeReturnUrl(providerId.toLowerCase());
+  }
+
+  async generateAuthUrl(
+    providerId: string,
+    userId: string,
+    organizationId: string,
+    returnUrl?: string,
+    additionalScopes?: string[],
+    options: { connectionId?: string; label?: string } = {}
+  ): Promise<{ authUrl: string; state: string }> {
+    const normalizedId = providerId.toLowerCase();
+    const metadata = this.providers.get(normalizedId);
+
+    if (!metadata) {
+      throw new Error(`Unsupported OAuth provider: ${providerId}`);
+    }
+
+    const state = `mock-${normalizedId}-${++this.stateCounter}`;
+    const redirectUri = normalizeReturnUrl(normalizedId, returnUrl);
+
+    this.pendingStates.set(state, {
+      userId,
+      organizationId,
+      provider: normalizedId,
+      returnUrl: redirectUri,
+      connectionId: options.connectionId,
+      label: options.label,
+      scopes: additionalScopes ?? metadata.provider.config.scopes,
+      createdAt: Date.now(),
+    });
+
+    const authUrl = `${metadata.provider.config.authUrl}?response_type=code&client_id=${encodeURIComponent(metadata.provider.config.clientId)}&redirect_uri=${encodeURIComponent(metadata.provider.config.redirectUri)}&state=${encodeURIComponent(state)}`;
+
+    return { authUrl, state };
+  }
+
+  private buildTokens(providerId: string, override?: Partial<OAuthTokens>): OAuthTokens {
+    const normalizedId = providerId.toLowerCase();
+    const accessToken = override?.accessToken ?? `${normalizedId}-access-token`;
+    const refreshToken = override?.refreshToken ?? `${normalizedId}-refresh-token`;
+
+    return {
+      accessToken,
+      refreshToken,
+      expiresAt: override?.expiresAt ?? DEFAULT_EXPIRES_AT,
+      tokenType: override?.tokenType ?? 'Bearer',
+      scope: override?.scope,
+    };
+  }
+
+  private buildUserInfo(providerId: string, userId: string, override?: OAuthUserInfo): OAuthUserInfo {
+    if (override) {
+      return override;
+    }
+
+    return {
+      id: `${providerId}-user-${userId}`,
+      email: `${userId}@example.test`,
+      name: `${providerId.toUpperCase()} Test User`,
+    };
+  }
+
+  async handleCallback(code: string, state: string, providerId: string): Promise<{
+    tokens: OAuthTokens;
+    userInfo?: OAuthUserInfo;
+    returnUrl: string;
+    connectionId: string;
+    label: string;
+    userInfoError?: string;
+  }> {
+    const normalizedId = providerId.toLowerCase();
+    const storedState = this.pendingStates.get(state);
+
+    if (!storedState || storedState.provider !== normalizedId) {
+      throw new Error('Invalid OAuth state');
+    }
+
+    this.pendingStates.delete(state);
+
+    const metadata = this.providers.get(normalizedId);
+    if (!metadata) {
+      throw new Error(`Unsupported OAuth provider: ${providerId}`);
+    }
+
+    const tokens = this.buildTokens(normalizedId, metadata.tokens);
+    if (tokens.scope === undefined && storedState.scopes?.length) {
+      tokens.scope = storedState.scopes.join(' ');
+    }
+
+    const userInfo = this.buildUserInfo(normalizedId, storedState.userId, metadata.userInfo);
+    const label = storedState.label ?? userInfo.email ?? `${metadata.provider.displayName} account`;
+
+    const connectionId = await connectionService.storeConnection(
+      storedState.userId,
+      storedState.organizationId,
+      normalizedId,
+      tokens,
+      userInfo,
+      {
+        name: label,
+        connectionId: storedState.connectionId,
+        metadata: {
+          providerId: normalizedId,
+          scopes: storedState.scopes ?? metadata.provider.config.scopes ?? [],
+          authUrl: metadata.provider.config.authUrl,
+          tokenUrl: metadata.provider.config.tokenUrl,
+          deterministic: true,
+        },
+      }
+    );
+
+    return {
+      tokens,
+      userInfo,
+      returnUrl: storedState.returnUrl,
+      connectionId,
+      label,
+    };
+  }
+
+  async refreshToken(userId: string, organizationId: string, providerId: string): Promise<OAuthTokens> {
+    const metadata = this.providers.get(providerId.toLowerCase());
+    const tokens = this.buildTokens(providerId, metadata?.tokens);
+
+    await connectionService.storeConnection(
+      userId,
+      organizationId,
+      providerId,
+      tokens,
+      metadata?.userInfo,
+      {
+        metadata: {
+          providerId,
+          deterministic: true,
+        },
+      }
+    );
+
+    return tokens;
+  }
+}
+
+export const oauthManager = new MockOAuthManager();


### PR DESCRIPTION
## Summary
- add a deterministic OAuth manager mock in server/oauth/__mocks__ that persists via ConnectionService
- update the OAuth route test to rely on the mock registry and assert persisted connection metadata
- configure Jest to map OAuthManager imports to the mock implementation during unit tests

## Testing
- npx tsx server/routes/__tests__/oauth-flow.test.ts *(fails in this environment: npm registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68df9157c91883318e0db3d2a2942c5b