### PR TITLE
Fix test connection credentials precedence for esbuild

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3964,7 +3964,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           appName: provider,
           functionId: 'test_connection',
           parameters: {},
-          credentials: context?.credentials ?? activeConnection.credentials || {},
+          credentials: context?.credentials ?? activeConnection.credentials ?? {},
           connectionId: activeConnection.id
         });
 


### PR DESCRIPTION
## Summary
- clarify the credentials fallback in the test connection health check to avoid mixed nullish and logical OR precedence issues flagged by esbuild

## Testing
- npm run build *(fails: missing dependencies in check:deps)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa0c14fbc83318d1e65da59a2cb9d