### PR TITLE
Add workflow idempotency contexts for connector requests

### DIFF
--- a/server/workflow/WorkflowRuntimeService.ts
+++ b/server/workflow/WorkflowRuntimeService.ts
@@ -209,13 +209,18 @@ export class WorkflowRuntimeService {
       });
     }
 
+    const idempotencyKey = this.buildIdempotencyKey(context.executionId, node.id);
+
     const executionResponse = await integrationManager.executeFunction({
       appName: appId,
       functionId,
       parameters: resolvedParams,
       credentials: credentialResolution.credentials,
       additionalConfig: credentialResolution.additionalConfig,
-      connectionId: credentialResolution.connectionId
+      connectionId: credentialResolution.connectionId,
+      executionId: context.executionId,
+      nodeId: String(node.id),
+      idempotencyKey
     });
 
     if (!executionResponse.success) {
@@ -277,6 +282,12 @@ export class WorkflowRuntimeService {
     }
 
     return 'action';
+  }
+
+  private buildIdempotencyKey(executionId: string, nodeId: string | number): string {
+    const executionPart = String(executionId || '').trim() || 'execution';
+    const nodePart = String(nodeId ?? '').trim() || 'node';
+    return `${executionPart}:${nodePart}`;
   }
 
   private executeCondition(


### PR DESCRIPTION
## Summary
- generate deterministic per-step idempotency keys from execution and node IDs during workflow runs and surface them in node metadata
- teach the retry manager to retain request/response hashes and expose them to execution tracking for restart-safe deduplication
- wire connector clients through a request context so BaseAPIClient can add provider-specific idempotency tokens or record request hashes when unavailable

## Testing
- `npm test -- --runTestsByPath server/core/__tests__/RetryManager.test.ts` *(fails: tsx not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e081a6a8e08331b09f2b31763c08b7