### PR TITLE
Fix execution log constraint naming

### DIFF
--- a/migrations/0007_execution_node_logs.ts
+++ b/migrations/0007_execution_node_logs.ts
@@ -5,7 +5,7 @@ type MigrationClient = { execute: (query: any) => Promise<unknown> };
 export async function up(db: MigrationClient): Promise<void> {
   await db.execute(sql`
     CREATE TABLE IF NOT EXISTS "execution_logs" (
-      "execution_id" text PRIMARY KEY,
+      "execution_id" text NOT NULL,
       "workflow_id" text NOT NULL,
       "workflow_name" text,
       "user_id" text,
@@ -25,14 +25,15 @@ export async function up(db: MigrationClient): Promise<void> {
       "metadata" jsonb,
       "timeline" jsonb,
       "created_at" timestamptz NOT NULL DEFAULT now(),
-      "updated_at" timestamptz NOT NULL DEFAULT now()
+      "updated_at" timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT "execution_logs_execution_id_pk" PRIMARY KEY ("execution_id")
     )
   `);
 
   await db.execute(sql`
     CREATE TABLE IF NOT EXISTS "node_logs" (
       "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-      "execution_id" text NOT NULL REFERENCES "execution_logs"("execution_id") ON DELETE CASCADE,
+      "execution_id" text NOT NULL,
       "node_id" text NOT NULL,
       "node_type" text,
       "node_label" text,
@@ -50,7 +51,8 @@ export async function up(db: MigrationClient): Promise<void> {
       "metadata" jsonb,
       "timeline" jsonb,
       "created_at" timestamptz NOT NULL DEFAULT now(),
-      "updated_at" timestamptz NOT NULL DEFAULT now()
+      "updated_at" timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT "node_logs_execution_id_execution_logs_execution_id_fk" FOREIGN KEY ("execution_id") REFERENCES "execution_logs"("execution_id") ON DELETE CASCADE
     )
   `);
 

--- a/migrations/0009_fix_execution_logs_pk.ts
+++ b/migrations/0009_fix_execution_logs_pk.ts
@@ -1,0 +1,65 @@
+import { sql } from 'drizzle-orm';
+
+type MigrationClient = { execute: (query: any) => Promise<unknown> };
+
+export async function up(db: MigrationClient): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    DROP CONSTRAINT IF EXISTS "node_logs_execution_id_execution_logs_execution_id_fk"
+  `);
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    DROP CONSTRAINT IF EXISTS "node_logs_execution_id_fkey"
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    DROP CONSTRAINT IF EXISTS "execution_logs_execution_id_pk"
+  `);
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    DROP CONSTRAINT IF EXISTS "execution_logs_pkey"
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    ADD CONSTRAINT "execution_logs_execution_id_pk" PRIMARY KEY ("execution_id")
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    ADD CONSTRAINT "node_logs_execution_id_execution_logs_execution_id_fk"
+    FOREIGN KEY ("execution_id") REFERENCES "execution_logs"("execution_id") ON DELETE CASCADE
+  `);
+}
+
+export async function down(db: MigrationClient): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    DROP CONSTRAINT IF EXISTS "node_logs_execution_id_execution_logs_execution_id_fk"
+  `);
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    DROP CONSTRAINT IF EXISTS "node_logs_execution_id_fkey"
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    DROP CONSTRAINT IF EXISTS "execution_logs_execution_id_pk"
+  `);
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    DROP CONSTRAINT IF EXISTS "execution_logs_pkey"
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    ADD CONSTRAINT "execution_logs_pkey" PRIMARY KEY ("execution_id")
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    ADD CONSTRAINT "node_logs_execution_id_fkey"
+    FOREIGN KEY ("execution_id") REFERENCES "execution_logs"("execution_id") ON DELETE CASCADE
+  `);
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1759132946664,
       "tag": "0008_organization_connector_entitlements",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1759132947664,
+      "tag": "0009_fix_execution_logs_pk",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- align the execution_logs and node_logs creation migration with the explicit primary and foreign key constraint names expected by the schema
- add a follow-up migration that recreates the execution_logs primary key and node_logs foreign key with the proper names and cascade behavior, handling existing constraint name variants
- update the drizzle migration journal to include the new migration entry

## Testing
- npx drizzle-kit generate *(fails: unable to download drizzle-kit from npm registry – 403 Forbidden)*
- npx drizzle-kit push *(fails: unable to download drizzle-kit from npm registry – 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb13f2c5c83319abc69b5b11a023a