### PR TITLE
Add data residency metadata and region-aware routing

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { getPermissionsForRole, Permission } from '../../configs/rbac';
 import { authService, AuthOrganization } from '../services/AuthService';
 import {
+  DataRegion,
   OrganizationPlan,
   OrganizationStatus,
   OrganizationLimits,
@@ -32,6 +33,7 @@ declare global {
         organizationStatus?: OrganizationStatus;
         organizationLimits?: OrganizationLimits;
         organizationUsage?: OrganizationUsageMetrics;
+        organizationRegion?: DataRegion;
         activeOrganization?: AuthOrganization;
         organizations?: AuthOrganization[];
         permissions?: Permission[];
@@ -42,6 +44,7 @@ declare global {
       organizationStatus?: OrganizationStatus;
       organizationLimits?: OrganizationLimits;
       organizationUsage?: OrganizationUsageMetrics;
+      organizationRegion?: DataRegion;
       permissions?: Permission[];
     }
   }
@@ -83,10 +86,12 @@ const buildDevUser = () => {
       storageUsed: 0,
       usersActive: 1,
     },
+    organizationRegion: 'us',
     activeOrganization: {
       id: 'dev-org',
       name: 'Developer Workspace',
       domain: null,
+      region: 'us',
       plan: 'enterprise',
       status: 'active',
       role: 'owner',
@@ -204,6 +209,7 @@ export const optionalAuth = async (req: Request, res: Response, next: NextFuncti
         req.organizationStatus = user.organizationStatus;
         req.organizationLimits = user.organizationLimits;
         req.organizationUsage = user.organizationUsage;
+        req.organizationRegion = user.organizationRegion as DataRegion | undefined;
         req.permissions = permissions;
         setRequestUser(user.id);
       }
@@ -216,6 +222,7 @@ export const optionalAuth = async (req: Request, res: Response, next: NextFuncti
       req.organizationStatus = devUser.organizationStatus as OrganizationStatus;
       req.organizationLimits = devUser.organizationLimits;
       req.organizationUsage = devUser.organizationUsage;
+      req.organizationRegion = devUser.organizationRegion as DataRegion;
       req.permissions = permissions;
       setRequestUser(devUser.id);
     }
@@ -231,6 +238,7 @@ export const optionalAuth = async (req: Request, res: Response, next: NextFuncti
       req.organizationStatus = devUser.organizationStatus as OrganizationStatus;
       req.organizationLimits = devUser.organizationLimits;
       req.organizationUsage = devUser.organizationUsage;
+      req.organizationRegion = devUser.organizationRegion as DataRegion;
       req.permissions = permissions;
       setRequestUser(devUser.id);
       next();

--- a/server/services/AuthService.ts
+++ b/server/services/AuthService.ts
@@ -3,6 +3,7 @@ import {
   users,
   sessions,
   db,
+  DataRegion,
   OrganizationPlan,
   OrganizationStatus,
   OrganizationLimits,
@@ -57,6 +58,7 @@ export interface AuthUser {
   organizationStatus?: OrganizationStatus;
   organizationLimits?: OrganizationLimits;
   organizationUsage?: OrganizationUsageMetrics;
+  organizationRegion?: DataRegion;
   activeOrganization?: AuthOrganization;
   organizations?: AuthOrganization[];
   permissions?: Permission[];
@@ -66,6 +68,7 @@ export interface AuthOrganization {
   id: string;
   name: string;
   domain: string | null;
+  region: DataRegion;
   plan: OrganizationPlan;
   status: OrganizationStatus;
   role: string;
@@ -513,6 +516,7 @@ export class AuthService {
       id: context.id,
       name: context.name,
       domain: context.domain,
+      region: context.region,
       plan: context.plan,
       status: context.status,
       role: context.role,
@@ -570,6 +574,7 @@ export class AuthService {
       organizationRole: activeOrganization?.role,
       organizationPlan: activeOrganization?.plan,
       organizationStatus: activeOrganization?.status,
+      organizationRegion: activeOrganization?.region,
       organizationLimits: activeOrganization?.limits,
       organizationUsage: activeOrganization?.usage,
       activeOrganization,

--- a/server/services/ComplianceReportService.ts
+++ b/server/services/ComplianceReportService.ts
@@ -1,0 +1,85 @@
+import { and, eq } from 'drizzle-orm';
+
+import {
+  db,
+  organizations,
+  tenantIsolations,
+  type DataRegion,
+} from '../database/schema.js';
+import { getErrorMessage } from '../types/common.js';
+
+export interface ResidencyReport {
+  organizationId: string;
+  region: DataRegion;
+  dataResidency: DataRegion;
+  storage: {
+    secretsNamespace: string;
+    filePrefix: string;
+    logPrefix: string;
+  };
+  workloads: {
+    executionQueueRegion: DataRegion;
+    schedulerRegion: DataRegion;
+    webhookRegion: DataRegion;
+  };
+}
+
+export class ComplianceReportService {
+  public async getResidencyReport(organizationId: string): Promise<ResidencyReport | null> {
+    if (!db) {
+      return null;
+    }
+
+    try {
+      const [row] = await db
+        .select({
+          id: organizations.id,
+          region: organizations.region,
+          compliance: organizations.compliance,
+          isolationRegion: tenantIsolations.region,
+          storagePrefix: tenantIsolations.storagePrefix,
+          logPrefix: tenantIsolations.logPrefix,
+        })
+        .from(organizations)
+        .leftJoin(
+          tenantIsolations,
+          and(eq(tenantIsolations.organizationId, organizations.id))
+        )
+        .where(eq(organizations.id, organizationId))
+        .limit(1);
+
+      if (!row) {
+        return null;
+      }
+
+      const orgRegion = (row.region as DataRegion) ?? 'us';
+      const storageRegion = (row.isolationRegion as DataRegion) ?? orgRegion;
+      const complianceResidency =
+        (row.compliance as { dataResidency?: DataRegion })?.dataResidency ?? orgRegion;
+
+      return {
+        organizationId: row.id,
+        region: orgRegion,
+        dataResidency: complianceResidency,
+        storage: {
+          secretsNamespace: `${storageRegion}-secrets`,
+          filePrefix: row.storagePrefix ?? `${storageRegion}/org_${organizationId}`,
+          logPrefix: row.logPrefix ?? `${storageRegion}.org.${organizationId}`,
+        },
+        workloads: {
+          executionQueueRegion: orgRegion,
+          schedulerRegion: storageRegion,
+          webhookRegion: orgRegion,
+        },
+      };
+    } catch (error) {
+      console.error(
+        'Failed to build residency compliance report:',
+        getErrorMessage(error)
+      );
+      throw error;
+    }
+  }
+}
+
+export const complianceReportService = new ComplianceReportService();

--- a/server/services/__tests__/ConnectionService.encryption.test.ts
+++ b/server/services/__tests__/ConnectionService.encryption.test.ts
@@ -43,18 +43,26 @@ assert.ok(fetched, 'connection should be retrievable');
 assert.equal(fetched?.iv, storedRecords[0].iv, 'fetched connection exposes iv');
 assert.deepEqual(fetched?.credentials, originalCredentials, 'credentials should decrypt to original payload');
 assert.equal(fetched?.encryptionKeyId ?? null, null, 'fetched connection exposes encryptionKeyId metadata');
+assert.equal(fetched?.metadata?.secretsNamespace, 'us-secrets', 'fetched metadata includes secrets namespace');
+assert.equal(fetched?.metadata?.residency?.storageRegion, 'us', 'fetched metadata tracks residency region');
 
 const byProvider = await service.getConnectionByProvider('user-123', 'org-123', 'openai');
 assert.ok(byProvider, 'connection should be retrievable by provider');
 assert.equal(byProvider?.iv, storedRecords[0].iv, 'provider lookup exposes iv');
 assert.deepEqual(byProvider?.credentials, originalCredentials, 'provider lookup decrypts credentials');
 assert.equal(byProvider?.encryptionKeyId ?? null, null, 'provider lookup exposes encryptionKeyId');
+assert.equal(
+  byProvider?.metadata?.residency?.filePrefix,
+  'us/org_org-123',
+  'provider metadata tracks residency file prefix'
+);
 
 const allConnections = await service.getUserConnections('user-123', 'org-123', 'openai');
 assert.equal(allConnections.length, 1, 'user should have one connection after creation');
 assert.equal(allConnections[0].iv, storedRecords[0].iv, 'list entries expose iv');
 assert.deepEqual(allConnections[0].credentials, originalCredentials, 'list entries decrypt credentials');
 assert.equal(allConnections[0].encryptionKeyId ?? null, null, 'list entries expose encryptionKeyId');
+assert.equal(allConnections[0].metadata?.storagePrefix, 'us/org_org-123', 'list metadata includes storage prefix');
 
 await rm(tempDir, { recursive: true, force: true });
 delete process.env.CONNECTION_STORE_PATH;

--- a/server/services/__tests__/ConnectionService.test.ts
+++ b/server/services/__tests__/ConnectionService.test.ts
@@ -51,12 +51,30 @@ assert.equal(
   testResult.message,
   'test error message captured during failed test'
 );
+assert.equal(connection?.metadata?.storageRegion, 'us', 'connection metadata includes storage region');
+assert.equal(
+  connection?.metadata?.residency?.filePrefix,
+  `us/org_${request.organizationId}`,
+  'connection metadata tracks residency file prefix'
+);
+assert.equal(
+  connection?.metadata?.residency?.logPrefix,
+  `us.org.${request.organizationId}`,
+  'connection metadata tracks residency log prefix'
+);
+assert.equal(
+  connection?.metadata?.residency?.secretsNamespace,
+  'us-secrets',
+  'connection metadata tracks residency secrets namespace'
+);
 
 const fetched = await service.getConnection(connectionId, request.userId, request.organizationId);
 assert.ok(fetched, 'connection can be fetched by id');
 assert.equal(fetched?.type, request.type, 'fetched connection preserves type');
 assert.equal(fetched?.testStatus, 'failed', 'fetched connection includes test status');
 assert.equal(fetched?.testError, testResult.message, 'fetched connection includes test error');
+assert.equal(fetched?.metadata?.storagePrefix, `us/org_${request.organizationId}`, 'fetched metadata includes storage prefix');
+assert.equal(fetched?.metadata?.logPrefix, `us.org.${request.organizationId}`, 'fetched metadata includes log prefix');
 
 // Verify expiring OAuth tokens are refreshed transparently
 const oauthModule = await import('../../oauth/OAuthManager.js');

--- a/server/services/__tests__/TriggerPersistenceService.fallback.test.ts
+++ b/server/services/__tests__/TriggerPersistenceService.fallback.test.ts
@@ -48,6 +48,7 @@ async function runTriggerPersistenceFallbackIntegration(): Promise<void> {
     cursor: { page: '1' },
     backoffCount: 1,
     lastStatus: 'error',
+    region: 'us',
   } as const;
 
   await service.savePollingTrigger({ ...pollingTrigger });

--- a/server/services/__tests__/TriggerPersistenceService.test.ts
+++ b/server/services/__tests__/TriggerPersistenceService.test.ts
@@ -57,13 +57,14 @@ async function runTriggerPersistenceUnitTests(): Promise<void> {
     triggerId: 'poll.trigger',
     interval: 45,
     nextPoll: dueAt,
-    nextPollAt: dueAt,
-    isActive: true,
-    metadata: { scenario: 'unit-test' },
-    cursor: { page: '1' },
-    backoffCount: 3,
-    lastStatus: 'error',
-  } as const;
+  nextPollAt: dueAt,
+  isActive: true,
+  metadata: { scenario: 'unit-test' },
+  cursor: { page: '1' },
+  backoffCount: 3,
+  lastStatus: 'error',
+  region: 'us',
+} as const;
 
   await service.savePollingTrigger({ ...pollingTrigger });
   const [stored] = await service.loadPollingTriggers();
@@ -72,7 +73,7 @@ async function runTriggerPersistenceUnitTests(): Promise<void> {
   assert.equal(stored?.backoffCount, pollingTrigger.backoffCount, 'backoff count should persist');
   assert.equal(stored?.lastStatus, pollingTrigger.lastStatus, 'last status should persist');
 
-  const claimed = await service.claimDuePollingTriggers({ now, limit: 1 });
+  const claimed = await service.claimDuePollingTriggers({ now, limit: 1, region: 'us' });
   assert.equal(claimed.length, 1, 'due polling trigger should be claimed');
 
   const expectedIntervalSeconds = service.computePollingIntervalWithBackoff(

--- a/server/types/workflowTimers.ts
+++ b/server/types/workflowTimers.ts
@@ -12,6 +12,8 @@ export interface WorkflowTimerMetadata {
   delayMs: number;
 }
 
+import type { DataRegion } from '../database/schema';
+
 export interface WorkflowTimerPayload {
   workflowId: string;
   organizationId?: string;
@@ -21,4 +23,5 @@ export interface WorkflowTimerPayload {
   resumeState: WorkflowResumeState;
   triggerType?: string;
   metadata: WorkflowTimerMetadata;
+  region: DataRegion;
 }

--- a/server/webhooks/types.ts
+++ b/server/webhooks/types.ts
@@ -1,3 +1,5 @@
+import type { DataRegion } from '../database/schema';
+
 export interface WebhookTrigger {
   id: string;
   appId: string;
@@ -10,6 +12,7 @@ export interface WebhookTrigger {
   metadata: Record<string, any>;
   organizationId?: string;
   userId?: string;
+  region?: DataRegion;
 }
 
 export interface TriggerEvent {
@@ -27,6 +30,7 @@ export interface TriggerEvent {
   dedupeToken?: string;
   organizationId: string;
   userId?: string;
+  region?: DataRegion;
 }
 
 export interface PollingTrigger {
@@ -44,4 +48,7 @@ export interface PollingTrigger {
   cursor?: Record<string, any> | null;
   backoffCount?: number;
   lastStatus?: string | null;
+  organizationId?: string;
+  userId?: string;
+  region?: DataRegion;
 }


### PR DESCRIPTION
## Summary
- add a shared `DataRegion` enum and new residency columns to the database schema
- propagate organization region information through auth responses, queue workers, triggers, and compliance reporting
- enrich connection metadata with residency details and ensure file-store updates remain region-aware, updating related tests

## Testing
- npm run test -- ConnectionService *(fails: tsx not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0810dc53c83319f9f537737ed0a8a