### PR TITLE
feat: externalize billing plans and add usage exports

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ import Terms from "./pages/Terms";
 import PreBuiltApps from "./pages/PreBuiltApps";
 import AIBuilder from "./pages/AIBuilder";
 import AdminSettings from "./pages/AdminSettings";
+import AdminUsage from "./pages/AdminUsage";
 import WorkflowBuilder from "./pages/WorkflowBuilder";
 import GraphEditor from "./pages/GraphEditor";
 import OAuthCallback from "./pages/OAuthCallback";
@@ -42,6 +43,7 @@ const App = () => (
             <Route path="/workflow-builder" element={<WorkflowBuilder />} />
             <Route path="/graph-editor" element={<GraphEditor />} />
             <Route path="/admin/settings" element={<AdminSettings />} />
+            <Route path="/admin/usage" element={<AdminUsage />} />
             <Route path="/pre-built-apps" element={<PreBuiltApps />} />
             <Route path="/schedule" element={<Schedule />} />
             <Route path="/contact" element={<Contact />} />

--- a/client/src/components/layout/Navbar.tsx
+++ b/client/src/components/layout/Navbar.tsx
@@ -79,6 +79,9 @@ export const Navbar = () => {
                 <DropdownMenuItem asChild>
                   <Link to="/admin/settings">Account settings</Link>
                 </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link to="/admin/usage">Usage &amp; billing</Link>
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onSelect={() => logout()}>Sign out</DropdownMenuItem>
               </DropdownMenuContent>

--- a/client/src/pages/AdminUsage.tsx
+++ b/client/src/pages/AdminUsage.tsx
@@ -1,0 +1,314 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { format } from 'date-fns';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useAuthStore } from '@/store/authStore';
+import { Loader2, Download, AlertTriangle } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface UsageExportRow {
+  userId: string;
+  email: string;
+  planCode: string;
+  planName: string;
+  apiCalls: number;
+  tokensUsed: number;
+  workflowRuns: number;
+  storageUsed: number;
+  estimatedCost: number;
+}
+
+interface UsageExportSummary {
+  totalApiCalls: number;
+  totalTokensUsed: number;
+  totalWorkflowRuns: number;
+  totalEstimatedCost: number;
+  distinctUsers: number;
+}
+
+interface UsageExportResponse {
+  success: boolean;
+  report?: {
+    rows: UsageExportRow[];
+    summary: UsageExportSummary;
+    period: { startDate: string; endDate: string };
+  };
+  error?: string;
+}
+
+interface UsageAlert {
+  userId: string;
+  type: 'approaching_limit' | 'limit_exceeded' | 'unusual_usage';
+  quotaType: string;
+  threshold: number;
+  current: number;
+  limit: number;
+  timestamp: string;
+}
+
+interface UsageAlertResponse {
+  success: boolean;
+  alerts: UsageAlert[];
+  error?: string;
+}
+
+const formatNumber = (value: number) => new Intl.NumberFormat().format(value);
+
+const AdminUsage: React.FC = () => {
+  const { authFetch } = useAuthStore((state) => ({ authFetch: state.authFetch }));
+  const [loading, setLoading] = useState(true);
+  const [alertsLoading, setAlertsLoading] = useState(true);
+  const [report, setReport] = useState<UsageExportResponse['report'] | null>(null);
+  const [alerts, setAlerts] = useState<UsageAlert[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [threshold, setThreshold] = useState(80);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const response = await authFetch('/api/usage/export?format=json');
+        const data = (await response.json()) as UsageExportResponse;
+        if (!response.ok || !data.success || !data.report) {
+          throw new Error(data.error || 'Failed to load usage report');
+        }
+        setReport(data.report);
+      } catch (err: any) {
+        setError(err?.message || 'Failed to load usage report');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void load();
+  }, [authFetch]);
+
+  const loadAlerts = async (nextThreshold: number) => {
+    setAlertsLoading(true);
+    try {
+      const response = await authFetch(`/api/usage/alerts?threshold=${nextThreshold}`);
+      const data = (await response.json()) as UsageAlertResponse;
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to load alerts');
+      }
+      setAlerts(data.alerts);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to load alerts');
+    } finally {
+      setAlertsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadAlerts(threshold);
+  }, [threshold]);
+
+  const handleDownloadCsv = async () => {
+    try {
+      const response = await authFetch('/api/usage/export?format=csv');
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Failed to download usage export');
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      const fileName = `usage-export-${format(new Date(), 'yyyy-MM-dd')}.csv`;
+      link.href = url;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      toast.success('Usage export downloaded');
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to download usage export');
+    }
+  };
+
+  const summarizedAlerts = useMemo(() => {
+    const grouped = new Map<string, UsageAlert[]>();
+    for (const alert of alerts) {
+      const key = `${alert.userId}-${alert.quotaType}`;
+      const existing = grouped.get(key) ?? [];
+      existing.push(alert);
+      grouped.set(key, existing);
+    }
+    return Array.from(grouped.values()).map((group) => group.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())[0]);
+  }, [alerts]);
+
+  return (
+    <>
+      <Helmet>
+        <title>Usage &amp; Billing Insights</title>
+      </Helmet>
+      <div className="container mx-auto py-10 space-y-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Usage &amp; Billing Insights</h1>
+            <p className="text-muted-foreground">Download finance-ready exports and monitor quota alerts in real time.</p>
+          </div>
+          <Button onClick={handleDownloadCsv} disabled={loading} className="inline-flex items-center gap-2">
+            <Download className="h-4 w-4" />
+            Download CSV
+          </Button>
+        </header>
+
+        {error && (
+          <Card className="border-destructive/30 bg-destructive/10">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-destructive">
+                <AlertTriangle className="h-5 w-5" />
+                {error}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+        )}
+
+        <section>
+          <Card>
+            <CardHeader>
+              <CardTitle>Usage summary</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {loading || !report ? (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Loading usage data...
+                </div>
+              ) : (
+                <div className="grid gap-6 md:grid-cols-4">
+                  <div>
+                    <p className="text-sm text-muted-foreground">Billing period</p>
+                    <p className="text-lg font-semibold">
+                      {format(new Date(report.period.startDate), 'MMM d, yyyy')} – {format(new Date(report.period.endDate), 'MMM d, yyyy')}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-muted-foreground">API calls</p>
+                    <p className="text-2xl font-bold">{formatNumber(report.summary.totalApiCalls)}</p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-muted-foreground">Tokens used</p>
+                    <p className="text-2xl font-bold">{formatNumber(report.summary.totalTokensUsed)}</p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-muted-foreground">Estimated spend</p>
+                    <p className="text-2xl font-bold">${(report.summary.totalEstimatedCost / 100).toFixed(2)}</p>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold">Quota alerts</h2>
+            <div className="flex items-center gap-3 text-sm">
+              <label htmlFor="threshold" className="text-muted-foreground">Threshold</label>
+              <input
+                id="threshold"
+                type="number"
+                min={10}
+                max={100}
+                step={5}
+                value={threshold}
+                onChange={(event) => setThreshold(Number(event.target.value) || 80)}
+                className="w-20 rounded-md border border-input bg-background px-2 py-1"
+              />
+            </div>
+          </div>
+          <Card>
+            <CardContent className="pt-6">
+              {alertsLoading ? (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Checking alerts...
+                </div>
+              ) : summarizedAlerts.length === 0 ? (
+                <p className="text-muted-foreground">No alerts at the moment. All teams are within their quotas.</p>
+              ) : (
+                <ul className="space-y-3">
+                  {summarizedAlerts.map((alert) => (
+                    <li key={`${alert.userId}-${alert.quotaType}`} className="flex items-center justify-between rounded-md border border-border/60 px-4 py-2">
+                      <div>
+                        <p className="font-medium">{alert.quotaType.replace('_', ' ')} • {alert.type === 'limit_exceeded' ? 'Limit exceeded' : 'Approaching limit'}</p>
+                        <p className="text-sm text-muted-foreground">
+                          User {alert.userId} is at {formatNumber(alert.current)} of {formatNumber(alert.limit)} ({((alert.current / alert.limit) * 100).toFixed(1)}%).
+                        </p>
+                      </div>
+                      <Badge variant={alert.type === 'limit_exceeded' ? 'destructive' : 'secondary'}>
+                        {format(new Date(alert.timestamp), 'MMM d, yyyy HH:mm')}
+                      </Badge>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-xl font-semibold">Detailed usage by account</h2>
+          <Card>
+            <CardContent className="p-0">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-muted/50 text-left">
+                    <tr>
+                      <th className="px-4 py-3 font-medium">User</th>
+                      <th className="px-4 py-3 font-medium">Plan</th>
+                      <th className="px-4 py-3 font-medium text-right">API calls</th>
+                      <th className="px-4 py-3 font-medium text-right">Tokens</th>
+                      <th className="px-4 py-3 font-medium text-right">Workflow runs</th>
+                      <th className="px-4 py-3 font-medium text-right">Storage (MB)</th>
+                      <th className="px-4 py-3 font-medium text-right">Est. cost</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {loading || !report ? (
+                      <tr>
+                        <td colSpan={7} className="px-4 py-6 text-center text-muted-foreground">
+                          Loading usage rows...
+                        </td>
+                      </tr>
+                    ) : report.rows.length === 0 ? (
+                      <tr>
+                        <td colSpan={7} className="px-4 py-6 text-center text-muted-foreground">
+                          No usage recorded this period.
+                        </td>
+                      </tr>
+                    ) : (
+                      report.rows.map((row) => (
+                        <tr key={row.userId} className="border-t border-border/60">
+                          <td className="px-4 py-3">
+                            <div className="font-medium">{row.email}</div>
+                            <div className="text-xs text-muted-foreground">{row.userId}</div>
+                          </td>
+                          <td className="px-4 py-3">
+                            <Badge variant="outline">{row.planName}</Badge>
+                          </td>
+                          <td className="px-4 py-3 text-right">{formatNumber(row.apiCalls)}</td>
+                          <td className="px-4 py-3 text-right">{formatNumber(row.tokensUsed)}</td>
+                          <td className="px-4 py-3 text-right">{formatNumber(row.workflowRuns)}</td>
+                          <td className="px-4 py-3 text-right">{(row.storageUsed / (1024 * 1024)).toFixed(2)}</td>
+                          <td className="px-4 py-3 text-right">${(row.estimatedCost / 100).toFixed(2)}</td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+    </>
+  );
+};
+
+export default AdminUsage;

--- a/configs/billing-plans.json
+++ b/configs/billing-plans.json
@@ -1,0 +1,151 @@
+[
+  {
+    "code": "free",
+    "name": "Free",
+    "priceCents": 0,
+    "currency": "usd",
+    "features": [
+      "Basic workflows",
+      "Community support"
+    ],
+    "usageQuotas": {
+      "apiCalls": 1000,
+      "tokens": 100000,
+      "workflowRuns": 100,
+      "storage": 104857600
+    },
+    "organizationLimits": {
+      "maxWorkflows": 10,
+      "maxExecutions": 2000,
+      "maxUsers": 3,
+      "maxStorage": 2048,
+      "maxConcurrentExecutions": 2,
+      "maxExecutionsPerMinute": 30
+    }
+  },
+  {
+    "code": "starter",
+    "name": "Starter",
+    "priceCents": 1900,
+    "currency": "usd",
+    "features": [
+      "Workflow templates",
+      "Email support"
+    ],
+    "usageQuotas": {
+      "apiCalls": 5000,
+      "tokens": 500000,
+      "workflowRuns": 500,
+      "storage": 536870912
+    },
+    "organizationLimits": {
+      "maxWorkflows": 25,
+      "maxExecutions": 5000,
+      "maxUsers": 5,
+      "maxStorage": 5120,
+      "maxConcurrentExecutions": 2,
+      "maxExecutionsPerMinute": 60
+    }
+  },
+  {
+    "code": "pro",
+    "name": "Pro",
+    "priceCents": 2900,
+    "currency": "usd",
+    "features": [
+      "Advanced workflows",
+      "Priority support",
+      "Custom connectors"
+    ],
+    "usageQuotas": {
+      "apiCalls": 10000,
+      "tokens": 1000000,
+      "workflowRuns": 1000,
+      "storage": 1073741824
+    },
+    "organizationLimits": {
+      "maxWorkflows": 100,
+      "maxExecutions": 50000,
+      "maxUsers": 25,
+      "maxStorage": 25600,
+      "maxConcurrentExecutions": 10,
+      "maxExecutionsPerMinute": 300
+    }
+  },
+  {
+    "code": "professional",
+    "name": "Professional",
+    "priceCents": 3900,
+    "currency": "usd",
+    "features": [
+      "Automation analytics",
+      "Phone support",
+      "Shared workspaces"
+    ],
+    "usageQuotas": {
+      "apiCalls": 20000,
+      "tokens": 2000000,
+      "workflowRuns": 2000,
+      "storage": 2147483648
+    },
+    "organizationLimits": {
+      "maxWorkflows": 100,
+      "maxExecutions": 50000,
+      "maxUsers": 25,
+      "maxStorage": 25600,
+      "maxConcurrentExecutions": 10,
+      "maxExecutionsPerMinute": 300
+    }
+  },
+  {
+    "code": "enterprise",
+    "name": "Enterprise",
+    "priceCents": 9900,
+    "currency": "usd",
+    "features": [
+      "Unlimited workflows",
+      "24/7 support",
+      "Custom integrations",
+      "SLA"
+    ],
+    "usageQuotas": {
+      "apiCalls": 100000,
+      "tokens": 10000000,
+      "workflowRuns": 10000,
+      "storage": 10737418240
+    },
+    "organizationLimits": {
+      "maxWorkflows": 500,
+      "maxExecutions": 250000,
+      "maxUsers": 250,
+      "maxStorage": 102400,
+      "maxConcurrentExecutions": 25,
+      "maxExecutionsPerMinute": 1200
+    }
+  },
+  {
+    "code": "enterprise_plus",
+    "name": "Enterprise Plus",
+    "priceCents": 19900,
+    "currency": "usd",
+    "features": [
+      "Dedicated infrastructure",
+      "Compliance automation",
+      "Enterprise onboarding"
+    ],
+    "usageQuotas": {
+      "apiCalls": 250000,
+      "tokens": 25000000,
+      "workflowRuns": 25000,
+      "storage": 21474836480
+    },
+    "organizationLimits": {
+      "maxWorkflows": 1000,
+      "maxExecutions": 1000000,
+      "maxUsers": 1000,
+      "maxStorage": 512000,
+      "maxConcurrentExecutions": 50,
+      "maxExecutionsPerMinute": 2500
+    }
+  }
+]

--- a/migrations/0010_billing_plans.ts
+++ b/migrations/0010_billing_plans.ts
@@ -1,0 +1,27 @@
+import { sql } from 'drizzle-orm';
+
+interface MigrationClient {
+  execute: (query: ReturnType<typeof sql>) => Promise<unknown>;
+}
+
+export async function up(db: MigrationClient): Promise<void> {
+  await db.execute(sql`CREATE TABLE IF NOT EXISTS "billing_plans" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "code" text NOT NULL UNIQUE,
+    "name" text NOT NULL,
+    "price_cents" integer NOT NULL,
+    "currency" text NOT NULL DEFAULT 'usd',
+    "features" jsonb NOT NULL DEFAULT '[]'::jsonb,
+    "usage_quotas" jsonb NOT NULL,
+    "organization_limits" jsonb,
+    "metadata" jsonb,
+    "billing_provider_product_id" text,
+    "is_active" boolean NOT NULL DEFAULT true,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+  )`);
+}
+
+export async function down(db: MigrationClient): Promise<void> {
+  await db.execute(sql`DROP TABLE IF EXISTS "billing_plans"`);
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -56,6 +56,7 @@ import type { OrganizationLimits } from './database/schema.js';
 import { env } from './env';
 import organizationSecurityRoutes from "./routes/organization-security";
 import organizationConnectorRoutes from "./routes/organization-connectors";
+import usageAdminRoutes from "./routes/usage";
 
 const SUPPORTED_CONNECTION_PROVIDERS = [
   'openai',
@@ -189,6 +190,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.use('/api/organizations', organizationRoleRoutes);
   app.use('/api/organizations', organizationSecurityRoutes);
   app.use('/api/organizations', organizationConnectorRoutes);
+  app.use('/api/usage', usageAdminRoutes);
 
   // (removed duplicate /api/ai/models in favor of aiRouter.get('/models'))
   
@@ -1327,7 +1329,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.get('/api/plans', async (req, res) => {
     try {
-      const plans = usageMeteringService.getAvailablePlans();
+      const plans = await usageMeteringService.getAvailablePlans();
       res.json({ success: true, plans });
     } catch (error) {
       res.status(500).json({ success: false, error: getErrorMessage(error) });
@@ -1337,7 +1339,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post('/api/upgrade',
     authenticateToken,
     securityService.validateInput([
-      { field: 'plan', type: 'string', required: true, allowedValues: ['free', 'pro', 'enterprise'] }
+      {
+        field: 'plan',
+        type: 'string',
+        required: true,
+        allowedValues: ['free', 'starter', 'pro', 'professional', 'enterprise', 'enterprise_plus'],
+      }
     ]),
     async (req, res) => {
       try {

--- a/server/routes/usage.ts
+++ b/server/routes/usage.ts
@@ -1,0 +1,45 @@
+import { Router } from 'express';
+
+import { authenticateToken, adminOnly } from '../middleware/auth';
+import { usageMeteringService } from '../services/UsageMeteringService';
+import { getErrorMessage } from '../types/common';
+
+const router = Router();
+
+router.get('/export', authenticateToken, adminOnly, async (req, res) => {
+  try {
+    const format = req.query.format === 'csv' ? 'csv' : 'json';
+    const planFilter = typeof req.query.plan === 'string' ? req.query.plan.split(',').map((value) => value.trim()).filter(Boolean) : undefined;
+    const startDate = req.query.startDate ? new Date(String(req.query.startDate)) : undefined;
+    const endDate = req.query.endDate ? new Date(String(req.query.endDate)) : undefined;
+
+    const report = await usageMeteringService.generateUsageExport({
+      format,
+      planCodes: planFilter,
+      startDate: startDate && !Number.isNaN(startDate.getTime()) ? startDate : undefined,
+      endDate: endDate && !Number.isNaN(endDate.getTime()) ? endDate : undefined,
+    });
+
+    if (format === 'csv' && report.csv) {
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader('Content-Disposition', `attachment; filename="usage-export-${report.period.startDate.toISOString().slice(0, 10)}.csv"`);
+      return res.send(report.csv);
+    }
+
+    return res.json({ success: true, report });
+  } catch (error) {
+    return res.status(500).json({ success: false, error: getErrorMessage(error) });
+  }
+});
+
+router.get('/alerts', authenticateToken, adminOnly, async (req, res) => {
+  try {
+    const threshold = Number.parseInt(String(req.query.threshold ?? '80'), 10);
+    const alerts = await usageMeteringService.listUsageAlerts(Number.isFinite(threshold) ? threshold : 80);
+    res.json({ success: true, alerts });
+  } catch (error) {
+    res.status(500).json({ success: false, error: getErrorMessage(error) });
+  }
+});
+
+export default router;

--- a/server/services/BillingPlanService.ts
+++ b/server/services/BillingPlanService.ts
@@ -1,0 +1,151 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  billingPlans,
+  type BillingPlanUsageQuotas,
+  type OrganizationLimits,
+  db,
+} from '../database/schema';
+
+export interface BillingPlanDefinition {
+  id?: string;
+  code: string;
+  name: string;
+  priceCents: number;
+  currency: string;
+  features: string[];
+  usageQuotas: BillingPlanUsageQuotas;
+  organizationLimits?: OrganizationLimits | null;
+  metadata?: Record<string, unknown> | null;
+  billingProviderProductId?: string | null;
+  isActive: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface BillingPlanProvider {
+  getPlan(code: string): Promise<BillingPlanDefinition | null>;
+  getUsagePlan(code: string): Promise<BillingPlanDefinition>;
+  listPlans(includeInactive?: boolean): Promise<BillingPlanDefinition[]>;
+  refresh(force?: boolean): Promise<void>;
+}
+
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+export class BillingPlanService implements BillingPlanProvider {
+  private readonly db = db;
+  private cache = new Map<string, BillingPlanDefinition>();
+  private lastLoaded = 0;
+  private loading: Promise<void> | null = null;
+
+  constructor(private readonly cacheTtlMs: number = DEFAULT_CACHE_TTL_MS) {}
+
+  public async getPlan(code: string): Promise<BillingPlanDefinition | null> {
+    await this.loadPlans();
+    return this.cache.get(code) ?? null;
+  }
+
+  public async getUsagePlan(code: string): Promise<BillingPlanDefinition> {
+    await this.loadPlans();
+    const plan = this.cache.get(code) ?? this.cache.get('free');
+    if (!plan) {
+      throw new Error(`No billing plan definitions are available for code: ${code}`);
+    }
+    return plan;
+  }
+
+  public async listPlans(includeInactive = false): Promise<BillingPlanDefinition[]> {
+    await this.loadPlans();
+    return Array.from(this.cache.values()).filter((plan) => includeInactive || plan.isActive);
+  }
+
+  public async refresh(force = false): Promise<void> {
+    await this.loadPlans(force);
+  }
+
+  private async loadPlans(force = false): Promise<void> {
+    if (!force && this.cache.size > 0 && Date.now() - this.lastLoaded < this.cacheTtlMs) {
+      return;
+    }
+
+    if (this.loading) {
+      return this.loading;
+    }
+
+    this.loading = (async () => {
+      await this.ensureSeedData();
+      const rows = await this.db.select().from(billingPlans);
+      this.cache = new Map(rows.map((row) => [row.code, this.mapRow(row)]));
+      this.lastLoaded = Date.now();
+      this.loading = null;
+    })();
+
+    return this.loading;
+  }
+
+  private mapRow(row: typeof billingPlans.$inferSelect): BillingPlanDefinition {
+    return {
+      id: row.id,
+      code: row.code,
+      name: row.name,
+      priceCents: row.priceCents,
+      currency: row.currency,
+      features: Array.isArray(row.features) ? row.features : [],
+      usageQuotas: row.usageQuotas as BillingPlanUsageQuotas,
+      organizationLimits: (row.organizationLimits as OrganizationLimits | null) ?? undefined,
+      metadata: row.metadata ?? undefined,
+      billingProviderProductId: row.billingProviderProductId ?? undefined,
+      isActive: row.isActive,
+      createdAt: row.createdAt ?? undefined,
+      updatedAt: row.updatedAt ?? undefined,
+    } satisfies BillingPlanDefinition;
+  }
+
+  private async ensureSeedData(): Promise<void> {
+    const [existing] = await this.db.select({ id: billingPlans.id }).from(billingPlans).limit(1);
+    if (existing) {
+      return;
+    }
+
+    const configPath = path.resolve(process.cwd(), 'configs/billing-plans.json');
+    let contents: string;
+    try {
+      contents = await fs.readFile(configPath, 'utf-8');
+    } catch (error) {
+      console.warn(`⚠️ Billing plan configuration not found at ${configPath}.`);
+      return;
+    }
+
+    const parsed = JSON.parse(contents) as Array<Omit<BillingPlanDefinition, 'isActive'>>;
+    for (const plan of parsed) {
+      await this.db.insert(billingPlans).values({
+        code: plan.code,
+        name: plan.name,
+        priceCents: plan.priceCents,
+        currency: plan.currency,
+        features: plan.features,
+        usageQuotas: plan.usageQuotas,
+        organizationLimits: plan.organizationLimits ?? null,
+        metadata: plan.metadata ?? null,
+        billingProviderProductId: plan.billingProviderProductId ?? null,
+        isActive: true,
+      }).onConflictDoUpdate({
+        target: billingPlans.code,
+        set: {
+          name: plan.name,
+          priceCents: plan.priceCents,
+          currency: plan.currency,
+          features: plan.features,
+          usageQuotas: plan.usageQuotas,
+          organizationLimits: plan.organizationLimits ?? null,
+          metadata: plan.metadata ?? null,
+          billingProviderProductId: plan.billingProviderProductId ?? null,
+          updatedAt: new Date(),
+        },
+      });
+    }
+  }
+}
+
+export const billingPlanService = new BillingPlanService();

--- a/server/services/BillingProviderService.ts
+++ b/server/services/BillingProviderService.ts
@@ -1,0 +1,84 @@
+export type MeteringEventType = 'api_calls' | 'tokens' | 'workflow_runs' | 'storage' | 'overage';
+
+export interface MeteringEvent {
+  eventId: string;
+  userId: string;
+  organizationId?: string;
+  planCode: string;
+  usageType: MeteringEventType;
+  quantity: number;
+  unitPriceCents: number;
+  occurredAt: Date;
+  metadata?: Record<string, unknown>;
+}
+
+export interface InvoiceAdjustment {
+  invoiceId: string;
+  amountDueCents: number;
+  description: string;
+  createdAt: Date;
+  userId?: string;
+  organizationId?: string;
+  relatedEvents?: string[];
+}
+
+export interface BillingProviderAdapter {
+  sendMeteringEvent(event: MeteringEvent): Promise<void>;
+  fetchInvoiceAdjustments(since: Date): Promise<InvoiceAdjustment[]>;
+}
+
+export class InMemoryBillingProviderAdapter implements BillingProviderAdapter {
+  private readonly events: MeteringEvent[] = [];
+  private readonly adjustments: InvoiceAdjustment[] = [];
+
+  async sendMeteringEvent(event: MeteringEvent): Promise<void> {
+    this.events.push(event);
+  }
+
+  async fetchInvoiceAdjustments(since: Date): Promise<InvoiceAdjustment[]> {
+    return this.adjustments.filter((adjustment) => adjustment.createdAt >= since);
+  }
+
+  public recordAdjustment(adjustment: InvoiceAdjustment): void {
+    this.adjustments.push(adjustment);
+  }
+
+  public getEvents(): MeteringEvent[] {
+    return [...this.events];
+  }
+}
+
+export class BillingProviderService {
+  private readonly listeners = new Set<(event: MeteringEvent) => void>();
+  private lastReconciliationAt = new Date(0);
+
+  constructor(private adapter: BillingProviderAdapter = new InMemoryBillingProviderAdapter()) {}
+
+  public setAdapter(adapter: BillingProviderAdapter): void {
+    this.adapter = adapter;
+  }
+
+  public onMeteringEvent(listener: (event: MeteringEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  public async emitMeteringEvent(event: MeteringEvent): Promise<void> {
+    await this.adapter.sendMeteringEvent(event);
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        console.error('❌ BillingProviderService listener error:', error);
+      }
+    }
+  }
+
+  public async reconcileInvoices(now = new Date()): Promise<InvoiceAdjustment[]> {
+    const adjustments = await this.adapter.fetchInvoiceAdjustments(this.lastReconciliationAt);
+    this.lastReconciliationAt = now;
+    return adjustments;
+  }
+}
+
+export const billingProviderService = new BillingProviderService();

--- a/server/services/UsageMeteringService.ts
+++ b/server/services/UsageMeteringService.ts
@@ -1,6 +1,14 @@
+import { randomUUID } from 'node:crypto';
 import { eq, and, gte, lte, sum, count } from 'drizzle-orm';
 import { users, usageTracking, workflowExecutions, workflows, db } from '../database/schema';
 import { organizationService } from './OrganizationService';
+import { billingPlanService, type BillingPlanDefinition, type BillingPlanProvider } from './BillingPlanService';
+import {
+  billingProviderService,
+  type MeteringEventType,
+  type BillingProviderService as BillingProvider,
+  type InvoiceAdjustment,
+} from './BillingProviderService';
 
 export interface UsageMetrics {
   userId: string;
@@ -69,60 +77,79 @@ export interface UsageAlert {
 }
 
 export interface PlanLimits {
+  code: string;
   name: string;
   apiCalls: number;
   tokens: number;
   workflowRuns: number;
   storage: number; // bytes
-  price: number; // cents per month
+  priceCents: number; // cents per month
+  currency: string;
   features: string[];
 }
 
+export interface UsageExportRow {
+  userId: string;
+  email: string;
+  planCode: string;
+  planName: string;
+  apiCalls: number;
+  tokensUsed: number;
+  workflowRuns: number;
+  storageUsed: number;
+  estimatedCost: number;
+}
+
+export interface UsageExportResult {
+  format: 'json' | 'csv';
+  rows: UsageExportRow[];
+  csv?: string;
+  summary: {
+    totalApiCalls: number;
+    totalTokensUsed: number;
+    totalWorkflowRuns: number;
+    totalEstimatedCost: number;
+    distinctUsers: number;
+  };
+  period: {
+    startDate: Date;
+    endDate: Date;
+  };
+}
+
+interface UsageMeteringDependencies {
+  planProvider?: BillingPlanProvider;
+  billingProvider?: BillingProviderService;
+  db?: typeof db;
+  now?: () => Date;
+}
+
 export class UsageMeteringService {
-  private db: any;
+  private readonly planProvider: BillingPlanProvider;
+  private readonly billingProvider: BillingProvider;
+  private readonly now: () => Date;
+  private readonly planCacheTtlMs = 5 * 60 * 1000;
+  private db: typeof db | null;
   private usageCache = new Map<string, UsageMetrics>();
   private cacheExpiry = new Map<string, number>();
+  private plans = new Map<string, PlanLimits>();
+  private plansExpireAt = 0;
+  private plansLoading: Promise<void> | null = null;
+  private reconciliationTimer: NodeJS.Timeout | null = null;
 
-  // Plan definitions
-  private readonly PLANS: Record<string, PlanLimits> = {
-    free: {
-      name: 'Free',
-      apiCalls: 1000,
-      tokens: 100000,
-      workflowRuns: 100,
-      storage: 100 * 1024 * 1024, // 100MB
-      price: 0,
-      features: ['Basic workflows', 'Community support']
-    },
-    pro: {
-      name: 'Pro',
-      apiCalls: 10000,
-      tokens: 1000000,
-      workflowRuns: 1000,
-      storage: 1024 * 1024 * 1024, // 1GB
-      price: 2900, // $29/month
-      features: ['Advanced workflows', 'Priority support', 'Custom connectors']
-    },
-    enterprise: {
-      name: 'Enterprise',
-      apiCalls: 100000,
-      tokens: 10000000,
-      workflowRuns: 10000,
-      storage: 10 * 1024 * 1024 * 1024, // 10GB
-      price: 9900, // $99/month
-      features: ['Unlimited workflows', '24/7 support', 'Custom integrations', 'SLA']
-    }
-  };
+  constructor(dependencies: UsageMeteringDependencies = {}) {
+    this.db = dependencies.db ?? db;
+    this.planProvider = dependencies.planProvider ?? billingPlanService;
+    this.billingProvider = dependencies.billingProvider ?? billingProviderService;
+    this.now = dependencies.now ?? (() => new Date());
 
-  constructor() {
-    this.db = db;
     if (!this.db && process.env.NODE_ENV !== 'development') {
       throw new Error('Database connection not available');
     }
-    
-    // Start usage tracking (only if database is available)
+
     if (this.db) {
       this.startUsageTracking();
+      this.scheduleInvoiceReconciliation();
     }
   }
 
@@ -136,8 +163,13 @@ export class UsageMeteringService {
     cost: number = 0,
     organizationId?: string
   ): Promise<void> {
+    if (!this.db) {
+      throw new Error('Database connection not available');
+    }
+
     const period = this.getCurrentBillingPeriod();
-    
+    const timestamp = this.now();
+
     try {
       // Update or insert usage record
       const existingUsage = await this.db
@@ -158,7 +190,7 @@ export class UsageMeteringService {
             apiCalls: existingUsage[0].apiCalls + apiCalls,
             tokensUsed: existingUsage[0].tokensUsed + tokensUsed,
             estimatedCost: existingUsage[0].estimatedCost + Math.round(cost * 100), // Convert to cents
-            updatedAt: new Date()
+            updatedAt: timestamp
           })
           .where(and(
             eq(usageTracking.userId, userId),
@@ -175,7 +207,9 @@ export class UsageMeteringService {
           tokensUsed,
           workflowRuns: 0,
           storageUsed: 0,
-          estimatedCost: Math.round(cost * 100)
+          estimatedCost: Math.round(cost * 100),
+          createdAt: timestamp,
+          updatedAt: timestamp
         });
       }
 
@@ -185,7 +219,7 @@ export class UsageMeteringService {
         .set({
           monthlyApiCalls: users.monthlyApiCalls + apiCalls,
           monthlyTokensUsed: users.monthlyTokensUsed + tokensUsed,
-          updatedAt: new Date()
+          updatedAt: timestamp
         })
         .where(eq(users.id, userId));
 
@@ -198,6 +232,16 @@ export class UsageMeteringService {
 
       // Check for quota alerts
       await this.checkQuotaAlerts(userId);
+
+      const user = await this.getUserWithUsage(userId);
+      if (user) {
+        const plan = await this.getPlanByCode(user.planType);
+        await this.emitMeteringEvents(plan, userId, organizationId, [
+          { type: 'api_calls', quantity: apiCalls },
+          { type: 'tokens', quantity: tokensUsed },
+        ]);
+        await this.detectOverages(user, plan, organizationId);
+      }
 
     } catch (error) {
       console.error('❌ Failed to record API usage:', error);
@@ -215,8 +259,13 @@ export class UsageMeteringService {
     tokensUsed: number = 0,
     apiCalls: number = 0
   ): Promise<void> {
+    if (!this.db) {
+      throw new Error('Database connection not available');
+    }
+
     const period = this.getCurrentBillingPeriod();
-    
+    const timestamp = this.now();
+
     try {
       // Update usage tracking
       const existingUsage = await this.db
@@ -236,7 +285,7 @@ export class UsageMeteringService {
             workflowRuns: existingUsage[0].workflowRuns + 1,
             apiCalls: existingUsage[0].apiCalls + apiCalls,
             tokensUsed: existingUsage[0].tokensUsed + tokensUsed,
-            updatedAt: new Date()
+            updatedAt: timestamp
           })
           .where(and(
             eq(usageTracking.userId, userId),
@@ -252,7 +301,9 @@ export class UsageMeteringService {
           tokensUsed,
           workflowRuns: 1,
           storageUsed: 0,
-          estimatedCost: 0
+          estimatedCost: 0,
+          createdAt: timestamp,
+          updatedAt: timestamp
         });
       }
 
@@ -262,12 +313,23 @@ export class UsageMeteringService {
         .set({
           totalRuns: workflows.totalRuns + 1,
           successfulRuns: success ? workflows.successfulRuns + 1 : workflows.successfulRuns,
-          lastRun: new Date(),
-          updatedAt: new Date()
+          lastRun: timestamp,
+          updatedAt: timestamp
         })
         .where(eq(workflows.id, workflowId));
 
       this.clearUserCache(userId);
+
+      const user = await this.getUserWithUsage(userId);
+      if (user) {
+        const plan = await this.getPlanByCode(user.planType);
+        await this.emitMeteringEvents(plan, userId, undefined, [
+          { type: 'workflow_runs', quantity: 1 },
+          { type: 'tokens', quantity: tokensUsed },
+          { type: 'api_calls', quantity: apiCalls },
+        ]);
+        await this.detectOverages(user, plan, undefined);
+      }
 
     } catch (error) {
       console.error('❌ Failed to record workflow execution:', error);
@@ -298,7 +360,7 @@ export class UsageMeteringService {
         };
       }
 
-      const plan = this.PLANS[user.planType] || this.PLANS.free;
+      const plan = await this.getPlanByCode(user.planType);
       const resetDate = this.getNextBillingPeriod().startDate;
 
       // Check API calls
@@ -354,7 +416,18 @@ export class UsageMeteringService {
    * Get usage metrics for user
    */
   public async getUserUsage(userId: string, year?: number, month?: number): Promise<UsageMetrics> {
-    const period = year && month ? { year, month } : this.getCurrentBillingPeriod();
+    if (!this.db) {
+      throw new Error('Database connection not available');
+    }
+
+    const period = year && month
+      ? {
+          year,
+          month,
+          startDate: new Date(year, month - 1, 1),
+          endDate: new Date(year, month, 0),
+        }
+      : this.getCurrentBillingPeriod();
     const cacheKey = `usage_${userId}_${period.year}_${period.month}`;
     
     // Check cache
@@ -371,8 +444,8 @@ export class UsageMeteringService {
         throw new Error('User not found');
       }
 
-      const plan = this.PLANS[user.planType] || this.PLANS.free;
-      
+      const plan = await this.getPlanByCode(user.planType);
+
       // Get usage data for the period
       const [usage] = await this.db
         .select()
@@ -447,6 +520,10 @@ export class UsageMeteringService {
       estimatedCost: number;
     }>;
   }> {
+    if (!this.db) {
+      throw new Error('Database connection not available');
+    }
+
     try {
       // Get total metrics
       const totalMetrics = await this.db
@@ -521,14 +598,20 @@ export class UsageMeteringService {
    */
   public async resetMonthlyUsage(): Promise<void> {
     console.log('🔄 Resetting monthly usage counters...');
-    
+
+    if (!this.db) {
+      throw new Error('Database connection not available');
+    }
+
+    const timestamp = this.now();
+
     try {
       await this.db
         .update(users)
         .set({
           monthlyApiCalls: 0,
           monthlyTokensUsed: 0,
-          updatedAt: new Date()
+          updatedAt: timestamp
         });
 
       // Clear all caches
@@ -547,20 +630,20 @@ export class UsageMeteringService {
    * Upgrade user plan
    */
   public async upgradeUserPlan(userId: string, newPlan: string): Promise<void> {
-    if (!this.PLANS[newPlan]) {
-      throw new Error(`Invalid plan: ${newPlan}`);
+    if (!this.db) {
+      throw new Error('Database connection not available');
     }
 
+    const plan = await this.getPlanByCode(newPlan);
+
     try {
-      const plan = this.PLANS[newPlan];
-      
       await this.db
         .update(users)
         .set({
           planType: newPlan,
           quotaApiCalls: plan.apiCalls,
           quotaTokens: plan.tokens,
-          updatedAt: new Date()
+          updatedAt: this.now()
         })
         .where(eq(users.id, userId));
 
@@ -576,18 +659,390 @@ export class UsageMeteringService {
   /**
    * Get available plans
    */
-  public getAvailablePlans(): PlanLimits[] {
-    return Object.values(this.PLANS);
+  public async getAvailablePlans(): Promise<PlanLimits[]> {
+    await this.loadPlans();
+    return Array.from(this.plans.values());
+  }
+
+  public async listUsageAlerts(thresholdPercent = 80): Promise<UsageAlert[]> {
+    if (!this.db) {
+      return [];
+    }
+
+    await this.loadPlans();
+
+    const usersList = await this.db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.isActive, true));
+
+    const alerts: UsageAlert[] = [];
+    for (const entry of usersList) {
+      try {
+        const usage = await this.getUserUsage(entry.id);
+        alerts.push(...this.buildUsageAlerts(entry.id, usage, thresholdPercent));
+      } catch (error) {
+        console.error(`❌ Failed to build usage alerts for user ${entry.id}:`, error);
+      }
+    }
+
+    return alerts.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+  }
+
+  public async generateUsageExport(options: {
+    startDate?: Date;
+    endDate?: Date;
+    format?: 'json' | 'csv';
+    planCodes?: string[];
+  } = {}): Promise<UsageExportResult> {
+    if (!this.db) {
+      throw new Error('Database connection not available');
+    }
+
+    const period = (() => {
+      if (options.startDate && options.endDate) {
+        return { startDate: options.startDate, endDate: options.endDate };
+      }
+      const current = this.getCurrentBillingPeriod();
+      return { startDate: current.startDate, endDate: current.endDate };
+    })();
+
+    const rows = await this.db
+      .select({
+        userId: usageTracking.userId,
+        email: users.email,
+        planType: users.planType,
+        apiCalls: sum(usageTracking.apiCalls),
+        tokensUsed: sum(usageTracking.tokensUsed),
+        workflowRuns: sum(usageTracking.workflowRuns),
+        storageUsed: sum(usageTracking.storageUsed),
+        estimatedCost: sum(usageTracking.estimatedCost),
+      })
+      .from(usageTracking)
+      .innerJoin(users, eq(usageTracking.userId, users.id))
+      .where(and(
+        gte(usageTracking.createdAt, period.startDate),
+        lte(usageTracking.createdAt, period.endDate),
+      ))
+      .groupBy(usageTracking.userId, users.email, users.planType);
+
+    await this.loadPlans();
+
+    const filtered = options.planCodes && options.planCodes.length > 0
+      ? rows.filter((row) => options.planCodes?.includes(row.planType))
+      : rows;
+
+    const exportRows: UsageExportRow[] = filtered.map((row) => {
+      const plan = this.plans.get(row.planType) ?? this.plans.get('free');
+      return {
+        userId: row.userId,
+        email: row.email,
+        planCode: row.planType,
+        planName: plan?.name ?? row.planType,
+        apiCalls: Number(row.apiCalls ?? 0),
+        tokensUsed: Number(row.tokensUsed ?? 0),
+        workflowRuns: Number(row.workflowRuns ?? 0),
+        storageUsed: Number(row.storageUsed ?? 0),
+        estimatedCost: Number(row.estimatedCost ?? 0),
+      } satisfies UsageExportRow;
+    });
+
+    const summary = exportRows.reduce(
+      (acc, row) => {
+        acc.totalApiCalls += row.apiCalls;
+        acc.totalTokensUsed += row.tokensUsed;
+        acc.totalWorkflowRuns += row.workflowRuns;
+        acc.totalEstimatedCost += row.estimatedCost;
+        return acc;
+      },
+      {
+        totalApiCalls: 0,
+        totalTokensUsed: 0,
+        totalWorkflowRuns: 0,
+        totalEstimatedCost: 0,
+        distinctUsers: exportRows.length,
+      },
+    );
+
+    const format = options.format ?? 'json';
+    const csv = format === 'csv' ? this.toCsv(exportRows) : undefined;
+
+    return {
+      format,
+      rows: exportRows,
+      csv,
+      summary,
+      period: {
+        startDate: period.startDate,
+        endDate: period.endDate,
+      },
+    } satisfies UsageExportResult;
+  }
+
+  public async calculateProratedCharge(options: {
+    planCode: string;
+    activationDate: Date;
+    periodStart: Date;
+    periodEnd: Date;
+    quantity?: number;
+  }): Promise<number> {
+    const plan = await this.getPlanByCode(options.planCode);
+    if (plan.priceCents <= 0) {
+      return 0;
+    }
+
+    const periodStart = new Date(options.periodStart);
+    const periodEnd = new Date(options.periodEnd);
+    const activation = new Date(options.activationDate);
+
+    const msPerDay = 86_400_000;
+    const totalDays = Math.max(1, Math.ceil((periodEnd.getTime() - periodStart.getTime()) / msPerDay) + 1);
+    const effectiveStart = activation > periodStart ? activation : periodStart;
+    const billableDays = Math.max(0, Math.ceil((periodEnd.getTime() - effectiveStart.getTime()) / msPerDay) + 1);
+
+    if (billableDays <= 0) {
+      return 0;
+    }
+
+    const ratio = Math.min(1, billableDays / totalDays);
+    const quantity = options.quantity ?? 1;
+    return Math.round(plan.priceCents * ratio * quantity);
+  }
+
+  public async reconcileInvoices(): Promise<InvoiceAdjustment[]> {
+    return this.billingProvider.reconcileInvoices(this.now());
   }
 
   /**
    * Private helper methods
    */
+  private async loadPlans(force = false): Promise<void> {
+    const now = this.now().getTime();
+    if (!force && this.plans.size > 0 && this.plansExpireAt > now) {
+      return;
+    }
+
+    if (this.plansLoading) {
+      await this.plansLoading;
+      return;
+    }
+
+    this.plansLoading = (async () => {
+      const definitions = await this.planProvider.listPlans(true);
+      const mapped = new Map<string, PlanLimits>();
+      for (const definition of definitions) {
+        mapped.set(definition.code, this.mapPlanDefinition(definition));
+      }
+      this.plans = mapped;
+      this.plansExpireAt = this.now().getTime() + this.planCacheTtlMs;
+      this.plansLoading = null;
+    })();
+
+    await this.plansLoading;
+  }
+
+  private mapPlanDefinition(plan: BillingPlanDefinition): PlanLimits {
+    return {
+      code: plan.code,
+      name: plan.name,
+      apiCalls: plan.usageQuotas.apiCalls,
+      tokens: plan.usageQuotas.tokens,
+      workflowRuns: plan.usageQuotas.workflowRuns,
+      storage: plan.usageQuotas.storage,
+      priceCents: plan.priceCents,
+      currency: plan.currency,
+      features: Array.isArray(plan.features) ? plan.features : [],
+    } satisfies PlanLimits;
+  }
+
+  private async getPlanByCode(planCode: string): Promise<PlanLimits> {
+    await this.loadPlans();
+    const plan = this.plans.get(planCode) ?? this.plans.get('free');
+    if (!plan) {
+      throw new Error('No billing plans have been configured');
+    }
+    return plan;
+  }
+
+  private calculateUnitPrice(plan: PlanLimits, type: MeteringEventType): number {
+    if (plan.priceCents <= 0) {
+      return 0;
+    }
+
+    let divisor = 0;
+    switch (type) {
+      case 'api_calls':
+        divisor = plan.apiCalls;
+        break;
+      case 'tokens':
+        divisor = plan.tokens;
+        break;
+      case 'workflow_runs':
+        divisor = plan.workflowRuns;
+        break;
+      case 'storage':
+        divisor = plan.storage;
+        break;
+      default:
+        divisor = 0;
+    }
+
+    if (divisor <= 0) {
+      return 0;
+    }
+
+    return Math.max(0, Math.round(plan.priceCents / divisor));
+  }
+
+  private async emitMeteringEvents(
+    plan: PlanLimits,
+    userId: string,
+    organizationId: string | undefined,
+    events: Array<{ type: MeteringEventType; quantity: number }>,
+  ): Promise<void> {
+    for (const event of events) {
+      if (!event.quantity || event.quantity <= 0) {
+        continue;
+      }
+
+      await this.billingProvider.emitMeteringEvent({
+        eventId: randomUUID(),
+        userId,
+        organizationId,
+        planCode: plan.code,
+        usageType: event.type,
+        quantity: event.quantity,
+        unitPriceCents: this.calculateUnitPrice(plan, event.type),
+        occurredAt: this.now(),
+        metadata: {
+          planName: plan.name,
+        },
+      });
+    }
+  }
+
+  private async detectOverages(
+    user: any,
+    plan: PlanLimits,
+    organizationId: string | undefined,
+  ): Promise<void> {
+    const overages: Array<{ resource: string; quantity: number }> = [];
+
+    if (user.monthlyApiCalls > plan.apiCalls) {
+      overages.push({ resource: 'api_calls', quantity: user.monthlyApiCalls - plan.apiCalls });
+    }
+
+    if (user.monthlyTokensUsed > plan.tokens) {
+      overages.push({ resource: 'tokens', quantity: user.monthlyTokensUsed - plan.tokens });
+    }
+
+    for (const overage of overages) {
+      await this.billingProvider.emitMeteringEvent({
+        eventId: randomUUID(),
+        userId: user.id ?? user.userId ?? 'unknown',
+        organizationId,
+        planCode: plan.code,
+        usageType: 'overage',
+        quantity: overage.quantity,
+        unitPriceCents: 0,
+        occurredAt: this.now(),
+        metadata: {
+          resource: overage.resource,
+          limit: overage.resource === 'api_calls' ? plan.apiCalls : plan.tokens,
+        },
+      });
+    }
+  }
+
+  private buildUsageAlerts(userId: string, usage: UsageMetrics, thresholdPercent: number): UsageAlert[] {
+    const alerts: UsageAlert[] = [];
+    const threshold = Math.max(0, thresholdPercent);
+
+    if (usage.usage.apiCallsPercent >= threshold) {
+      alerts.push({
+        userId,
+        type: usage.usage.apiCallsPercent > 100 ? 'limit_exceeded' : 'approaching_limit',
+        quotaType: 'api_calls',
+        threshold: threshold,
+        current: usage.apiCalls,
+        limit: usage.quotas.apiCalls,
+        timestamp: this.now(),
+      });
+    }
+
+    if (usage.usage.tokensPercent >= threshold) {
+      alerts.push({
+        userId,
+        type: usage.usage.tokensPercent > 100 ? 'limit_exceeded' : 'approaching_limit',
+        quotaType: 'tokens',
+        threshold: threshold,
+        current: usage.tokensUsed,
+        limit: usage.quotas.tokens,
+        timestamp: this.now(),
+      });
+    }
+
+    if (usage.usage.workflowRunsPercent >= threshold) {
+      alerts.push({
+        userId,
+        type: usage.usage.workflowRunsPercent > 100 ? 'limit_exceeded' : 'approaching_limit',
+        quotaType: 'workflow_runs',
+        threshold: threshold,
+        current: usage.workflowRuns,
+        limit: usage.quotas.workflowRuns,
+        timestamp: this.now(),
+      });
+    }
+
+    if (usage.usage.storagePercent >= threshold) {
+      alerts.push({
+        userId,
+        type: usage.usage.storagePercent > 100 ? 'limit_exceeded' : 'approaching_limit',
+        quotaType: 'storage',
+        threshold: threshold,
+        current: usage.storageUsed,
+        limit: usage.quotas.storage,
+        timestamp: this.now(),
+      });
+    }
+
+    return alerts;
+  }
+
+  private toCsv(rows: UsageExportRow[]): string {
+    const headers = ['userId', 'email', 'planCode', 'planName', 'apiCalls', 'tokensUsed', 'workflowRuns', 'storageUsed', 'estimatedCost'];
+    const body = rows
+      .map((row) =>
+        [
+          row.userId,
+          row.email,
+          row.planCode,
+          row.planName,
+          row.apiCalls,
+          row.tokensUsed,
+          row.workflowRuns,
+          row.storageUsed,
+          row.estimatedCost,
+        ]
+          .map((value) => {
+            if (typeof value === 'string') {
+              const escaped = value.replace(/"/g, '""');
+              return `"${escaped}"`;
+            }
+            return String(value);
+          })
+          .join(','),
+      )
+      .join('\n');
+
+    return `${headers.join(',')}\n${body}`;
+  }
+
   private getCurrentBillingPeriod(): BillingPeriod {
-    const now = new Date();
+    const now = this.now();
     const year = now.getFullYear();
     const month = now.getMonth() + 1;
-    
+
     return {
       startDate: new Date(year, month - 1, 1),
       endDate: new Date(year, month, 0),
@@ -597,10 +1052,10 @@ export class UsageMeteringService {
   }
 
   private getNextBillingPeriod(): BillingPeriod {
-    const now = new Date();
+    const now = this.now();
     const year = now.getMonth() === 11 ? now.getFullYear() + 1 : now.getFullYear();
     const month = now.getMonth() === 11 ? 1 : now.getMonth() + 2;
-    
+
     return {
       startDate: new Date(year, month - 1, 1),
       endDate: new Date(year, month, 0),
@@ -620,6 +1075,10 @@ export class UsageMeteringService {
   }
 
   private async getTotalActiveUsers(): Promise<number> {
+    if (!this.db) {
+      return 0;
+    }
+
     const result = await this.db
       .select({ count: count() })
       .from(users)
@@ -638,35 +1097,8 @@ export class UsageMeteringService {
   private async checkQuotaAlerts(userId: string): Promise<void> {
     try {
       const usage = await this.getUserUsage(userId);
-      
-      // Check for approaching limits (80% threshold)
-      const alerts: UsageAlert[] = [];
-      
-      if (usage.usage.apiCallsPercent > 80) {
-        alerts.push({
-          userId,
-          type: usage.usage.apiCallsPercent > 100 ? 'limit_exceeded' : 'approaching_limit',
-          quotaType: 'api_calls',
-          threshold: 80,
-          current: usage.apiCalls,
-          limit: usage.quotas.apiCalls,
-          timestamp: new Date()
-        });
-      }
+      const alerts = this.buildUsageAlerts(userId, usage, 80);
 
-      if (usage.usage.tokensPercent > 80) {
-        alerts.push({
-          userId,
-          type: usage.usage.tokensPercent > 100 ? 'limit_exceeded' : 'approaching_limit',
-          quotaType: 'tokens',
-          threshold: 80,
-          current: usage.tokensUsed,
-          limit: usage.quotas.tokens,
-          timestamp: new Date()
-        });
-      }
-
-      // Send alerts (in a real implementation, you'd send emails/notifications)
       for (const alert of alerts) {
         console.log(`🚨 Usage alert for user ${userId}: ${alert.type} for ${alert.quotaType}`);
       }
@@ -680,7 +1112,7 @@ export class UsageMeteringService {
     console.log('📊 Starting usage tracking...');
 
     // Reset monthly usage on the 1st of each month
-    const now = new Date();
+    const now = this.now();
     const nextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
     const MAX_TIMEOUT_MS = 2_147_483_647; // Maximum delay supported by Node.js timers
 
@@ -717,6 +1149,33 @@ export class UsageMeteringService {
     };
 
     scheduleNextReset(nextMonth);
+  }
+
+  private scheduleInvoiceReconciliation(intervalMs = 1000 * 60 * 60): void {
+    if (process.env.NODE_ENV === 'test') {
+      return;
+    }
+
+    const run = async () => {
+      try {
+        const adjustments = await this.billingProvider.reconcileInvoices(this.now());
+        if (adjustments.length > 0) {
+          console.log(`📄 Reconciled ${adjustments.length} billing adjustments.`);
+        }
+      } catch (error) {
+        console.error('❌ Failed to reconcile invoices:', error);
+      }
+    };
+
+    void run();
+
+    if (this.reconciliationTimer) {
+      clearInterval(this.reconciliationTimer);
+    }
+
+    this.reconciliationTimer = setInterval(() => {
+      void run();
+    }, Math.max(5 * 60 * 1000, intervalMs));
   }
 }
 

--- a/server/services/__tests__/UsageMeteringService.billingFlows.test.ts
+++ b/server/services/__tests__/UsageMeteringService.billingFlows.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { UsageMeteringService, type PlanLimits } from '../UsageMeteringService';
+import type { BillingPlanProvider, BillingPlanDefinition } from '../BillingPlanService';
+import { BillingProviderService, InMemoryBillingProviderAdapter, type MeteringEvent } from '../BillingProviderService';
+
+type MinimalPlan = BillingPlanDefinition & { organizationLimits?: any };
+
+const basePlan: MinimalPlan = {
+  id: 'plan-pro',
+  code: 'pro',
+  name: 'Pro',
+  priceCents: 10000,
+  currency: 'usd',
+  features: ['Priority support'],
+  usageQuotas: {
+    apiCalls: 1000,
+    tokens: 10000,
+    workflowRuns: 100,
+    storage: 1024 * 1024,
+  },
+  organizationLimits: {
+    maxWorkflows: 100,
+    maxExecutions: 50000,
+    maxUsers: 25,
+    maxStorage: 25600,
+    maxConcurrentExecutions: 10,
+    maxExecutionsPerMinute: 300,
+  },
+  isActive: true,
+};
+
+class RecordingAdapter extends InMemoryBillingProviderAdapter {
+  public getRecordedEvents(): MeteringEvent[] {
+    return this.getEvents();
+  }
+}
+
+const createService = () => {
+  const plans: MinimalPlan[] = [basePlan];
+  const planProvider: BillingPlanProvider = {
+    async getPlan(code) {
+      return plans.find((plan) => plan.code === code) ?? null;
+    },
+    async getUsagePlan(code) {
+      return plans.find((plan) => plan.code === code) ?? basePlan;
+    },
+    async listPlans() {
+      return plans;
+    },
+    async refresh() {
+      return;
+    },
+  };
+
+  const adapter = new RecordingAdapter();
+  const billingProvider = new BillingProviderService(adapter);
+  const dbStub = {
+    update: () => ({
+      set: () => ({
+        where: async () => [],
+      }),
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [],
+        }),
+        limit: async () => [],
+        groupBy: () => ({
+          orderBy: () => ({
+            limit: async () => [],
+          }),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: async () => [],
+    }),
+  } as any;
+
+  const service = new UsageMeteringService({
+    planProvider,
+    billingProvider,
+    db: dbStub,
+    now: () => new Date('2024-01-15T00:00:00Z'),
+  });
+
+  return { service, adapter };
+};
+
+test('calculateProratedCharge returns prorated cents based on activation date', async () => {
+  const { service } = createService();
+  const cents = await service.calculateProratedCharge({
+    planCode: 'pro',
+    activationDate: new Date('2024-01-16T00:00:00Z'),
+    periodStart: new Date('2024-01-01T00:00:00Z'),
+    periodEnd: new Date('2024-01-31T23:59:59Z'),
+  });
+
+  // Half-month usage should charge approximately half the monthly price.
+  assert.equal(cents, 5000);
+});
+
+test('detectOverages emits metering events when usage exceeds plan limits', async () => {
+  const { service, adapter } = createService();
+  const plan = await (service as any).getPlanByCode('pro') as PlanLimits;
+
+  await (service as any).detectOverages(
+    {
+      id: 'user-123',
+      monthlyApiCalls: plan.apiCalls + 25,
+      monthlyTokensUsed: plan.tokens + 4000,
+    },
+    plan,
+    'org-1'
+  );
+
+  const events = adapter.getRecordedEvents().filter((event) => event.usageType === 'overage');
+  assert.equal(events.length, 2);
+  const apiEvent = events.find((event) => event.metadata?.resource === 'api_calls');
+  const tokenEvent = events.find((event) => event.metadata?.resource === 'tokens');
+  assert.ok(apiEvent);
+  assert.ok(tokenEvent);
+  assert.equal(apiEvent?.quantity, 25);
+  assert.equal(tokenEvent?.quantity, 4000);
+});
+
+test('reconcileInvoices delegates to billing provider adapter', async () => {
+  const { service, adapter } = createService();
+  adapter.recordAdjustment({
+    invoiceId: 'inv-1',
+    amountDueCents: 1234,
+    description: 'Overage adjustment',
+    createdAt: new Date('2024-01-15T12:00:00Z'),
+  });
+
+  const adjustments = await service.reconcileInvoices();
+  assert.equal(adjustments.length, 1);
+  assert.equal(adjustments[0]?.amountDueCents, 1234);
+});


### PR DESCRIPTION
## Summary
- move billing plan quotas into a database-backed configuration service seeded from `configs/billing-plans.json` and migrate existing plan consumers
- wire the usage metering service to emit metering and overage events to a billing provider abstraction and expose invoice reconciliation utilities
- add finance-focused usage export and alert APIs plus an `/admin/usage` UI for downloading CSV reports and monitoring quota alerts
- cover prorated billing, overage detection, and reconciliation flows with new automated tests

## Testing
- Not run (package installation blocked by npm registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68e08b2bd75c83319e2beaf5c6314c04