### PR TITLE
Add environment template and document local compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,48 @@
+# Base runtime configuration
+NODE_ENV=development
+PORT=5000
+SERVER_PUBLIC_URL=http://localhost:5000
+
+# Database connection (PostgreSQL URL)
+# Format: postgres://USER:PASSWORD@HOST:PORT/DATABASE
+DATABASE_URL=postgres://postgres:postgres@postgres:5432/automation
+
+# Authentication & encryption secrets (generate per developer)
+# Use a unique 32-byte base64 string, e.g. `openssl rand -base64 32`
+ENCRYPTION_MASTER_KEY=
+# Use a unique high-entropy string for signing JWTs (32+ characters recommended)
+JWT_SECRET=
+
+# LLM provider API keys (optional for local development)
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+CLAUDE_API_KEY=
+GOOGLE_API_KEY=
+GEMINI_API_KEY=
+
+# Feature flags
+ENABLE_LLM_FEATURES=false
+GENERIC_EXECUTOR_ENABLED=false
+CONNECTOR_SIMULATOR_ENABLED=false
+CONNECTOR_SIMULATOR_FIXTURES_DIR=server/testing/fixtures
+
+# Queue / Redis configuration
+QUEUE_REDIS_HOST=redis
+QUEUE_REDIS_PORT=6379
+QUEUE_REDIS_DB=0
+QUEUE_REDIS_USERNAME=
+QUEUE_REDIS_PASSWORD=
+QUEUE_REDIS_TLS=false
+QUEUE_METRICS_INTERVAL_MS=60000
+
+# Observability & OpenTelemetry
+OBSERVABILITY_ENABLED=false
+OTEL_SERVICE_NAME=automation-platform
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_EXPORTER_OTLP_HEADERS=
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=
+OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=
+OTEL_METRICS_EXPORTER=otlp
+PROMETHEUS_METRICS_PORT=9464
+PROMETHEUS_METRICS_HOST=0.0.0.0
+PROMETHEUS_METRICS_ENDPOINT=/metrics

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,40 @@
+# Local Development Environment
+
+This guide covers the quickest path to booting the platform locally with Docker Compose.
+
+## 1. Prepare environment variables
+
+1. Copy the sample environment file and use it as your personal development configuration:
+   ```bash
+   cp .env.example .env.development
+   ```
+2. Edit `.env.development` to match your local setup. Sensitive values must be generated per developer:
+   - `ENCRYPTION_MASTER_KEY`: generate a unique 32-byte value (`openssl rand -base64 32`).
+   - `JWT_SECRET`: use a unique, high-entropy string (32+ characters). Avoid reusing production values.
+3. Fill in any provider API keys you plan to exercise (OpenAI, Anthropic, Claude, Google, Gemini). Leave them blank to disable those integrations locally.
+
+> ℹ️  When running outside of Docker Compose, either export the variables manually or copy `.env.development` to `.env` so `dotenv` can pick them up. Never commit personal secrets.
+
+## 2. Start the Docker Compose stack
+
+With `.env.development` in place, launch the local services:
+
+```bash
+docker compose --env-file .env.development up --build
+```
+
+The default configuration in `.env.example` assumes PostgreSQL and Redis are running inside the Compose stack. Adjust the hostnames or ports if you are using external services.
+
+## 3. Next steps
+
+- `npm run dev:server` starts the backend in watch mode.
+- `npm run dev:client` starts the frontend dev server.
+- Consult `docs/operations/queue.md` if you need advanced Redis/BullMQ tuning.
+
+Shut the stack down with:
+
+```bash
+docker compose --env-file .env.development down
+```
+
+This tears down containers but leaves volumes intact so your data persists between sessions.


### PR DESCRIPTION
## Summary
- add a tracked .env.example that mirrors server/env.ts with local-friendly defaults and guidance for sensitive secrets
- document the Docker Compose workflow in docs/local-development.md, instructing contributors to copy the template to .env.development before starting services

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df97df48888331be3ad5bfc2dae0b1