### PR TITLE
Add sandbox resource and network policy enforcement

### DIFF
--- a/server/runtime/NodeSandbox.ts
+++ b/server/runtime/NodeSandbox.ts
@@ -8,13 +8,21 @@ import {
   SandboxExecutorRunOptions,
   SandboxAbortError,
   SandboxTimeoutError,
+  SandboxPolicyEvent,
+  SandboxPolicyViolationError,
+  SandboxResourceLimits,
   dedupeSecrets,
   sanitizeForTransfer,
 } from './SandboxShared';
 import { WorkerSandboxExecutor } from './WorkerSandboxExecutor';
 import { ProcessSandboxExecutor } from './ProcessSandboxExecutor';
+import { connectionService } from '../services/ConnectionService.js';
 
 const DEFAULT_TIMEOUT_MS = 15_000;
+const ENV_CPU_LIMIT_MS = Number(process.env.SANDBOX_MAX_CPU_MS);
+const ENV_MEMORY_LIMIT_MB = Number(process.env.SANDBOX_MAX_MEMORY_MB);
+const ENV_HEARTBEAT_INTERVAL_MS = Number(process.env.SANDBOX_HEARTBEAT_INTERVAL_MS);
+const ENV_HEARTBEAT_TIMEOUT_MS = Number(process.env.SANDBOX_HEARTBEAT_TIMEOUT_MS);
 
 export interface SandboxExecutionOptions {
   code: string;
@@ -24,11 +32,20 @@ export interface SandboxExecutionOptions {
   timeoutMs?: number;
   signal?: AbortSignal;
   secrets?: string[];
+  resourceLimits?: SandboxResourceLimits;
+  heartbeatIntervalMs?: number;
+  heartbeatTimeoutMs?: number;
 }
 
 export { collectSecretStrings } from './SandboxShared';
 export type { SandboxLogEntry } from './SandboxShared';
-export { SandboxAbortError, SandboxTimeoutError } from './SandboxShared';
+export {
+  SandboxAbortError,
+  SandboxTimeoutError,
+  SandboxPolicyViolationError,
+  SandboxResourceLimitError,
+  SandboxHeartbeatTimeoutError,
+} from './SandboxShared';
 
 function resolveExecutorFromEnv(): SandboxExecutor {
   const requested = (process.env.SANDBOX_EXECUTOR || '').toLowerCase();
@@ -72,6 +89,9 @@ export class NodeSandbox {
       timeoutMs = DEFAULT_TIMEOUT_MS,
       signal,
       secrets = [],
+      resourceLimits,
+      heartbeatIntervalMs,
+      heartbeatTimeoutMs,
     } = options;
 
     if (typeof code !== 'string' || code.trim().length === 0) {
@@ -91,10 +111,56 @@ export class NodeSandbox {
 
     return tracer.startActiveSpan('workflow.sandbox', { attributes: spanAttributes }, async (span) => {
       const start = performance.now();
+      const policyEvents: SandboxPolicyEvent[] = [];
       try {
         const sanitizedParams = sanitizeForTransfer(params, 'params');
         const sanitizedContext = sanitizeForTransfer(context, 'context');
         const collectedSecrets = dedupeSecrets(secrets);
+
+        const resolvedResourceLimits = this.resolveResourceLimits(resourceLimits);
+        const resolvedHeartbeatInterval = Number.isFinite(heartbeatIntervalMs)
+          ? Math.max(25, Math.floor(heartbeatIntervalMs))
+          : Number.isFinite(ENV_HEARTBEAT_INTERVAL_MS)
+            ? Math.max(25, Math.floor(ENV_HEARTBEAT_INTERVAL_MS))
+            : undefined;
+        const resolvedHeartbeatTimeout = Number.isFinite(heartbeatTimeoutMs)
+          ? Math.max(resolvedHeartbeatInterval ? resolvedHeartbeatInterval * 2 : 100, Math.floor(heartbeatTimeoutMs))
+          : Number.isFinite(ENV_HEARTBEAT_TIMEOUT_MS)
+            ? Math.max(resolvedHeartbeatInterval ? resolvedHeartbeatInterval * 2 : 100, Math.floor(ENV_HEARTBEAT_TIMEOUT_MS))
+            : undefined;
+
+        const organizationId = typeof (context as any)?.organizationId === 'string'
+          ? (context as any).organizationId
+          : undefined;
+        const executionId = typeof (context as any)?.executionId === 'string'
+          ? (context as any).executionId
+          : undefined;
+        const nodeId = typeof (context as any)?.nodeId === 'string'
+          ? (context as any).nodeId
+          : undefined;
+        const connectionId = typeof (context as any)?.connectionId === 'string'
+          ? (context as any).connectionId
+          : undefined;
+        const userId = typeof (context as any)?.userId === 'string'
+          ? (context as any).userId
+          : undefined;
+
+        const allowlist = organizationId
+          ? await connectionService.getOrganizationNetworkAllowlist(organizationId)
+          : null;
+
+        const networkPolicy = allowlist
+          ? {
+              allowlist,
+              audit: {
+                organizationId,
+                executionId,
+                nodeId,
+                connectionId,
+                userId,
+              },
+            }
+          : null;
 
         const executorOptions: SandboxExecutorRunOptions = {
           code,
@@ -104,6 +170,28 @@ export class NodeSandbox {
           timeoutMs,
           signal,
           secrets: collectedSecrets,
+          resourceLimits: resolvedResourceLimits,
+          networkPolicy,
+          heartbeatIntervalMs: resolvedHeartbeatInterval,
+          heartbeatTimeoutMs: resolvedHeartbeatTimeout,
+          onPolicyEvent: (event) => {
+            policyEvents.push(event);
+            if (event.type === 'network-denied') {
+              try {
+                connectionService.recordDeniedNetworkAccess({
+                  organizationId,
+                  connectionId,
+                  userId,
+                  attemptedHost: event.host,
+                  attemptedUrl: event.url,
+                  reason: event.reason,
+                  allowlist: allowlist ?? undefined,
+                });
+              } catch (recordError) {
+                console.warn('[Sandbox] Failed to record denied network access', recordError);
+              }
+            }
+          },
         };
 
         const outcome = await this.executor.run(executorOptions);
@@ -113,21 +201,56 @@ export class NodeSandbox {
         return outcome;
       } catch (error) {
         const exception = error instanceof Error ? error : new Error(String(error));
+        if (!(exception instanceof SandboxPolicyViolationError) && policyEvents.length > 0) {
+          const violation = policyEvents[policyEvents.length - 1];
+          throw new SandboxPolicyViolationError(exception.message, violation, { cause: exception });
+        }
         span.recordException(exception);
         span.setStatus({ code: SpanStatusCode.ERROR, message: exception.message });
         throw error;
       } finally {
         const durationMs = performance.now() - start;
         span.setAttribute('sandbox.duration_ms', durationMs);
-        recordNodeLatency(durationMs, {
+        if (policyEvents.length > 0) {
+          const violation = policyEvents[policyEvents.length - 1];
+          span.setAttribute('sandbox.policy_violation', true);
+          span.setAttribute('sandbox.policy_violation_type', violation.type);
+          if (violation.type === 'resource-limit') {
+            span.setAttribute('sandbox.policy_violation_resource', violation.resource);
+          }
+        }
+        const metricAttributes: Record<string, unknown> = {
           workflow_id: spanAttributes['workflow.workflow_id'],
           execution_id: spanAttributes['workflow.execution_id'],
           node_id: spanAttributes['workflow.node_id'],
           entry_point: entryPoint,
-        });
+        };
+        if (policyEvents.length > 0) {
+          const violation = policyEvents[policyEvents.length - 1];
+          metricAttributes.policy_violation = violation.type;
+          if (violation.type === 'resource-limit') {
+            metricAttributes.policy_resource = violation.resource;
+          }
+        }
+        recordNodeLatency(durationMs, metricAttributes);
         span.end();
       }
     });
+  }
+
+  private resolveResourceLimits(overrides?: SandboxResourceLimits): SandboxResourceLimits | undefined {
+    const limits: SandboxResourceLimits = { ...overrides };
+    if (!Number.isFinite(limits.maxCpuMs) && Number.isFinite(ENV_CPU_LIMIT_MS)) {
+      limits.maxCpuMs = Math.max(0, Number(ENV_CPU_LIMIT_MS));
+    }
+    if (!Number.isFinite(limits.maxMemoryBytes) && Number.isFinite(ENV_MEMORY_LIMIT_MB)) {
+      const bytes = Number(ENV_MEMORY_LIMIT_MB) * 1024 * 1024;
+      limits.maxMemoryBytes = Math.max(0, bytes);
+    }
+    if (!limits.maxCpuMs && !limits.maxMemoryBytes) {
+      return undefined;
+    }
+    return limits;
   }
 }
 

--- a/server/runtime/ProcessSandboxExecutor.ts
+++ b/server/runtime/ProcessSandboxExecutor.ts
@@ -10,16 +10,52 @@ import {
   formatLog,
   SandboxAbortError,
   SandboxTimeoutError,
+  SandboxResourceLimitError,
+  SandboxHeartbeatTimeoutError,
+  SandboxPolicyEvent,
 } from './SandboxShared';
+
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 500;
+const DEFAULT_HEARTBEAT_TIMEOUT_MS = 3_000;
+const RESOURCE_POLL_INTERVAL_MS = 200;
 
 const EXECUTOR_ENV_KEY = 'SANDBOX_PAYLOAD';
 
 export class ProcessSandboxExecutor implements SandboxExecutor {
   async run(options: SandboxExecutorRunOptions): Promise<SandboxExecutionResult> {
-    const { code, entryPoint, params, context, timeoutMs, signal, secrets } = options;
+    const {
+      code,
+      entryPoint,
+      params,
+      context,
+      timeoutMs,
+      signal,
+      secrets,
+      resourceLimits,
+      networkPolicy,
+      heartbeatIntervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS,
+      heartbeatTimeoutMs,
+      onPolicyEvent,
+    } = options;
 
     const start = performance.now();
-    const payload = JSON.stringify({ code, entryPoint, params, context, timeoutMs, secrets });
+    const effectiveHeartbeatInterval = Number.isFinite(heartbeatIntervalMs)
+      ? Math.max(25, Math.floor(heartbeatIntervalMs))
+      : DEFAULT_HEARTBEAT_INTERVAL_MS;
+    const effectiveHeartbeatTimeout = Number.isFinite(heartbeatTimeoutMs)
+      ? Math.max(effectiveHeartbeatInterval * 2, Math.floor(heartbeatTimeoutMs))
+      : Math.max(effectiveHeartbeatInterval * 3, DEFAULT_HEARTBEAT_TIMEOUT_MS);
+
+    const payload = JSON.stringify({
+      code,
+      entryPoint,
+      params,
+      context,
+      timeoutMs,
+      secrets,
+      networkPolicy: networkPolicy ?? null,
+      heartbeatIntervalMs: effectiveHeartbeatInterval,
+    });
 
     const child = spawn(process.execPath, ['--input-type=module', '--no-warnings', '-e', SANDBOX_BOOTSTRAP_SOURCE], {
       stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
@@ -30,16 +66,96 @@ export class ProcessSandboxExecutor implements SandboxExecutor {
     });
 
     const logs: SandboxLogEntry[] = [];
+    let lastHeartbeat = Date.now();
+
+    const emitPolicyEvent = (event: SandboxPolicyEvent) => {
+      try {
+        onPolicyEvent?.(event);
+      } catch (error) {
+        console.warn('[Sandbox] Failed to dispatch policy event', error);
+      }
+    };
+
+    const normalizePolicyEvent = (message: any): SandboxPolicyEvent | null => {
+      if (!message || typeof message !== 'object') {
+        return null;
+      }
+      if (message.type === 'network-denied') {
+        const allowlistSource = message.allowlist;
+        const allowlist = allowlistSource && typeof allowlistSource === 'object'
+          ? {
+              domains: Array.isArray(allowlistSource.domains)
+                ? allowlistSource.domains.filter((value: any) => typeof value === 'string')
+                : [],
+              ipRanges: Array.isArray(allowlistSource.ipRanges)
+                ? allowlistSource.ipRanges.filter((value: any) => typeof value === 'string')
+                : [],
+            }
+          : null;
+        const auditSource = message.audit;
+        const audit = auditSource && typeof auditSource === 'object'
+          ? {
+              organizationId: typeof auditSource.organizationId === 'string' ? auditSource.organizationId : undefined,
+              executionId: typeof auditSource.executionId === 'string' ? auditSource.executionId : undefined,
+              nodeId: typeof auditSource.nodeId === 'string' ? auditSource.nodeId : undefined,
+              connectionId: typeof auditSource.connectionId === 'string' ? auditSource.connectionId : undefined,
+              userId: typeof auditSource.userId === 'string' ? auditSource.userId : undefined,
+            }
+          : undefined;
+        const host = typeof message.host === 'string' ? message.host : '';
+        const url = typeof message.url === 'string' ? message.url : '';
+        const reason = typeof message.reason === 'string' ? message.reason : 'policy_violation';
+        if (!host || !url) {
+          return null;
+        }
+        return {
+          type: 'network-denied',
+          host,
+          url,
+          reason,
+          allowlist,
+          audit,
+        };
+      }
+      if (message.type === 'resource-limit') {
+        const resource = message.resource === 'cpu' || message.resource === 'memory' ? message.resource : null;
+        if (!resource) {
+          return null;
+        }
+        const usage = Number(message.usage);
+        const limit = Number(message.limit);
+        if (!Number.isFinite(usage) || !Number.isFinite(limit)) {
+          return null;
+        }
+        return {
+          type: 'resource-limit',
+          resource,
+          usage,
+          limit,
+        };
+      }
+      return null;
+    };
 
     return new Promise<SandboxExecutionResult>((resolve, reject) => {
       let settled = false;
       let hardTimeout: NodeJS.Timeout | null = null;
+      let heartbeatMonitor: NodeJS.Timeout | null = null;
+      let resourceMonitor: NodeJS.Timeout | null = null;
 
       const cleanup = () => {
         signal?.removeEventListener('abort', handleAbort);
         child.removeAllListeners('message');
         child.removeAllListeners('error');
         child.removeAllListeners('exit');
+        if (heartbeatMonitor) {
+          clearInterval(heartbeatMonitor);
+          heartbeatMonitor = null;
+        }
+        if (resourceMonitor) {
+          clearInterval(resourceMonitor);
+          resourceMonitor = null;
+        }
       };
 
       const terminate = (signalType: NodeJS.Signals = 'SIGKILL') => {
@@ -72,6 +188,77 @@ export class ProcessSandboxExecutor implements SandboxExecutor {
         }
       };
 
+      const triggerResourceViolation = (
+        resource: 'cpu' | 'memory',
+        usage: number,
+        limit: number,
+      ) => {
+        const event: SandboxPolicyEvent = { type: 'resource-limit', resource, usage, limit };
+        emitPolicyEvent(event);
+        const message = resource === 'cpu'
+          ? `Sandbox CPU limit exceeded: ${usage.toFixed(2)}ms > ${limit.toFixed(2)}ms`
+          : `Sandbox memory limit exceeded: ${Math.round(usage / (1024 * 1024))}MB > ${Math.round(limit / (1024 * 1024))}MB`;
+        finalize(new SandboxResourceLimitError(resource, usage, limit, message));
+      };
+
+      const startMonitors = () => {
+        if (!heartbeatMonitor) {
+          heartbeatMonitor = setInterval(() => {
+            const elapsed = Date.now() - lastHeartbeat;
+            if (elapsed > effectiveHeartbeatTimeout) {
+              finalize(
+                new SandboxHeartbeatTimeoutError(
+                  `Sandbox heartbeat missed for ${elapsed}ms (timeout=${effectiveHeartbeatTimeout}ms)`,
+                ),
+              );
+            }
+          }, Math.min(Math.max(effectiveHeartbeatInterval, 50), effectiveHeartbeatTimeout));
+          if (typeof heartbeatMonitor.unref === 'function') {
+            heartbeatMonitor.unref();
+          }
+        }
+
+        if (resourceLimits && !resourceMonitor) {
+          const maxCpuMs = Number(resourceLimits.maxCpuMs);
+          const maxMemoryBytes = Number(resourceLimits.maxMemoryBytes);
+          if (Number.isFinite(maxCpuMs) || Number.isFinite(maxMemoryBytes)) {
+            resourceMonitor = setInterval(() => {
+              if (settled) {
+                return;
+              }
+              try {
+                const usage = child.resourceUsage();
+                if (!usage) {
+                  return;
+                }
+                if (Number.isFinite(maxCpuMs)) {
+                  const cpuLimit = Number(maxCpuMs);
+                  const cpuMs = (usage.userCPUTime + usage.systemCPUTime) / 1000;
+                  if (cpuMs > cpuLimit) {
+                    triggerResourceViolation('cpu', cpuMs, cpuLimit);
+                    return;
+                  }
+                }
+                if (Number.isFinite(maxMemoryBytes) && usage.maxRSS) {
+                  const memoryLimit = Number(maxMemoryBytes);
+                  const rssBytes = usage.maxRSS * 1024;
+                  if (rssBytes > memoryLimit) {
+                    triggerResourceViolation('memory', rssBytes, memoryLimit);
+                  }
+                }
+              } catch (error) {
+                // resourceUsage may throw before the child is fully initialized
+              }
+            }, RESOURCE_POLL_INTERVAL_MS);
+            if (resourceMonitor && typeof resourceMonitor.unref === 'function') {
+              resourceMonitor.unref();
+            }
+          }
+        }
+      };
+
+      child.once('spawn', startMonitors);
+
       const handleAbort = () => {
         try {
           child.send({ type: 'abort' });
@@ -101,6 +288,17 @@ export class ProcessSandboxExecutor implements SandboxExecutor {
 
       child.on('message', (message: any) => {
         if (!message) return;
+        if (message.type === 'heartbeat') {
+          lastHeartbeat = Date.now();
+          return;
+        }
+        if (message.type === 'policy_violation') {
+          const event = normalizePolicyEvent(message.event);
+          if (event) {
+            emitPolicyEvent(event);
+          }
+          return;
+        }
         if (message.type === 'log') {
           try {
             const formatted = typeof message.data === 'string'

--- a/server/services/ConnectionService.ts
+++ b/server/services/ConnectionService.ts
@@ -335,6 +335,24 @@ export class ConnectionService {
     return { domains, ipRanges };
   }
 
+  public async getOrganizationNetworkAllowlist(
+    organizationId: string | undefined
+  ): Promise<OrganizationNetworkAllowlist | null> {
+    if (!organizationId) {
+      return null;
+    }
+
+    const allowlist = await this.resolveNetworkAllowlist(organizationId);
+    if (!allowlist) {
+      return null;
+    }
+
+    return {
+      domains: Array.isArray(allowlist.domains) ? allowlist.domains : [],
+      ipRanges: Array.isArray(allowlist.ipRanges) ? allowlist.ipRanges : [],
+    };
+  }
+
   public invalidateOrganizationSecurityCache(organizationId: string): void {
     this.organizationSecurityCache.delete(organizationId);
   }


### PR DESCRIPTION
## Summary
- add network allowlist-aware fetch wrapper and heartbeat signaling to the sandbox runtime
- enforce process sandbox CPU and memory limits with policy event reporting and heartbeat monitoring
- surface sandbox policy violations through workflow telemetry, retry manager DLQ handling, and new workflow runtime test coverage

## Testing
- npm test -- --runTestsByPath server/runtime/__tests__/WorkflowRuntime.sandbox.test.ts *(fails: tsx command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e001c26330833182d5585bbe815ada