### PR TITLE
Add in-memory queue driver fallback when Redis is unavailable

### DIFF
--- a/docs/operations/queue.md
+++ b/docs/operations/queue.md
@@ -1,6 +1,6 @@
 # Queue & Worker Infrastructure
 
-This service uses [BullMQ](https://docs.bullmq.io/) backed by Redis for all background job processing. The utilities in `server/queue/BullMQFactory.ts` centralize queue configuration so that every queue, worker, and queue-events instance shares the same connection parameters, telemetry, and defaults.
+This service uses [BullMQ](https://docs.bullmq.io/) backed by Redis for all background job processing when a Redis instance is available. The queue helpers in `server/queue/index.ts` select the BullMQ driver by default and fall back to an in-memory queue that mimics the BullMQ APIs used by the platform when Redis is unavailable. The utilities centralize queue configuration so that every queue, worker, and queue-events instance shares the same connection parameters, telemetry, and defaults.
 
 ## Environment variables
 
@@ -53,7 +53,7 @@ export QUEUE_REDIS_PORT=6379
 export QUEUE_REDIS_DB=0
 ```
 
-When TLS or authentication is required, set `QUEUE_REDIS_USERNAME`, `QUEUE_REDIS_PASSWORD`, and `QUEUE_REDIS_TLS=true` accordingly.
+When TLS or authentication is required, set `QUEUE_REDIS_USERNAME`, `QUEUE_REDIS_PASSWORD`, and `QUEUE_REDIS_TLS=true` accordingly. Set `QUEUE_DRIVER=inmemory` to force the non-persistent in-memory driver in local development.
 
 ## Telemetry & metrics helpers
 
@@ -62,7 +62,7 @@ Use `registerQueueTelemetry` to attach logging and periodic metrics collection t
 Example:
 
 ```ts
-import { createQueue, createQueueEvents, registerQueueTelemetry } from '../queue/BullMQFactory';
+import { createQueue, createQueueEvents, registerQueueTelemetry } from '../queue';
 
 const executionQueue = createQueue('workflow.execute');
 const executionEvents = createQueueEvents('workflow.execute');

--- a/server/integrations/RateLimiter.ts
+++ b/server/integrations/RateLimiter.ts
@@ -1,6 +1,6 @@
 import IORedis from 'ioredis';
 
-import { getRedisConnectionOptions } from '../queue/BullMQFactory';
+import { getRedisConnectionOptions } from '../queue/index';
 
 export type RateLimitRules = {
   requestsPerSecond?: number;

--- a/server/observability/index.ts
+++ b/server/observability/index.ts
@@ -11,7 +11,7 @@ import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 
 import pkg from '../../package.json' assert { type: 'json' };
 import { env } from '../env';
-import type { QueueJobCounts, QueueName } from '../queue/BullMQFactory.js';
+import type { QueueJobCounts, QueueName } from '../queue/index.js';
 
 type MetricAttributes = Record<string, string | number | boolean>;
 

--- a/server/queue/BullMQFactory.ts
+++ b/server/queue/BullMQFactory.ts
@@ -10,47 +10,13 @@ import {
 } from 'bullmq';
 
 import { env } from '../env';
-import type { WorkflowResumeState } from '../types/workflowTimers';
-
-export type WorkflowExecuteJobPayload = {
-  workflowId: string;
-  executionId: string;
-  organizationId: string;
-  userId?: string;
-  triggerType: string;
-  triggerData?: Record<string, unknown> | null;
-  metadata?: Record<string, unknown>;
-  resumeState?: WorkflowResumeState | null;
-  initialData?: any;
-  timerId?: string | null;
-};
-
-export interface JobPayloads {
-  'workflow.execute': WorkflowExecuteJobPayload;
-}
-
-export type QueueName = keyof JobPayloads;
-
-type JobPayload<Name extends QueueName> = JobPayloads[Name];
-
-export type QueueJobCounts<Name extends QueueName> = Awaited<
-  ReturnType<Queue<JobPayload<Name>, unknown, Name>['getJobCounts']>
->;
-
-export interface QueueTelemetryHandlers<Name extends QueueName> {
-  onCompleted?: (payload: { jobId: string; returnValue: unknown }) => void;
-  onFailed?: (payload: { jobId: string; failedReason: string; attemptsMade: number }) => void;
-  onStalled?: (payload: { jobId: string }) => void;
-  onWaiting?: (payload: { jobId: string }) => void;
-  onError?: (error: Error) => void;
-}
-
-export interface QueueTelemetryOptions<Name extends QueueName> {
-  logger?: Pick<Console, 'info' | 'warn' | 'error'>;
-  handlers?: QueueTelemetryHandlers<Name>;
-  metricsIntervalMs?: number;
-  onMetrics?: (counts: QueueJobCounts<Name>) => void;
-}
+import type {
+  JobPayload,
+  JobPayloads,
+  QueueJobCounts,
+  QueueName,
+  QueueTelemetryOptions,
+} from './types';
 
 const defaultLogger: Pick<Console, 'info' | 'warn' | 'error'> = console;
 

--- a/server/queue/InMemoryQueue.ts
+++ b/server/queue/InMemoryQueue.ts
@@ -1,0 +1,487 @@
+import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
+
+import type {
+  JobsOptions,
+  Processor,
+  Queue,
+  QueueEvents,
+  QueueEventsOptions,
+  QueueOptions,
+  Worker,
+  WorkerOptions,
+} from 'bullmq';
+
+import type { JobPayload, QueueJobCounts, QueueName } from './types';
+
+const DEFAULT_GROUP_KEY = '__ungrouped__';
+
+interface JobRecord<Name extends QueueName, ResultType = unknown> {
+  id: string;
+  name: Name;
+  data: JobPayload<Name>;
+  attemptsMade: number;
+  opts: JobsOptions<JobPayload<Name>, ResultType, Name>;
+  maxAttempts: number;
+  groupId: string;
+}
+
+interface DelayedJob<Name extends QueueName, ResultType = unknown> {
+  job: JobRecord<Name, ResultType>;
+  timeout: NodeJS.Timeout | null;
+}
+
+interface QueueState<Name extends QueueName, ResultType = unknown> {
+  options?: QueueOptions<JobPayload<Name>, ResultType, Name>;
+  waiting: JobRecord<Name, ResultType>[];
+  active: Set<JobRecord<Name, ResultType>>;
+  delayed: Set<DelayedJob<Name, ResultType>>;
+  completed: number;
+  failed: number;
+  workers: Set<InMemoryWorker<Name, ResultType>>;
+  events: Set<InMemoryQueueEvents<Name>>;
+}
+
+class InMemoryJob<Name extends QueueName, ResultType = unknown>
+  implements JobRecord<Name, ResultType>
+{
+  public id: string;
+  public name: Name;
+  public data: JobPayload<Name>;
+  public attemptsMade: number;
+  public opts: JobsOptions<JobPayload<Name>, ResultType, Name>;
+  public maxAttempts: number;
+  public groupId: string;
+  public returnvalue?: ResultType;
+  public failedReason?: string;
+
+  constructor(record: JobRecord<Name, ResultType>) {
+    this.id = record.id;
+    this.name = record.name;
+    this.data = record.data;
+    this.attemptsMade = record.attemptsMade;
+    this.opts = record.opts;
+    this.maxAttempts = record.maxAttempts;
+    this.groupId = record.groupId;
+  }
+}
+
+class InMemoryQueueEvents<Name extends QueueName> extends EventEmitter implements QueueEvents {
+  constructor(private readonly queueName: Name, private readonly driver: InMemoryQueueDriver) {
+    super();
+  }
+
+  public async close(): Promise<void> {
+    this.removeAllListeners();
+    this.driver.unregisterQueueEvents(this.queueName, this as InMemoryQueueEvents<Name>);
+  }
+}
+
+class InMemoryQueue<Name extends QueueName, ResultType = unknown>
+  extends EventEmitter
+  implements Queue<JobPayload<Name>, ResultType, Name>
+{
+  public readonly name: Name;
+  private readonly driver: InMemoryQueueDriver;
+  private readonly options?: QueueOptions<JobPayload<Name>, ResultType, Name>;
+
+  constructor(name: Name, driver: InMemoryQueueDriver, options?: QueueOptions<JobPayload<Name>, ResultType, Name>) {
+    super();
+    this.name = name;
+    this.driver = driver;
+    this.options = options;
+  }
+
+  public async add(
+    name: Name,
+    data: JobPayload<Name>,
+    options: JobsOptions<JobPayload<Name>, ResultType, Name> = {}
+  ): Promise<InMemoryJob<Name, ResultType>> {
+    const jobId = options.jobId ?? randomUUID();
+    const defaultOptions = this.options?.defaultJobOptions ?? {};
+    const mergedOptions: JobsOptions<JobPayload<Name>, ResultType, Name> = {
+      ...defaultOptions,
+      ...options,
+      backoff: { ...((defaultOptions as any)?.backoff ?? {}), ...((options as any)?.backoff ?? {}) },
+      group: {
+        id: options.group?.id ?? (defaultOptions as any)?.group?.id ?? DEFAULT_GROUP_KEY,
+      },
+    };
+
+    const maxAttempts = Math.max(1, Number(mergedOptions.attempts ?? defaultOptions.attempts ?? 1));
+
+    const record: JobRecord<Name, ResultType> = {
+      id: jobId,
+      name,
+      data,
+      attemptsMade: 0,
+      opts: mergedOptions,
+      maxAttempts,
+      groupId: mergedOptions.group?.id ?? DEFAULT_GROUP_KEY,
+    };
+
+    this.driver.enqueueJob(this.name, record, this.options);
+
+    return new InMemoryJob<Name, ResultType>(record);
+  }
+
+  public async close(): Promise<void> {
+    this.driver.closeQueue(this.name);
+  }
+
+  public async getJobCounts(..._types: string[]): Promise<QueueJobCounts<Name>> {
+    return this.driver.getJobCounts(this.name) as QueueJobCounts<Name>;
+  }
+
+  public get opts(): QueueOptions<JobPayload<Name>, ResultType, Name> | undefined {
+    return this.options;
+  }
+}
+
+class InMemoryWorker<Name extends QueueName, ResultType = unknown>
+  extends EventEmitter
+  implements Worker<JobPayload<Name>, ResultType, Name>
+{
+  private running = true;
+  private readonly concurrency: number;
+  private readonly groupConcurrency: number;
+  private readonly activeGroups = new Map<string, number>();
+  private readonly settings: WorkerOptions<JobPayload<Name>, ResultType, Name>['settings'] | undefined;
+  private activeJobs = 0;
+
+  constructor(
+    private readonly name: Name,
+    private readonly driver: InMemoryQueueDriver,
+    private readonly processor: Processor<JobPayload<Name>, ResultType, Name>,
+    private readonly options: WorkerOptions<JobPayload<Name>, ResultType, Name>
+  ) {
+    super();
+    this.concurrency = Math.max(1, Number(options.concurrency ?? 1));
+    const groupConcurrency = Math.max(1, Number(options.group?.concurrency ?? this.concurrency));
+    this.groupConcurrency = Math.min(this.concurrency, groupConcurrency);
+    this.settings = options.settings;
+  }
+
+  public async close(): Promise<void> {
+    this.running = false;
+    this.driver.unregisterWorker(this.name, this as InMemoryWorker<Name, ResultType>);
+  }
+
+  public requestWork(): void {
+    if (!this.running) {
+      return;
+    }
+    this.driver.schedule(this.name);
+  }
+
+  public hasCapacity(): boolean {
+    return this.activeJobs < this.concurrency;
+  }
+
+  public canProcessGroup(groupId: string): boolean {
+    const active = this.activeGroups.get(groupId) ?? 0;
+    return active < this.groupConcurrency;
+  }
+
+  public markGroupStarted(groupId: string): void {
+    const active = this.activeGroups.get(groupId) ?? 0;
+    this.activeGroups.set(groupId, active + 1);
+  }
+
+  public markGroupFinished(groupId: string): void {
+    const active = this.activeGroups.get(groupId) ?? 0;
+    if (active <= 1) {
+      this.activeGroups.delete(groupId);
+    } else {
+      this.activeGroups.set(groupId, active - 1);
+    }
+  }
+
+  public incrementActiveJobs(): void {
+    this.activeJobs += 1;
+  }
+
+  public decrementActiveJobs(): void {
+    this.activeJobs = Math.max(0, this.activeJobs - 1);
+  }
+
+  public getProcessor(): Processor<JobPayload<Name>, ResultType, Name> {
+    return this.processor;
+  }
+
+  public getSettings(): WorkerOptions<JobPayload<Name>, ResultType, Name>['settings'] | undefined {
+    return this.settings;
+  }
+}
+
+export class InMemoryQueueDriver {
+  private readonly queues = new Map<string, QueueState<any, any>>();
+
+  public createQueue<Name extends QueueName, ResultType = unknown>(
+    name: Name,
+    options?: QueueOptions<JobPayload<Name>, ResultType, Name>
+  ): Queue<JobPayload<Name>, ResultType, Name> {
+    if (!this.queues.has(name)) {
+      const state: QueueState<Name, ResultType> = {
+        options,
+        waiting: [],
+        active: new Set(),
+        delayed: new Set(),
+        completed: 0,
+        failed: 0,
+        workers: new Set(),
+        events: new Set(),
+      };
+      this.queues.set(name, state);
+    } else {
+      const state = this.queues.get(name) as QueueState<Name, ResultType>;
+      state.options = options;
+    }
+
+    return new InMemoryQueue<Name, ResultType>(name, this, options) as unknown as Queue<
+      JobPayload<Name>,
+      ResultType,
+      Name
+    >;
+  }
+
+  public createWorker<Name extends QueueName, ResultType = unknown>(
+    name: Name,
+    processor: Processor<JobPayload<Name>, ResultType, Name>,
+    options?: WorkerOptions<JobPayload<Name>, ResultType, Name>
+  ): Worker<JobPayload<Name>, ResultType, Name> {
+    const worker = new InMemoryWorker<Name, ResultType>(name, this, processor, options ?? {} as any);
+    const state = this.ensureState<Name, ResultType>(name);
+    state.workers.add(worker as InMemoryWorker<Name, ResultType>);
+    worker.requestWork();
+    return worker as unknown as Worker<JobPayload<Name>, ResultType, Name>;
+  }
+
+  public createQueueEvents<Name extends QueueName>(
+    name: Name,
+    _options?: QueueEventsOptions
+  ): QueueEvents {
+    const events = new InMemoryQueueEvents<Name>(name, this);
+    const state = this.ensureState<Name, unknown>(name);
+    state.events.add(events as InMemoryQueueEvents<Name>);
+    return events as unknown as QueueEvents;
+  }
+
+  public registerQueueTelemetry<Name extends QueueName>(
+    queue: Queue<JobPayload<Name>, unknown, Name>,
+    events: QueueEvents,
+    handler: (cleanup: () => void) => void
+  ): void {
+    handler(() => {
+      events.removeAllListeners();
+    });
+  }
+
+  public enqueueJob<Name extends QueueName, ResultType = unknown>(
+    name: Name,
+    record: JobRecord<Name, ResultType>,
+    options?: QueueOptions<JobPayload<Name>, ResultType, Name>
+  ): void {
+    const state = this.ensureState<Name, ResultType>(name);
+    state.options = options;
+    state.waiting.push(record);
+    this.emitEvent(name, 'waiting', { jobId: record.id });
+    this.schedule(name);
+  }
+
+  public schedule<Name extends QueueName>(name: Name): void {
+    const state = this.ensureState<Name, unknown>(name);
+    for (const worker of state.workers) {
+      this.processForWorker(name, worker as InMemoryWorker<Name, unknown>);
+    }
+  }
+
+  public closeQueue<Name extends QueueName>(name: Name): void {
+    const state = this.ensureState<Name, unknown>(name);
+    for (const delayed of state.delayed) {
+      if (delayed.timeout) {
+        clearTimeout(delayed.timeout);
+      }
+    }
+    state.delayed.clear();
+    state.waiting.length = 0;
+  }
+
+  public unregisterWorker<Name extends QueueName, ResultType = unknown>(
+    name: Name,
+    worker: InMemoryWorker<Name, ResultType>
+  ): void {
+    const state = this.ensureState<Name, ResultType>(name);
+    state.workers.delete(worker as InMemoryWorker<Name, ResultType>);
+  }
+
+  public unregisterQueueEvents<Name extends QueueName>(
+    name: Name,
+    events: InMemoryQueueEvents<Name>
+  ): void {
+    const state = this.ensureState<Name, unknown>(name);
+    state.events.delete(events as InMemoryQueueEvents<Name>);
+  }
+
+  public getJobCounts<Name extends QueueName>(name: Name): Record<string, number> {
+    const state = this.ensureState<Name, unknown>(name);
+    return {
+      waiting: state.waiting.length,
+      active: state.active.size,
+      completed: state.completed,
+      failed: state.failed,
+      delayed: state.delayed.size,
+      paused: 0,
+    };
+  }
+
+  private ensureState<Name extends QueueName, ResultType = unknown>(
+    name: Name
+  ): QueueState<Name, ResultType> {
+    if (!this.queues.has(name)) {
+      this.queues.set(name, {
+        waiting: [],
+        active: new Set(),
+        delayed: new Set(),
+        completed: 0,
+        failed: 0,
+        workers: new Set(),
+        events: new Set(),
+      });
+    }
+    return this.queues.get(name) as QueueState<Name, ResultType>;
+  }
+
+  private processForWorker<Name extends QueueName, ResultType = unknown>(
+    name: Name,
+    worker: InMemoryWorker<Name, ResultType>
+  ): void {
+    const state = this.ensureState<Name, ResultType>(name);
+    if (!worker.hasCapacity()) {
+      return;
+    }
+
+    const nextIndex = state.waiting.findIndex((job) => worker.canProcessGroup(job.groupId));
+    if (nextIndex === -1) {
+      return;
+    }
+
+    const [job] = state.waiting.splice(nextIndex, 1);
+    state.active.add(job);
+    worker.incrementActiveJobs();
+    worker.markGroupStarted(job.groupId);
+
+    const jobInstance = new InMemoryJob<Name, ResultType>(job);
+    void this.executeJob(name, worker, state, job, jobInstance);
+  }
+
+  private async executeJob<Name extends QueueName, ResultType = unknown>(
+    name: Name,
+    worker: InMemoryWorker<Name, ResultType>,
+    state: QueueState<Name, ResultType>,
+    record: JobRecord<Name, ResultType>,
+    job: InMemoryJob<Name, ResultType>
+  ): Promise<void> {
+    try {
+      const result = await worker.getProcessor()(job as any);
+      job.returnvalue = result;
+      state.completed += 1;
+      this.emitEvent(name, 'completed', { jobId: job.id, returnvalue: result });
+      this.finishJob(name, worker, state, record);
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      job.failedReason = err.message;
+      record.attemptsMade += 1;
+      if (record.attemptsMade < record.maxAttempts) {
+        const delay = this.resolveBackoff(worker, record);
+        this.requeueJob(name, record, delay);
+        this.emitEvent(name, 'failed', {
+          jobId: job.id,
+          failedReason: err.message,
+          attemptsMade: record.attemptsMade,
+        });
+      } else {
+        state.failed += 1;
+        this.emitEvent(name, 'failed', {
+          jobId: job.id,
+          failedReason: err.message,
+          attemptsMade: record.attemptsMade,
+        });
+      }
+      this.finishJob(name, worker, state, record);
+    }
+  }
+
+  private finishJob<Name extends QueueName, ResultType = unknown>(
+    name: Name,
+    worker: InMemoryWorker<Name, ResultType>,
+    state: QueueState<Name, ResultType>,
+    record: JobRecord<Name, ResultType>
+  ): void {
+    state.active.delete(record);
+    worker.decrementActiveJobs();
+    worker.markGroupFinished(record.groupId);
+    this.schedule(name);
+  }
+
+  private resolveBackoff<Name extends QueueName, ResultType = unknown>(
+    worker: InMemoryWorker<Name, ResultType>,
+    record: JobRecord<Name, ResultType>
+  ): number {
+    const backoff = (record.opts as any)?.backoff;
+    if (!backoff || typeof backoff !== 'object') {
+      return 0;
+    }
+
+    const backoffType = (backoff as { type?: string }).type;
+    if (!backoffType) {
+      return 0;
+    }
+
+    const settings = worker.getSettings();
+    const strategy = settings?.backoffStrategies?.[backoffType as keyof typeof settings.backoffStrategies];
+    if (typeof strategy === 'function') {
+      try {
+        return Math.max(0, Number(strategy(record.attemptsMade)) || 0);
+      } catch (error) {
+        console.warn('In-memory queue backoff strategy failed:', (error as Error)?.message ?? error);
+      }
+    }
+
+    return 0;
+  }
+
+  private requeueJob<Name extends QueueName, ResultType = unknown>(
+    name: Name,
+    record: JobRecord<Name, ResultType>,
+    delayMs: number
+  ): void {
+    const state = this.ensureState<Name, ResultType>(name);
+    if (delayMs > 0) {
+      const delayed: DelayedJob<Name, ResultType> = { job: record, timeout: null };
+      delayed.timeout = setTimeout(() => {
+        state.delayed.delete(delayed);
+        state.waiting.push(record);
+        this.emitEvent(name, 'waiting', { jobId: record.id });
+        this.schedule(name);
+      }, delayMs);
+      delayed.timeout.unref?.();
+      state.delayed.add(delayed);
+    } else {
+      state.waiting.push(record);
+      this.emitEvent(name, 'waiting', { jobId: record.id });
+      this.schedule(name);
+    }
+  }
+
+  private emitEvent<Name extends QueueName>(name: Name, event: string, payload: any): void {
+    const state = this.ensureState<Name, unknown>(name);
+    for (const listener of state.events) {
+      listener.emit(event, payload);
+    }
+  }
+}
+
+export function createInMemoryQueueDriver(): InMemoryQueueDriver {
+  return new InMemoryQueueDriver();
+}

--- a/server/queue/index.ts
+++ b/server/queue/index.ts
@@ -1,0 +1,192 @@
+import type {
+  Processor,
+  Queue,
+  QueueEvents,
+  QueueEventsOptions,
+  QueueOptions,
+  Worker,
+  WorkerOptions,
+} from 'bullmq';
+
+import { getErrorMessage } from '../types/common.js';
+
+import {
+  createQueue as createBullQueue,
+  createQueueEvents as createBullQueueEvents,
+  createWorker as createBullWorker,
+  getRedisConnectionOptions,
+  registerQueueTelemetry as registerBullQueueTelemetry,
+} from './BullMQFactory.js';
+import { createInMemoryQueueDriver, InMemoryQueueDriver } from './InMemoryQueue.js';
+import type { JobPayload, QueueName, QueueTelemetryOptions } from './types.js';
+
+export type { QueueTelemetryHandlers, QueueJobCounts } from './types.js';
+export type { JobPayloads, QueueName, WorkflowExecuteJobPayload } from './types.js';
+export type {
+  Processor,
+  Queue,
+  QueueEvents,
+  QueueEventsOptions,
+  QueueOptions,
+  Worker,
+  WorkerOptions,
+} from './types.js';
+
+type QueueDriverName = 'bullmq' | 'inmemory';
+
+type QueueDriverState = {
+  name: QueueDriverName;
+  memoryDriver: InMemoryQueueDriver | null;
+  warnedFallback: boolean;
+};
+
+const state: QueueDriverState = {
+  name: resolveInitialDriver(),
+  memoryDriver: null,
+  warnedFallback: false,
+};
+
+function resolveInitialDriver(): QueueDriverName {
+  const override = process.env.QUEUE_DRIVER?.toLowerCase();
+  if (override === 'inmemory') {
+    console.warn('[Queue] QUEUE_DRIVER=inmemory detected. Using in-memory queue driver.');
+    return 'inmemory';
+  }
+  return 'bullmq';
+}
+
+function getMemoryDriver(): InMemoryQueueDriver {
+  if (!state.memoryDriver) {
+    state.memoryDriver = createInMemoryQueueDriver();
+  }
+  return state.memoryDriver;
+}
+
+function isRedisConnectionError(error: unknown): boolean {
+  if (!error) {
+    return false;
+  }
+  const code = (error as { code?: string }).code ?? '';
+  const message = typeof (error as { message?: string }).message === 'string'
+    ? (error as { message: string }).message
+    : '';
+  const lowered = message.toLowerCase();
+
+  const indicativeCodes = new Set([
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'ETIMEDOUT',
+    'EHOSTUNREACH',
+    'ENOTFOUND',
+  ]);
+
+  if (code && indicativeCodes.has(code)) {
+    return true;
+  }
+
+  const indicativeMessages = [
+    'connect ECONNREFUSED',
+    'connect etimedout',
+    'connection is closed',
+    'ready check failed',
+    'getaddrinfo enotfound',
+    'getaddrinfo eai_again',
+    'redis connection',
+  ];
+
+  return indicativeMessages.some((needle) => lowered.includes(needle));
+}
+
+function switchToInMemoryDriver(reason?: unknown): void {
+  if (state.name === 'inmemory') {
+    return;
+  }
+  state.name = 'inmemory';
+  if (!state.warnedFallback) {
+    const explanation = reason ? getErrorMessage(reason) : 'unknown error';
+    console.warn(
+      `[Queue] Falling back to in-memory queue driver due to Redis issue: ${explanation}. Jobs will not be persisted.`
+    );
+    state.warnedFallback = true;
+  }
+}
+
+export function handleQueueDriverError(error: unknown): boolean {
+  if (state.name === 'inmemory') {
+    return false;
+  }
+  if (!isRedisConnectionError(error)) {
+    return false;
+  }
+  switchToInMemoryDriver(error);
+  return true;
+}
+
+export function createQueue<Name extends QueueName, ResultType = unknown>(
+  name: Name,
+  options?: QueueOptions<JobPayload<Name>, ResultType, Name>
+): Queue<JobPayload<Name>, ResultType, Name> {
+  if (state.name === 'bullmq') {
+    try {
+      return createBullQueue<Name, ResultType>(name, options);
+    } catch (error) {
+      if (handleQueueDriverError(error)) {
+        return createQueue<Name, ResultType>(name, options);
+      }
+      throw error;
+    }
+  }
+
+  return getMemoryDriver().createQueue<Name, ResultType>(name, options);
+}
+
+export function createWorker<Name extends QueueName, ResultType = unknown>(
+  name: Name,
+  processor: Processor<JobPayload<Name>, ResultType, Name>,
+  options?: WorkerOptions<JobPayload<Name>, ResultType, Name>
+): Worker<JobPayload<Name>, ResultType, Name> {
+  if (state.name === 'bullmq') {
+    try {
+      return createBullWorker<Name, ResultType>(name, processor, options);
+    } catch (error) {
+      if (handleQueueDriverError(error)) {
+        return createWorker<Name, ResultType>(name, processor, options);
+      }
+      throw error;
+    }
+  }
+
+  return getMemoryDriver().createWorker<Name, ResultType>(name, processor, options);
+}
+
+export function createQueueEvents<Name extends QueueName>(
+  name: Name,
+  options?: QueueEventsOptions
+): QueueEvents {
+  if (state.name === 'bullmq') {
+    try {
+      return createBullQueueEvents<Name>(name, options);
+    } catch (error) {
+      if (handleQueueDriverError(error)) {
+        return createQueueEvents<Name>(name, options);
+      }
+      throw error;
+    }
+  }
+
+  return getMemoryDriver().createQueueEvents<Name>(name, options);
+}
+
+export function registerQueueTelemetry<Name extends QueueName>(
+  queue: Queue<JobPayload<Name>, unknown, Name>,
+  events: QueueEvents,
+  options: QueueTelemetryOptions<Name> = {}
+): () => void {
+  return registerBullQueueTelemetry(queue, events, options);
+}
+
+export { getRedisConnectionOptions };
+
+export function getActiveQueueDriver(): QueueDriverName {
+  return state.name;
+}

--- a/server/queue/types.ts
+++ b/server/queue/types.ts
@@ -1,0 +1,63 @@
+import type {
+  JobsOptions,
+  Processor,
+  Queue,
+  QueueEvents,
+  QueueEventsOptions,
+  QueueOptions,
+  Worker,
+  WorkerOptions,
+} from 'bullmq';
+
+import type { WorkflowResumeState } from '../types/workflowTimers';
+
+export type WorkflowExecuteJobPayload = {
+  workflowId: string;
+  executionId: string;
+  organizationId: string;
+  userId?: string;
+  triggerType: string;
+  triggerData?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown>;
+  resumeState?: WorkflowResumeState | null;
+  initialData?: any;
+  timerId?: string | null;
+};
+
+export interface JobPayloads {
+  'workflow.execute': WorkflowExecuteJobPayload;
+}
+
+export type QueueName = keyof JobPayloads;
+
+export type JobPayload<Name extends QueueName> = JobPayloads[Name];
+
+export type QueueJobCounts<Name extends QueueName> = Awaited<
+  ReturnType<Queue<JobPayload<Name>, unknown, Name>['getJobCounts']>
+>;
+
+export interface QueueTelemetryHandlers<Name extends QueueName> {
+  onCompleted?: (payload: { jobId: string; returnValue: unknown }) => void;
+  onFailed?: (payload: { jobId: string; failedReason: string; attemptsMade: number }) => void;
+  onStalled?: (payload: { jobId: string }) => void;
+  onWaiting?: (payload: { jobId: string }) => void;
+  onError?: (error: Error) => void;
+}
+
+export interface QueueTelemetryOptions<Name extends QueueName> {
+  logger?: Pick<Console, 'info' | 'warn' | 'error'>;
+  handlers?: QueueTelemetryHandlers<Name>;
+  metricsIntervalMs?: number;
+  onMetrics?: (counts: QueueJobCounts<Name>) => void;
+}
+
+export type {
+  JobsOptions,
+  Processor,
+  Queue,
+  QueueEvents,
+  QueueEventsOptions,
+  QueueOptions,
+  Worker,
+  WorkerOptions,
+};

--- a/server/workers/queueWorker.ts
+++ b/server/workers/queueWorker.ts
@@ -1,11 +1,7 @@
 import type { Job, Processor, Worker, WorkerOptions } from 'bullmq';
 import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
 
-import {
-  createWorker,
-  type JobPayloads,
-  type QueueName,
-} from '../queue/BullMQFactory.js';
+import { createWorker, type JobPayloads, type QueueName } from '../queue/index.js';
 import { tracer } from '../observability/index.js';
 
 type JobPayload<Name extends QueueName> = JobPayloads[Name];


### PR DESCRIPTION
## Summary
- add a queue factory that prefers BullMQ but transparently falls back to an in-memory driver when Redis cannot be reached
- implement an in-memory queue driver supporting grouped processing, retries, and telemetry hooks
- update the execution queue service, workers, and documentation to rely on the new abstraction

## Testing
- npm run check *(fails: missing @types/node/@types/vite in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df97eb8a8c833183ca3b46257ff04a