### PR TITLE
Persist webhook dedupe tokens across restarts

### DIFF
--- a/server/observability/index.ts
+++ b/server/observability/index.ts
@@ -34,6 +34,10 @@ const nodeLatencyHistogram = meter.createHistogram('workflow_node_latency_ms', {
   unit: 'ms',
 });
 
+const webhookDedupeCounter = meter.createCounter('webhook_dedupe_events_total', {
+  description: 'Counts webhook deduplication hits and misses',
+});
+
 const queueDepthGauge = meter.createObservableGauge('workflow_queue_depth', {
   description: 'Number of jobs in workflow queues by state',
   unit: '{job}',
@@ -77,6 +81,14 @@ export function recordHttpRequestDuration(durationMs: number, attributes: Record
 
 export function recordNodeLatency(durationMs: number, attributes: Record<string, unknown>): void {
   nodeLatencyHistogram.record(durationMs, sanitizeAttributes(attributes));
+}
+
+export function recordWebhookDedupeHit(attributes: Record<string, unknown>): void {
+  webhookDedupeCounter.add(1, sanitizeAttributes({ ...attributes, outcome: 'hit' }));
+}
+
+export function recordWebhookDedupeMiss(attributes: Record<string, unknown>): void {
+  webhookDedupeCounter.add(1, sanitizeAttributes({ ...attributes, outcome: 'miss' }));
 }
 
 export function updateQueueDepthMetric<Name extends QueueName>(


### PR DESCRIPTION
## Summary
- persist webhook dedupe metadata in TriggerPersistenceService with provider-aware TTL management and duplicate listing
- enforce shared dedupe checks in WebhookManager, expose duplicate event route, and emit webhook_dedupe metrics
- surface duplicate drop messaging in the run viewer UI and update related test doubles

## Testing
- not run (dependencies unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e00785da3083318ce3f0e7c04f8897