### PR TITLE
feat: track connector lifecycle and contract tests

### DIFF
--- a/client/src/pages/AdminSettings.tsx
+++ b/client/src/pages/AdminSettings.tsx
@@ -7,6 +7,22 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Separator } from '@/components/ui/separator';
+import { Switch } from '@/components/ui/switch';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import {
   Settings,
   Key,
@@ -17,11 +33,85 @@ import {
   AlertCircle,
   Activity,
   Eye,
-  EyeOff
+  EyeOff,
+  Loader2
 } from 'lucide-react';
 import ConnectionManager from '@/components/connections/ConnectionManager';
 import { useAuthStore } from '@/store/authStore';
 import { toast } from 'sonner';
+
+type ConnectorLifecycleStatus = 'ga' | 'beta' | 'deprecated' | 'sunset';
+
+interface ConnectorLifecycleRow {
+  id: string;
+  slug: string;
+  name: string;
+  version: string;
+  semanticVersion: string;
+  lifecycleStatus: ConnectorLifecycleStatus;
+  isBeta: boolean;
+  betaStartAt: string | null;
+  betaEndAt: string | null;
+  deprecationStartAt: string | null;
+  sunsetAt: string | null;
+  updating?: boolean;
+}
+
+const LIFECYCLE_OPTIONS: ConnectorLifecycleStatus[] = ['ga', 'beta', 'deprecated', 'sunset'];
+
+const LIFECYCLE_LABELS: Record<ConnectorLifecycleStatus, string> = {
+  ga: 'General Availability',
+  beta: 'Beta',
+  deprecated: 'Deprecated',
+  sunset: 'Sunset Scheduled',
+};
+
+const formatDateForInput = (value: string | null) => (value ? value.slice(0, 10) : '');
+
+const formatDateForBadge = (value: string | null) => {
+  if (!value) {
+    return '';
+  }
+  try {
+    return new Date(value).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  } catch {
+    return value;
+  }
+};
+
+const normalizeConnectorLifecycle = (item: any): ConnectorLifecycleRow => {
+  const coerceStatus = (status: any): ConnectorLifecycleStatus => {
+    const normalized = String(status ?? '').toLowerCase();
+    return LIFECYCLE_OPTIONS.includes(normalized as ConnectorLifecycleStatus)
+      ? (normalized as ConnectorLifecycleStatus)
+      : 'ga';
+  };
+
+  const status = coerceStatus(item.lifecycleStatus ?? (item.isBeta ? 'beta' : 'ga'));
+  const version = typeof item.version === 'string' && item.version ? item.version : '1.0.0';
+  const semanticVersion = typeof item.semanticVersion === 'string' && item.semanticVersion
+    ? item.semanticVersion
+    : version;
+
+  return {
+    id: item.id,
+    slug: item.slug,
+    name: item.name,
+    version,
+    semanticVersion,
+    lifecycleStatus: status,
+    isBeta: Boolean(item.isBeta ?? status === 'beta'),
+    betaStartAt: item.betaStartAt ?? null,
+    betaEndAt: item.betaEndAt ?? null,
+    deprecationStartAt: item.deprecationStartAt ?? null,
+    sunsetAt: item.sunsetAt ?? null,
+    updating: false,
+  };
+};
 
 export default function AdminSettings() {
   const [apiKeys, setApiKeys] = useState({
@@ -48,6 +138,8 @@ export default function AdminSettings() {
     concurrentExecutions: 0,
     executionsInCurrentWindow: 0
   });
+  const [connectorLifecycle, setConnectorLifecycle] = useState<ConnectorLifecycleRow[]>([]);
+  const [connectorLifecycleLoading, setConnectorLifecycleLoading] = useState(false);
 
   const { authFetch, activeOrganizationId } = useAuthStore((state) => ({
     authFetch: state.authFetch,
@@ -192,6 +284,85 @@ export default function AdminSettings() {
       ...prev,
       [provider]: !prev[provider]
     }));
+  };
+
+  const loadConnectorLifecycle = async () => {
+    setConnectorLifecycleLoading(true);
+    try {
+      const response = await authFetch('/api/admin/connectors/lifecycle');
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data?.error || 'Failed to load connector lifecycle');
+      }
+
+      const rows = Array.isArray(data.data)
+        ? data.data.map(normalizeConnectorLifecycle)
+        : [];
+      setConnectorLifecycle(rows);
+    } catch (error: any) {
+      console.error('Failed to load connector lifecycle:', error);
+      toast.error(error?.message || 'Failed to load connector lifecycle');
+    } finally {
+      setConnectorLifecycleLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadConnectorLifecycle();
+  }, [authFetch]);
+
+  const toIsoOrNull = (value: string): string | null => {
+    if (!value) {
+      return null;
+    }
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+    return parsed.toISOString();
+  };
+
+  const updateConnectorLifecycle = async (slug: string, updates: Partial<ConnectorLifecycleRow>) => {
+    if (!slug) {
+      return;
+    }
+
+    let previous: ConnectorLifecycleRow | undefined;
+    setConnectorLifecycle(prev => prev.map((connector) => {
+      if (connector.slug !== slug) {
+        return connector;
+      }
+      previous = { ...connector };
+      return { ...connector, ...updates, updating: true };
+    }));
+
+    try {
+      const response = await authFetch(`/api/admin/connectors/${slug}/lifecycle`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data?.error || 'Failed to update connector lifecycle');
+      }
+
+      const normalized = normalizeConnectorLifecycle(data.data);
+      setConnectorLifecycle(prev => prev.map((connector) => (connector.slug === slug ? normalized : connector)));
+      toast.success(`Updated ${normalized.name}`);
+    } catch (error: any) {
+      console.error('Failed to update connector lifecycle:', error);
+      toast.error(error?.message || 'Failed to update connector lifecycle');
+      if (previous) {
+        setConnectorLifecycle(prev => prev.map((connector) => (
+          connector.slug === slug
+            ? { ...previous!, updating: false }
+            : connector
+        )));
+      } else {
+        loadConnectorLifecycle();
+      }
+    }
   };
 
   return (
@@ -502,6 +673,204 @@ export default function AdminSettings() {
                   💰 <strong>Cost Savings</strong>: Using Gemini Pro saves ~95% vs GPT-4 while maintaining quality
                 </p>
               </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <CardTitle className="flex items-center gap-2">
+                  <AlertCircle className="w-5 h-5 text-amber-600" />
+                  Connector Lifecycle Management
+                </CardTitle>
+                <Badge variant="outline" className="text-xs">
+                  {connectorLifecycle.length} connectors
+                </Badge>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Mark beta rollouts, plan deprecations, and keep semantic versions aligned with connector releases.
+              </p>
+            </CardHeader>
+            <CardContent>
+              {connectorLifecycleLoading ? (
+                <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Loading connector metadata…
+                </div>
+              ) : connectorLifecycle.length === 0 ? (
+                <div className="py-10 text-center text-sm text-muted-foreground">
+                  No connectors found. Seed connector definitions to manage lifecycle.
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="min-w-[220px]">Connector</TableHead>
+                        <TableHead className="min-w-[140px]">Version</TableHead>
+                        <TableHead className="min-w-[160px]">Status</TableHead>
+                        <TableHead className="min-w-[260px]">Beta Program</TableHead>
+                        <TableHead className="min-w-[260px]">Deprecation &amp; Sunset</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {connectorLifecycle.map((row) => (
+                        <TableRow key={row.id}>
+                          <TableCell>
+                            <div className="flex flex-col gap-1">
+                              <div className="flex items-center gap-2">
+                                <span className="font-medium text-sm text-gray-900">{row.name}</span>
+                                {row.updating && (
+                                  <Badge className="flex items-center gap-1 bg-blue-100 text-blue-700 border-blue-200 text-[10px] uppercase tracking-wide">
+                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                    Saving
+                                  </Badge>
+                                )}
+                              </div>
+                              <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                <span>{row.slug}</span>
+                                <Badge className="bg-slate-100 text-slate-700 border-slate-200 text-[10px]">
+                                  {LIFECYCLE_LABELS[row.lifecycleStatus]}
+                                </Badge>
+                                {row.lifecycleStatus === 'beta' && (
+                                  <Badge className="bg-amber-100 text-amber-700 border-amber-200 text-[10px]">Beta</Badge>
+                                )}
+                                {row.lifecycleStatus === 'deprecated' && (
+                                  <Badge className="bg-red-100 text-red-700 border-red-200 text-[10px]">Deprecated</Badge>
+                                )}
+                                {row.lifecycleStatus === 'sunset' && row.sunsetAt && (
+                                  <Badge className="bg-orange-100 text-orange-700 border-orange-200 text-[10px]">
+                                    Sunsets {formatDateForBadge(row.sunsetAt)}
+                                  </Badge>
+                                )}
+                              </div>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <Badge variant="outline" className="text-[10px] px-2 py-0.5 bg-slate-100 text-slate-700">
+                                v{row.semanticVersion}
+                              </Badge>
+                              {row.version && row.version !== row.semanticVersion && (
+                                <Badge variant="outline" className="text-[10px] px-2 py-0.5">
+                                  schema {row.version}
+                                </Badge>
+                              )}
+                              {row.sunsetAt && (
+                                <span className="text-[10px] text-muted-foreground">
+                                  Sunset {formatDateForBadge(row.sunsetAt)}
+                                </span>
+                              )}
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <Select
+                              value={row.lifecycleStatus}
+                              onValueChange={(value) =>
+                                updateConnectorLifecycle(row.slug, {
+                                  lifecycleStatus: value as ConnectorLifecycleStatus,
+                                  isBeta: value === 'beta',
+                                })
+                              }
+                              disabled={row.updating}
+                            >
+                              <SelectTrigger className="w-[180px]" disabled={row.updating}>
+                                <SelectValue placeholder="Select status" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {LIFECYCLE_OPTIONS.map((option) => (
+                                  <SelectItem key={option} value={option}>
+                                    {LIFECYCLE_LABELS[option]}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex flex-col gap-2">
+                              <div className="flex items-center gap-2">
+                                <Switch
+                                  checked={row.isBeta}
+                                  onCheckedChange={(checked) =>
+                                    updateConnectorLifecycle(row.slug, {
+                                      isBeta: checked,
+                                      lifecycleStatus:
+                                        checked
+                                          ? 'beta'
+                                          : row.lifecycleStatus === 'beta'
+                                            ? 'ga'
+                                            : row.lifecycleStatus,
+                                    })
+                                  }
+                                  disabled={row.updating}
+                                />
+                                <span className="text-xs text-muted-foreground">
+                                  {row.isBeta ? 'Beta enabled' : 'Beta disabled'}
+                                </span>
+                              </div>
+                              <div className="grid grid-cols-2 gap-2">
+                                <Input
+                                  type="date"
+                                  value={formatDateForInput(row.betaStartAt)}
+                                  onChange={(event) =>
+                                    updateConnectorLifecycle(row.slug, {
+                                      betaStartAt: toIsoOrNull(event.target.value),
+                                    })
+                                  }
+                                  disabled={row.updating}
+                                />
+                                <Input
+                                  type="date"
+                                  value={formatDateForInput(row.betaEndAt)}
+                                  onChange={(event) =>
+                                    updateConnectorLifecycle(row.slug, {
+                                      betaEndAt: toIsoOrNull(event.target.value),
+                                    })
+                                  }
+                                  disabled={row.updating}
+                                />
+                              </div>
+                              <p className="text-[10px] text-muted-foreground">Define beta invite window</p>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <div className="grid grid-cols-2 gap-2">
+                              <Input
+                                type="date"
+                                value={formatDateForInput(row.deprecationStartAt)}
+                                onChange={(event) =>
+                                  updateConnectorLifecycle(row.slug, {
+                                    deprecationStartAt: toIsoOrNull(event.target.value),
+                                  })
+                                }
+                                disabled={row.updating}
+                              />
+                              <Input
+                                type="date"
+                                value={formatDateForInput(row.sunsetAt)}
+                                onChange={(event) =>
+                                  updateConnectorLifecycle(row.slug, {
+                                    sunsetAt: toIsoOrNull(event.target.value),
+                                  })
+                                }
+                                disabled={row.updating}
+                              />
+                            </div>
+                            <div className="mt-1 space-y-1 text-[10px] text-muted-foreground">
+                              {row.deprecationStartAt && (
+                                <div>Deprecates {formatDateForBadge(row.deprecationStartAt)}</div>
+                              )}
+                              {row.sunsetAt && (
+                                <div>Sunsets {formatDateForBadge(row.sunsetAt)}</div>
+                              )}
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/connectors/adobesign/definition.json
+++ b/connectors/adobesign/definition.json
@@ -11,7 +11,11 @@
     "config": {
       "authUrl": "https://secure.na1.echosign.com/public/oauth",
       "tokenUrl": "https://api.na1.echosign.com/oauth/token",
-      "scopes": ["agreement_read", "agreement_write", "agreement_send"]
+      "scopes": [
+        "agreement_read",
+        "agreement_write",
+        "agreement_send"
+      ]
     }
   },
   "baseUrl": "https://api.na1.echosign.com/api/rest/v6",
@@ -43,9 +47,15 @@
             "items": {
               "type": "object",
               "properties": {
-                "documentURL": {"type": "string"},
-                "fileName": {"type": "string"},
-                "mimeType": {"type": "string"}
+                "documentURL": {
+                  "type": "string"
+                },
+                "fileName": {
+                  "type": "string"
+                },
+                "mimeType": {
+                  "type": "string"
+                }
               }
             },
             "description": "Array of file information objects"
@@ -55,30 +65,52 @@
             "items": {
               "type": "object",
               "properties": {
-                "memberInfos": {"type": "array"},
-                "order": {"type": "number"},
-                "role": {"type": "string", "enum": ["SIGNER", "APPROVER", "DELEGATOR", "FORM_FILLER"]}
+                "memberInfos": {
+                  "type": "array"
+                },
+                "order": {
+                  "type": "number"
+                },
+                "role": {
+                  "type": "string",
+                  "enum": [
+                    "SIGNER",
+                    "APPROVER",
+                    "DELEGATOR",
+                    "FORM_FILLER"
+                  ]
+                }
               }
             },
             "description": "Array of participant set information"
           },
           "signatureType": {
             "type": "string",
-            "enum": ["ESIGN", "WRITTEN"],
+            "enum": [
+              "ESIGN",
+              "WRITTEN"
+            ],
             "default": "ESIGN",
             "description": "Signature type"
           },
           "state": {
             "type": "string",
-            "enum": ["IN_PROCESS", "AUTHORING"],
+            "enum": [
+              "IN_PROCESS",
+              "AUTHORING"
+            ],
             "default": "IN_PROCESS",
             "description": "Agreement state"
           },
           "emailOption": {
             "type": "object",
             "properties": {
-              "sendOptions": {"type": "object"},
-              "reminderFrequency": {"type": "string"}
+              "sendOptions": {
+                "type": "object"
+              },
+              "reminderFrequency": {
+                "type": "string"
+              }
             },
             "description": "Email options"
           },
@@ -91,7 +123,11 @@
             "description": "Custom message to participants"
           }
         },
-        "required": ["name", "fileInfos", "participantSetsInfo"],
+        "required": [
+          "name",
+          "fileInfos",
+          "participantSetsInfo"
+        ],
         "additionalProperties": false
       }
     },
@@ -107,7 +143,9 @@
             "description": "Agreement ID to send"
           }
         },
-        "required": ["agreementId"],
+        "required": [
+          "agreementId"
+        ],
         "additionalProperties": false
       }
     },
@@ -123,7 +161,9 @@
             "description": "Agreement ID"
           }
         },
-        "required": ["agreementId"],
+        "required": [
+          "agreementId"
+        ],
         "additionalProperties": false
       }
     },
@@ -143,7 +183,9 @@
             "description": "Cancellation comment"
           }
         },
-        "required": ["agreementId"],
+        "required": [
+          "agreementId"
+        ],
         "additionalProperties": false
       }
     }
@@ -168,10 +210,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventType": {"type": "string"},
-          "agreementId": {"type": "string"},
-          "participantSetId": {"type": "string"},
-          "timestamp": {"type": "string"}
+          "eventType": {
+            "type": "string"
+          },
+          "agreementId": {
+            "type": "string"
+          },
+          "participantSetId": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          }
         }
       }
     },
@@ -189,9 +239,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventType": {"type": "string"},
-          "agreementId": {"type": "string"},
-          "actionType": {"type": "string"}
+          "eventType": {
+            "type": "string"
+          },
+          "agreementId": {
+            "type": "string"
+          },
+          "actionType": {
+            "type": "string"
+          }
         }
       }
     }
@@ -199,5 +255,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/adp/definition.json
+++ b/connectors/adp/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://accounts.adp.com/auth/oauth/v2/authorize",
       "tokenUrl": "https://accounts.adp.com/auth/oauth/v2/token",
-      "scopes": ["api"]
+      "scopes": [
+        "api"
+      ]
     }
   },
   "baseUrl": "https://api.adp.com",
@@ -39,7 +41,9 @@
             "description": "Worker ID"
           }
         },
-        "required": ["worker_id"],
+        "required": [
+          "worker_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -57,8 +61,14 @@
           "workerDates": {
             "type": "object",
             "properties": {
-              "originalHireDate": {"type": "string", "format": "date"},
-              "rehireDate": {"type": "string", "format": "date"}
+              "originalHireDate": {
+                "type": "string",
+                "format": "date"
+              },
+              "rehireDate": {
+                "type": "string",
+                "format": "date"
+              }
             },
             "description": "Worker dates"
           },
@@ -68,16 +78,26 @@
               "legalName": {
                 "type": "object",
                 "properties": {
-                  "givenName": {"type": "string"},
-                  "familyName1": {"type": "string"},
-                  "middleName": {"type": "string"}
+                  "givenName": {
+                    "type": "string"
+                  },
+                  "familyName1": {
+                    "type": "string"
+                  },
+                  "middleName": {
+                    "type": "string"
+                  }
                 }
               },
               "communication": {
                 "type": "object",
                 "properties": {
-                  "emails": {"type": "array"},
-                  "phones": {"type": "array"}
+                  "emails": {
+                    "type": "array"
+                  },
+                  "phones": {
+                    "type": "array"
+                  }
                 }
               }
             },
@@ -85,11 +105,15 @@
           },
           "workAssignments": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Work assignments"
           }
         },
-        "required": ["person"],
+        "required": [
+          "person"
+        ],
         "additionalProperties": false
       }
     },
@@ -109,7 +133,9 @@
             "description": "Updated person information"
           }
         },
-        "required": ["worker_id"],
+        "required": [
+          "worker_id"
+        ],
         "additionalProperties": false
       }
     }
@@ -129,8 +155,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventType": {"type": "string"},
-          "worker": {"type": "object"}
+          "eventType": {
+            "type": "string"
+          },
+          "worker": {
+            "type": "object"
+          }
         }
       }
     }
@@ -138,5 +168,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/hr/v2/workers"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/adyen/definition.json
+++ b/connectors/adyen/definition.json
@@ -37,8 +37,12 @@
           "amount": {
             "type": "object",
             "properties": {
-              "currency": {"type": "string"},
-              "value": {"type": "number"}
+              "currency": {
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              }
             },
             "description": "Payment amount"
           },
@@ -49,11 +53,21 @@
           "paymentMethod": {
             "type": "object",
             "properties": {
-              "type": {"type": "string"},
-              "encryptedCardNumber": {"type": "string"},
-              "encryptedExpiryMonth": {"type": "string"},
-              "encryptedExpiryYear": {"type": "string"},
-              "encryptedSecurityCode": {"type": "string"}
+              "type": {
+                "type": "string"
+              },
+              "encryptedCardNumber": {
+                "type": "string"
+              },
+              "encryptedExpiryMonth": {
+                "type": "string"
+              },
+              "encryptedExpiryYear": {
+                "type": "string"
+              },
+              "encryptedSecurityCode": {
+                "type": "string"
+              }
             },
             "description": "Payment method details"
           },
@@ -80,7 +94,13 @@
             "description": "Country code"
           }
         },
-        "required": ["amount", "reference", "paymentMethod", "returnUrl", "merchantAccount"],
+        "required": [
+          "amount",
+          "reference",
+          "paymentMethod",
+          "returnUrl",
+          "merchantAccount"
+        ],
         "additionalProperties": false
       }
     },
@@ -98,8 +118,12 @@
           "amount": {
             "type": "object",
             "properties": {
-              "currency": {"type": "string"},
-              "value": {"type": "number"}
+              "currency": {
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              }
             },
             "description": "Amount to capture"
           },
@@ -112,7 +136,11 @@
             "description": "Capture reference"
           }
         },
-        "required": ["paymentPspReference", "amount", "merchantAccount"],
+        "required": [
+          "paymentPspReference",
+          "amount",
+          "merchantAccount"
+        ],
         "additionalProperties": false
       }
     },
@@ -130,8 +158,12 @@
           "amount": {
             "type": "object",
             "properties": {
-              "currency": {"type": "string"},
-              "value": {"type": "number"}
+              "currency": {
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              }
             },
             "description": "Refund amount"
           },
@@ -144,7 +176,11 @@
             "description": "Refund reference"
           }
         },
-        "required": ["paymentPspReference", "amount", "merchantAccount"],
+        "required": [
+          "paymentPspReference",
+          "amount",
+          "merchantAccount"
+        ],
         "additionalProperties": false
       }
     }
@@ -164,10 +200,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "pspReference": {"type": "string"},
-          "merchantReference": {"type": "string"},
-          "eventCode": {"type": "string"},
-          "success": {"type": "boolean"}
+          "pspReference": {
+            "type": "string"
+          },
+          "merchantReference": {
+            "type": "string"
+          },
+          "eventCode": {
+            "type": "string"
+          },
+          "success": {
+            "type": "boolean"
+          }
         }
       }
     }
@@ -175,5 +219,19 @@
   "testConnection": {
     "method": "POST",
     "endpoint": "/payments"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/airtable-enhanced/definition.json
+++ b/connectors/airtable-enhanced/definition.json
@@ -44,7 +44,9 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to retrieve"
           },
           "filterByFormula": {
@@ -70,8 +72,16 @@
             "items": {
               "type": "object",
               "properties": {
-                "field": {"type": "string"},
-                "direction": {"type": "string", "enum": ["asc", "desc"]}
+                "field": {
+                  "type": "string"
+                },
+                "direction": {
+                  "type": "string",
+                  "enum": [
+                    "asc",
+                    "desc"
+                  ]
+                }
               }
             },
             "description": "Sort configuration"
@@ -82,7 +92,10 @@
           },
           "cellFormat": {
             "type": "string",
-            "enum": ["json", "string"],
+            "enum": [
+              "json",
+              "string"
+            ],
             "default": "json",
             "description": "Cell format"
           },
@@ -95,7 +108,10 @@
             "description": "User locale"
           }
         },
-        "required": ["baseId", "tableId"],
+        "required": [
+          "baseId",
+          "tableId"
+        ],
         "additionalProperties": false
       }
     },
@@ -119,7 +135,11 @@
             "description": "Record ID"
           }
         },
-        "required": ["baseId", "tableId", "recordId"],
+        "required": [
+          "baseId",
+          "tableId",
+          "recordId"
+        ],
         "additionalProperties": false
       }
     },
@@ -148,7 +168,11 @@
             "description": "Automatically typecast field values"
           }
         },
-        "required": ["baseId", "tableId", "fields"],
+        "required": [
+          "baseId",
+          "tableId",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -181,7 +205,12 @@
             "description": "Automatically typecast field values"
           }
         },
-        "required": ["baseId", "tableId", "recordId", "fields"],
+        "required": [
+          "baseId",
+          "tableId",
+          "recordId",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -205,7 +234,11 @@
             "description": "Record ID"
           }
         },
-        "required": ["baseId", "tableId", "recordId"],
+        "required": [
+          "baseId",
+          "tableId",
+          "recordId"
+        ],
         "additionalProperties": false
       }
     },
@@ -229,7 +262,9 @@
             "items": {
               "type": "object",
               "properties": {
-                "fields": {"type": "object"}
+                "fields": {
+                  "type": "object"
+                }
               }
             },
             "maxItems": 10,
@@ -241,7 +276,11 @@
             "description": "Automatically typecast field values"
           }
         },
-        "required": ["baseId", "tableId", "records"],
+        "required": [
+          "baseId",
+          "tableId",
+          "records"
+        ],
         "additionalProperties": false
       }
     },
@@ -265,8 +304,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"},
-                "fields": {"type": "object"}
+                "id": {
+                  "type": "string"
+                },
+                "fields": {
+                  "type": "object"
+                }
               }
             },
             "maxItems": 10,
@@ -278,7 +321,11 @@
             "description": "Automatically typecast field values"
           }
         },
-        "required": ["baseId", "tableId", "records"],
+        "required": [
+          "baseId",
+          "tableId",
+          "records"
+        ],
         "additionalProperties": false
       }
     }
@@ -307,9 +354,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "fields": {"type": "object"},
-          "createdTime": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "object"
+          },
+          "createdTime": {
+            "type": "string"
+          }
         }
       }
     },
@@ -332,9 +385,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "fields": {"type": "object"},
-          "createdTime": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "object"
+          },
+          "createdTime": {
+            "type": "string"
+          }
         }
       }
     }
@@ -342,5 +401,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/meta/bases"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/airtable/definition.json
+++ b/connectors/airtable/definition.json
@@ -53,7 +53,11 @@
             "description": "Automatically format data"
           }
         },
-        "required": ["baseId", "tableId", "fields"],
+        "required": [
+          "baseId",
+          "tableId",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -86,7 +90,12 @@
             "description": "Automatically format data"
           }
         },
-        "required": ["baseId", "tableId", "recordId", "fields"],
+        "required": [
+          "baseId",
+          "tableId",
+          "recordId",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -110,7 +119,11 @@
             "description": "Record ID"
           }
         },
-        "required": ["baseId", "tableId", "recordId"],
+        "required": [
+          "baseId",
+          "tableId",
+          "recordId"
+        ],
         "additionalProperties": false
       }
     },
@@ -131,7 +144,9 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to include"
           },
           "filterByFormula": {
@@ -153,8 +168,16 @@
             "items": {
               "type": "object",
               "properties": {
-                "field": {"type": "string"},
-                "direction": {"type": "string", "enum": ["asc", "desc"]}
+                "field": {
+                  "type": "string"
+                },
+                "direction": {
+                  "type": "string",
+                  "enum": [
+                    "asc",
+                    "desc"
+                  ]
+                }
               }
             },
             "description": "Sort configuration"
@@ -164,7 +187,10 @@
             "description": "View name"
           }
         },
-        "required": ["baseId", "tableId"],
+        "required": [
+          "baseId",
+          "tableId"
+        ],
         "additionalProperties": false
       }
     },
@@ -188,7 +214,11 @@
             "description": "Record ID"
           }
         },
-        "required": ["baseId", "tableId", "recordId"],
+        "required": [
+          "baseId",
+          "tableId",
+          "recordId"
+        ],
         "additionalProperties": false
       }
     }
@@ -217,9 +247,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "fields": {"type": "object"},
-          "createdTime": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "object"
+          },
+          "createdTime": {
+            "type": "string"
+          }
         }
       }
     },
@@ -246,9 +282,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "fields": {"type": "object"},
-          "createdTime": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "object"
+          },
+          "createdTime": {
+            "type": "string"
+          }
         }
       }
     }
@@ -256,5 +298,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/meta/bases"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/ansible/definition.json
+++ b/connectors/ansible/definition.json
@@ -54,7 +54,9 @@
             "description": "Host pattern to limit execution"
           }
         },
-        "required": ["job_template_id"],
+        "required": [
+          "job_template_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -71,7 +73,9 @@
             "description": "Job ID"
           }
         },
-        "required": ["job_id"],
+        "required": [
+          "job_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -96,7 +100,9 @@
             "description": "Organization ID"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -121,7 +127,10 @@
             "description": "Host variables"
           }
         },
-        "required": ["inventory_id", "name"],
+        "required": [
+          "inventory_id",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -150,7 +159,9 @@
             "description": "Job template ID"
           }
         },
-        "required": ["job_template_id"],
+        "required": [
+          "job_template_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -182,7 +193,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["successful", "failed", "error", "canceled"],
+            "enum": [
+              "successful",
+              "failed",
+              "error",
+              "canceled"
+            ],
             "description": "Filter by job status"
           }
         },
@@ -207,5 +223,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/argocd/definition.json
+++ b/connectors/argocd/definition.json
@@ -76,7 +76,10 @@
             "description": "Enable automatic sync"
           }
         },
-        "required": ["name", "repo_url"],
+        "required": [
+          "name",
+          "repo_url"
+        ],
         "additionalProperties": false
       }
     },
@@ -107,7 +110,9 @@
             "description": "Perform a dry run"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -124,7 +129,9 @@
             "description": "Application name"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -146,7 +153,9 @@
             "description": "Delete application resources"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -178,7 +187,11 @@
           },
           "sync_status": {
             "type": "string",
-            "enum": ["Synced", "OutOfSync", "Unknown"],
+            "enum": [
+              "Synced",
+              "OutOfSync",
+              "Unknown"
+            ],
             "description": "Filter by sync status"
           }
         },
@@ -200,7 +213,14 @@
           },
           "health_status": {
             "type": "string",
-            "enum": ["Healthy", "Progressing", "Degraded", "Suspended", "Missing", "Unknown"],
+            "enum": [
+              "Healthy",
+              "Progressing",
+              "Degraded",
+              "Suspended",
+              "Missing",
+              "Unknown"
+            ],
             "description": "Filter by health status"
           }
         },
@@ -208,5 +228,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/asana-enhanced/definition.json
+++ b/connectors/asana-enhanced/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://app.asana.com/-/oauth_authorize",
       "tokenUrl": "https://app.asana.com/-/oauth_token",
-      "scopes": ["default"]
+      "scopes": [
+        "default"
+      ]
     }
   },
   "baseUrl": "https://app.asana.com/api/1.0",
@@ -45,7 +47,9 @@
           },
           "projects": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Project IDs to add the task to"
           },
           "assignee": {
@@ -68,17 +72,25 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["low", "normal", "high"],
+            "enum": [
+              "low",
+              "normal",
+              "high"
+            ],
             "description": "Task priority"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Tag IDs to apply to the task"
           },
           "followers": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "User IDs to follow the task"
           },
           "parent": {
@@ -86,7 +98,9 @@
             "description": "Parent task ID (for subtasks)"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -124,11 +138,17 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["low", "normal", "high"],
+            "enum": [
+              "low",
+              "normal",
+              "high"
+            ],
             "description": "Task priority"
           }
         },
-        "required": ["task_gid"],
+        "required": [
+          "task_gid"
+        ],
         "additionalProperties": false
       }
     },
@@ -148,7 +168,9 @@
             "description": "Comma-separated list of fields to return"
           }
         },
-        "required": ["task_gid"],
+        "required": [
+          "task_gid"
+        ],
         "additionalProperties": false
       }
     },
@@ -217,21 +239,50 @@
           },
           "color": {
             "type": "string",
-            "enum": ["dark-pink", "dark-green", "dark-blue", "dark-red", "dark-teal", "dark-brown", "dark-orange", "dark-purple", "dark-warm-gray", "light-pink", "light-green", "light-blue", "light-red", "light-teal", "light-yellow", "light-orange", "light-purple", "light-warm-gray"],
+            "enum": [
+              "dark-pink",
+              "dark-green",
+              "dark-blue",
+              "dark-red",
+              "dark-teal",
+              "dark-brown",
+              "dark-orange",
+              "dark-purple",
+              "dark-warm-gray",
+              "light-pink",
+              "light-green",
+              "light-blue",
+              "light-red",
+              "light-teal",
+              "light-yellow",
+              "light-orange",
+              "light-purple",
+              "light-warm-gray"
+            ],
             "description": "Project color"
           },
           "layout": {
             "type": "string",
-            "enum": ["list", "board"],
+            "enum": [
+              "list",
+              "board"
+            ],
             "description": "Project layout"
           },
           "privacy_setting": {
             "type": "string",
-            "enum": ["public_to_workspace", "public_to_team", "private"],
+            "enum": [
+              "public_to_workspace",
+              "public_to_team",
+              "private"
+            ],
             "description": "Project privacy setting"
           }
         },
-        "required": ["name", "workspace"],
+        "required": [
+          "name",
+          "workspace"
+        ],
         "additionalProperties": false
       }
     },
@@ -263,7 +314,9 @@
             "description": "Archive/unarchive the project"
           }
         },
-        "required": ["project_gid"],
+        "required": [
+          "project_gid"
+        ],
         "additionalProperties": false
       }
     },
@@ -320,7 +373,10 @@
             "description": "Task ID to insert before"
           }
         },
-        "required": ["task_gid", "project"],
+        "required": [
+          "task_gid",
+          "project"
+        ],
         "additionalProperties": false
       }
     },
@@ -349,7 +405,10 @@
             "description": "Due date"
           }
         },
-        "required": ["parent", "name"],
+        "required": [
+          "parent",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -373,7 +432,10 @@
             "description": "Pin the comment"
           }
         },
-        "required": ["task_gid", "text"],
+        "required": [
+          "task_gid",
+          "text"
+        ],
         "additionalProperties": false
       }
     },
@@ -419,12 +481,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "gid": {"type": "string"},
-          "name": {"type": "string"},
-          "assignee": {"type": "object"},
-          "projects": {"type": "array"},
-          "due_on": {"type": "string"},
-          "created_at": {"type": "string"}
+          "gid": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "assignee": {
+            "type": "object"
+          },
+          "projects": {
+            "type": "array"
+          },
+          "due_on": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          }
         }
       }
     },
@@ -447,10 +521,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "gid": {"type": "string"},
-          "name": {"type": "string"},
-          "completed_at": {"type": "string"},
-          "assignee": {"type": "object"}
+          "gid": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "completed_at": {
+            "type": "string"
+          },
+          "assignee": {
+            "type": "object"
+          }
         }
       }
     },
@@ -468,7 +550,9 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Specific fields to watch for changes"
           }
         },
@@ -478,10 +562,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "gid": {"type": "string"},
-          "name": {"type": "string"},
-          "modified_at": {"type": "string"},
-          "changes": {"type": "object"}
+          "gid": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "modified_at": {
+            "type": "string"
+          },
+          "changes": {
+            "type": "object"
+          }
         }
       }
     }
@@ -489,5 +581,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/aws-cloudformation/definition.json
+++ b/connectors/aws-cloudformation/definition.json
@@ -61,8 +61,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "ParameterKey": {"type": "string"},
-                "ParameterValue": {"type": "string"}
+                "ParameterKey": {
+                  "type": "string"
+                },
+                "ParameterValue": {
+                  "type": "string"
+                }
               }
             },
             "description": "Stack parameters"
@@ -71,7 +75,11 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+              "enum": [
+                "CAPABILITY_IAM",
+                "CAPABILITY_NAMED_IAM",
+                "CAPABILITY_AUTO_EXPAND"
+              ]
             },
             "description": "Stack capabilities"
           },
@@ -80,14 +88,20 @@
             "items": {
               "type": "object",
               "properties": {
-                "Key": {"type": "string"},
-                "Value": {"type": "string"}
+                "Key": {
+                  "type": "string"
+                },
+                "Value": {
+                  "type": "string"
+                }
               }
             },
             "description": "Stack tags"
           }
         },
-        "required": ["stack_name"],
+        "required": [
+          "stack_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -116,14 +130,20 @@
             "items": {
               "type": "object",
               "properties": {
-                "ParameterKey": {"type": "string"},
-                "ParameterValue": {"type": "string"}
+                "ParameterKey": {
+                  "type": "string"
+                },
+                "ParameterValue": {
+                  "type": "string"
+                }
               }
             },
             "description": "Updated stack parameters"
           }
         },
-        "required": ["stack_name"],
+        "required": [
+          "stack_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -140,7 +160,9 @@
             "description": "Stack name to delete"
           }
         },
-        "required": ["stack_name"],
+        "required": [
+          "stack_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -157,7 +179,9 @@
             "description": "Stack name"
           }
         },
-        "required": ["stack_name"],
+        "required": [
+          "stack_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -206,7 +230,11 @@
           },
           "operation": {
             "type": "string",
-            "enum": ["CREATE", "UPDATE", "DELETE"],
+            "enum": [
+              "CREATE",
+              "UPDATE",
+              "DELETE"
+            ],
             "description": "Filter by operation type"
           }
         },
@@ -214,5 +242,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/aws-codepipeline/definition.json
+++ b/connectors/aws-codepipeline/definition.json
@@ -54,7 +54,11 @@
           },
           "source_provider": {
             "type": "string",
-            "enum": ["GitHub", "CodeCommit", "S3"],
+            "enum": [
+              "GitHub",
+              "CodeCommit",
+              "S3"
+            ],
             "description": "Source provider"
           },
           "repository": {
@@ -67,7 +71,12 @@
             "description": "Branch to monitor"
           }
         },
-        "required": ["name", "role_arn", "source_provider", "repository"],
+        "required": [
+          "name",
+          "role_arn",
+          "source_provider",
+          "repository"
+        ],
         "additionalProperties": false
       }
     },
@@ -84,7 +93,9 @@
             "description": "Pipeline name"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -101,7 +112,9 @@
             "description": "Pipeline name"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -122,7 +135,10 @@
             "description": "Pipeline execution ID"
           }
         },
-        "required": ["name", "execution_id"],
+        "required": [
+          "name",
+          "execution_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -191,5 +207,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/azure-devops/definition.json
+++ b/connectors/azure-devops/definition.json
@@ -45,7 +45,12 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["Bug", "Task", "User Story", "Feature"],
+            "enum": [
+              "Bug",
+              "Task",
+              "User Story",
+              "Feature"
+            ],
             "description": "Work item type"
           },
           "title": {
@@ -75,7 +80,10 @@
             "description": "Priority level"
           }
         },
-        "required": ["type", "title"],
+        "required": [
+          "type",
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -101,7 +109,9 @@
             "description": "Build parameters"
           }
         },
-        "required": ["definition_id"],
+        "required": [
+          "definition_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -126,14 +136,20 @@
             "items": {
               "type": "object",
               "properties": {
-                "alias": {"type": "string"},
-                "instanceReference": {"type": "object"}
+                "alias": {
+                  "type": "string"
+                },
+                "instanceReference": {
+                  "type": "object"
+                }
               }
             },
             "description": "Release artifacts"
           }
         },
-        "required": ["definition_id"],
+        "required": [
+          "definition_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -150,7 +166,9 @@
             "description": "Build ID"
           }
         },
-        "required": ["build_id"],
+        "required": [
+          "build_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -182,7 +200,11 @@
           },
           "result": {
             "type": "string",
-            "enum": ["succeeded", "failed", "canceled"],
+            "enum": [
+              "succeeded",
+              "failed",
+              "canceled"
+            ],
             "description": "Filter by build result"
           }
         },
@@ -200,7 +222,12 @@
         "properties": {
           "work_item_type": {
             "type": "string",
-            "enum": ["Bug", "Task", "User Story", "Feature"],
+            "enum": [
+              "Bug",
+              "Task",
+              "User Story",
+              "Feature"
+            ],
             "description": "Filter by work item type"
           },
           "area_path": {
@@ -212,5 +239,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/bamboohr/definition.json
+++ b/connectors/bamboohr/definition.json
@@ -48,7 +48,10 @@
             "description": "Comma-separated list of fields"
           }
         },
-        "required": ["companyDomain", "employeeId"],
+        "required": [
+          "companyDomain",
+          "employeeId"
+        ],
         "additionalProperties": false
       }
     },
@@ -94,7 +97,11 @@
             "description": "Supervisor ID"
           }
         },
-        "required": ["companyDomain", "firstName", "lastName"],
+        "required": [
+          "companyDomain",
+          "firstName",
+          "lastName"
+        ],
         "additionalProperties": false
       }
     },
@@ -118,7 +125,11 @@
             "description": "Fields to update"
           }
         },
-        "required": ["companyDomain", "employeeId", "fields"],
+        "required": [
+          "companyDomain",
+          "employeeId",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -148,7 +159,9 @@
             "description": "Employee ID filter"
           }
         },
-        "required": ["companyDomain"],
+        "required": [
+          "companyDomain"
+        ],
         "additionalProperties": false
       }
     }
@@ -168,10 +181,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "firstName": {"type": "string"},
-          "lastName": {"type": "string"},
-          "workEmail": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "workEmail": {
+            "type": "string"
+          }
         }
       }
     },
@@ -189,8 +210,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "changes": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "changes": {
+            "type": "object"
+          }
         }
       }
     }
@@ -198,5 +223,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/{companyDomain}/v1/employees/directory"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/basecamp/definition.json
+++ b/connectors/basecamp/definition.json
@@ -47,7 +47,10 @@
             "description": "Project description"
           }
         },
-        "required": ["accountId", "name"],
+        "required": [
+          "accountId",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -75,7 +78,11 @@
             "description": "To-do list description"
           }
         },
-        "required": ["accountId", "projectId", "name"],
+        "required": [
+          "accountId",
+          "projectId",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -108,7 +115,9 @@
           },
           "assignee_ids": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Assignee IDs"
           },
           "due_on": {
@@ -117,7 +126,12 @@
             "description": "Due date"
           }
         },
-        "required": ["accountId", "projectId", "todoListId", "content"],
+        "required": [
+          "accountId",
+          "projectId",
+          "todoListId",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -145,7 +159,12 @@
             "description": "Message content"
           }
         },
-        "required": ["accountId", "projectId", "subject", "content"],
+        "required": [
+          "accountId",
+          "projectId",
+          "subject",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -177,7 +196,12 @@
             "description": "File description"
           }
         },
-        "required": ["accountId", "projectId", "file", "filename"],
+        "required": [
+          "accountId",
+          "projectId",
+          "file",
+          "filename"
+        ],
         "additionalProperties": false
       }
     }
@@ -202,9 +226,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "content": {"type": "string"},
-          "completed": {"type": "boolean"}
+          "id": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "completed": {
+            "type": "boolean"
+          }
         }
       }
     },
@@ -222,9 +252,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
         }
       }
     }
@@ -232,5 +268,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/authorization.json"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/bigcommerce/definition.json
+++ b/connectors/bigcommerce/definition.json
@@ -39,7 +39,10 @@
           },
           "type": {
             "type": "string",
-            "enum": ["physical", "digital"],
+            "enum": [
+              "physical",
+              "digital"
+            ],
             "description": "Product type"
           },
           "sku": {
@@ -60,7 +63,9 @@
           },
           "categories": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Category IDs"
           },
           "is_visible": {
@@ -73,7 +78,11 @@
             "description": "Inventory level"
           }
         },
-        "required": ["name", "type", "price"],
+        "required": [
+          "name",
+          "type",
+          "price"
+        ],
         "additionalProperties": false
       }
     },
@@ -105,7 +114,9 @@
             "description": "Inventory level"
           }
         },
-        "required": ["product_id"],
+        "required": [
+          "product_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -121,7 +132,9 @@
             "description": "Product ID"
           }
         },
-        "required": ["product_id"],
+        "required": [
+          "product_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -153,12 +166,17 @@
           },
           "type": {
             "type": "string",
-            "enum": ["physical", "digital"],
+            "enum": [
+              "physical",
+              "digital"
+            ],
             "description": "Filter by product type"
           },
           "categories:in": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Filter by category IDs"
           }
         },
@@ -182,8 +200,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "product_id": {"type": "number"},
-                "quantity": {"type": "number"}
+                "product_id": {
+                  "type": "number"
+                },
+                "quantity": {
+                  "type": "number"
+                }
               }
             },
             "description": "Order products"
@@ -197,7 +219,9 @@
             "description": "Shipping address"
           }
         },
-        "required": ["products"],
+        "required": [
+          "products"
+        ],
         "additionalProperties": false
       }
     }
@@ -217,10 +241,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "status": {"type": "string"},
-          "total": {"type": "string"},
-          "customer_id": {"type": "number"}
+          "id": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          },
+          "total": {
+            "type": "string"
+          },
+          "customer_id": {
+            "type": "number"
+          }
         }
       }
     },
@@ -238,9 +270,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "name": {"type": "string"},
-          "sku": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sku": {
+            "type": "string"
+          }
         }
       }
     }
@@ -248,5 +286,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/store"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/bigquery/definition.json
+++ b/connectors/bigquery/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://accounts.google.com/o/oauth2/auth",
       "tokenUrl": "https://oauth2.googleapis.com/token",
-      "scopes": ["https://www.googleapis.com/auth/bigquery"]
+      "scopes": [
+        "https://www.googleapis.com/auth/bigquery"
+      ]
     }
   },
   "baseUrl": "https://bigquery.googleapis.com/bigquery/v2",
@@ -62,11 +64,16 @@
           },
           "parameters": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Query parameters"
           }
         },
-        "required": ["projectId", "query"],
+        "required": [
+          "projectId",
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -98,7 +105,10 @@
             "description": "Default table expiration time"
           }
         },
-        "required": ["projectId", "datasetId"],
+        "required": [
+          "projectId",
+          "datasetId"
+        ],
         "additionalProperties": false
       }
     },
@@ -126,7 +136,9 @@
             "properties": {
               "fields": {
                 "type": "array",
-                "items": {"type": "object"}
+                "items": {
+                  "type": "object"
+                }
               }
             },
             "description": "Table schema"
@@ -136,7 +148,12 @@
             "description": "Table description"
           }
         },
-        "required": ["projectId", "datasetId", "tableId", "schema"],
+        "required": [
+          "projectId",
+          "datasetId",
+          "tableId",
+          "schema"
+        ],
         "additionalProperties": false
       }
     },
@@ -161,7 +178,9 @@
           },
           "rows": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Rows to insert"
           },
           "ignoreUnknownValues": {
@@ -175,7 +194,12 @@
             "description": "Skip invalid rows"
           }
         },
-        "required": ["projectId", "datasetId", "tableId", "rows"],
+        "required": [
+          "projectId",
+          "datasetId",
+          "tableId",
+          "rows"
+        ],
         "additionalProperties": false
       }
     },
@@ -199,7 +223,9 @@
             "description": "Include hidden datasets"
           }
         },
-        "required": ["projectId"],
+        "required": [
+          "projectId"
+        ],
         "additionalProperties": false
       }
     },
@@ -223,7 +249,10 @@
             "description": "Maximum number of results"
           }
         },
-        "required": ["projectId", "datasetId"],
+        "required": [
+          "projectId",
+          "datasetId"
+        ],
         "additionalProperties": false
       }
     }
@@ -248,9 +277,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "jobId": {"type": "string"},
-          "status": {"type": "string"},
-          "projectId": {"type": "string"}
+          "jobId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "projectId": {
+            "type": "string"
+          }
         }
       }
     }
@@ -258,5 +293,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/projects"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/bitbucket/definition.json
+++ b/connectors/bitbucket/definition.json
@@ -11,7 +11,11 @@
     "config": {
       "authUrl": "https://bitbucket.org/site/oauth2/authorize",
       "tokenUrl": "https://bitbucket.org/site/oauth2/access_token",
-      "scopes": ["repositories", "issues", "pullrequests"]
+      "scopes": [
+        "repositories",
+        "issues",
+        "pullrequests"
+      ]
     }
   },
   "baseUrl": "https://api.bitbucket.org/2.0",
@@ -49,30 +53,56 @@
           "content": {
             "type": "object",
             "properties": {
-              "raw": {"type": "string"},
-              "markup": {"type": "string", "enum": ["markdown", "creole", "plaintext"]}
+              "raw": {
+                "type": "string"
+              },
+              "markup": {
+                "type": "string",
+                "enum": [
+                  "markdown",
+                  "creole",
+                  "plaintext"
+                ]
+              }
             },
             "description": "Issue content"
           },
           "kind": {
             "type": "string",
-            "enum": ["bug", "enhancement", "proposal", "task"],
+            "enum": [
+              "bug",
+              "enhancement",
+              "proposal",
+              "task"
+            ],
             "description": "Issue kind"
           },
           "priority": {
             "type": "string",
-            "enum": ["trivial", "minor", "major", "critical", "blocker"],
+            "enum": [
+              "trivial",
+              "minor",
+              "major",
+              "critical",
+              "blocker"
+            ],
             "description": "Issue priority"
           },
           "assignee": {
             "type": "object",
             "properties": {
-              "account_id": {"type": "string"}
+              "account_id": {
+                "type": "string"
+              }
             },
             "description": "Issue assignee"
           }
         },
-        "required": ["workspace", "repo_slug", "title"],
+        "required": [
+          "workspace",
+          "repo_slug",
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -102,14 +132,28 @@
           "source": {
             "type": "object",
             "properties": {
-              "branch": {"type": "object", "properties": {"name": {"type": "string"}}}
+              "branch": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "description": "Source branch"
           },
           "destination": {
             "type": "object",
             "properties": {
-              "branch": {"type": "object", "properties": {"name": {"type": "string"}}}
+              "branch": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "description": "Destination branch"
           },
@@ -118,7 +162,9 @@
             "items": {
               "type": "object",
               "properties": {
-                "account_id": {"type": "string"}
+                "account_id": {
+                  "type": "string"
+                }
               }
             },
             "description": "Pull request reviewers"
@@ -128,7 +174,13 @@
             "description": "Close source branch after merge"
           }
         },
-        "required": ["workspace", "repo_slug", "title", "source", "destination"],
+        "required": [
+          "workspace",
+          "repo_slug",
+          "title",
+          "source",
+          "destination"
+        ],
         "additionalProperties": false
       }
     },
@@ -148,7 +200,10 @@
             "description": "Repository slug"
           }
         },
-        "required": ["workspace", "repo_slug"],
+        "required": [
+          "workspace",
+          "repo_slug"
+        ],
         "additionalProperties": false
       }
     },
@@ -165,7 +220,12 @@
           },
           "role": {
             "type": "string",
-            "enum": ["owner", "admin", "contributor", "member"],
+            "enum": [
+              "owner",
+              "admin",
+              "contributor",
+              "member"
+            ],
             "description": "Filter by role"
           },
           "q": {
@@ -174,11 +234,17 @@
           },
           "sort": {
             "type": "string",
-            "enum": ["created_on", "updated_on", "name"],
+            "enum": [
+              "created_on",
+              "updated_on",
+              "name"
+            ],
             "description": "Sort field"
           }
         },
-        "required": ["workspace"],
+        "required": [
+          "workspace"
+        ],
         "additionalProperties": false
       }
     },
@@ -213,11 +279,18 @@
           },
           "events": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Events to trigger webhook"
           }
         },
-        "required": ["workspace", "repo_slug", "url", "events"],
+        "required": [
+          "workspace",
+          "repo_slug",
+          "url",
+          "events"
+        ],
         "additionalProperties": false
       }
     }
@@ -246,9 +319,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "repository": {"type": "object"},
-          "push": {"type": "object"},
-          "actor": {"type": "object"}
+          "repository": {
+            "type": "object"
+          },
+          "push": {
+            "type": "object"
+          },
+          "actor": {
+            "type": "object"
+          }
         }
       }
     },
@@ -271,9 +350,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "pullrequest": {"type": "object"},
-          "repository": {"type": "object"},
-          "actor": {"type": "object"}
+          "pullrequest": {
+            "type": "object"
+          },
+          "repository": {
+            "type": "object"
+          },
+          "actor": {
+            "type": "object"
+          }
         }
       }
     }
@@ -281,5 +366,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/box/definition.json
+++ b/connectors/box/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://account.box.com/api/oauth2/authorize",
       "tokenUrl": "https://api.box.com/oauth2/token",
-      "scopes": ["root_readwrite", "root_readonly"]
+      "scopes": [
+        "root_readwrite",
+        "root_readonly"
+      ]
     }
   },
   "baseUrl": "https://api.box.com/2.0",
@@ -58,7 +61,10 @@
             "description": "Content modification date"
           }
         },
-        "required": ["file_name", "file_content"],
+        "required": [
+          "file_name",
+          "file_content"
+        ],
         "additionalProperties": false
       }
     },
@@ -78,7 +84,9 @@
             "description": "File version"
           }
         },
-        "required": ["file_id"],
+        "required": [
+          "file_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -99,7 +107,9 @@
             "description": "Parent folder ID"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -119,7 +129,9 @@
             "description": "Comma-separated list of fields"
           }
         },
-        "required": ["file_id"],
+        "required": [
+          "file_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -168,17 +180,24 @@
           },
           "file_extensions": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "File extensions to filter"
           },
           "type": {
             "type": "string",
-            "enum": ["file", "folder"],
+            "enum": [
+              "file",
+              "folder"
+            ],
             "description": "Item type filter"
           },
           "content_types": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Content types to filter"
           },
           "limit": {
@@ -189,7 +208,9 @@
             "description": "Number of results"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -206,12 +227,19 @@
           },
           "item_type": {
             "type": "string",
-            "enum": ["file", "folder"],
+            "enum": [
+              "file",
+              "folder"
+            ],
             "description": "Item type"
           },
           "access": {
             "type": "string",
-            "enum": ["open", "company", "collaborators"],
+            "enum": [
+              "open",
+              "company",
+              "collaborators"
+            ],
             "description": "Access level"
           },
           "password": {
@@ -232,7 +260,10 @@
             "description": "Allow previews"
           }
         },
-        "required": ["item_id", "item_type"],
+        "required": [
+          "item_id",
+          "item_type"
+        ],
         "additionalProperties": false
       }
     }
@@ -257,10 +288,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "created_by": {"type": "object"}
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": "object"
+          }
         }
       }
     },
@@ -278,9 +317,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "id": {"type": "string"},
-          "name": {"type": "string"}
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
         }
       }
     }
@@ -288,5 +333,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/braze/definition.json
+++ b/connectors/braze/definition.json
@@ -56,7 +56,9 @@
             "description": "Event properties"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -74,8 +76,12 @@
           "user_alias": {
             "type": "object",
             "properties": {
-              "alias_name": {"type": "string"},
-              "alias_label": {"type": "string"}
+              "alias_name": {
+                "type": "string"
+              },
+              "alias_label": {
+                "type": "string"
+              }
             },
             "description": "User alias"
           },
@@ -156,9 +162,15 @@
             "items": {
               "type": "object",
               "properties": {
-                "external_user_id": {"type": "string"},
-                "user_alias": {"type": "object"},
-                "trigger_properties": {"type": "object"}
+                "external_user_id": {
+                  "type": "string"
+                },
+                "user_alias": {
+                  "type": "object"
+                },
+                "trigger_properties": {
+                  "type": "object"
+                }
               }
             },
             "description": "Specific recipients"
@@ -193,11 +205,16 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Campaign tags"
           }
         },
-        "required": ["name", "messages"],
+        "required": [
+          "name",
+          "messages"
+        ],
         "additionalProperties": false
       }
     },
@@ -210,27 +227,37 @@
         "properties": {
           "external_ids": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "User external IDs to export"
           },
           "user_ids": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "User IDs to export"
           },
           "email_address": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Email addresses to export"
           },
           "phone": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Phone numbers to export"
           },
           "fields_to_export": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to include in export"
           }
         },
@@ -259,10 +286,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "type": {"type": "string"},
-          "tags": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array"
+          }
         }
       }
     },
@@ -285,10 +320,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "user_id": {"type": "string"},
-          "external_user_id": {"type": "string"},
-          "event_name": {"type": "string"},
-          "properties": {"type": "object"}
+          "user_id": {
+            "type": "string"
+          },
+          "external_user_id": {
+            "type": "string"
+          },
+          "event_name": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object"
+          }
         }
       }
     }
@@ -296,5 +339,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/canvas/data_series"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/brex/definition.json
+++ b/connectors/brex/definition.json
@@ -11,7 +11,11 @@
     "config": {
       "authUrl": "https://accounts.brex.com/oauth2/v1/auth",
       "tokenUrl": "https://accounts.brex.com/oauth2/v1/access_token",
-      "scopes": ["transactions:read", "cards:read", "users:read"]
+      "scopes": [
+        "transactions:read",
+        "cards:read",
+        "users:read"
+      ]
     }
   },
   "baseUrl": "https://platform.brexapis.com",
@@ -36,12 +40,16 @@
         "properties": {
           "card_id": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by card IDs"
           },
           "user_id": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by user IDs"
           },
           "posted_at_start": {
@@ -56,7 +64,14 @@
           },
           "expand": {
             "type": "array",
-            "items": {"type": "string", "enum": ["card", "receipt", "merchant"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "card",
+                "receipt",
+                "merchant"
+              ]
+            },
             "description": "Additional data to expand"
           },
           "limit": {
@@ -88,11 +103,20 @@
           },
           "expand": {
             "type": "array",
-            "items": {"type": "string", "enum": ["card", "receipt", "merchant"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "card",
+                "receipt",
+                "merchant"
+              ]
+            },
             "description": "Additional data to expand"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -105,7 +129,9 @@
         "properties": {
           "user_id": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by user IDs"
           },
           "limit": {
@@ -136,7 +162,9 @@
             "description": "Card ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -150,8 +178,15 @@
           "owner": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["USER"]},
-              "user_id": {"type": "string"}
+              "type": {
+                "type": "string",
+                "enum": [
+                  "USER"
+                ]
+              },
+              "user_id": {
+                "type": "string"
+              }
             },
             "description": "Card owner"
           },
@@ -161,19 +196,29 @@
           },
           "card_type": {
             "type": "string",
-            "enum": ["VIRTUAL", "PHYSICAL"],
+            "enum": [
+              "VIRTUAL",
+              "PHYSICAL"
+            ],
             "description": "Card type"
           },
           "limit_type": {
             "type": "string",
-            "enum": ["CARD", "MONTHLY"],
+            "enum": [
+              "CARD",
+              "MONTHLY"
+            ],
             "description": "Limit type"
           },
           "spending_controls": {
             "type": "object",
             "properties": {
-              "spend_limit": {"type": "object"},
-              "locked": {"type": "boolean"}
+              "spend_limit": {
+                "type": "object"
+              },
+              "locked": {
+                "type": "boolean"
+              }
             },
             "description": "Spending controls"
           },
@@ -182,7 +227,10 @@
             "description": "Card metadata"
           }
         },
-        "required": ["owner", "card_type"],
+        "required": [
+          "owner",
+          "card_type"
+        ],
         "additionalProperties": false
       }
     },
@@ -204,8 +252,12 @@
           "spending_controls": {
             "type": "object",
             "properties": {
-              "spend_limit": {"type": "object"},
-              "locked": {"type": "boolean"}
+              "spend_limit": {
+                "type": "object"
+              },
+              "locked": {
+                "type": "boolean"
+              }
             },
             "description": "Spending controls"
           },
@@ -214,7 +266,9 @@
             "description": "Card metadata"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -262,10 +316,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "card_id": {"type": "string"},
-          "amount": {"type": "object"},
-          "merchant": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "card_id": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "object"
+          },
+          "merchant": {
+            "type": "object"
+          }
         }
       }
     },
@@ -283,9 +345,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "card_name": {"type": "string"},
-          "card_type": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "card_name": {
+            "type": "string"
+          },
+          "card_type": {
+            "type": "string"
+          }
         }
       }
     }
@@ -293,5 +361,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/v2/cards"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/caldotcom/definition.json
+++ b/connectors/caldotcom/definition.json
@@ -43,7 +43,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["accepted", "pending", "cancelled", "rejected"],
+            "enum": [
+              "accepted",
+              "pending",
+              "cancelled",
+              "rejected"
+            ],
             "description": "Filter by booking status"
           },
           "take": {
@@ -59,12 +64,19 @@
           },
           "orderBy": {
             "type": "string",
-            "enum": ["createdAt", "startTime", "endTime"],
+            "enum": [
+              "createdAt",
+              "startTime",
+              "endTime"
+            ],
             "description": "Order by field"
           },
           "sortOrder": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "description": "Sort order"
           }
         },
@@ -84,7 +96,9 @@
             "description": "Booking ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -112,9 +126,16 @@
           "attendee": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "email": {"type": "string", "format": "email"},
-              "timeZone": {"type": "string"}
+              "name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "timeZone": {
+                "type": "string"
+              }
             },
             "description": "Attendee information"
           },
@@ -140,7 +161,12 @@
             "description": "Custom field values"
           }
         },
-        "required": ["eventTypeId", "start", "end", "attendee"],
+        "required": [
+          "eventTypeId",
+          "start",
+          "end",
+          "attendee"
+        ],
         "additionalProperties": false
       }
     },
@@ -175,11 +201,18 @@
           },
           "status": {
             "type": "string",
-            "enum": ["accepted", "pending", "cancelled", "rejected"],
+            "enum": [
+              "accepted",
+              "pending",
+              "cancelled",
+              "rejected"
+            ],
             "description": "Booking status"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -199,7 +232,9 @@
             "description": "Cancellation reason"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -260,7 +295,12 @@
             "description": "Timezone"
           }
         },
-        "required": ["userId", "eventTypeId", "dateFrom", "dateTo"],
+        "required": [
+          "userId",
+          "eventTypeId",
+          "dateFrom",
+          "dateTo"
+        ],
         "additionalProperties": false
       }
     }
@@ -285,10 +325,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "title": {"type": "string"},
-          "startTime": {"type": "string"},
-          "endTime": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          }
         }
       }
     },
@@ -306,9 +354,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "reason": {"type": "string"},
-          "cancelledAt": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "cancelledAt": {
+            "type": "string"
+          }
         }
       }
     }
@@ -316,5 +370,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/calendly/definition.json
+++ b/connectors/calendly/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://auth.calendly.com/oauth/authorize",
       "tokenUrl": "https://auth.calendly.com/oauth/token",
-      "scopes": ["default"]
+      "scopes": [
+        "default"
+      ]
     }
   },
   "baseUrl": "https://api.calendly.com",
@@ -55,12 +57,18 @@
           },
           "sort": {
             "type": "string",
-            "enum": ["start_time:asc", "start_time:desc"],
+            "enum": [
+              "start_time:asc",
+              "start_time:desc"
+            ],
             "description": "Sort order"
           },
           "status": {
             "type": "string",
-            "enum": ["active", "canceled"],
+            "enum": [
+              "active",
+              "canceled"
+            ],
             "description": "Event status filter"
           },
           "min_start_time": {
@@ -107,16 +115,24 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "canceled"],
+            "enum": [
+              "active",
+              "canceled"
+            ],
             "description": "Invitee status filter"
           },
           "sort": {
             "type": "string",
-            "enum": ["created_at:asc", "created_at:desc"],
+            "enum": [
+              "created_at:asc",
+              "created_at:desc"
+            ],
             "description": "Sort order"
           }
         },
-        "required": ["event_uuid"],
+        "required": [
+          "event_uuid"
+        ],
         "additionalProperties": false
       }
     },
@@ -164,7 +180,10 @@
           },
           "sort": {
             "type": "string",
-            "enum": ["name:asc", "name:desc"],
+            "enum": [
+              "name:asc",
+              "name:desc"
+            ],
             "description": "Sort order"
           },
           "active": {
@@ -192,7 +211,9 @@
             "description": "Cancellation reason"
           }
         },
-        "required": ["event_uuid"],
+        "required": [
+          "event_uuid"
+        ],
         "additionalProperties": false
       }
     }
@@ -221,11 +242,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
-          "time": {"type": "string"},
-          "created_at": {"type": "string"},
-          "updated_at": {"type": "string"},
-          "payload": {"type": "object"}
+          "event": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object"
+          }
         }
       }
     },
@@ -248,9 +279,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
-          "time": {"type": "string"},
-          "payload": {"type": "object"}
+          "event": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object"
+          }
         }
       }
     }
@@ -258,5 +295,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/circleci/definition.json
+++ b/connectors/circleci/definition.json
@@ -50,7 +50,9 @@
             "description": "Pipeline parameters"
           }
         },
-        "required": ["project_slug"],
+        "required": [
+          "project_slug"
+        ],
         "additionalProperties": false
       }
     },
@@ -74,7 +76,9 @@
             "description": "Pagination token"
           }
         },
-        "required": ["project_slug"],
+        "required": [
+          "project_slug"
+        ],
         "additionalProperties": false
       }
     },
@@ -90,7 +94,9 @@
             "description": "Pipeline ID"
           }
         },
-        "required": ["pipeline_id"],
+        "required": [
+          "pipeline_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -110,7 +116,9 @@
             "description": "Pagination token"
           }
         },
-        "required": ["pipeline_id"],
+        "required": [
+          "pipeline_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -130,7 +138,9 @@
             "description": "Pagination token"
           }
         },
-        "required": ["workflow_id"],
+        "required": [
+          "workflow_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -146,7 +156,9 @@
             "description": "Workflow ID to cancel"
           }
         },
-        "required": ["workflow_id"],
+        "required": [
+          "workflow_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -174,7 +186,9 @@
             "description": "Rerun sparse tree"
           }
         },
-        "required": ["workflow_id"],
+        "required": [
+          "workflow_id"
+        ],
         "additionalProperties": false
       }
     }
@@ -199,10 +213,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "status": {"type": "string"},
-          "project_slug": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "project_slug": {
+            "type": "string"
+          }
         }
       }
     },
@@ -220,10 +242,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "job_name": {"type": "string"},
-          "job_number": {"type": "number"},
-          "status": {"type": "string"},
-          "workflow_id": {"type": "string"}
+          "job_name": {
+            "type": "string"
+          },
+          "job_number": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          },
+          "workflow_id": {
+            "type": "string"
+          }
         }
       }
     }
@@ -231,5 +261,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/clickup/definition.json
+++ b/connectors/clickup/definition.json
@@ -47,12 +47,16 @@
           },
           "assignees": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Array of assignee user IDs"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of tag names"
           },
           "status": {
@@ -61,7 +65,12 @@
           },
           "priority": {
             "type": "number",
-            "enum": [1, 2, 3, 4],
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ],
             "description": "Task priority (1=urgent, 2=high, 3=normal, 4=low)"
           },
           "due_date": {
@@ -98,11 +107,16 @@
           },
           "custom_fields": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Custom field values"
           }
         },
-        "required": ["list_id", "name"],
+        "required": [
+          "list_id",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -131,14 +145,29 @@
           },
           "priority": {
             "type": "number",
-            "enum": [1, 2, 3, 4],
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ],
             "description": "Task priority"
           },
           "assignees": {
             "type": "object",
             "properties": {
-              "add": {"type": "array", "items": {"type": "number"}},
-              "rem": {"type": "array", "items": {"type": "number"}}
+              "add": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "rem": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
             },
             "description": "Assignees to add or remove"
           },
@@ -147,7 +176,9 @@
             "description": "Due date as Unix timestamp"
           }
         },
-        "required": ["task_id"],
+        "required": [
+          "task_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -175,7 +206,9 @@
             "description": "Include subtasks"
           }
         },
-        "required": ["task_id"],
+        "required": [
+          "task_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -200,7 +233,12 @@
           },
           "order_by": {
             "type": "string",
-            "enum": ["id", "created", "updated", "due_date"],
+            "enum": [
+              "id",
+              "created",
+              "updated",
+              "due_date"
+            ],
             "description": "Order by field"
           },
           "reverse": {
@@ -213,7 +251,9 @@
           },
           "statuses": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by statuses"
           },
           "include_closed": {
@@ -222,12 +262,16 @@
           },
           "assignees": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Filter by assignees"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by tags"
           },
           "due_date_gt": {
@@ -263,7 +307,9 @@
             "description": "Done date less than (Unix timestamp)"
           }
         },
-        "required": ["list_id"],
+        "required": [
+          "list_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -287,7 +333,9 @@
             "description": "Team ID (required if using custom task IDs)"
           }
         },
-        "required": ["task_id"],
+        "required": [
+          "task_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -315,7 +363,10 @@
             "description": "Notify all task members"
           }
         },
-        "required": ["task_id", "comment_text"],
+        "required": [
+          "task_id",
+          "comment_text"
+        ],
         "additionalProperties": false
       }
     },
@@ -335,7 +386,9 @@
             "description": "Include archived lists"
           }
         },
-        "required": ["folder_id"],
+        "required": [
+          "folder_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -355,7 +408,9 @@
             "description": "Include archived spaces"
           }
         },
-        "required": ["team_id"],
+        "required": [
+          "team_id"
+        ],
         "additionalProperties": false
       }
     }
@@ -380,10 +435,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "task_id": {"type": "string"},
-          "name": {"type": "string"},
-          "status": {"type": "object"},
-          "creator": {"type": "object"}
+          "task_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "object"
+          },
+          "creator": {
+            "type": "object"
+          }
         }
       }
     },
@@ -401,9 +464,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "task_id": {"type": "string"},
-          "name": {"type": "string"},
-          "history_items": {"type": "array"}
+          "task_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "history_items": {
+            "type": "array"
+          }
         }
       }
     }
@@ -411,5 +480,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/coda/definition.json
+++ b/connectors/coda/definition.json
@@ -78,7 +78,9 @@
             "description": "Document ID"
           }
         },
-        "required": ["docId"],
+        "required": [
+          "docId"
+        ],
         "additionalProperties": false
       }
     },
@@ -106,16 +108,28 @@
           },
           "sortBy": {
             "type": "string",
-            "enum": ["name", "createdAt", "tableType"],
+            "enum": [
+              "name",
+              "createdAt",
+              "tableType"
+            ],
             "description": "Sort field"
           },
           "tableTypes": {
             "type": "array",
-            "items": {"type": "string", "enum": ["table", "view"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "table",
+                "view"
+              ]
+            },
             "description": "Filter by table types"
           }
         },
-        "required": ["docId"],
+        "required": [
+          "docId"
+        ],
         "additionalProperties": false
       }
     },
@@ -135,7 +149,10 @@
             "description": "Table ID or name"
           }
         },
-        "required": ["docId", "tableIdOrName"],
+        "required": [
+          "docId",
+          "tableIdOrName"
+        ],
         "additionalProperties": false
       }
     },
@@ -171,7 +188,11 @@
           },
           "sortBy": {
             "type": "string",
-            "enum": ["natural", "createdAt", "updatedAt"],
+            "enum": [
+              "natural",
+              "createdAt",
+              "updatedAt"
+            ],
             "description": "Sort field"
           },
           "useColumnNames": {
@@ -180,7 +201,11 @@
           },
           "valueFormat": {
             "type": "string",
-            "enum": ["simple", "simpleWithArrays", "rich"],
+            "enum": [
+              "simple",
+              "simpleWithArrays",
+              "rich"
+            ],
             "description": "Value format"
           },
           "visibleOnly": {
@@ -188,7 +213,10 @@
             "description": "Return only visible rows"
           }
         },
-        "required": ["docId", "tableIdOrName"],
+        "required": [
+          "docId",
+          "tableIdOrName"
+        ],
         "additionalProperties": false
       }
     },
@@ -212,14 +240,18 @@
             "properties": {
               "cells": {
                 "type": "array",
-                "items": {"type": "object"}
+                "items": {
+                  "type": "object"
+                }
               }
             },
             "description": "Row data"
           },
           "keyColumns": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Key columns for upsert"
           },
           "disableParsing": {
@@ -227,7 +259,11 @@
             "description": "Disable parsing of cell values"
           }
         },
-        "required": ["docId", "tableIdOrName", "row"],
+        "required": [
+          "docId",
+          "tableIdOrName",
+          "row"
+        ],
         "additionalProperties": false
       }
     },
@@ -255,7 +291,9 @@
             "properties": {
               "cells": {
                 "type": "array",
-                "items": {"type": "object"}
+                "items": {
+                  "type": "object"
+                }
               }
             },
             "description": "Updated row data"
@@ -265,7 +303,12 @@
             "description": "Disable parsing of cell values"
           }
         },
-        "required": ["docId", "tableIdOrName", "rowIdOrName", "row"],
+        "required": [
+          "docId",
+          "tableIdOrName",
+          "rowIdOrName",
+          "row"
+        ],
         "additionalProperties": false
       }
     },
@@ -289,7 +332,11 @@
             "description": "Row ID or name"
           }
         },
-        "required": ["docId", "tableIdOrName", "rowIdOrName"],
+        "required": [
+          "docId",
+          "tableIdOrName",
+          "rowIdOrName"
+        ],
         "additionalProperties": false
       }
     }
@@ -318,10 +365,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "type": {"type": "string"},
-          "href": {"type": "string"},
-          "values": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "href": {
+            "type": "string"
+          },
+          "values": {
+            "type": "object"
+          }
         }
       }
     },
@@ -344,9 +399,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "type": {"type": "string"},
-          "updatedAt": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
         }
       }
     }
@@ -354,5 +415,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/whoami"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/concur/definition.json
+++ b/connectors/concur/definition.json
@@ -11,7 +11,11 @@
     "config": {
       "authUrl": "https://www.concursolutions.com/net2/oauth2/Login.aspx",
       "tokenUrl": "https://www.concursolutions.com/net2/oauth2/GetAccessToken.ashx",
-      "scopes": ["EXPRPT", "BANK", "TRVREQ"]
+      "scopes": [
+        "EXPRPT",
+        "BANK",
+        "TRVREQ"
+      ]
     }
   },
   "baseUrl": "https://www.concursolutions.com/api/v3.0",
@@ -51,12 +55,32 @@
           },
           "paymentStatusCode": {
             "type": "string",
-            "enum": ["NOT_PAID", "EXTRACTED", "PAID", "PAYC_SENT"],
+            "enum": [
+              "NOT_PAID",
+              "EXTRACTED",
+              "PAID",
+              "PAYC_SENT"
+            ],
             "description": "Filter by payment status"
           },
           "approvalStatusCode": {
             "type": "string",
-            "enum": ["A_AAFH", "A_ACCO", "A_APPR", "A_EXTF", "A_FILE", "A_NOTF", "A_PBDG", "A_PEND", "A_PVAL", "A_RESU", "A_RHLD", "A_SUBM", "A_TEXP", "A_TRVL"],
+            "enum": [
+              "A_AAFH",
+              "A_ACCO",
+              "A_APPR",
+              "A_EXTF",
+              "A_FILE",
+              "A_NOTF",
+              "A_PBDG",
+              "A_PEND",
+              "A_PVAL",
+              "A_RESU",
+              "A_RHLD",
+              "A_SUBM",
+              "A_TEXP",
+              "A_TRVL"
+            ],
             "description": "Filter by approval status"
           },
           "modifiedDateAfter": {
@@ -100,7 +124,9 @@
             "description": "User login ID"
           }
         },
-        "required": ["reportId"],
+        "required": [
+          "reportId"
+        ],
         "additionalProperties": false
       }
     },
@@ -141,7 +167,9 @@
             "description": "User defined date"
           }
         },
-        "required": ["Name"],
+        "required": [
+          "Name"
+        ],
         "additionalProperties": false
       }
     },
@@ -172,7 +200,9 @@
             "description": "User login ID"
           }
         },
-        "required": ["reportId"],
+        "required": [
+          "reportId"
+        ],
         "additionalProperties": false
       }
     },
@@ -221,7 +251,12 @@
             "description": "Entry comment"
           }
         },
-        "required": ["reportId", "ExpenseTypeCode", "TransactionDate", "TransactionAmount"],
+        "required": [
+          "reportId",
+          "ExpenseTypeCode",
+          "TransactionDate",
+          "TransactionAmount"
+        ],
         "additionalProperties": false
       }
     },
@@ -290,10 +325,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "ID": {"type": "string"},
-          "Name": {"type": "string"},
-          "Total": {"type": "number"},
-          "ApprovalStatusCode": {"type": "string"}
+          "ID": {
+            "type": "string"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Total": {
+            "type": "number"
+          },
+          "ApprovalStatusCode": {
+            "type": "string"
+          }
         }
       }
     },
@@ -311,9 +354,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "ID": {"type": "string"},
-          "Name": {"type": "string"},
-          "ApprovalStatusCode": {"type": "string"}
+          "ID": {
+            "type": "string"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "ApprovalStatusCode": {
+            "type": "string"
+          }
         }
       }
     }
@@ -321,5 +370,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/common/users"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/confluence/definition.json
+++ b/connectors/confluence/definition.json
@@ -11,7 +11,11 @@
     "config": {
       "authUrl": "https://auth.atlassian.com/authorize",
       "tokenUrl": "https://auth.atlassian.com/oauth/token",
-      "scopes": ["read:confluence-content.all", "write:confluence-content", "read:confluence-space.summary"]
+      "scopes": [
+        "read:confluence-content.all",
+        "write:confluence-content",
+        "read:confluence-space.summary"
+      ]
     }
   },
   "baseUrl": "https://api.atlassian.com/ex/confluence",
@@ -40,7 +44,10 @@
           },
           "type": {
             "type": "string",
-            "enum": ["page", "blogpost"],
+            "enum": [
+              "page",
+              "blogpost"
+            ],
             "default": "page",
             "description": "Content type"
           },
@@ -51,7 +58,9 @@
           "space": {
             "type": "object",
             "properties": {
-              "key": {"type": "string"}
+              "key": {
+                "type": "string"
+              }
             },
             "description": "Space information"
           },
@@ -61,8 +70,17 @@
               "storage": {
                 "type": "object",
                 "properties": {
-                  "value": {"type": "string"},
-                  "representation": {"type": "string", "enum": ["storage", "view", "wiki"]}
+                  "value": {
+                    "type": "string"
+                  },
+                  "representation": {
+                    "type": "string",
+                    "enum": [
+                      "storage",
+                      "view",
+                      "wiki"
+                    ]
+                  }
                 }
               }
             },
@@ -73,7 +91,9 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"}
+                "id": {
+                  "type": "string"
+                }
               }
             },
             "description": "Parent pages"
@@ -83,7 +103,12 @@
             "description": "Page metadata"
           }
         },
-        "required": ["cloudid", "title", "space", "body"],
+        "required": [
+          "cloudid",
+          "title",
+          "space",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -104,7 +129,10 @@
           },
           "type": {
             "type": "string",
-            "enum": ["page", "blogpost"],
+            "enum": [
+              "page",
+              "blogpost"
+            ],
             "description": "Content type"
           },
           "title": {
@@ -117,8 +145,12 @@
               "storage": {
                 "type": "object",
                 "properties": {
-                  "value": {"type": "string"},
-                  "representation": {"type": "string"}
+                  "value": {
+                    "type": "string"
+                  },
+                  "representation": {
+                    "type": "string"
+                  }
                 }
               }
             },
@@ -127,12 +159,18 @@
           "version": {
             "type": "object",
             "properties": {
-              "number": {"type": "number"}
+              "number": {
+                "type": "number"
+              }
             },
             "description": "Version information"
           }
         },
-        "required": ["cloudid", "id", "version"],
+        "required": [
+          "cloudid",
+          "id",
+          "version"
+        ],
         "additionalProperties": false
       }
     },
@@ -153,12 +191,18 @@
           },
           "expand": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Properties to expand"
           },
           "status": {
             "type": "string",
-            "enum": ["current", "trashed", "draft"],
+            "enum": [
+              "current",
+              "trashed",
+              "draft"
+            ],
             "description": "Page status filter"
           },
           "version": {
@@ -166,7 +210,10 @@
             "description": "Specific version number"
           }
         },
-        "required": ["cloudid", "id"],
+        "required": [
+          "cloudid",
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -191,7 +238,9 @@
           },
           "expand": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Properties to expand"
           },
           "start": {
@@ -210,7 +259,10 @@
             "description": "Include archived spaces"
           }
         },
-        "required": ["cloudid", "cql"],
+        "required": [
+          "cloudid",
+          "cql"
+        ],
         "additionalProperties": false
       }
     },
@@ -227,22 +279,32 @@
           },
           "spaceKey": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by space keys"
           },
           "type": {
             "type": "string",
-            "enum": ["global", "personal"],
+            "enum": [
+              "global",
+              "personal"
+            ],
             "description": "Space type filter"
           },
           "status": {
             "type": "string",
-            "enum": ["current", "archived"],
+            "enum": [
+              "current",
+              "archived"
+            ],
             "description": "Space status filter"
           },
           "label": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by labels"
           },
           "favourite": {
@@ -251,7 +313,9 @@
           },
           "expand": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Properties to expand"
           },
           "start": {
@@ -266,7 +330,9 @@
             "description": "Number of spaces to return"
           }
         },
-        "required": ["cloudid"],
+        "required": [
+          "cloudid"
+        ],
         "additionalProperties": false
       }
     },
@@ -287,11 +353,17 @@
           },
           "status": {
             "type": "string",
-            "enum": ["current", "trashed"],
+            "enum": [
+              "current",
+              "trashed"
+            ],
             "description": "Current page status"
           }
         },
-        "required": ["cloudid", "id"],
+        "required": [
+          "cloudid",
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -309,8 +381,12 @@
           "container": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"},
-              "type": {"type": "string"}
+              "id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
             },
             "description": "Container (page) information"
           },
@@ -320,8 +396,12 @@
               "storage": {
                 "type": "object",
                 "properties": {
-                  "value": {"type": "string"},
-                  "representation": {"type": "string"}
+                  "value": {
+                    "type": "string"
+                  },
+                  "representation": {
+                    "type": "string"
+                  }
                 }
               }
             },
@@ -329,12 +409,18 @@
           },
           "type": {
             "type": "string",
-            "enum": ["comment"],
+            "enum": [
+              "comment"
+            ],
             "default": "comment",
             "description": "Content type"
           }
         },
-        "required": ["cloudid", "container", "body"],
+        "required": [
+          "cloudid",
+          "container",
+          "body"
+        ],
         "additionalProperties": false
       }
     }
@@ -359,10 +445,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "type": {"type": "string"},
-          "title": {"type": "string"},
-          "space": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "space": {
+            "type": "object"
+          }
         }
       }
     },
@@ -385,9 +479,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "version": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "version": {
+            "type": "object"
+          }
         }
       }
     }
@@ -395,5 +495,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/{cloudid}/wiki/rest/api/space"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/coupa/definition.json
+++ b/connectors/coupa/definition.json
@@ -46,7 +46,14 @@
           },
           "status": {
             "type": "string",
-            "enum": ["draft", "pending_approval", "approved", "pending_receipt", "received", "closed"],
+            "enum": [
+              "draft",
+              "pending_approval",
+              "approved",
+              "pending_receipt",
+              "received",
+              "closed"
+            ],
             "description": "Filter by status"
           },
           "exported": {
@@ -94,7 +101,9 @@
             "description": "Purchase order ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -108,10 +117,18 @@
           "requisition-header": {
             "type": "object",
             "properties": {
-              "requested-by": {"type": "object"},
-              "ship-to-address": {"type": "object"},
-              "supplier": {"type": "object"},
-              "currency": {"type": "object"}
+              "requested-by": {
+                "type": "object"
+              },
+              "ship-to-address": {
+                "type": "object"
+              },
+              "supplier": {
+                "type": "object"
+              },
+              "currency": {
+                "type": "object"
+              }
             },
             "description": "Purchase order header information"
           },
@@ -120,17 +137,29 @@
             "items": {
               "type": "object",
               "properties": {
-                "description": {"type": "string"},
-                "quantity": {"type": "number"},
-                "price": {"type": "number"},
-                "total": {"type": "number"},
-                "currency": {"type": "object"}
+                "description": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "number"
+                },
+                "price": {
+                  "type": "number"
+                },
+                "total": {
+                  "type": "number"
+                },
+                "currency": {
+                  "type": "object"
+                }
               }
             },
             "description": "Order line items"
           }
         },
-        "required": ["requisition-header"],
+        "required": [
+          "requisition-header"
+        ],
         "additionalProperties": false
       }
     },
@@ -158,7 +187,10 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "inactive"],
+            "enum": [
+              "active",
+              "inactive"
+            ],
             "description": "Filter by status"
           },
           "created-at[gt]": {
@@ -188,20 +220,32 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "inactive"],
+            "enum": [
+              "active",
+              "inactive"
+            ],
             "description": "Supplier status"
           },
           "supplier-addresses": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Supplier addresses"
           },
           "primary-contact": {
             "type": "object",
             "properties": {
-              "email": {"type": "string", "format": "email"},
-              "name-given": {"type": "string"},
-              "name-family": {"type": "string"}
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "name-given": {
+                "type": "string"
+              },
+              "name-family": {
+                "type": "string"
+              }
             },
             "description": "Primary contact information"
           },
@@ -210,7 +254,9 @@
             "description": "Payment terms"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -234,7 +280,13 @@
           },
           "status": {
             "type": "string",
-            "enum": ["draft", "pending_approval", "approved", "paid", "voided"],
+            "enum": [
+              "draft",
+              "pending_approval",
+              "approved",
+              "paid",
+              "voided"
+            ],
             "description": "Filter by status"
           },
           "supplier-id": {
@@ -277,7 +329,9 @@
             "description": "Approval comment"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     }
@@ -302,10 +356,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "po-number": {"type": "string"},
-          "status": {"type": "string"},
-          "total": {"type": "number"}
+          "id": {
+            "type": "number"
+          },
+          "po-number": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "total": {
+            "type": "number"
+          }
         }
       }
     },
@@ -323,10 +385,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "invoice-number": {"type": "string"},
-          "status": {"type": "string"},
-          "total": {"type": "number"}
+          "id": {
+            "type": "number"
+          },
+          "invoice-number": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "total": {
+            "type": "number"
+          }
         }
       }
     }
@@ -334,5 +404,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/databricks/definition.json
+++ b/connectors/databricks/definition.json
@@ -55,7 +55,9 @@
             "description": "Cluster ID"
           }
         },
-        "required": ["cluster_id"],
+        "required": [
+          "cluster_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -71,7 +73,9 @@
             "description": "Cluster ID to start"
           }
         },
-        "required": ["cluster_id"],
+        "required": [
+          "cluster_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -87,7 +91,9 @@
             "description": "Cluster ID to stop"
           }
         },
-        "required": ["cluster_id"],
+        "required": [
+          "cluster_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -105,9 +111,15 @@
           "new_cluster": {
             "type": "object",
             "properties": {
-              "spark_version": {"type": "string"},
-              "node_type_id": {"type": "string"},
-              "num_workers": {"type": "number"}
+              "spark_version": {
+                "type": "string"
+              },
+              "node_type_id": {
+                "type": "string"
+              },
+              "num_workers": {
+                "type": "number"
+              }
             },
             "description": "New cluster configuration"
           },
@@ -118,31 +130,54 @@
           "notebook_task": {
             "type": "object",
             "properties": {
-              "notebook_path": {"type": "string"},
-              "base_parameters": {"type": "object"}
+              "notebook_path": {
+                "type": "string"
+              },
+              "base_parameters": {
+                "type": "object"
+              }
             },
             "description": "Notebook task configuration"
           },
           "spark_jar_task": {
             "type": "object",
             "properties": {
-              "main_class_name": {"type": "string"},
-              "parameters": {"type": "array", "items": {"type": "string"}}
+              "main_class_name": {
+                "type": "string"
+              },
+              "parameters": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             },
             "description": "Spark JAR task configuration"
           },
           "spark_python_task": {
             "type": "object",
             "properties": {
-              "python_file": {"type": "string"},
-              "parameters": {"type": "array", "items": {"type": "string"}}
+              "python_file": {
+                "type": "string"
+              },
+              "parameters": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             },
             "description": "Spark Python task configuration"
           },
           "spark_submit_task": {
             "type": "object",
             "properties": {
-              "parameters": {"type": "array", "items": {"type": "string"}}
+              "parameters": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             },
             "description": "Spark submit task configuration"
           },
@@ -175,7 +210,9 @@
             "description": "Include run history"
           }
         },
-        "required": ["run_id"],
+        "required": [
+          "run_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -191,7 +228,9 @@
             "description": "Run ID to cancel"
           }
         },
-        "required": ["run_id"],
+        "required": [
+          "run_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -251,15 +290,32 @@
           },
           "libraries": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Job libraries"
           },
           "email_notifications": {
             "type": "object",
             "properties": {
-              "on_start": {"type": "array", "items": {"type": "string"}},
-              "on_success": {"type": "array", "items": {"type": "string"}},
-              "on_failure": {"type": "array", "items": {"type": "string"}}
+              "on_start": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "on_success": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "on_failure": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             },
             "description": "Email notification settings"
           },
@@ -282,8 +338,12 @@
           "schedule": {
             "type": "object",
             "properties": {
-              "quartz_cron_expression": {"type": "string"},
-              "timezone_id": {"type": "string"}
+              "quartz_cron_expression": {
+                "type": "string"
+              },
+              "timezone_id": {
+                "type": "string"
+              }
             },
             "description": "Job schedule configuration"
           },
@@ -317,10 +377,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "run_id": {"type": "number"},
-          "job_id": {"type": "number"},
-          "run_name": {"type": "string"},
-          "state": {"type": "object"}
+          "run_id": {
+            "type": "number"
+          },
+          "job_id": {
+            "type": "number"
+          },
+          "run_name": {
+            "type": "string"
+          },
+          "state": {
+            "type": "object"
+          }
         }
       }
     },
@@ -338,9 +406,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "cluster_id": {"type": "string"},
-          "cluster_name": {"type": "string"},
-          "state": {"type": "string"}
+          "cluster_id": {
+            "type": "string"
+          },
+          "cluster_name": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
         }
       }
     }
@@ -348,5 +422,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/clusters/list"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/datadog/definition.json
+++ b/connectors/datadog/definition.json
@@ -38,20 +38,50 @@
             "items": {
               "type": "object",
               "properties": {
-                "metric": {"type": "string"},
-                "points": {"type": "array", "items": {"type": "array"}},
-                "type": {"type": "string", "enum": ["gauge", "rate", "count"]},
-                "interval": {"type": "number"},
-                "host": {"type": "string"},
-                "tags": {"type": "array", "items": {"type": "string"}},
-                "unit": {"type": "string"}
+                "metric": {
+                  "type": "string"
+                },
+                "points": {
+                  "type": "array",
+                  "items": {
+                    "type": "array"
+                  }
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "gauge",
+                    "rate",
+                    "count"
+                  ]
+                },
+                "interval": {
+                  "type": "number"
+                },
+                "host": {
+                  "type": "string"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "unit": {
+                  "type": "string"
+                }
               },
-              "required": ["metric", "points"]
+              "required": [
+                "metric",
+                "points"
+              ]
             },
             "description": "Metrics data series"
           }
         },
-        "required": ["series"],
+        "required": [
+          "series"
+        ],
         "additionalProperties": false
       }
     },
@@ -75,7 +105,11 @@
             "description": "End timestamp (Unix epoch)"
           }
         },
-        "required": ["query", "from", "to"],
+        "required": [
+          "query",
+          "from",
+          "to"
+        ],
         "additionalProperties": false
       }
     },
@@ -100,7 +134,10 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["normal", "low"],
+            "enum": [
+              "normal",
+              "low"
+            ],
             "description": "Event priority"
           },
           "host": {
@@ -109,12 +146,19 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Event tags"
           },
           "alert_type": {
             "type": "string",
-            "enum": ["error", "warning", "info", "success"],
+            "enum": [
+              "error",
+              "warning",
+              "info",
+              "success"
+            ],
             "description": "Alert type"
           },
           "aggregation_key": {
@@ -126,7 +170,10 @@
             "description": "Source type"
           }
         },
-        "required": ["title", "text"],
+        "required": [
+          "title",
+          "text"
+        ],
         "additionalProperties": false
       }
     },
@@ -147,7 +194,10 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["normal", "low"],
+            "enum": [
+              "normal",
+              "low"
+            ],
             "description": "Filter by priority"
           },
           "sources": {
@@ -163,7 +213,10 @@
             "description": "Return unaggregated events"
           }
         },
-        "required": ["start", "end"],
+        "required": [
+          "start",
+          "end"
+        ],
         "additionalProperties": false
       }
     },
@@ -176,7 +229,16 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["metric alert", "service check", "event alert", "process alert", "log alert", "anomaly", "outlier", "forecast"],
+            "enum": [
+              "metric alert",
+              "service check",
+              "event alert",
+              "process alert",
+              "log alert",
+              "anomaly",
+              "outlier",
+              "forecast"
+            ],
             "description": "Monitor type"
           },
           "query": {
@@ -193,16 +255,26 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Monitor tags"
           },
           "options": {
             "type": "object",
             "properties": {
-              "thresholds": {"type": "object"},
-              "notify_audit": {"type": "boolean"},
-              "timeout_h": {"type": "number"},
-              "evaluation_delay": {"type": "number"}
+              "thresholds": {
+                "type": "object"
+              },
+              "notify_audit": {
+                "type": "boolean"
+              },
+              "timeout_h": {
+                "type": "number"
+              },
+              "evaluation_delay": {
+                "type": "number"
+              }
             },
             "description": "Monitor options"
           },
@@ -212,11 +284,17 @@
           },
           "restricted_roles": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Restricted roles"
           }
         },
-        "required": ["type", "query", "name"],
+        "required": [
+          "type",
+          "query",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -229,7 +307,18 @@
         "properties": {
           "group_states": {
             "type": "array",
-            "items": {"type": "string", "enum": ["Alert", "Ignored", "No Data", "OK", "Skipped", "Unknown", "Warn"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "Alert",
+                "Ignored",
+                "No Data",
+                "OK",
+                "Skipped",
+                "Unknown",
+                "Warn"
+              ]
+            },
             "description": "Filter by group states"
           },
           "name": {
@@ -238,12 +327,16 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by tags"
           },
           "monitor_tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by monitor tags"
           },
           "with_downtimes": {
@@ -291,10 +384,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "name": {"type": "string"},
-          "query": {"type": "string"},
-          "state": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
         }
       }
     },
@@ -312,9 +413,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "metric": {"type": "string"},
-          "value": {"type": "number"},
-          "threshold": {"type": "number"}
+          "metric": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          },
+          "threshold": {
+            "type": "number"
+          }
         }
       }
     }
@@ -322,5 +429,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/validate"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/docker-hub/definition.json
+++ b/connectors/docker-hub/definition.json
@@ -69,7 +69,10 @@
             "description": "Repository name"
           }
         },
-        "required": ["namespace", "repository"],
+        "required": [
+          "namespace",
+          "repository"
+        ],
         "additionalProperties": false
       }
     },
@@ -96,7 +99,10 @@
             "description": "Number of tags per page"
           }
         },
-        "required": ["namespace", "repository"],
+        "required": [
+          "namespace",
+          "repository"
+        ],
         "additionalProperties": false
       }
     },
@@ -121,7 +127,11 @@
             "description": "Tag name"
           }
         },
-        "required": ["namespace", "repository", "tag"],
+        "required": [
+          "namespace",
+          "repository",
+          "tag"
+        ],
         "additionalProperties": false
       }
     },
@@ -181,5 +191,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/docusign/definition.json
+++ b/connectors/docusign/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://account.docusign.com/oauth/auth",
       "tokenUrl": "https://account.docusign.com/oauth/token",
-      "scopes": ["signature", "impersonation"]
+      "scopes": [
+        "signature",
+        "impersonation"
+      ]
     }
   },
   "baseUrl": "https://na3.docusign.net/restapi/v2.1",
@@ -44,7 +47,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["sent", "created", "draft"],
+            "enum": [
+              "sent",
+              "created",
+              "draft"
+            ],
             "default": "sent",
             "description": "Envelope status"
           },
@@ -53,12 +60,24 @@
             "items": {
               "type": "object",
               "properties": {
-                "documentBase64": {"type": "string"},
-                "name": {"type": "string"},
-                "fileExtension": {"type": "string"},
-                "documentId": {"type": "string"}
+                "documentBase64": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "fileExtension": {
+                  "type": "string"
+                },
+                "documentId": {
+                  "type": "string"
+                }
               },
-              "required": ["documentBase64", "name", "documentId"]
+              "required": [
+                "documentBase64",
+                "name",
+                "documentId"
+              ]
             },
             "description": "Documents to be signed"
           },
@@ -70,13 +89,28 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "email": {"type": "string", "format": "email"},
-                    "name": {"type": "string"},
-                    "recipientId": {"type": "string"},
-                    "routingOrder": {"type": "string"},
-                    "tabs": {"type": "object"}
+                    "email": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "recipientId": {
+                      "type": "string"
+                    },
+                    "routingOrder": {
+                      "type": "string"
+                    },
+                    "tabs": {
+                      "type": "object"
+                    }
                   },
-                  "required": ["email", "name", "recipientId"]
+                  "required": [
+                    "email",
+                    "name",
+                    "recipientId"
+                  ]
                 }
               },
               "carbonCopies": {
@@ -84,9 +118,16 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "email": {"type": "string", "format": "email"},
-                    "name": {"type": "string"},
-                    "recipientId": {"type": "string"}
+                    "email": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "recipientId": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -96,16 +137,38 @@
           "eventNotification": {
             "type": "object",
             "properties": {
-              "url": {"type": "string", "format": "uri"},
-              "loggingEnabled": {"type": "boolean"},
-              "requireAcknowledgment": {"type": "boolean"},
-              "envelopeEvents": {"type": "array", "items": {"type": "object"}},
-              "recipientEvents": {"type": "array", "items": {"type": "object"}}
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "loggingEnabled": {
+                "type": "boolean"
+              },
+              "requireAcknowledgment": {
+                "type": "boolean"
+              },
+              "envelopeEvents": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "recipientEvents": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
             },
             "description": "Event notification settings"
           }
         },
-        "required": ["accountId", "emailSubject", "documents", "recipients"],
+        "required": [
+          "accountId",
+          "emailSubject",
+          "documents",
+          "recipients"
+        ],
         "additionalProperties": false
       }
     },
@@ -129,7 +192,10 @@
             "description": "Additional data to include"
           }
         },
-        "required": ["accountId", "envelopeId"],
+        "required": [
+          "accountId",
+          "envelopeId"
+        ],
         "additionalProperties": false
       }
     },
@@ -146,7 +212,15 @@
           },
           "status": {
             "type": "string",
-            "enum": ["sent", "delivered", "completed", "declined", "voided", "created", "deleted"],
+            "enum": [
+              "sent",
+              "delivered",
+              "completed",
+              "declined",
+              "voided",
+              "created",
+              "deleted"
+            ],
             "description": "Filter by envelope status"
           },
           "from_date": {
@@ -176,16 +250,26 @@
           },
           "order": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "description": "Sort order"
           },
           "order_by": {
             "type": "string",
-            "enum": ["status", "created", "sent", "subject"],
+            "enum": [
+              "status",
+              "created",
+              "sent",
+              "subject"
+            ],
             "description": "Sort field"
           }
         },
-        "required": ["accountId"],
+        "required": [
+          "accountId"
+        ],
         "additionalProperties": false
       }
     },
@@ -205,7 +289,10 @@
             "description": "Envelope ID"
           }
         },
-        "required": ["accountId", "envelopeId"],
+        "required": [
+          "accountId",
+          "envelopeId"
+        ],
         "additionalProperties": false
       }
     },
@@ -233,7 +320,10 @@
             "description": "Include extended recipient info"
           }
         },
-        "required": ["accountId", "envelopeId"],
+        "required": [
+          "accountId",
+          "envelopeId"
+        ],
         "additionalProperties": false
       }
     },
@@ -262,11 +352,17 @@
           },
           "encoding": {
             "type": "string",
-            "enum": ["base64"],
+            "enum": [
+              "base64"
+            ],
             "description": "Document encoding"
           }
         },
-        "required": ["accountId", "envelopeId", "documentId"],
+        "required": [
+          "accountId",
+          "envelopeId",
+          "documentId"
+        ],
         "additionalProperties": false
       }
     },
@@ -290,7 +386,11 @@
             "description": "Reason for voiding"
           }
         },
-        "required": ["accountId", "envelopeId", "voidedReason"],
+        "required": [
+          "accountId",
+          "envelopeId",
+          "voidedReason"
+        ],
         "additionalProperties": false
       }
     }
@@ -315,9 +415,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "envelopeId": {"type": "string"},
-          "status": {"type": "string"},
-          "completedDateTime": {"type": "string"}
+          "envelopeId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "completedDateTime": {
+            "type": "string"
+          }
         }
       }
     },
@@ -335,9 +441,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "envelopeId": {"type": "string"},
-          "status": {"type": "string"},
-          "sentDateTime": {"type": "string"}
+          "envelopeId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "sentDateTime": {
+            "type": "string"
+          }
         }
       }
     },
@@ -355,9 +467,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "envelopeId": {"type": "string"},
-          "recipientId": {"type": "string"},
-          "status": {"type": "string"}
+          "envelopeId": {
+            "type": "string"
+          },
+          "recipientId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
         }
       }
     }
@@ -365,5 +483,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/accounts"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/dropbox-enhanced/definition.json
+++ b/connectors/dropbox-enhanced/definition.json
@@ -11,7 +11,14 @@
     "config": {
       "authUrl": "https://www.dropbox.com/oauth2/authorize",
       "tokenUrl": "https://api.dropboxapi.com/oauth2/token",
-      "scopes": ["files.content.write", "files.content.read", "files.metadata.write", "files.metadata.read", "sharing.write", "sharing.read"]
+      "scopes": [
+        "files.content.write",
+        "files.content.read",
+        "files.metadata.write",
+        "files.metadata.read",
+        "sharing.write",
+        "sharing.read"
+      ]
     }
   },
   "baseUrl": "https://api.dropboxapi.com/2",
@@ -44,7 +51,11 @@
           },
           "mode": {
             "type": "string",
-            "enum": ["add", "overwrite", "update"],
+            "enum": [
+              "add",
+              "overwrite",
+              "update"
+            ],
             "default": "add",
             "description": "Write mode"
           },
@@ -69,7 +80,10 @@
             "description": "Force conflict resolution"
           }
         },
-        "required": ["path", "content"],
+        "required": [
+          "path",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -89,7 +103,9 @@
             "description": "Specific revision to download"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -159,7 +175,9 @@
             "description": "Auto-rename if folder exists"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -175,7 +193,9 @@
             "description": "Path to delete"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -210,7 +230,10 @@
             "description": "Allow ownership transfer"
           }
         },
-        "required": ["from_path", "to_path"],
+        "required": [
+          "from_path",
+          "to_path"
+        ],
         "additionalProperties": false
       }
     },
@@ -245,7 +268,10 @@
             "description": "Allow ownership transfer"
           }
         },
-        "required": ["from_path", "to_path"],
+        "required": [
+          "from_path",
+          "to_path"
+        ],
         "additionalProperties": false
       }
     },
@@ -276,7 +302,9 @@
             "description": "Include sharing info"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -294,9 +322,21 @@
           "settings": {
             "type": "object",
             "properties": {
-              "requested_visibility": {"type": "string", "enum": ["public", "team_only", "password"]},
-              "link_password": {"type": "string"},
-              "expires": {"type": "string", "format": "date-time"}
+              "requested_visibility": {
+                "type": "string",
+                "enum": [
+                  "public",
+                  "team_only",
+                  "password"
+                ]
+              },
+              "link_password": {
+                "type": "string"
+              },
+              "expires": {
+                "type": "string",
+                "format": "date-time"
+              }
             },
             "description": "Shared link settings"
           },
@@ -306,7 +346,9 @@
             "description": "Create short URL"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -335,7 +377,11 @@
           },
           "mode": {
             "type": "string",
-            "enum": ["filename", "filename_and_content", "deleted_filename"],
+            "enum": [
+              "filename",
+              "filename_and_content",
+              "deleted_filename"
+            ],
             "default": "filename",
             "description": "Search mode"
           },
@@ -345,7 +391,9 @@
             "description": "Include search highlights"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     }
@@ -370,10 +418,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "path_lower": {"type": "string"},
-          "name": {"type": "string"},
-          "size": {"type": "number"},
-          "client_modified": {"type": "string"}
+          "path_lower": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "client_modified": {
+            "type": "string"
+          }
         }
       }
     },
@@ -396,8 +452,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "path_lower": {"type": "string"},
-          "name": {"type": "string"}
+          "path_lower": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
         }
       }
     },
@@ -415,9 +475,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "shared_folder_id": {"type": "string"},
-          "name": {"type": "string"},
-          "access_type": {"type": "string"}
+          "shared_folder_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "access_type": {
+            "type": "string"
+          }
         }
       }
     }
@@ -425,5 +491,19 @@
   "testConnection": {
     "method": "POST",
     "endpoint": "/users/get_current_account"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/dropbox/definition.json
+++ b/connectors/dropbox/definition.json
@@ -11,7 +11,11 @@
     "config": {
       "authUrl": "https://www.dropbox.com/oauth2/authorize",
       "tokenUrl": "https://api.dropboxapi.com/oauth2/token",
-      "scopes": ["files.content.write", "files.content.read", "files.metadata.read"]
+      "scopes": [
+        "files.content.write",
+        "files.content.read",
+        "files.metadata.read"
+      ]
     }
   },
   "baseUrl": "https://api.dropboxapi.com/2",
@@ -44,7 +48,11 @@
           },
           "mode": {
             "type": "string",
-            "enum": ["add", "overwrite", "update"],
+            "enum": [
+              "add",
+              "overwrite",
+              "update"
+            ],
             "default": "add",
             "description": "Write mode"
           },
@@ -59,7 +67,10 @@
             "description": "Mute notifications"
           }
         },
-        "required": ["path", "content"],
+        "required": [
+          "path",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -75,7 +86,9 @@
             "description": "File path in Dropbox"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -139,7 +152,9 @@
             "description": "Auto-rename if folder exists"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -157,7 +172,9 @@
             "description": "Path to delete"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -184,7 +201,10 @@
             "description": "Auto-rename if destination exists"
           }
         },
-        "required": ["from_path", "to_path"],
+        "required": [
+          "from_path",
+          "to_path"
+        ],
         "additionalProperties": false
       }
     },
@@ -211,7 +231,10 @@
             "description": "Auto-rename if destination exists"
           }
         },
-        "required": ["from_path", "to_path"],
+        "required": [
+          "from_path",
+          "to_path"
+        ],
         "additionalProperties": false
       }
     },
@@ -239,7 +262,9 @@
             "description": "Include deleted files"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -270,12 +295,18 @@
           },
           "mode": {
             "type": "string",
-            "enum": ["filename", "filename_and_content", "deleted_filename"],
+            "enum": [
+              "filename",
+              "filename_and_content",
+              "deleted_filename"
+            ],
             "default": "filename",
             "description": "Search mode"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -293,7 +324,9 @@
             "description": "Path of the file or folder"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     }
@@ -318,9 +351,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "path_lower": {"type": "string"},
-          "name": {"type": "string"},
-          "size": {"type": "number"}
+          "path_lower": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          }
         }
       }
     },
@@ -338,8 +377,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "path_lower": {"type": "string"},
-          "name": {"type": "string"}
+          "path_lower": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
         }
       }
     }
@@ -347,6 +390,19 @@
   "testConnection": {
     "method": "POST",
     "endpoint": "/users/get_current_account"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }
-

--- a/connectors/dynamics365/definition.json
+++ b/connectors/dynamics365/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-      "scopes": ["https://dynamics.microsoft.com/user_impersonation"]
+      "scopes": [
+        "https://dynamics.microsoft.com/user_impersonation"
+      ]
     }
   },
   "baseUrl": "https://{organization}.dynamics.com/api/data/v9.2",
@@ -93,7 +95,9 @@
             "description": "Account description"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -117,7 +121,9 @@
             "description": "Related entities to expand"
           }
         },
-        "required": ["accountid"],
+        "required": [
+          "accountid"
+        ],
         "additionalProperties": false
       }
     },
@@ -163,7 +169,9 @@
             "description": "Account description"
           }
         },
-        "required": ["accountid"],
+        "required": [
+          "accountid"
+        ],
         "additionalProperties": false
       }
     },
@@ -267,7 +275,9 @@
             "description": "Contact description"
           }
         },
-        "required": ["lastname"],
+        "required": [
+          "lastname"
+        ],
         "additionalProperties": false
       }
     },
@@ -336,7 +346,10 @@
             "description": "Lead description"
           }
         },
-        "required": ["lastname", "subject"],
+        "required": [
+          "lastname",
+          "subject"
+        ],
         "additionalProperties": false
       }
     },
@@ -387,7 +400,9 @@
             "description": "Opportunity description"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     }
@@ -412,9 +427,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "accountid": {"type": "string"},
-          "name": {"type": "string"},
-          "createdon": {"type": "string"}
+          "accountid": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "createdon": {
+            "type": "string"
+          }
         }
       }
     },
@@ -432,9 +453,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "leadid": {"type": "string"},
-          "subject": {"type": "string"},
-          "fullname": {"type": "string"}
+          "leadid": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "fullname": {
+            "type": "string"
+          }
         }
       }
     },
@@ -452,9 +479,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "opportunityid": {"type": "string"},
-          "name": {"type": "string"},
-          "actualvalue": {"type": "number"}
+          "opportunityid": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "actualvalue": {
+            "type": "number"
+          }
         }
       }
     }
@@ -462,5 +495,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/accounts?$top=1"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/egnyte/definition.json
+++ b/connectors/egnyte/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://{domain}.egnyte.com/puboauth/token",
       "tokenUrl": "https://{domain}.egnyte.com/puboauth/token",
-      "scopes": ["Egnyte.filesystem"]
+      "scopes": [
+        "Egnyte.filesystem"
+      ]
     }
   },
   "baseUrl": "https://{domain}.egnyte.com/pubapi/v1",
@@ -48,7 +50,10 @@
             "description": "Overwrite existing file"
           }
         },
-        "required": ["path", "content"],
+        "required": [
+          "path",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -64,7 +69,9 @@
             "description": "File path to download"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -107,7 +114,9 @@
             "description": "Folder path to create"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -123,7 +132,9 @@
             "description": "Path to delete"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -143,7 +154,10 @@
             "description": "Destination path"
           }
         },
-        "required": ["source", "destination"],
+        "required": [
+          "source",
+          "destination"
+        ],
         "additionalProperties": false
       }
     },
@@ -163,7 +177,10 @@
             "description": "Destination path"
           }
         },
-        "required": ["source", "destination"],
+        "required": [
+          "source",
+          "destination"
+        ],
         "additionalProperties": false
       }
     },
@@ -180,12 +197,20 @@
           },
           "type": {
             "type": "string",
-            "enum": ["file", "folder"],
+            "enum": [
+              "file",
+              "folder"
+            ],
             "description": "Link type"
           },
           "accessibility": {
             "type": "string",
-            "enum": ["anyone", "password", "domain", "recipients"],
+            "enum": [
+              "anyone",
+              "password",
+              "domain",
+              "recipients"
+            ],
             "default": "domain",
             "description": "Link accessibility"
           },
@@ -201,7 +226,10 @@
           },
           "recipients": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "Email recipients"
           },
           "message": {
@@ -209,7 +237,10 @@
             "description": "Message to include with link"
           }
         },
-        "required": ["path", "type"],
+        "required": [
+          "path",
+          "type"
+        ],
         "additionalProperties": false
       }
     },
@@ -231,7 +262,10 @@
           },
           "type": {
             "type": "string",
-            "enum": ["file", "folder"],
+            "enum": [
+              "file",
+              "folder"
+            ],
             "description": "Search for files or folders"
           },
           "modified_after": {
@@ -252,7 +286,9 @@
             "description": "Maximum results to return"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     }
@@ -277,10 +313,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "path": {"type": "string"},
-          "name": {"type": "string"},
-          "size": {"type": "number"},
-          "modified": {"type": "string"}
+          "path": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "modified": {
+            "type": "string"
+          }
         }
       }
     },
@@ -303,8 +347,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "path": {"type": "string"},
-          "name": {"type": "string"}
+          "path": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
         }
       }
     }
@@ -312,5 +360,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/userinfo"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/excel-online/definition.json
+++ b/connectors/excel-online/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-      "scopes": ["https://graph.microsoft.com/Files.ReadWrite"]
+      "scopes": [
+        "https://graph.microsoft.com/Files.ReadWrite"
+      ]
     }
   },
   "baseUrl": "https://graph.microsoft.com/v1.0",
@@ -48,7 +50,10 @@
             "description": "Workbook name"
           }
         },
-        "required": ["driveId", "name"],
+        "required": [
+          "driveId",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -68,7 +73,10 @@
             "description": "Workbook item ID"
           }
         },
-        "required": ["driveId", "itemId"],
+        "required": [
+          "driveId",
+          "itemId"
+        ],
         "additionalProperties": false
       }
     },
@@ -88,7 +96,10 @@
             "description": "Workbook item ID"
           }
         },
-        "required": ["driveId", "itemId"],
+        "required": [
+          "driveId",
+          "itemId"
+        ],
         "additionalProperties": false
       }
     },
@@ -112,7 +123,11 @@
             "description": "Worksheet name"
           }
         },
-        "required": ["driveId", "itemId", "name"],
+        "required": [
+          "driveId",
+          "itemId",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -145,7 +160,12 @@
             "description": "Return only values"
           }
         },
-        "required": ["driveId", "itemId", "worksheetId", "address"],
+        "required": [
+          "driveId",
+          "itemId",
+          "worksheetId",
+          "address"
+        ],
         "additionalProperties": false
       }
     },
@@ -174,16 +194,26 @@
           },
           "values": {
             "type": "array",
-            "items": {"type": "array"},
+            "items": {
+              "type": "array"
+            },
             "description": "2D array of values to set"
           },
           "numberFormat": {
             "type": "array",
-            "items": {"type": "array"},
+            "items": {
+              "type": "array"
+            },
             "description": "2D array of number formats"
           }
         },
-        "required": ["driveId", "itemId", "worksheetId", "address", "values"],
+        "required": [
+          "driveId",
+          "itemId",
+          "worksheetId",
+          "address",
+          "values"
+        ],
         "additionalProperties": false
       }
     },
@@ -212,7 +242,9 @@
           },
           "values": {
             "type": "array",
-            "items": {"type": "array"},
+            "items": {
+              "type": "array"
+            },
             "description": "Row values as 2D array"
           },
           "index": {
@@ -220,7 +252,13 @@
             "description": "Index where to insert row"
           }
         },
-        "required": ["driveId", "itemId", "worksheetId", "tableId", "values"],
+        "required": [
+          "driveId",
+          "itemId",
+          "worksheetId",
+          "tableId",
+          "values"
+        ],
         "additionalProperties": false
       }
     },
@@ -244,7 +282,11 @@
             "description": "Worksheet ID or name"
           }
         },
-        "required": ["driveId", "itemId", "worksheetId"],
+        "required": [
+          "driveId",
+          "itemId",
+          "worksheetId"
+        ],
         "additionalProperties": false
       }
     },
@@ -277,7 +319,12 @@
             "description": "Table has headers"
           }
         },
-        "required": ["driveId", "itemId", "worksheetId", "address"],
+        "required": [
+          "driveId",
+          "itemId",
+          "worksheetId",
+          "address"
+        ],
         "additionalProperties": false
       }
     },
@@ -302,7 +349,14 @@
           },
           "type": {
             "type": "string",
-            "enum": ["ColumnClustered", "ColumnStacked", "Line", "Pie", "XYScatter", "Area"],
+            "enum": [
+              "ColumnClustered",
+              "ColumnStacked",
+              "Line",
+              "Pie",
+              "XYScatter",
+              "Area"
+            ],
             "description": "Chart type"
           },
           "sourceData": {
@@ -311,12 +365,22 @@
           },
           "seriesBy": {
             "type": "string",
-            "enum": ["Auto", "Columns", "Rows"],
+            "enum": [
+              "Auto",
+              "Columns",
+              "Rows"
+            ],
             "default": "Auto",
             "description": "How series are arranged"
           }
         },
-        "required": ["driveId", "itemId", "worksheetId", "type", "sourceData"],
+        "required": [
+          "driveId",
+          "itemId",
+          "worksheetId",
+          "type",
+          "sourceData"
+        ],
         "additionalProperties": false
       }
     }
@@ -341,9 +405,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "lastModifiedDateTime": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "lastModifiedDateTime": {
+            "type": "string"
+          }
         }
       }
     },
@@ -366,9 +436,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "tableId": {"type": "string"},
-          "rowIndex": {"type": "number"},
-          "values": {"type": "array"}
+          "tableId": {
+            "type": "string"
+          },
+          "rowIndex": {
+            "type": "number"
+          },
+          "values": {
+            "type": "array"
+          }
         }
       }
     }
@@ -376,5 +452,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/me/drive"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/expensify/definition.json
+++ b/connectors/expensify/definition.json
@@ -86,7 +86,12 @@
             "description": "Receipt data (base64 encoded)"
           }
         },
-        "required": ["partnerUserSecret", "amount", "merchant", "created"],
+        "required": [
+          "partnerUserSecret",
+          "amount",
+          "merchant",
+          "created"
+        ],
         "additionalProperties": false
       }
     },
@@ -113,7 +118,13 @@
           },
           "reportState": {
             "type": "string",
-            "enum": ["OPEN", "PROCESSING", "APPROVED", "REIMBURSED", "ARCHIVED"],
+            "enum": [
+              "OPEN",
+              "PROCESSING",
+              "APPROVED",
+              "REIMBURSED",
+              "ARCHIVED"
+            ],
             "description": "Filter by report state"
           },
           "policyID": {
@@ -128,7 +139,9 @@
             "description": "Maximum reports to return"
           }
         },
-        "required": ["partnerUserSecret"],
+        "required": [
+          "partnerUserSecret"
+        ],
         "additionalProperties": false
       }
     },
@@ -153,7 +166,10 @@
             "description": "Return random filename for export"
           }
         },
-        "required": ["partnerUserSecret", "reportID"],
+        "required": [
+          "partnerUserSecret",
+          "reportID"
+        ],
         "additionalProperties": false
       }
     },
@@ -178,17 +194,26 @@
           },
           "fileExtension": {
             "type": "string",
-            "enum": ["csv", "pdf"],
+            "enum": [
+              "csv",
+              "pdf"
+            ],
             "default": "csv",
             "description": "Export file format"
           },
           "onReceive": {
             "type": "string",
-            "enum": ["returnRandomFileName", "markAsExported"],
+            "enum": [
+              "returnRandomFileName",
+              "markAsExported"
+            ],
             "description": "Action on export"
           }
         },
-        "required": ["partnerUserSecret", "reportIDList"],
+        "required": [
+          "partnerUserSecret",
+          "reportIDList"
+        ],
         "additionalProperties": false
       }
     },
@@ -204,7 +229,9 @@
             "description": "Partner user secret"
           }
         },
-        "required": ["partnerUserSecret"],
+        "required": [
+          "partnerUserSecret"
+        ],
         "additionalProperties": false
       }
     },
@@ -228,7 +255,11 @@
             "description": "Comma-separated tag names"
           }
         },
-        "required": ["partnerUserSecret", "policyID", "tags"],
+        "required": [
+          "partnerUserSecret",
+          "policyID",
+          "tags"
+        ],
         "additionalProperties": false
       }
     },
@@ -256,7 +287,11 @@
             "description": "Transaction ID to attach receipt to"
           }
         },
-        "required": ["partnerUserSecret", "filename", "receiptData"],
+        "required": [
+          "partnerUserSecret",
+          "filename",
+          "receiptData"
+        ],
         "additionalProperties": false
       }
     }
@@ -281,10 +316,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "reportID": {"type": "string"},
-          "reportName": {"type": "string"},
-          "total": {"type": "number"},
-          "state": {"type": "string"}
+          "reportID": {
+            "type": "string"
+          },
+          "reportName": {
+            "type": "string"
+          },
+          "total": {
+            "type": "number"
+          },
+          "state": {
+            "type": "string"
+          }
         }
       }
     },
@@ -302,9 +345,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "reportID": {"type": "string"},
-          "approver": {"type": "string"},
-          "approvedDate": {"type": "string"}
+          "reportID": {
+            "type": "string"
+          },
+          "approver": {
+            "type": "string"
+          },
+          "approvedDate": {
+            "type": "string"
+          }
         }
       }
     },
@@ -322,10 +371,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "transactionID": {"type": "string"},
-          "amount": {"type": "number"},
-          "merchant": {"type": "string"},
-          "created": {"type": "string"}
+          "transactionID": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "merchant": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string"
+          }
         }
       }
     }
@@ -333,5 +390,19 @@
   "testConnection": {
     "method": "POST",
     "endpoint": "/"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/freshdesk/definition.json
+++ b/connectors/freshdesk/definition.json
@@ -58,17 +58,35 @@
           },
           "status": {
             "type": "number",
-            "enum": [2, 3, 4, 5],
+            "enum": [
+              2,
+              3,
+              4,
+              5
+            ],
             "description": "Ticket status (2=Open, 3=Pending, 4=Resolved, 5=Closed)"
           },
           "priority": {
             "type": "number",
-            "enum": [1, 2, 3, 4],
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ],
             "description": "Ticket priority (1=Low, 2=Medium, 3=High, 4=Urgent)"
           },
           "source": {
             "type": "number",
-            "enum": [1, 2, 3, 7, 8, 9, 10],
+            "enum": [
+              1,
+              2,
+              3,
+              7,
+              8,
+              9,
+              10
+            ],
             "description": "Ticket source (1=Email, 2=Portal, 3=Phone, 7=Chat, 8=Mobihelp, 9=Feedback, 10=Outbound Email)"
           },
           "type": {
@@ -77,12 +95,17 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Ticket tags"
           },
           "cc_emails": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "CC email addresses"
           },
           "custom_fields": {
@@ -100,7 +123,10 @@
             "description": "First response due date"
           }
         },
-        "required": ["subject", "description"],
+        "required": [
+          "subject",
+          "description"
+        ],
         "additionalProperties": false
       }
     },
@@ -125,17 +151,29 @@
           },
           "status": {
             "type": "number",
-            "enum": [2, 3, 4, 5],
+            "enum": [
+              2,
+              3,
+              4,
+              5
+            ],
             "description": "Ticket status"
           },
           "priority": {
             "type": "number",
-            "enum": [1, 2, 3, 4],
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ],
             "description": "Ticket priority"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Ticket tags"
           },
           "custom_fields": {
@@ -143,7 +181,9 @@
             "description": "Custom field values"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -160,11 +200,20 @@
           },
           "include": {
             "type": "array",
-            "items": {"type": "string", "enum": ["requester", "company", "stats"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "requester",
+                "company",
+                "stats"
+              ]
+            },
             "description": "Additional data to include"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -177,7 +226,12 @@
         "properties": {
           "filter": {
             "type": "string",
-            "enum": ["new_and_my_open", "watching", "spam", "deleted"],
+            "enum": [
+              "new_and_my_open",
+              "watching",
+              "spam",
+              "deleted"
+            ],
             "description": "Filter preset"
           },
           "page": {
@@ -195,12 +249,20 @@
           },
           "order_by": {
             "type": "string",
-            "enum": ["created_at", "due_by", "updated_at", "status"],
+            "enum": [
+              "created_at",
+              "due_by",
+              "updated_at",
+              "status"
+            ],
             "description": "Sort field"
           },
           "order_type": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "description": "Sort order"
           },
           "updated_since": {
@@ -210,7 +272,14 @@
           },
           "include": {
             "type": "array",
-            "items": {"type": "string", "enum": ["requester", "company", "stats"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "requester",
+                "company",
+                "stats"
+              ]
+            },
             "description": "Additional data to include"
           }
         },
@@ -244,16 +313,25 @@
           },
           "cc_emails": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "CC email addresses"
           },
           "bcc_emails": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "BCC email addresses"
           }
         },
-        "required": ["ticket_id", "body"],
+        "required": [
+          "ticket_id",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -283,11 +361,17 @@
           },
           "notify_emails": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "Notify these emails"
           }
         },
-        "required": ["ticket_id", "body"],
+        "required": [
+          "ticket_id",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -309,7 +393,9 @@
             "description": "Page number"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     }
@@ -334,10 +420,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "subject": {"type": "string"},
-          "status": {"type": "number"},
-          "priority": {"type": "number"}
+          "id": {
+            "type": "number"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "status": {
+            "type": "number"
+          },
+          "priority": {
+            "type": "number"
+          }
         }
       }
     },
@@ -355,9 +449,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "status": {"type": "number"},
-          "updated_at": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "status": {
+            "type": "number"
+          },
+          "updated_at": {
+            "type": "string"
+          }
         }
       }
     }
@@ -365,5 +465,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/agents/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/github-enhanced/definition.json
+++ b/connectors/github-enhanced/definition.json
@@ -11,14 +11,19 @@
     "config": {
       "authUrl": "https://github.com/login/oauth/authorize",
       "tokenUrl": "https://github.com/login/oauth/access_token",
-      "scopes": ["repo", "user", "admin:org", "admin:repo_hook"]
+      "scopes": [
+        "repo",
+        "user",
+        "admin:org",
+        "admin:repo_hook"
+      ]
     }
   },
   "baseUrl": "https://api.github.com",
   "actions": [
     {
       "id": "test_connection",
-      "name": "Test Connection", 
+      "name": "Test Connection",
       "description": "Test the connection to GitHub",
       "parameters": {
         "type": "object",
@@ -39,7 +44,7 @@
             "description": "Repository owner"
           },
           "repo": {
-            "type": "string", 
+            "type": "string",
             "description": "Repository name"
           },
           "title": {
@@ -52,7 +57,9 @@
           },
           "assignees": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Usernames to assign"
           },
           "milestone": {
@@ -61,11 +68,17 @@
           },
           "labels": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Issue labels"
           }
         },
-        "required": ["owner", "repo", "title"],
+        "required": [
+          "owner",
+          "repo",
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -98,21 +111,32 @@
           },
           "state": {
             "type": "string",
-            "enum": ["open", "closed"],
+            "enum": [
+              "open",
+              "closed"
+            ],
             "description": "Issue state"
           },
           "assignees": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Usernames to assign"
           },
           "labels": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Issue labels"
           }
         },
-        "required": ["owner", "repo", "issue_number"],
+        "required": [
+          "owner",
+          "repo",
+          "issue_number"
+        ],
         "additionalProperties": false
       }
     },
@@ -158,7 +182,13 @@
             "description": "Allow maintainer edits"
           }
         },
-        "required": ["owner", "repo", "title", "head", "base"],
+        "required": [
+          "owner",
+          "repo",
+          "title",
+          "head",
+          "base"
+        ],
         "additionalProperties": false
       }
     },
@@ -191,12 +221,20 @@
           },
           "merge_method": {
             "type": "string",
-            "enum": ["merge", "squash", "rebase"],
+            "enum": [
+              "merge",
+              "squash",
+              "rebase"
+            ],
             "default": "merge",
             "description": "Merge method"
           }
         },
-        "required": ["owner", "repo", "pull_number"],
+        "required": [
+          "owner",
+          "repo",
+          "pull_number"
+        ],
         "additionalProperties": false
       }
     },
@@ -283,7 +321,9 @@
             "description": "Allow rebase merging"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -310,17 +350,38 @@
           "config": {
             "type": "object",
             "properties": {
-              "url": {"type": "string", "format": "uri"},
-              "content_type": {"type": "string", "enum": ["json", "form"]},
-              "secret": {"type": "string"},
-              "insecure_ssl": {"type": "string", "enum": ["0", "1"]}
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "content_type": {
+                "type": "string",
+                "enum": [
+                  "json",
+                  "form"
+                ]
+              },
+              "secret": {
+                "type": "string"
+              },
+              "insecure_ssl": {
+                "type": "string",
+                "enum": [
+                  "0",
+                  "1"
+                ]
+              }
             },
             "description": "Webhook configuration"
           },
           "events": {
             "type": "array",
-            "items": {"type": "string"},
-            "default": ["push"],
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "push"
+            ],
             "description": "Events to trigger webhook"
           },
           "active": {
@@ -329,7 +390,11 @@
             "description": "Webhook active status"
           }
         },
-        "required": ["owner", "repo", "config"],
+        "required": [
+          "owner",
+          "repo",
+          "config"
+        ],
         "additionalProperties": false
       }
     },
@@ -346,12 +411,20 @@
           },
           "sort": {
             "type": "string",
-            "enum": ["stars", "forks", "help-wanted-issues", "updated"],
+            "enum": [
+              "stars",
+              "forks",
+              "help-wanted-issues",
+              "updated"
+            ],
             "description": "Sort field"
           },
           "order": {
             "type": "string",
-            "enum": ["desc", "asc"],
+            "enum": [
+              "desc",
+              "asc"
+            ],
             "default": "desc",
             "description": "Sort order"
           },
@@ -369,7 +442,9 @@
             "description": "Page number"
           }
         },
-        "required": ["q"],
+        "required": [
+          "q"
+        ],
         "additionalProperties": false
       }
     }
@@ -398,10 +473,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "ref": {"type": "string"},
-          "repository": {"type": "object"},
-          "commits": {"type": "array"},
-          "pusher": {"type": "object"}
+          "ref": {
+            "type": "string"
+          },
+          "repository": {
+            "type": "object"
+          },
+          "commits": {
+            "type": "array"
+          },
+          "pusher": {
+            "type": "object"
+          }
         }
       }
     },
@@ -415,7 +498,12 @@
         "properties": {
           "action": {
             "type": "string",
-            "enum": ["opened", "closed", "reopened", "synchronize"],
+            "enum": [
+              "opened",
+              "closed",
+              "reopened",
+              "synchronize"
+            ],
             "description": "Filter by action"
           }
         },
@@ -425,10 +513,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "action": {"type": "string"},
-          "number": {"type": "number"},
-          "pull_request": {"type": "object"},
-          "repository": {"type": "object"}
+          "action": {
+            "type": "string"
+          },
+          "number": {
+            "type": "number"
+          },
+          "pull_request": {
+            "type": "object"
+          },
+          "repository": {
+            "type": "object"
+          }
         }
       }
     },
@@ -442,7 +538,13 @@
         "properties": {
           "action": {
             "type": "string",
-            "enum": ["opened", "closed", "reopened", "assigned", "unassigned"],
+            "enum": [
+              "opened",
+              "closed",
+              "reopened",
+              "assigned",
+              "unassigned"
+            ],
             "description": "Filter by action"
           }
         },
@@ -452,9 +554,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "action": {"type": "string"},
-          "issue": {"type": "object"},
-          "repository": {"type": "object"}
+          "action": {
+            "type": "string"
+          },
+          "issue": {
+            "type": "object"
+          },
+          "repository": {
+            "type": "object"
+          }
         }
       }
     }
@@ -462,5 +570,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/github/definition.json
+++ b/connectors/github/definition.json
@@ -11,7 +11,11 @@
     "config": {
       "authUrl": "https://github.com/login/oauth/authorize",
       "tokenUrl": "https://github.com/login/oauth/access_token",
-      "scopes": ["repo", "read:user", "user:email"]
+      "scopes": [
+        "repo",
+        "read:user",
+        "user:email"
+      ]
     }
   },
   "baseUrl": "https://api.github.com",
@@ -58,7 +62,9 @@
           },
           "assignees": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of usernames to assign to the issue"
           },
           "milestone": {
@@ -67,11 +73,17 @@
           },
           "labels": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of label names"
           }
         },
-        "required": ["owner", "repo", "title"],
+        "required": [
+          "owner",
+          "repo",
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -84,11 +96,21 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "owner": {"type":"string"},
-          "repo": {"type":"string"},
-          "issue_number": {"type":"number"}
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "issue_number": {
+            "type": "number"
+          }
         },
-        "required": ["owner","repo","issue_number"],
+        "required": [
+          "owner",
+          "repo",
+          "issue_number"
+        ],
         "additionalProperties": false
       }
     },
@@ -101,12 +123,28 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "owner": {"type":"string"},
-          "repo": {"type":"string"},
-          "issue_number": {"type":"number"},
-          "labels": {"type":"array","items":{"type":"string"}}
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "issue_number": {
+            "type": "number"
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         },
-        "required": ["owner","repo","issue_number","labels"],
+        "required": [
+          "owner",
+          "repo",
+          "issue_number",
+          "labels"
+        ],
         "additionalProperties": false
       }
     },
@@ -141,21 +179,32 @@
           },
           "state": {
             "type": "string",
-            "enum": ["open", "closed"],
+            "enum": [
+              "open",
+              "closed"
+            ],
             "description": "Issue state"
           },
           "assignees": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of usernames to assign"
           },
           "labels": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of label names"
           }
         },
-        "required": ["owner", "repo", "issue_number"],
+        "required": [
+          "owner",
+          "repo",
+          "issue_number"
+        ],
         "additionalProperties": false
       }
     },
@@ -181,7 +230,11 @@
             "description": "Issue number"
           }
         },
-        "required": ["owner", "repo", "issue_number"],
+        "required": [
+          "owner",
+          "repo",
+          "issue_number"
+        ],
         "additionalProperties": false
       }
     },
@@ -204,7 +257,11 @@
           },
           "state": {
             "type": "string",
-            "enum": ["open", "closed", "all"],
+            "enum": [
+              "open",
+              "closed",
+              "all"
+            ],
             "default": "open",
             "description": "Issue state filter"
           },
@@ -222,13 +279,20 @@
           },
           "sort": {
             "type": "string",
-            "enum": ["created", "updated", "comments"],
+            "enum": [
+              "created",
+              "updated",
+              "comments"
+            ],
             "default": "created",
             "description": "Sort field"
           },
           "direction": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "default": "desc",
             "description": "Sort direction"
           },
@@ -239,7 +303,10 @@
             "description": "Number of items per page"
           }
         },
-        "required": ["owner", "repo"],
+        "required": [
+          "owner",
+          "repo"
+        ],
         "additionalProperties": false
       }
     },
@@ -285,7 +352,13 @@
             "description": "Allow maintainers to modify the pull request"
           }
         },
-        "required": ["owner", "repo", "title", "head", "base"],
+        "required": [
+          "owner",
+          "repo",
+          "title",
+          "head",
+          "base"
+        ],
         "additionalProperties": false
       }
     },
@@ -320,7 +393,10 @@
           },
           "state": {
             "type": "string",
-            "enum": ["open", "closed"],
+            "enum": [
+              "open",
+              "closed"
+            ],
             "description": "Pull request state"
           },
           "base": {
@@ -328,7 +404,11 @@
             "description": "Branch to merge into"
           }
         },
-        "required": ["owner", "repo", "pull_number"],
+        "required": [
+          "owner",
+          "repo",
+          "pull_number"
+        ],
         "additionalProperties": false
       }
     },
@@ -363,12 +443,20 @@
           },
           "merge_method": {
             "type": "string",
-            "enum": ["merge", "squash", "rebase"],
+            "enum": [
+              "merge",
+              "squash",
+              "rebase"
+            ],
             "default": "merge",
             "description": "Merge method"
           }
         },
-        "required": ["owner", "repo", "pull_number"],
+        "required": [
+          "owner",
+          "repo",
+          "pull_number"
+        ],
         "additionalProperties": false
       }
     },
@@ -391,7 +479,11 @@
           },
           "state": {
             "type": "string",
-            "enum": ["open", "closed", "all"],
+            "enum": [
+              "open",
+              "closed",
+              "all"
+            ],
             "default": "open",
             "description": "Pull request state filter"
           },
@@ -405,18 +497,29 @@
           },
           "sort": {
             "type": "string",
-            "enum": ["created", "updated", "popularity", "long-running"],
+            "enum": [
+              "created",
+              "updated",
+              "popularity",
+              "long-running"
+            ],
             "default": "created",
             "description": "Sort field"
           },
           "direction": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "default": "desc",
             "description": "Sort direction"
           }
         },
-        "required": ["owner", "repo"],
+        "required": [
+          "owner",
+          "repo"
+        ],
         "additionalProperties": false
       }
     },
@@ -444,7 +547,12 @@
             "description": "Comment body"
           }
         },
-        "required": ["owner", "repo", "issue_number", "body"],
+        "required": [
+          "owner",
+          "repo",
+          "issue_number",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -464,7 +572,10 @@
             "description": "Repository name"
           }
         },
-        "required": ["owner", "repo"],
+        "required": [
+          "owner",
+          "repo"
+        ],
         "additionalProperties": false
       }
     },
@@ -479,31 +590,53 @@
         "properties": {
           "visibility": {
             "type": "string",
-            "enum": ["all", "public", "private"],
+            "enum": [
+              "all",
+              "public",
+              "private"
+            ],
             "default": "all",
             "description": "Repository visibility filter"
           },
           "affiliation": {
             "type": "string",
-            "enum": ["owner", "collaborator", "organization_member"],
+            "enum": [
+              "owner",
+              "collaborator",
+              "organization_member"
+            ],
             "default": "owner",
             "description": "Repository affiliation filter"
           },
           "type": {
             "type": "string",
-            "enum": ["all", "owner", "public", "private", "member"],
+            "enum": [
+              "all",
+              "owner",
+              "public",
+              "private",
+              "member"
+            ],
             "default": "all",
             "description": "Repository type filter"
           },
           "sort": {
             "type": "string",
-            "enum": ["created", "updated", "pushed", "full_name"],
+            "enum": [
+              "created",
+              "updated",
+              "pushed",
+              "full_name"
+            ],
             "default": "full_name",
             "description": "Sort field"
           },
           "direction": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "default": "asc",
             "description": "Sort direction"
           }
@@ -536,13 +669,20 @@
           },
           "events": {
             "type": "array",
-            "items": {"type": "string"},
-            "default": ["push"],
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "push"
+            ],
             "description": "List of events to trigger webhook"
           },
           "content_type": {
             "type": "string",
-            "enum": ["json", "form"],
+            "enum": [
+              "json",
+              "form"
+            ],
             "default": "json",
             "description": "Content type for webhook payload"
           },
@@ -556,7 +696,11 @@
             "description": "Whether webhook is active"
           }
         },
-        "required": ["owner", "repo", "url"],
+        "required": [
+          "owner",
+          "repo",
+          "url"
+        ],
         "additionalProperties": false
       }
     }
@@ -587,7 +731,9 @@
           },
           "labels": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by specific labels"
           }
         },
@@ -597,11 +743,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "action": {"type": "string"},
-          "number": {"type": "number"},
-          "issue": {"type": "object"},
-          "repository": {"type": "object"},
-          "sender": {"type": "object"}
+          "action": {
+            "type": "string"
+          },
+          "number": {
+            "type": "number"
+          },
+          "issue": {
+            "type": "object"
+          },
+          "repository": {
+            "type": "object"
+          },
+          "sender": {
+            "type": "object"
+          }
         }
       }
     },
@@ -639,11 +795,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "action": {"type": "string"},
-          "number": {"type": "number"},
-          "pull_request": {"type": "object"},
-          "repository": {"type": "object"},
-          "sender": {"type": "object"}
+          "action": {
+            "type": "string"
+          },
+          "number": {
+            "type": "number"
+          },
+          "pull_request": {
+            "type": "object"
+          },
+          "repository": {
+            "type": "object"
+          },
+          "sender": {
+            "type": "object"
+          }
         }
       }
     },
@@ -681,12 +847,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "ref": {"type": "string"},
-          "before": {"type": "string"},
-          "after": {"type": "string"},
-          "commits": {"type": "array"},
-          "repository": {"type": "object"},
-          "pusher": {"type": "object"}
+          "ref": {
+            "type": "string"
+          },
+          "before": {
+            "type": "string"
+          },
+          "after": {
+            "type": "string"
+          },
+          "commits": {
+            "type": "array"
+          },
+          "repository": {
+            "type": "object"
+          },
+          "pusher": {
+            "type": "object"
+          }
         }
       }
     },
@@ -720,9 +898,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "action": {"type": "string"},
-          "issue": {"type": "object"},
-          "repository": {"type": "object"}
+          "action": {
+            "type": "string"
+          },
+          "issue": {
+            "type": "object"
+          },
+          "repository": {
+            "type": "object"
+          }
         }
       }
     },
@@ -756,9 +940,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "action": {"type": "string"},
-          "pull_request": {"type": "object"},
-          "repository": {"type": "object"}
+          "action": {
+            "type": "string"
+          },
+          "pull_request": {
+            "type": "object"
+          },
+          "repository": {
+            "type": "object"
+          }
         }
       }
     }
@@ -766,6 +956,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }
-

--- a/connectors/gitlab/definition.json
+++ b/connectors/gitlab/definition.json
@@ -11,7 +11,11 @@
     "config": {
       "authUrl": "https://gitlab.com/oauth/authorize",
       "tokenUrl": "https://gitlab.com/oauth/token",
-      "scopes": ["api", "read_user", "read_repository"]
+      "scopes": [
+        "api",
+        "read_user",
+        "read_repository"
+      ]
     }
   },
   "baseUrl": "https://gitlab.com/api/v4",
@@ -48,7 +52,9 @@
           },
           "assignee_ids": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "User IDs to assign"
           },
           "milestone_id": {
@@ -69,7 +75,10 @@
             "description": "Issue weight"
           }
         },
-        "required": ["id", "title"],
+        "required": [
+          "id",
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -123,7 +132,12 @@
             "description": "Squash commits when merging"
           }
         },
-        "required": ["id", "source_branch", "target_branch", "title"],
+        "required": [
+          "id",
+          "source_branch",
+          "target_branch",
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -148,7 +162,11 @@
           },
           "visibility": {
             "type": "string",
-            "enum": ["private", "internal", "public"],
+            "enum": [
+              "private",
+              "internal",
+              "public"
+            ],
             "default": "private",
             "description": "Project visibility"
           },
@@ -177,7 +195,9 @@
             "description": "Namespace ID"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -194,17 +214,31 @@
           },
           "visibility": {
             "type": "string",
-            "enum": ["public", "internal", "private"],
+            "enum": [
+              "public",
+              "internal",
+              "private"
+            ],
             "description": "Filter by visibility"
           },
           "order_by": {
             "type": "string",
-            "enum": ["id", "name", "path", "created_at", "updated_at", "last_activity_at"],
+            "enum": [
+              "id",
+              "name",
+              "path",
+              "created_at",
+              "updated_at",
+              "last_activity_at"
+            ],
             "description": "Order by field"
           },
           "sort": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "description": "Sort order"
           },
           "search": {
@@ -244,15 +278,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "object_kind": {"type": "string"},
-          "project": {"type": "object"},
-          "commits": {"type": "array"}
+          "object_kind": {
+            "type": "string"
+          },
+          "project": {
+            "type": "object"
+          },
+          "commits": {
+            "type": "array"
+          }
         }
       }
     },
     {
       "id": "merge_request_events",
-      "name": "Merge Request Events", 
+      "name": "Merge Request Events",
       "description": "Triggered on merge request events",
       "type": "webhook",
       "parameters": {
@@ -264,9 +304,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "object_kind": {"type": "string"},
-          "object_attributes": {"type": "object"},
-          "project": {"type": "object"}
+          "object_kind": {
+            "type": "string"
+          },
+          "object_attributes": {
+            "type": "object"
+          },
+          "project": {
+            "type": "object"
+          }
         }
       }
     }
@@ -274,5 +320,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/gmail-enhanced/definition.json
+++ b/connectors/gmail-enhanced/definition.json
@@ -42,17 +42,26 @@
         "properties": {
           "to": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "Recipient email addresses"
           },
           "cc": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "CC email addresses"
           },
           "bcc": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "BCC email addresses"
           },
           "subject": {
@@ -68,9 +77,15 @@
             "items": {
               "type": "object",
               "properties": {
-                "filename": {"type": "string"},
-                "data": {"type": "string"},
-                "mimeType": {"type": "string"}
+                "filename": {
+                  "type": "string"
+                },
+                "data": {
+                  "type": "string"
+                },
+                "mimeType": {
+                  "type": "string"
+                }
               }
             },
             "description": "Email attachments"
@@ -86,7 +101,11 @@
             "description": "Email body is HTML"
           }
         },
-        "required": ["to", "subject", "body"],
+        "required": [
+          "to",
+          "subject",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -108,17 +127,26 @@
           },
           "format": {
             "type": "string",
-            "enum": ["minimal", "full", "raw", "metadata"],
+            "enum": [
+              "minimal",
+              "full",
+              "raw",
+              "metadata"
+            ],
             "default": "full",
             "description": "Message format"
           },
           "metadataHeaders": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Headers to include when format is metadata"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -140,7 +168,9 @@
           },
           "labelIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Label IDs to filter by"
           },
           "includeSpamTrash": {
@@ -182,16 +212,22 @@
           },
           "addLabelIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Label IDs to add"
           },
           "removeLabelIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Label IDs to remove"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -212,7 +248,9 @@
             "description": "Message ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -230,7 +268,10 @@
           },
           "to": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "Recipient email addresses"
           },
           "subject": {
@@ -242,7 +283,11 @@
             "description": "Email body"
           }
         },
-        "required": ["to", "subject", "body"],
+        "required": [
+          "to",
+          "subject",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -281,32 +326,48 @@
           },
           "messageListVisibility": {
             "type": "string",
-            "enum": ["show", "hide"],
+            "enum": [
+              "show",
+              "hide"
+            ],
             "default": "show",
             "description": "Message list visibility"
           },
           "labelListVisibility": {
             "type": "string",
-            "enum": ["labelShow", "labelShowIfUnread", "labelHide"],
+            "enum": [
+              "labelShow",
+              "labelShowIfUnread",
+              "labelHide"
+            ],
             "default": "labelShow",
             "description": "Label list visibility"
           },
           "type": {
             "type": "string",
-            "enum": ["system", "user"],
+            "enum": [
+              "system",
+              "user"
+            ],
             "default": "user",
             "description": "Label type"
           },
           "color": {
             "type": "object",
             "properties": {
-              "textColor": {"type": "string"},
-              "backgroundColor": {"type": "string"}
+              "textColor": {
+                "type": "string"
+              },
+              "backgroundColor": {
+                "type": "string"
+              }
             },
             "description": "Label color"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -380,7 +441,9 @@
         "properties": {
           "labelIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by labels"
           },
           "query": {
@@ -394,10 +457,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "threadId": {"type": "string"},
-          "snippet": {"type": "string"},
-          "payload": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object"
+          }
         }
       }
     },
@@ -415,8 +486,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "labelIds": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "labelIds": {
+            "type": "array"
+          }
         }
       }
     }
@@ -424,5 +499,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me/profile"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/gmail/definition.json
+++ b/connectors/gmail/definition.json
@@ -84,7 +84,11 @@
             "description": "Email attachments"
           }
         },
-        "required": ["to", "subject", "body"],
+        "required": [
+          "to",
+          "subject",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -112,7 +116,9 @@
             "description": "Include emails from spam and trash"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -129,12 +135,19 @@
           },
           "format": {
             "type": "string",
-            "enum": ["minimal", "full", "raw", "metadata"],
+            "enum": [
+              "minimal",
+              "full",
+              "raw",
+              "metadata"
+            ],
             "default": "full",
             "description": "Format of the email data to return"
           }
         },
-        "required": ["messageId"],
+        "required": [
+          "messageId"
+        ],
         "additionalProperties": false
       }
     },
@@ -159,7 +172,10 @@
             "description": "Whether to reply to all recipients"
           }
         },
-        "required": ["messageId", "body"],
+        "required": [
+          "messageId",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -178,7 +194,9 @@
             "description": "Array of Gmail message IDs to mark as read"
           }
         },
-        "required": ["messageIds"],
+        "required": [
+          "messageIds"
+        ],
         "additionalProperties": false
       }
     },
@@ -204,7 +222,10 @@
             "description": "Array of label IDs to add"
           }
         },
-        "required": ["messageIds", "labelIds"],
+        "required": [
+          "messageIds",
+          "labelIds"
+        ],
         "additionalProperties": false
       }
     }
@@ -250,7 +271,9 @@
             "description": "Optional subject filter"
           }
         },
-        "required": ["fromEmail"],
+        "required": [
+          "fromEmail"
+        ],
         "additionalProperties": false
       }
     },
@@ -277,5 +300,19 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/google-admin/definition.json
+++ b/connectors/google-admin/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://accounts.google.com/o/oauth2/v2/auth",
       "tokenUrl": "https://oauth2.googleapis.com/token",
-      "scopes": ["https://www.googleapis.com/auth/admin.directory.user", "https://www.googleapis.com/auth/admin.directory.group"]
+      "scopes": [
+        "https://www.googleapis.com/auth/admin.directory.user",
+        "https://www.googleapis.com/auth/admin.directory.group"
+      ]
     }
   },
   "baseUrl": "https://admin.googleapis.com/admin/directory/v1",
@@ -42,8 +45,12 @@
           "name": {
             "type": "object",
             "properties": {
-              "givenName": {"type": "string"},
-              "familyName": {"type": "string"}
+              "givenName": {
+                "type": "string"
+              },
+              "familyName": {
+                "type": "string"
+              }
             },
             "description": "User's name"
           },
@@ -76,7 +83,11 @@
             "description": "Recovery phone number"
           }
         },
-        "required": ["primaryEmail", "name", "password"],
+        "required": [
+          "primaryEmail",
+          "name",
+          "password"
+        ],
         "additionalProperties": false
       }
     },
@@ -93,7 +104,11 @@
           },
           "projection": {
             "type": "string",
-            "enum": ["basic", "custom", "full"],
+            "enum": [
+              "basic",
+              "custom",
+              "full"
+            ],
             "default": "full",
             "description": "Fields to include"
           },
@@ -103,12 +118,17 @@
           },
           "viewType": {
             "type": "string",
-            "enum": ["admin_view", "domain_public"],
+            "enum": [
+              "admin_view",
+              "domain_public"
+            ],
             "default": "admin_view",
             "description": "View type"
           }
         },
-        "required": ["userKey"],
+        "required": [
+          "userKey"
+        ],
         "additionalProperties": false
       }
     },
@@ -126,8 +146,12 @@
           "name": {
             "type": "object",
             "properties": {
-              "givenName": {"type": "string"},
-              "familyName": {"type": "string"}
+              "givenName": {
+                "type": "string"
+              },
+              "familyName": {
+                "type": "string"
+              }
             },
             "description": "Updated name"
           },
@@ -148,7 +172,9 @@
             "description": "Force password change"
           }
         },
-        "required": ["userKey"],
+        "required": [
+          "userKey"
+        ],
         "additionalProperties": false
       }
     },
@@ -164,7 +190,9 @@
             "description": "User email or ID"
           }
         },
-        "required": ["userKey"],
+        "required": [
+          "userKey"
+        ],
         "additionalProperties": false
       }
     },
@@ -193,12 +221,19 @@
           },
           "orderBy": {
             "type": "string",
-            "enum": ["email", "familyName", "givenName"],
+            "enum": [
+              "email",
+              "familyName",
+              "givenName"
+            ],
             "description": "Sort field"
           },
           "sortOrder": {
             "type": "string",
-            "enum": ["ASCENDING", "DESCENDING"],
+            "enum": [
+              "ASCENDING",
+              "DESCENDING"
+            ],
             "description": "Sort order"
           },
           "query": {
@@ -207,7 +242,11 @@
           },
           "projection": {
             "type": "string",
-            "enum": ["basic", "custom", "full"],
+            "enum": [
+              "basic",
+              "custom",
+              "full"
+            ],
             "default": "full",
             "description": "Fields to include"
           },
@@ -242,7 +281,10 @@
             "description": "Group description"
           }
         },
-        "required": ["email", "name"],
+        "required": [
+          "email",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -264,18 +306,30 @@
           },
           "role": {
             "type": "string",
-            "enum": ["MEMBER", "MANAGER", "OWNER"],
+            "enum": [
+              "MEMBER",
+              "MANAGER",
+              "OWNER"
+            ],
             "default": "MEMBER",
             "description": "Member role"
           },
           "type": {
             "type": "string",
-            "enum": ["CUSTOMER", "EXTERNAL", "GROUP", "USER"],
+            "enum": [
+              "CUSTOMER",
+              "EXTERNAL",
+              "GROUP",
+              "USER"
+            ],
             "default": "USER",
             "description": "Member type"
           }
         },
-        "required": ["groupKey", "email"],
+        "required": [
+          "groupKey",
+          "email"
+        ],
         "additionalProperties": false
       }
     },
@@ -295,7 +349,10 @@
             "description": "Member email or ID"
           }
         },
-        "required": ["groupKey", "memberKey"],
+        "required": [
+          "groupKey",
+          "memberKey"
+        ],
         "additionalProperties": false
       }
     }
@@ -320,10 +377,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "primaryEmail": {"type": "string"},
-          "name": {"type": "object"},
-          "orgUnitPath": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "primaryEmail": {
+            "type": "string"
+          },
+          "name": {
+            "type": "object"
+          },
+          "orgUnitPath": {
+            "type": "string"
+          }
         }
       }
     },
@@ -341,9 +406,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "primaryEmail": {"type": "string"},
-          "suspended": {"type": "boolean"}
+          "id": {
+            "type": "string"
+          },
+          "primaryEmail": {
+            "type": "string"
+          },
+          "suspended": {
+            "type": "boolean"
+          }
         }
       }
     }
@@ -351,5 +422,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users?customer=my_customer&maxResults=1"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/google-calendar/definition.json
+++ b/connectors/google-calendar/definition.json
@@ -64,18 +64,34 @@
           "start": {
             "type": "object",
             "properties": {
-              "dateTime": {"type": "string", "format": "date-time"},
-              "date": {"type": "string", "format": "date"},
-              "timeZone": {"type": "string"}
+              "dateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "date": {
+                "type": "string",
+                "format": "date"
+              },
+              "timeZone": {
+                "type": "string"
+              }
             },
             "description": "Start time (ISO 8601 format)"
           },
           "end": {
             "type": "object",
             "properties": {
-              "dateTime": {"type": "string", "format": "date-time"},
-              "date": {"type": "string", "format": "date"},
-              "timeZone": {"type": "string"}
+              "dateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "date": {
+                "type": "string",
+                "format": "date"
+              },
+              "timeZone": {
+                "type": "string"
+              }
             },
             "description": "End time (ISO 8601 format)"
           },
@@ -84,29 +100,48 @@
             "items": {
               "type": "object",
               "properties": {
-                "email": {"type": "string", "format": "email"},
-                "displayName": {"type": "string"},
-                "optional": {"type": "boolean"}
+                "email": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "displayName": {
+                  "type": "string"
+                },
+                "optional": {
+                  "type": "boolean"
+                }
               }
             },
             "description": "Event attendees"
           },
           "recurrence": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Recurrence rules (RRULE format)"
           },
           "reminders": {
             "type": "object",
             "properties": {
-              "useDefault": {"type": "boolean"},
+              "useDefault": {
+                "type": "boolean"
+              },
               "overrides": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "method": {"type": "string", "enum": ["email", "popup"]},
-                    "minutes": {"type": "number"}
+                    "method": {
+                      "type": "string",
+                      "enum": [
+                        "email",
+                        "popup"
+                      ]
+                    },
+                    "minutes": {
+                      "type": "number"
+                    }
                   }
                 }
               }
@@ -115,11 +150,20 @@
           },
           "visibility": {
             "type": "string",
-            "enum": ["default", "public", "private", "confidential"],
+            "enum": [
+              "default",
+              "public",
+              "private",
+              "confidential"
+            ],
             "description": "Event visibility"
           }
         },
-        "required": ["summary", "start", "end"],
+        "required": [
+          "summary",
+          "start",
+          "end"
+        ],
         "additionalProperties": false
       }
     },
@@ -156,18 +200,34 @@
           "start": {
             "type": "object",
             "properties": {
-              "dateTime": {"type": "string", "format": "date-time"},
-              "date": {"type": "string", "format": "date"},
-              "timeZone": {"type": "string"}
+              "dateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "date": {
+                "type": "string",
+                "format": "date"
+              },
+              "timeZone": {
+                "type": "string"
+              }
             },
             "description": "Start time"
           },
           "end": {
             "type": "object",
             "properties": {
-              "dateTime": {"type": "string", "format": "date-time"},
-              "date": {"type": "string", "format": "date"},
-              "timeZone": {"type": "string"}
+              "dateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "date": {
+                "type": "string",
+                "format": "date"
+              },
+              "timeZone": {
+                "type": "string"
+              }
             },
             "description": "End time"
           },
@@ -176,14 +236,21 @@
             "items": {
               "type": "object",
               "properties": {
-                "email": {"type": "string", "format": "email"},
-                "displayName": {"type": "string"}
+                "email": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "displayName": {
+                  "type": "string"
+                }
               }
             },
             "description": "Event attendees"
           }
         },
-        "required": ["eventId"],
+        "required": [
+          "eventId"
+        ],
         "additionalProperties": false
       }
     },
@@ -206,7 +273,9 @@
             "description": "Event ID to retrieve"
           }
         },
-        "required": ["eventId"],
+        "required": [
+          "eventId"
+        ],
         "additionalProperties": false
       }
     },
@@ -242,7 +311,10 @@
           },
           "orderBy": {
             "type": "string",
-            "enum": ["startTime", "updated"],
+            "enum": [
+              "startTime",
+              "updated"
+            ],
             "description": "Sort order"
           },
           "q": {
@@ -279,12 +351,18 @@
           },
           "sendUpdates": {
             "type": "string",
-            "enum": ["all", "externalOnly", "none"],
+            "enum": [
+              "all",
+              "externalOnly",
+              "none"
+            ],
             "default": "none",
             "description": "Send updates to attendees"
           }
         },
-        "required": ["eventId"],
+        "required": [
+          "eventId"
+        ],
         "additionalProperties": false
       }
     },
@@ -334,7 +412,9 @@
             "description": "Calendar time zone"
           }
         },
-        "required": ["summary"],
+        "required": [
+          "summary"
+        ],
         "additionalProperties": false
       }
     },
@@ -362,7 +442,9 @@
             "description": "Calendar time zone"
           }
         },
-        "required": ["calendarId"],
+        "required": [
+          "calendarId"
+        ],
         "additionalProperties": false
       }
     },
@@ -390,13 +472,19 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"}
+                "id": {
+                  "type": "string"
+                }
               }
             },
             "description": "Calendars to query"
           }
         },
-        "required": ["timeMin", "timeMax", "items"],
+        "required": [
+          "timeMin",
+          "timeMax",
+          "items"
+        ],
         "additionalProperties": false
       }
     },
@@ -420,12 +508,18 @@
           },
           "sendUpdates": {
             "type": "string",
-            "enum": ["all", "externalOnly", "none"],
+            "enum": [
+              "all",
+              "externalOnly",
+              "none"
+            ],
             "default": "none",
             "description": "Send updates to attendees"
           }
         },
-        "required": ["text"],
+        "required": [
+          "text"
+        ],
         "additionalProperties": false
       }
     },
@@ -457,7 +551,9 @@
             "description": "Webhook callback URL"
           }
         },
-        "required": ["address"],
+        "required": [
+          "address"
+        ],
         "additionalProperties": false
       }
     },
@@ -479,7 +575,10 @@
             "description": "Watched resource identifier"
           }
         },
-        "required": ["id", "resourceId"],
+        "required": [
+          "id",
+          "resourceId"
+        ],
         "additionalProperties": false
       }
     }
@@ -504,15 +603,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventId": {"type": "string"},
-          "summary": {"type": "string"},
-          "description": {"type": "string"},
-          "location": {"type": "string"},
-          "start": {"type": "object"},
-          "end": {"type": "object"},
-          "attendees": {"type": "array"},
-          "creator": {"type": "object"},
-          "organizer": {"type": "object"}
+          "eventId": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "start": {
+            "type": "object"
+          },
+          "end": {
+            "type": "object"
+          },
+          "attendees": {
+            "type": "array"
+          },
+          "creator": {
+            "type": "object"
+          },
+          "organizer": {
+            "type": "object"
+          }
         }
       }
     },
@@ -535,10 +652,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventId": {"type": "string"},
-          "summary": {"type": "string"},
-          "updated": {"type": "string"},
-          "sequence": {"type": "number"}
+          "eventId": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "string"
+          },
+          "sequence": {
+            "type": "number"
+          }
         }
       }
     },
@@ -566,11 +691,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventId": {"type": "string"},
-          "summary": {"type": "string"},
-          "start": {"type": "object"},
-          "location": {"type": "string"},
-          "attendees": {"type": "array"}
+          "eventId": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "start": {
+            "type": "object"
+          },
+          "location": {
+            "type": "string"
+          },
+          "attendees": {
+            "type": "array"
+          }
         }
       }
     }
@@ -578,6 +713,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me/calendarList"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }
-

--- a/connectors/google-chat/definition.json
+++ b/connectors/google-chat/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://accounts.google.com/o/oauth2/v2/auth",
       "tokenUrl": "https://oauth2.googleapis.com/token",
-      "scopes": ["https://www.googleapis.com/auth/chat.messages", "https://www.googleapis.com/auth/chat.spaces"]
+      "scopes": [
+        "https://www.googleapis.com/auth/chat.messages",
+        "https://www.googleapis.com/auth/chat.spaces"
+      ]
     }
   },
   "baseUrl": "https://chat.googleapis.com/v1",
@@ -45,30 +48,43 @@
           "thread": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"}
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Thread to reply to"
           },
           "cards": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Card attachments"
           },
           "cardsV2": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Card v2 attachments"
           },
           "actionResponse": {
             "type": "object",
             "properties": {
-              "type": {"type": "string"},
-              "url": {"type": "string"}
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
             },
             "description": "Action response configuration"
           }
         },
-        "required": ["space", "text"],
+        "required": [
+          "space",
+          "text"
+        ],
         "additionalProperties": false
       }
     },
@@ -85,7 +101,11 @@
           },
           "spaceType": {
             "type": "string",
-            "enum": ["SPACE", "GROUP_CHAT", "DIRECT_MESSAGE"],
+            "enum": [
+              "SPACE",
+              "GROUP_CHAT",
+              "DIRECT_MESSAGE"
+            ],
             "default": "SPACE",
             "description": "Type of space"
           },
@@ -101,12 +121,17 @@
           },
           "spaceHistoryState": {
             "type": "string",
-            "enum": ["HISTORY_OFF", "HISTORY_ON"],
+            "enum": [
+              "HISTORY_OFF",
+              "HISTORY_ON"
+            ],
             "default": "HISTORY_ON",
             "description": "Chat history setting"
           }
         },
-        "required": ["displayName"],
+        "required": [
+          "displayName"
+        ],
         "additionalProperties": false
       }
     },
@@ -149,7 +174,9 @@
             "description": "Space name (spaces/AAABBBCCC)"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -185,7 +212,9 @@
             "description": "Include group memberships"
           }
         },
-        "required": ["parent"],
+        "required": [
+          "parent"
+        ],
         "additionalProperties": false
       }
     },
@@ -203,20 +232,36 @@
           "member": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "displayName": {"type": "string"},
-              "type": {"type": "string", "enum": ["HUMAN", "BOT"]}
+              "name": {
+                "type": "string"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "HUMAN",
+                  "BOT"
+                ]
+              }
             },
             "description": "Member to add"
           },
           "role": {
             "type": "string",
-            "enum": ["ROLE_MEMBER", "ROLE_MANAGER"],
+            "enum": [
+              "ROLE_MEMBER",
+              "ROLE_MANAGER"
+            ],
             "default": "ROLE_MEMBER",
             "description": "Member role"
           }
         },
-        "required": ["parent", "member"],
+        "required": [
+          "parent",
+          "member"
+        ],
         "additionalProperties": false
       }
     },
@@ -256,7 +301,9 @@
             "description": "Include deleted messages"
           }
         },
-        "required": ["parent"],
+        "required": [
+          "parent"
+        ],
         "additionalProperties": false
       }
     },
@@ -272,7 +319,9 @@
             "description": "Message name (spaces/AAABBB/messages/CCCDDD)"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -293,7 +342,9 @@
           },
           "cards": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Updated card attachments"
           },
           "updateMask": {
@@ -301,7 +352,9 @@
             "description": "Fields to update"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -322,7 +375,9 @@
             "description": "Force delete even if message has reactions"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     }
@@ -347,11 +402,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "sender": {"type": "object"},
-          "text": {"type": "string"},
-          "space": {"type": "object"},
-          "thread": {"type": "object"}
+          "name": {
+            "type": "string"
+          },
+          "sender": {
+            "type": "object"
+          },
+          "text": {
+            "type": "string"
+          },
+          "space": {
+            "type": "object"
+          },
+          "thread": {
+            "type": "object"
+          }
         }
       }
     },
@@ -369,10 +434,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "displayName": {"type": "string"},
-          "spaceType": {"type": "string"},
-          "createTime": {"type": "string"}
+          "name": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "spaceType": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string"
+          }
         }
       }
     },
@@ -395,10 +468,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "member": {"type": "object"},
-          "space": {"type": "object"},
-          "role": {"type": "string"}
+          "name": {
+            "type": "string"
+          },
+          "member": {
+            "type": "object"
+          },
+          "space": {
+            "type": "object"
+          },
+          "role": {
+            "type": "string"
+          }
         }
       }
     }
@@ -406,5 +487,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/spaces?pageSize=1"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/google-contacts/definition.json
+++ b/connectors/google-contacts/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://accounts.google.com/o/oauth2/v2/auth",
       "tokenUrl": "https://oauth2.googleapis.com/token",
-      "scopes": ["https://www.googleapis.com/auth/contacts"]
+      "scopes": [
+        "https://www.googleapis.com/auth/contacts"
+      ]
     }
   },
   "baseUrl": "https://people.googleapis.com/v1",
@@ -39,9 +41,15 @@
             "items": {
               "type": "object",
               "properties": {
-                "givenName": {"type": "string"},
-                "familyName": {"type": "string"},
-                "displayName": {"type": "string"}
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "displayName": {
+                  "type": "string"
+                }
               }
             },
             "description": "Contact names"
@@ -51,8 +59,13 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string", "format": "email"},
-                "type": {"type": "string"}
+                "value": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "type": {
+                  "type": "string"
+                }
               }
             },
             "description": "Email addresses"
@@ -62,8 +75,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string"},
-                "type": {"type": "string"}
+                "value": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
               }
             },
             "description": "Phone numbers"
@@ -73,13 +90,27 @@
             "items": {
               "type": "object",
               "properties": {
-                "formattedValue": {"type": "string"},
-                "type": {"type": "string"},
-                "streetAddress": {"type": "string"},
-                "city": {"type": "string"},
-                "region": {"type": "string"},
-                "postalCode": {"type": "string"},
-                "country": {"type": "string"}
+                "formattedValue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "streetAddress": {
+                  "type": "string"
+                },
+                "city": {
+                  "type": "string"
+                },
+                "region": {
+                  "type": "string"
+                },
+                "postalCode": {
+                  "type": "string"
+                },
+                "country": {
+                  "type": "string"
+                }
               }
             },
             "description": "Addresses"
@@ -89,9 +120,15 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {"type": "string"},
-                "title": {"type": "string"},
-                "department": {"type": "string"}
+                "name": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "department": {
+                  "type": "string"
+                }
               }
             },
             "description": "Organizations"
@@ -101,7 +138,9 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string"}
+                "value": {
+                  "type": "string"
+                }
               }
             },
             "description": "Biography"
@@ -128,7 +167,9 @@
             "description": "Fields to include"
           }
         },
-        "required": ["resourceName"],
+        "required": [
+          "resourceName"
+        ],
         "additionalProperties": false
       }
     },
@@ -152,9 +193,15 @@
             "items": {
               "type": "object",
               "properties": {
-                "givenName": {"type": "string"},
-                "familyName": {"type": "string"},
-                "displayName": {"type": "string"}
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "displayName": {
+                  "type": "string"
+                }
               }
             },
             "description": "Updated names"
@@ -164,8 +211,13 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string", "format": "email"},
-                "type": {"type": "string"}
+                "value": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "type": {
+                  "type": "string"
+                }
               }
             },
             "description": "Updated email addresses"
@@ -175,14 +227,20 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string"},
-                "type": {"type": "string"}
+                "value": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
               }
             },
             "description": "Updated phone numbers"
           }
         },
-        "required": ["resourceName"],
+        "required": [
+          "resourceName"
+        ],
         "additionalProperties": false
       }
     },
@@ -198,7 +256,9 @@
             "description": "Contact resource name"
           }
         },
-        "required": ["resourceName"],
+        "required": [
+          "resourceName"
+        ],
         "additionalProperties": false
       }
     },
@@ -227,7 +287,12 @@
           },
           "sortOrder": {
             "type": "string",
-            "enum": ["LAST_MODIFIED_ASCENDING", "LAST_MODIFIED_DESCENDING", "FIRST_NAME_ASCENDING", "LAST_NAME_ASCENDING"],
+            "enum": [
+              "LAST_MODIFIED_ASCENDING",
+              "LAST_MODIFIED_DESCENDING",
+              "FIRST_NAME_ASCENDING",
+              "LAST_NAME_ASCENDING"
+            ],
             "description": "Sort order"
           }
         },
@@ -259,7 +324,9 @@
             "description": "Fields to include"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -280,7 +347,9 @@
             "description": "Fields to return"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -332,10 +401,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "resourceName": {"type": "string"},
-          "names": {"type": "array"},
-          "emailAddresses": {"type": "array"},
-          "phoneNumbers": {"type": "array"}
+          "resourceName": {
+            "type": "string"
+          },
+          "names": {
+            "type": "array"
+          },
+          "emailAddresses": {
+            "type": "array"
+          },
+          "phoneNumbers": {
+            "type": "array"
+          }
         }
       }
     },
@@ -353,10 +430,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "resourceName": {"type": "string"},
-          "names": {"type": "array"},
-          "emailAddresses": {"type": "array"},
-          "phoneNumbers": {"type": "array"}
+          "resourceName": {
+            "type": "string"
+          },
+          "names": {
+            "type": "array"
+          },
+          "emailAddresses": {
+            "type": "array"
+          },
+          "phoneNumbers": {
+            "type": "array"
+          }
         }
       }
     }
@@ -364,5 +449,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/people/me?personFields=names"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/google-docs/definition.json
+++ b/connectors/google-docs/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://accounts.google.com/o/oauth2/v2/auth",
       "tokenUrl": "https://oauth2.googleapis.com/token",
-      "scopes": ["https://www.googleapis.com/auth/documents"]
+      "scopes": [
+        "https://www.googleapis.com/auth/documents"
+      ]
     }
   },
   "baseUrl": "https://docs.googleapis.com/v1",
@@ -60,7 +62,9 @@
             "description": "Include tabs content"
           }
         },
-        "required": ["documentId"],
+        "required": [
+          "documentId"
+        ],
         "additionalProperties": false
       }
     },
@@ -77,19 +81,28 @@
           },
           "requests": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Array of batch update requests"
           },
           "writeControl": {
             "type": "object",
             "properties": {
-              "requiredRevisionId": {"type": "string"},
-              "targetRevisionId": {"type": "string"}
+              "requiredRevisionId": {
+                "type": "string"
+              },
+              "targetRevisionId": {
+                "type": "string"
+              }
             },
             "description": "Write control settings"
           }
         },
-        "required": ["documentId", "requests"],
+        "required": [
+          "documentId",
+          "requests"
+        ],
         "additionalProperties": false
       }
     },
@@ -118,7 +131,10 @@
             "description": "Segment ID for tab-specific insertion"
           }
         },
-        "required": ["documentId", "text"],
+        "required": [
+          "documentId",
+          "text"
+        ],
         "additionalProperties": false
       }
     },
@@ -140,8 +156,13 @@
           "containsText": {
             "type": "object",
             "properties": {
-              "text": {"type": "string"},
-              "matchCase": {"type": "boolean", "default": false}
+              "text": {
+                "type": "string"
+              },
+              "matchCase": {
+                "type": "boolean",
+                "default": false
+              }
             },
             "description": "Text to find and replace"
           },
@@ -150,7 +171,11 @@
             "description": "Tab ID for tab-specific replacement"
           }
         },
-        "required": ["documentId", "replaceText", "containsText"],
+        "required": [
+          "documentId",
+          "replaceText",
+          "containsText"
+        ],
         "additionalProperties": false
       }
     },
@@ -168,14 +193,23 @@
           "range": {
             "type": "object",
             "properties": {
-              "startIndex": {"type": "number"},
-              "endIndex": {"type": "number"},
-              "segmentId": {"type": "string"}
+              "startIndex": {
+                "type": "number"
+              },
+              "endIndex": {
+                "type": "number"
+              },
+              "segmentId": {
+                "type": "string"
+              }
             },
             "description": "Range to delete"
           }
         },
-        "required": ["documentId", "range"],
+        "required": [
+          "documentId",
+          "range"
+        ],
         "additionalProperties": false
       }
     },
@@ -210,7 +244,11 @@
             "description": "Segment ID for tab-specific insertion"
           }
         },
-        "required": ["documentId", "rows", "columns"],
+        "required": [
+          "documentId",
+          "rows",
+          "columns"
+        ],
         "additionalProperties": false
       }
     },
@@ -244,7 +282,10 @@
             "description": "Segment ID for tab-specific insertion"
           }
         },
-        "required": ["documentId", "uri"],
+        "required": [
+          "documentId",
+          "uri"
+        ],
         "additionalProperties": false
       }
     },
@@ -262,22 +303,42 @@
           "range": {
             "type": "object",
             "properties": {
-              "startIndex": {"type": "number"},
-              "endIndex": {"type": "number"},
-              "segmentId": {"type": "string"}
+              "startIndex": {
+                "type": "number"
+              },
+              "endIndex": {
+                "type": "number"
+              },
+              "segmentId": {
+                "type": "string"
+              }
             },
             "description": "Range to style"
           },
           "textStyle": {
             "type": "object",
             "properties": {
-              "bold": {"type": "boolean"},
-              "italic": {"type": "boolean"},
-              "underline": {"type": "boolean"},
-              "strikethrough": {"type": "boolean"},
-              "fontSize": {"type": "object"},
-              "foregroundColor": {"type": "object"},
-              "backgroundColor": {"type": "object"}
+              "bold": {
+                "type": "boolean"
+              },
+              "italic": {
+                "type": "boolean"
+              },
+              "underline": {
+                "type": "boolean"
+              },
+              "strikethrough": {
+                "type": "boolean"
+              },
+              "fontSize": {
+                "type": "object"
+              },
+              "foregroundColor": {
+                "type": "object"
+              },
+              "backgroundColor": {
+                "type": "object"
+              }
             },
             "description": "Text style properties"
           },
@@ -286,7 +347,11 @@
             "description": "Fields to update"
           }
         },
-        "required": ["documentId", "range", "textStyle"],
+        "required": [
+          "documentId",
+          "range",
+          "textStyle"
+        ],
         "additionalProperties": false
       }
     }
@@ -306,10 +371,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "documentId": {"type": "string"},
-          "title": {"type": "string"},
-          "body": {"type": "object"},
-          "revisionId": {"type": "string"}
+          "documentId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "object"
+          },
+          "revisionId": {
+            "type": "string"
+          }
         }
       }
     },
@@ -332,10 +405,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "documentId": {"type": "string"},
-          "title": {"type": "string"},
-          "body": {"type": "object"},
-          "revisionId": {"type": "string"}
+          "documentId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "object"
+          },
+          "revisionId": {
+            "type": "string"
+          }
         }
       }
     }
@@ -343,5 +424,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/documents/test"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/google-drive/definition.json
+++ b/connectors/google-drive/definition.json
@@ -70,7 +70,10 @@
             "description": "Base64-encoded file content"
           }
         },
-        "required": ["name", "mimeType"],
+        "required": [
+          "name",
+          "mimeType"
+        ],
         "additionalProperties": false
       }
     },
@@ -98,7 +101,10 @@
             "description": "MIME type of the file"
           }
         },
-        "required": ["name", "content"],
+        "required": [
+          "name",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -120,7 +126,9 @@
             "description": "Comma-separated list of fields to return"
           }
         },
-        "required": ["fileId"],
+        "required": [
+          "fileId"
+        ],
         "additionalProperties": false
       }
     },
@@ -139,11 +147,21 @@
           },
           "format": {
             "type": "string",
-            "enum": ["pdf", "docx", "xlsx", "pptx", "txt", "html", "odt"],
+            "enum": [
+              "pdf",
+              "docx",
+              "xlsx",
+              "pptx",
+              "txt",
+              "html",
+              "odt"
+            ],
             "description": "Export format for Google Workspace files"
           }
         },
-        "required": ["fileId"],
+        "required": [
+          "fileId"
+        ],
         "additionalProperties": false
       }
     },
@@ -172,7 +190,18 @@
           },
           "orderBy": {
             "type": "string",
-            "enum": ["createdTime", "folder", "modifiedByMeTime", "modifiedTime", "name", "quotaBytesUsed", "recency", "sharedWithMeTime", "starred", "viewedByMeTime"],
+            "enum": [
+              "createdTime",
+              "folder",
+              "modifiedByMeTime",
+              "modifiedTime",
+              "name",
+              "quotaBytesUsed",
+              "recency",
+              "sharedWithMeTime",
+              "starred",
+              "viewedByMeTime"
+            ],
             "description": "Sort order"
           },
           "fields": {
@@ -202,7 +231,9 @@
             "description": "ID of the parent folder"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -226,7 +257,10 @@
             "description": "Comma-separated list of parent IDs to remove"
           }
         },
-        "required": ["fileId", "newParentId"],
+        "required": [
+          "fileId",
+          "newParentId"
+        ],
         "additionalProperties": false
       }
     },
@@ -250,7 +284,9 @@
             "description": "ID of the parent folder for the copy"
           }
         },
-        "required": ["fileId"],
+        "required": [
+          "fileId"
+        ],
         "additionalProperties": false
       }
     },
@@ -268,7 +304,9 @@
             "description": "ID of the file to delete"
           }
         },
-        "required": ["fileId"],
+        "required": [
+          "fileId"
+        ],
         "additionalProperties": false
       }
     },
@@ -292,13 +330,23 @@
           },
           "role": {
             "type": "string",
-            "enum": ["reader", "writer", "commenter", "owner"],
+            "enum": [
+              "reader",
+              "writer",
+              "commenter",
+              "owner"
+            ],
             "default": "reader",
             "description": "Permission role for the user"
           },
           "type": {
             "type": "string",
-            "enum": ["user", "group", "domain", "anyone"],
+            "enum": [
+              "user",
+              "group",
+              "domain",
+              "anyone"
+            ],
             "default": "user",
             "description": "Type of permission"
           },
@@ -308,7 +356,9 @@
             "description": "Whether to send notification email"
           }
         },
-        "required": ["fileId"],
+        "required": [
+          "fileId"
+        ],
         "additionalProperties": false
       }
     },
@@ -324,7 +374,9 @@
             "description": "ID of the file"
           }
         },
-        "required": ["fileId"],
+        "required": [
+          "fileId"
+        ],
         "additionalProperties": false
       }
     },
@@ -350,7 +402,9 @@
             "description": "New description for the file"
           }
         },
-        "required": ["fileId"],
+        "required": [
+          "fileId"
+        ],
         "additionalProperties": false
       }
     },
@@ -372,7 +426,10 @@
             "description": "ID of the permission to remove"
           }
         },
-        "required": ["fileId", "permissionId"],
+        "required": [
+          "fileId",
+          "permissionId"
+        ],
         "additionalProperties": false
       }
     },
@@ -395,11 +452,20 @@
           },
           "role": {
             "type": "string",
-            "enum": ["reader", "writer", "commenter", "owner"],
+            "enum": [
+              "reader",
+              "writer",
+              "commenter",
+              "owner"
+            ],
             "description": "New role for the permission"
           }
         },
-        "required": ["fileId", "permissionId", "role"],
+        "required": [
+          "fileId",
+          "permissionId",
+          "role"
+        ],
         "additionalProperties": false
       }
     }
@@ -428,13 +494,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "fileId": {"type": "string"},
-          "name": {"type": "string"},
-          "mimeType": {"type": "string"},
-          "size": {"type": "number"},
-          "createdTime": {"type": "string"},
-          "modifiedTime": {"type": "string"},
-          "webViewLink": {"type": "string"}
+          "fileId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "createdTime": {
+            "type": "string"
+          },
+          "modifiedTime": {
+            "type": "string"
+          },
+          "webViewLink": {
+            "type": "string"
+          }
         }
       }
     },
@@ -461,10 +541,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "fileId": {"type": "string"},
-          "name": {"type": "string"},
-          "modifiedTime": {"type": "string"},
-          "lastModifyingUser": {"type": "object"}
+          "fileId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "modifiedTime": {
+            "type": "string"
+          },
+          "lastModifyingUser": {
+            "type": "object"
+          }
         }
       }
     },
@@ -487,10 +575,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "fileId": {"type": "string"},
-          "name": {"type": "string"},
-          "sharedWithUser": {"type": "string"},
-          "permissionId": {"type": "string"}
+          "fileId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sharedWithUser": {
+            "type": "string"
+          },
+          "permissionId": {
+            "type": "string"
+          }
         }
       }
     }
@@ -498,6 +594,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/about"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }
-

--- a/connectors/google-forms/definition.json
+++ b/connectors/google-forms/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://accounts.google.com/o/oauth2/v2/auth",
       "tokenUrl": "https://oauth2.googleapis.com/token",
-      "scopes": ["https://www.googleapis.com/auth/forms", "https://www.googleapis.com/auth/forms.responses.readonly"]
+      "scopes": [
+        "https://www.googleapis.com/auth/forms",
+        "https://www.googleapis.com/auth/forms.responses.readonly"
+      ]
     }
   },
   "baseUrl": "https://forms.googleapis.com/v1",
@@ -37,9 +40,15 @@
           "info": {
             "type": "object",
             "properties": {
-              "title": {"type": "string"},
-              "description": {"type": "string"},
-              "documentTitle": {"type": "string"}
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "documentTitle": {
+                "type": "string"
+              }
             },
             "description": "Form information"
           }
@@ -60,7 +69,9 @@
             "description": "Form ID"
           }
         },
-        "required": ["formId"],
+        "required": [
+          "formId"
+        ],
         "additionalProperties": false
       }
     },
@@ -77,7 +88,9 @@
           },
           "requests": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Array of batch update requests"
           },
           "includeFormInResponse": {
@@ -88,13 +101,20 @@
           "writeControl": {
             "type": "object",
             "properties": {
-              "requiredRevisionId": {"type": "string"},
-              "targetRevisionId": {"type": "string"}
+              "requiredRevisionId": {
+                "type": "string"
+              },
+              "targetRevisionId": {
+                "type": "string"
+              }
             },
             "description": "Write control settings"
           }
         },
-        "required": ["formId", "requests"],
+        "required": [
+          "formId",
+          "requests"
+        ],
         "additionalProperties": false
       }
     },
@@ -112,19 +132,33 @@
           "item": {
             "type": "object",
             "properties": {
-              "title": {"type": "string"},
-              "description": {"type": "string"},
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
               "questionItem": {
                 "type": "object",
                 "properties": {
                   "question": {
                     "type": "object",
                     "properties": {
-                      "questionId": {"type": "string"},
-                      "required": {"type": "boolean"},
-                      "choiceQuestion": {"type": "object"},
-                      "textQuestion": {"type": "object"},
-                      "scaleQuestion": {"type": "object"}
+                      "questionId": {
+                        "type": "string"
+                      },
+                      "required": {
+                        "type": "boolean"
+                      },
+                      "choiceQuestion": {
+                        "type": "object"
+                      },
+                      "textQuestion": {
+                        "type": "object"
+                      },
+                      "scaleQuestion": {
+                        "type": "object"
+                      }
                     }
                   }
                 }
@@ -135,12 +169,17 @@
           "location": {
             "type": "object",
             "properties": {
-              "index": {"type": "number"}
+              "index": {
+                "type": "number"
+              }
             },
             "description": "Location to insert question"
           }
         },
-        "required": ["formId", "item"],
+        "required": [
+          "formId",
+          "item"
+        ],
         "additionalProperties": false
       }
     },
@@ -158,9 +197,15 @@
           "info": {
             "type": "object",
             "properties": {
-              "title": {"type": "string"},
-              "description": {"type": "string"},
-              "documentTitle": {"type": "string"}
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "documentTitle": {
+                "type": "string"
+              }
             },
             "description": "Updated form information"
           },
@@ -169,7 +214,10 @@
             "description": "Fields to update"
           }
         },
-        "required": ["formId", "info"],
+        "required": [
+          "formId",
+          "info"
+        ],
         "additionalProperties": false
       }
     },
@@ -187,12 +235,17 @@
           "location": {
             "type": "object",
             "properties": {
-              "index": {"type": "number"}
+              "index": {
+                "type": "number"
+              }
             },
             "description": "Location of item to delete"
           }
         },
-        "required": ["formId", "location"],
+        "required": [
+          "formId",
+          "location"
+        ],
         "additionalProperties": false
       }
     },
@@ -223,7 +276,9 @@
             "description": "Page token for pagination"
           }
         },
-        "required": ["formId"],
+        "required": [
+          "formId"
+        ],
         "additionalProperties": false
       }
     },
@@ -243,7 +298,10 @@
             "description": "Response ID"
           }
         },
-        "required": ["formId", "responseId"],
+        "required": [
+          "formId",
+          "responseId"
+        ],
         "additionalProperties": false
       }
     },
@@ -261,8 +319,12 @@
           "settings": {
             "type": "object",
             "properties": {
-              "quizSettings": {"type": "object"},
-              "submitSettings": {"type": "object"}
+              "quizSettings": {
+                "type": "object"
+              },
+              "submitSettings": {
+                "type": "object"
+              }
             },
             "description": "Form settings"
           },
@@ -271,7 +333,10 @@
             "description": "Fields to update"
           }
         },
-        "required": ["formId", "settings"],
+        "required": [
+          "formId",
+          "settings"
+        ],
         "additionalProperties": false
       }
     }
@@ -296,11 +361,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "formId": {"type": "string"},
-          "responseId": {"type": "string"},
-          "answers": {"type": "object"},
-          "createTime": {"type": "string"},
-          "lastSubmittedTime": {"type": "string"}
+          "formId": {
+            "type": "string"
+          },
+          "responseId": {
+            "type": "string"
+          },
+          "answers": {
+            "type": "object"
+          },
+          "createTime": {
+            "type": "string"
+          },
+          "lastSubmittedTime": {
+            "type": "string"
+          }
         }
       }
     },
@@ -318,9 +393,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "formId": {"type": "string"},
-          "info": {"type": "object"},
-          "revisionId": {"type": "string"}
+          "formId": {
+            "type": "string"
+          },
+          "info": {
+            "type": "object"
+          },
+          "revisionId": {
+            "type": "string"
+          }
         }
       }
     }
@@ -328,5 +409,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/forms"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/google-meet/definition.json
+++ b/connectors/google-meet/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://accounts.google.com/o/oauth2/v2/auth",
       "tokenUrl": "https://oauth2.googleapis.com/token",
-      "scopes": ["https://www.googleapis.com/auth/meetings.space.created", "https://www.googleapis.com/auth/meetings.space.readonly"]
+      "scopes": [
+        "https://www.googleapis.com/auth/meetings.space.created",
+        "https://www.googleapis.com/auth/meetings.space.readonly"
+      ]
     }
   },
   "baseUrl": "https://meet.googleapis.com/v2",
@@ -39,13 +42,20 @@
             "properties": {
               "accessType": {
                 "type": "string",
-                "enum": ["OPEN", "TRUSTED", "RESTRICTED"],
+                "enum": [
+                  "OPEN",
+                  "TRUSTED",
+                  "RESTRICTED"
+                ],
                 "default": "TRUSTED",
                 "description": "Access type for the space"
               },
               "entryPointAccess": {
                 "type": "string",
-                "enum": ["ALL", "CREATOR_APP_ONLY"],
+                "enum": [
+                  "ALL",
+                  "CREATOR_APP_ONLY"
+                ],
                 "default": "ALL",
                 "description": "Entry point access"
               }
@@ -69,7 +79,9 @@
             "description": "Space name (spaces/SPACE_ID)"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -85,7 +97,9 @@
             "description": "Space name (spaces/SPACE_ID)"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -116,7 +130,9 @@
             "description": "Filter expression"
           }
         },
-        "required": ["parent"],
+        "required": [
+          "parent"
+        ],
         "additionalProperties": false
       }
     },
@@ -132,7 +148,9 @@
             "description": "Conference record name"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -163,7 +181,9 @@
             "description": "Filter expression"
           }
         },
-        "required": ["parent"],
+        "required": [
+          "parent"
+        ],
         "additionalProperties": false
       }
     },
@@ -179,7 +199,9 @@
             "description": "Participant name"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -210,7 +232,9 @@
             "description": "Filter expression"
           }
         },
-        "required": ["parent"],
+        "required": [
+          "parent"
+        ],
         "additionalProperties": false
       }
     },
@@ -226,7 +250,9 @@
             "description": "Participant session name"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     }
@@ -246,11 +272,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "meetingUri": {"type": "string"},
-          "meetingCode": {"type": "string"},
-          "config": {"type": "object"},
-          "activeConference": {"type": "object"}
+          "name": {
+            "type": "string"
+          },
+          "meetingUri": {
+            "type": "string"
+          },
+          "meetingCode": {
+            "type": "string"
+          },
+          "config": {
+            "type": "object"
+          },
+          "activeConference": {
+            "type": "object"
+          }
         }
       }
     },
@@ -273,10 +309,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "startTime": {"type": "string"},
-          "endTime": {"type": "string"},
-          "space": {"type": "string"}
+          "name": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "space": {
+            "type": "string"
+          }
         }
       }
     },
@@ -299,12 +343,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "signedinUser": {"type": "object"},
-          "anonymousUser": {"type": "object"},
-          "phoneUser": {"type": "object"},
-          "earliestStartTime": {"type": "string"},
-          "latestEndTime": {"type": "string"}
+          "name": {
+            "type": "string"
+          },
+          "signedinUser": {
+            "type": "object"
+          },
+          "anonymousUser": {
+            "type": "object"
+          },
+          "phoneUser": {
+            "type": "object"
+          },
+          "earliestStartTime": {
+            "type": "string"
+          },
+          "latestEndTime": {
+            "type": "string"
+          }
         }
       }
     }
@@ -312,5 +368,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/spaces"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/google-sheets-enhanced/definition.json
+++ b/connectors/google-sheets-enhanced/definition.json
@@ -52,17 +52,26 @@
           },
           "values": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of cell values to append"
           },
           "valueInputOption": {
             "type": "string",
-            "enum": ["RAW", "USER_ENTERED"],
+            "enum": [
+              "RAW",
+              "USER_ENTERED"
+            ],
             "default": "USER_ENTERED",
             "description": "How values should be interpreted"
           }
         },
-        "required": ["spreadsheetId", "sheet", "values"],
+        "required": [
+          "spreadsheetId",
+          "sheet",
+          "values"
+        ],
         "additionalProperties": false
       }
     },
@@ -87,12 +96,19 @@
           },
           "valueInputOption": {
             "type": "string",
-            "enum": ["RAW", "USER_ENTERED"],
+            "enum": [
+              "RAW",
+              "USER_ENTERED"
+            ],
             "default": "USER_ENTERED",
             "description": "How values should be interpreted"
           }
         },
-        "required": ["spreadsheetId", "range", "value"],
+        "required": [
+          "spreadsheetId",
+          "range",
+          "value"
+        ],
         "additionalProperties": false
       }
     },
@@ -115,18 +131,27 @@
             "type": "array",
             "items": {
               "type": "array",
-              "items": {"type": "string"}
+              "items": {
+                "type": "string"
+              }
             },
             "description": "2D array of cell values"
           },
           "valueInputOption": {
             "type": "string",
-            "enum": ["RAW", "USER_ENTERED"],
+            "enum": [
+              "RAW",
+              "USER_ENTERED"
+            ],
             "default": "USER_ENTERED",
             "description": "How values should be interpreted"
           }
         },
-        "required": ["spreadsheetId", "range", "values"],
+        "required": [
+          "spreadsheetId",
+          "range",
+          "values"
+        ],
         "additionalProperties": false
       }
     },
@@ -147,18 +172,28 @@
           },
           "valueRenderOption": {
             "type": "string",
-            "enum": ["FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA"],
+            "enum": [
+              "FORMATTED_VALUE",
+              "UNFORMATTED_VALUE",
+              "FORMULA"
+            ],
             "default": "FORMATTED_VALUE",
             "description": "How values should be rendered"
           },
           "dateTimeRenderOption": {
             "type": "string",
-            "enum": ["SERIAL_NUMBER", "FORMATTED_STRING"],
+            "enum": [
+              "SERIAL_NUMBER",
+              "FORMATTED_STRING"
+            ],
             "default": "FORMATTED_STRING",
             "description": "How dates and times should be rendered"
           }
         },
-        "required": ["spreadsheetId", "range"],
+        "required": [
+          "spreadsheetId",
+          "range"
+        ],
         "additionalProperties": false
       }
     },
@@ -178,7 +213,10 @@
             "description": "Cell range to clear (e.g., 'Sheet1!A1:C10')"
           }
         },
-        "required": ["spreadsheetId", "range"],
+        "required": [
+          "spreadsheetId",
+          "range"
+        ],
         "additionalProperties": false
       }
     },
@@ -204,13 +242,20 @@
           "gridProperties": {
             "type": "object",
             "properties": {
-              "rowCount": {"type": "number"},
-              "columnCount": {"type": "number"}
+              "rowCount": {
+                "type": "number"
+              },
+              "columnCount": {
+                "type": "number"
+              }
             },
             "description": "Grid properties for the sheet"
           }
         },
-        "required": ["spreadsheetId", "title"],
+        "required": [
+          "spreadsheetId",
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -230,7 +275,10 @@
             "description": "Sheet ID to delete"
           }
         },
-        "required": ["spreadsheetId", "sheetId"],
+        "required": [
+          "spreadsheetId",
+          "sheetId"
+        ],
         "additionalProperties": false
       }
     },
@@ -254,7 +302,10 @@
             "description": "Name for the new duplicated sheet"
           }
         },
-        "required": ["spreadsheetId", "sourceSheetId"],
+        "required": [
+          "spreadsheetId",
+          "sourceSheetId"
+        ],
         "additionalProperties": false
       }
     },
@@ -276,15 +327,27 @@
           "format": {
             "type": "object",
             "properties": {
-              "backgroundColor": {"type": "object"},
-              "textFormat": {"type": "object"},
-              "numberFormat": {"type": "object"},
-              "borders": {"type": "object"}
+              "backgroundColor": {
+                "type": "object"
+              },
+              "textFormat": {
+                "type": "object"
+              },
+              "numberFormat": {
+                "type": "object"
+              },
+              "borders": {
+                "type": "object"
+              }
             },
             "description": "Format properties to apply"
           }
         },
-        "required": ["spreadsheetId", "range", "format"],
+        "required": [
+          "spreadsheetId",
+          "range",
+          "format"
+        ],
         "additionalProperties": false
       }
     },
@@ -327,7 +390,11 @@
             "description": "Match entire cell content"
           }
         },
-        "required": ["spreadsheetId", "find", "replacement"],
+        "required": [
+          "spreadsheetId",
+          "find",
+          "replacement"
+        ],
         "additionalProperties": false
       }
     },
@@ -351,14 +418,26 @@
             "items": {
               "type": "object",
               "properties": {
-                "dimensionIndex": {"type": "number"},
-                "sortOrder": {"type": "string", "enum": ["ASCENDING", "DESCENDING"]}
+                "dimensionIndex": {
+                  "type": "number"
+                },
+                "sortOrder": {
+                  "type": "string",
+                  "enum": [
+                    "ASCENDING",
+                    "DESCENDING"
+                  ]
+                }
               }
             },
             "description": "Sort specifications"
           }
         },
-        "required": ["spreadsheetId", "range", "sortSpecs"],
+        "required": [
+          "spreadsheetId",
+          "range",
+          "sortSpecs"
+        ],
         "additionalProperties": false
       }
     }
@@ -381,16 +460,29 @@
             "description": "Specific sheet name to monitor"
           }
         },
-        "required": ["spreadsheetId"],
+        "required": [
+          "spreadsheetId"
+        ],
         "additionalProperties": false
       },
       "outputSchema": {
         "type": "object",
         "properties": {
-          "rowIndex": {"type": "number"},
-          "values": {"type": "array", "items": {"type": "string"}},
-          "sheetName": {"type": "string"},
-          "spreadsheetId": {"type": "string"}
+          "rowIndex": {
+            "type": "number"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sheetName": {
+            "type": "string"
+          },
+          "spreadsheetId": {
+            "type": "string"
+          }
         }
       }
     },
@@ -411,17 +503,29 @@
             "description": "Specific range to monitor (optional)"
           }
         },
-        "required": ["spreadsheetId"],
+        "required": [
+          "spreadsheetId"
+        ],
         "additionalProperties": false
       },
       "outputSchema": {
         "type": "object",
         "properties": {
-          "range": {"type": "string"},
-          "oldValue": {"type": "string"},
-          "newValue": {"type": "string"},
-          "sheetName": {"type": "string"},
-          "spreadsheetId": {"type": "string"}
+          "range": {
+            "type": "string"
+          },
+          "oldValue": {
+            "type": "string"
+          },
+          "newValue": {
+            "type": "string"
+          },
+          "sheetName": {
+            "type": "string"
+          },
+          "spreadsheetId": {
+            "type": "string"
+          }
         }
       }
     }
@@ -429,5 +533,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/spreadsheets"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/google-slides/definition.json
+++ b/connectors/google-slides/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://accounts.google.com/o/oauth2/v2/auth",
       "tokenUrl": "https://oauth2.googleapis.com/token",
-      "scopes": ["https://www.googleapis.com/auth/presentations"]
+      "scopes": [
+        "https://www.googleapis.com/auth/presentations"
+      ]
     }
   },
   "baseUrl": "https://slides.googleapis.com/v1",
@@ -55,7 +57,9 @@
             "description": "Presentation ID"
           }
         },
-        "required": ["presentationId"],
+        "required": [
+          "presentationId"
+        ],
         "additionalProperties": false
       }
     },
@@ -72,18 +76,25 @@
           },
           "requests": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Array of batch update requests"
           },
           "writeControl": {
             "type": "object",
             "properties": {
-              "requiredRevisionId": {"type": "string"}
+              "requiredRevisionId": {
+                "type": "string"
+              }
             },
             "description": "Write control settings"
           }
         },
-        "required": ["presentationId", "requests"],
+        "required": [
+          "presentationId",
+          "requests"
+        ],
         "additionalProperties": false
       }
     },
@@ -103,10 +114,24 @@
             "properties": {
               "predefinedLayout": {
                 "type": "string",
-                "enum": ["BLANK", "CAPTION_ONLY", "TITLE", "TITLE_AND_BODY", "TITLE_AND_TWO_COLUMNS", "TITLE_ONLY", "SECTION_HEADER", "SECTION_TITLE_AND_DESCRIPTION", "ONE_COLUMN_TEXT", "MAIN_POINT", "BIG_NUMBER"],
+                "enum": [
+                  "BLANK",
+                  "CAPTION_ONLY",
+                  "TITLE",
+                  "TITLE_AND_BODY",
+                  "TITLE_AND_TWO_COLUMNS",
+                  "TITLE_ONLY",
+                  "SECTION_HEADER",
+                  "SECTION_TITLE_AND_DESCRIPTION",
+                  "ONE_COLUMN_TEXT",
+                  "MAIN_POINT",
+                  "BIG_NUMBER"
+                ],
                 "description": "Predefined layout"
               },
-              "layoutId": {"type": "string"}
+              "layoutId": {
+                "type": "string"
+              }
             },
             "description": "Slide layout reference"
           },
@@ -120,11 +145,15 @@
           },
           "placeholderIdMappings": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Placeholder ID mappings"
           }
         },
-        "required": ["presentationId"],
+        "required": [
+          "presentationId"
+        ],
         "additionalProperties": false
       }
     },
@@ -144,7 +173,10 @@
             "description": "Object ID to delete"
           }
         },
-        "required": ["presentationId", "objectId"],
+        "required": [
+          "presentationId",
+          "objectId"
+        ],
         "additionalProperties": false
       }
     },
@@ -173,7 +205,11 @@
             "description": "Character index to insert at"
           }
         },
-        "required": ["presentationId", "objectId", "text"],
+        "required": [
+          "presentationId",
+          "objectId",
+          "text"
+        ],
         "additionalProperties": false
       }
     },
@@ -191,8 +227,13 @@
           "containsText": {
             "type": "object",
             "properties": {
-              "text": {"type": "string"},
-              "matchCase": {"type": "boolean", "default": false}
+              "text": {
+                "type": "string"
+              },
+              "matchCase": {
+                "type": "boolean",
+                "default": false
+              }
             },
             "description": "Text to find and replace"
           },
@@ -202,11 +243,17 @@
           },
           "pageObjectIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Limit replacement to specific slides"
           }
         },
-        "required": ["presentationId", "containsText", "replaceText"],
+        "required": [
+          "presentationId",
+          "containsText",
+          "replaceText"
+        ],
         "additionalProperties": false
       }
     },
@@ -231,20 +278,136 @@
           },
           "shapeType": {
             "type": "string",
-            "enum": ["TEXT_BOX", "RECTANGLE", "ROUND_RECTANGLE", "ELLIPSE", "ARC", "BENT_ARROW", "BENT_UP_ARROW", "BEVEL", "BLOCK_ARC", "BRACE_PAIR", "BRACKET_PAIR", "CAN", "CHEVRON", "CHORD", "CLOUD", "CORNER", "CUBE", "CURVED_DOWN_ARROW", "CURVED_LEFT_ARROW", "CURVED_RIGHT_ARROW", "CURVED_UP_ARROW", "DECAGON", "DIAGONAL_STRIPE", "DIAMOND", "DODECAGON", "DONUT", "DOUBLE_WAVE", "DOWN_ARROW", "DOWN_ARROW_CALLOUT", "FOLDED_CORNER", "FRAME", "HALF_FRAME", "HEART", "HEPTAGON", "HEXAGON", "HOME_PLATE", "HORIZONTAL_SCROLL", "IRREGULAR_SEAL_1", "IRREGULAR_SEAL_2", "LEFT_ARROW", "LEFT_ARROW_CALLOUT", "LEFT_BRACE", "LEFT_BRACKET", "LEFT_RIGHT_ARROW", "LEFT_RIGHT_ARROW_CALLOUT", "LEFT_RIGHT_UP_ARROW", "LEFT_UP_ARROW", "LIGHTNING_BOLT", "MATH_DIVIDE", "MATH_EQUAL", "MATH_MINUS", "MATH_MULTIPLY", "MATH_NOT_EQUAL", "MATH_PLUS", "MOON", "NONE", "NO_SMOKING", "NOTCHED_RIGHT_ARROW", "OCTAGON", "PARALLELOGRAM", "PENTAGON", "PIE", "PLAQUE", "PLUS", "QUAD_ARROW", "QUAD_ARROW_CALLOUT", "RIBBON", "RIBBON_2", "RIGHT_ARROW", "RIGHT_ARROW_CALLOUT", "RIGHT_BRACE", "RIGHT_BRACKET", "RIGHT_TRIANGLE", "ROUND_1_RECTANGLE", "ROUND_2_DIAGONAL_RECTANGLE", "ROUND_2_SAME_RECTANGLE", "SMILEY_FACE", "SNIP_1_RECTANGLE", "SNIP_2_DIAGONAL_RECTANGLE", "SNIP_2_SAME_RECTANGLE", "SNIP_ROUND_RECTANGLE", "STAR_10", "STAR_12", "STAR_16", "STAR_24", "STAR_32", "STAR_4", "STAR_5", "STAR_6", "STAR_7", "STAR_8", "STRIPED_RIGHT_ARROW", "SUN", "TRAPEZOID", "TRIANGLE", "UP_ARROW", "UP_ARROW_CALLOUT", "UP_DOWN_ARROW", "UTURN_ARROW", "VERTICAL_SCROLL", "WAVE", "WEDGE_ELLIPSE_CALLOUT", "WEDGE_RECTANGLE_CALLOUT", "WEDGE_ROUND_RECTANGLE_CALLOUT"],
+            "enum": [
+              "TEXT_BOX",
+              "RECTANGLE",
+              "ROUND_RECTANGLE",
+              "ELLIPSE",
+              "ARC",
+              "BENT_ARROW",
+              "BENT_UP_ARROW",
+              "BEVEL",
+              "BLOCK_ARC",
+              "BRACE_PAIR",
+              "BRACKET_PAIR",
+              "CAN",
+              "CHEVRON",
+              "CHORD",
+              "CLOUD",
+              "CORNER",
+              "CUBE",
+              "CURVED_DOWN_ARROW",
+              "CURVED_LEFT_ARROW",
+              "CURVED_RIGHT_ARROW",
+              "CURVED_UP_ARROW",
+              "DECAGON",
+              "DIAGONAL_STRIPE",
+              "DIAMOND",
+              "DODECAGON",
+              "DONUT",
+              "DOUBLE_WAVE",
+              "DOWN_ARROW",
+              "DOWN_ARROW_CALLOUT",
+              "FOLDED_CORNER",
+              "FRAME",
+              "HALF_FRAME",
+              "HEART",
+              "HEPTAGON",
+              "HEXAGON",
+              "HOME_PLATE",
+              "HORIZONTAL_SCROLL",
+              "IRREGULAR_SEAL_1",
+              "IRREGULAR_SEAL_2",
+              "LEFT_ARROW",
+              "LEFT_ARROW_CALLOUT",
+              "LEFT_BRACE",
+              "LEFT_BRACKET",
+              "LEFT_RIGHT_ARROW",
+              "LEFT_RIGHT_ARROW_CALLOUT",
+              "LEFT_RIGHT_UP_ARROW",
+              "LEFT_UP_ARROW",
+              "LIGHTNING_BOLT",
+              "MATH_DIVIDE",
+              "MATH_EQUAL",
+              "MATH_MINUS",
+              "MATH_MULTIPLY",
+              "MATH_NOT_EQUAL",
+              "MATH_PLUS",
+              "MOON",
+              "NONE",
+              "NO_SMOKING",
+              "NOTCHED_RIGHT_ARROW",
+              "OCTAGON",
+              "PARALLELOGRAM",
+              "PENTAGON",
+              "PIE",
+              "PLAQUE",
+              "PLUS",
+              "QUAD_ARROW",
+              "QUAD_ARROW_CALLOUT",
+              "RIBBON",
+              "RIBBON_2",
+              "RIGHT_ARROW",
+              "RIGHT_ARROW_CALLOUT",
+              "RIGHT_BRACE",
+              "RIGHT_BRACKET",
+              "RIGHT_TRIANGLE",
+              "ROUND_1_RECTANGLE",
+              "ROUND_2_DIAGONAL_RECTANGLE",
+              "ROUND_2_SAME_RECTANGLE",
+              "SMILEY_FACE",
+              "SNIP_1_RECTANGLE",
+              "SNIP_2_DIAGONAL_RECTANGLE",
+              "SNIP_2_SAME_RECTANGLE",
+              "SNIP_ROUND_RECTANGLE",
+              "STAR_10",
+              "STAR_12",
+              "STAR_16",
+              "STAR_24",
+              "STAR_32",
+              "STAR_4",
+              "STAR_5",
+              "STAR_6",
+              "STAR_7",
+              "STAR_8",
+              "STRIPED_RIGHT_ARROW",
+              "SUN",
+              "TRAPEZOID",
+              "TRIANGLE",
+              "UP_ARROW",
+              "UP_ARROW_CALLOUT",
+              "UP_DOWN_ARROW",
+              "UTURN_ARROW",
+              "VERTICAL_SCROLL",
+              "WAVE",
+              "WEDGE_ELLIPSE_CALLOUT",
+              "WEDGE_RECTANGLE_CALLOUT",
+              "WEDGE_ROUND_RECTANGLE_CALLOUT"
+            ],
             "description": "Shape type"
           },
           "elementProperties": {
             "type": "object",
             "properties": {
-              "pageObjectId": {"type": "string"},
-              "size": {"type": "object"},
-              "transform": {"type": "object"}
+              "pageObjectId": {
+                "type": "string"
+              },
+              "size": {
+                "type": "object"
+              },
+              "transform": {
+                "type": "object"
+              }
             },
             "description": "Element properties"
           }
         },
-        "required": ["presentationId", "pageId", "objectId", "shapeType"],
+        "required": [
+          "presentationId",
+          "pageId",
+          "objectId",
+          "shapeType"
+        ],
         "additionalProperties": false
       }
     },
@@ -275,14 +438,25 @@
           "elementProperties": {
             "type": "object",
             "properties": {
-              "pageObjectId": {"type": "string"},
-              "size": {"type": "object"},
-              "transform": {"type": "object"}
+              "pageObjectId": {
+                "type": "string"
+              },
+              "size": {
+                "type": "object"
+              },
+              "transform": {
+                "type": "object"
+              }
             },
             "description": "Element properties"
           }
         },
-        "required": ["presentationId", "pageId", "objectId", "url"],
+        "required": [
+          "presentationId",
+          "pageId",
+          "objectId",
+          "url"
+        ],
         "additionalProperties": false
       }
     }
@@ -302,11 +476,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "presentationId": {"type": "string"},
-          "title": {"type": "string"},
-          "locale": {"type": "string"},
-          "revisionId": {"type": "string"},
-          "pageSize": {"type": "object"}
+          "presentationId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "revisionId": {
+            "type": "string"
+          },
+          "pageSize": {
+            "type": "object"
+          }
         }
       }
     },
@@ -329,10 +513,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "presentationId": {"type": "string"},
-          "title": {"type": "string"},
-          "revisionId": {"type": "string"},
-          "slides": {"type": "array"}
+          "presentationId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "revisionId": {
+            "type": "string"
+          },
+          "slides": {
+            "type": "array"
+          }
         }
       }
     }
@@ -340,5 +532,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/presentations/test"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/grafana/definition.json
+++ b/connectors/grafana/definition.json
@@ -43,7 +43,9 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Dashboard tags"
           },
           "folder_id": {
@@ -56,7 +58,9 @@
             "description": "Overwrite existing dashboard"
           }
         },
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -74,7 +78,13 @@
           },
           "type": {
             "type": "string",
-            "enum": ["prometheus", "influxdb", "elasticsearch", "mysql", "postgres"],
+            "enum": [
+              "prometheus",
+              "influxdb",
+              "elasticsearch",
+              "mysql",
+              "postgres"
+            ],
             "description": "Data source type"
           },
           "url": {
@@ -83,7 +93,10 @@
           },
           "access": {
             "type": "string",
-            "enum": ["proxy", "direct"],
+            "enum": [
+              "proxy",
+              "direct"
+            ],
             "default": "proxy",
             "description": "Access mode"
           },
@@ -93,7 +106,11 @@
             "description": "Enable basic authentication"
           }
         },
-        "required": ["name", "type", "url"],
+        "required": [
+          "name",
+          "type",
+          "url"
+        ],
         "additionalProperties": false
       }
     },
@@ -124,12 +141,19 @@
           },
           "no_data_state": {
             "type": "string",
-            "enum": ["NoData", "Alerting", "OK"],
+            "enum": [
+              "NoData",
+              "Alerting",
+              "OK"
+            ],
             "default": "NoData",
             "description": "State when no data"
           }
         },
-        "required": ["title", "condition"],
+        "required": [
+          "title",
+          "condition"
+        ],
         "additionalProperties": false
       }
     },
@@ -146,7 +170,9 @@
             "description": "Dashboard UID"
           }
         },
-        "required": ["uid"],
+        "required": [
+          "uid"
+        ],
         "additionalProperties": false
       }
     },
@@ -202,5 +228,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/greenhouse/definition.json
+++ b/connectors/greenhouse/definition.json
@@ -84,7 +84,9 @@
             "description": "Candidate ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -116,8 +118,19 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string"},
-                "type": {"type": "string", "enum": ["home", "work", "mobile", "skype", "other"]}
+                "value": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "home",
+                    "work",
+                    "mobile",
+                    "skype",
+                    "other"
+                  ]
+                }
               }
             },
             "description": "Phone numbers"
@@ -127,8 +140,17 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string"},
-                "type": {"type": "string", "enum": ["home", "work", "other"]}
+                "value": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "home",
+                    "work",
+                    "other"
+                  ]
+                }
               }
             },
             "description": "Addresses"
@@ -138,8 +160,18 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string", "format": "email"},
-                "type": {"type": "string", "enum": ["personal", "work", "other"]}
+                "value": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "personal",
+                    "work",
+                    "other"
+                  ]
+                }
               }
             },
             "description": "Email addresses"
@@ -149,8 +181,21 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string", "format": "uri"},
-                "type": {"type": "string", "enum": ["personal", "company", "portfolio", "blog", "social", "other"]}
+                "value": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "personal",
+                    "company",
+                    "portfolio",
+                    "blog",
+                    "social",
+                    "other"
+                  ]
+                }
               }
             },
             "description": "Website addresses"
@@ -160,7 +205,9 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string"}
+                "value": {
+                  "type": "string"
+                }
               }
             },
             "description": "Social media addresses"
@@ -168,22 +215,34 @@
           "recruiter": {
             "type": "object",
             "properties": {
-              "id": {"type": "number"},
-              "email": {"type": "string", "format": "email"}
+              "id": {
+                "type": "number"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
             },
             "description": "Recruiter information"
           },
           "coordinator": {
             "type": "object",
             "properties": {
-              "id": {"type": "number"},
-              "email": {"type": "string", "format": "email"}
+              "id": {
+                "type": "number"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
             },
             "description": "Coordinator information"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Tags"
           },
           "custom_fields": {
@@ -195,10 +254,24 @@
             "items": {
               "type": "object",
               "properties": {
-                "body": {"type": "string"},
-                "user_id": {"type": "number"},
-                "private": {"type": "boolean", "default": false},
-                "visibility": {"type": "string", "enum": ["admin_only", "private", "public"]}
+                "body": {
+                  "type": "string"
+                },
+                "user_id": {
+                  "type": "number"
+                },
+                "private": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "visibility": {
+                  "type": "string",
+                  "enum": [
+                    "admin_only",
+                    "private",
+                    "public"
+                  ]
+                }
               }
             },
             "description": "Activity feed notes"
@@ -238,22 +311,34 @@
           "recruiter": {
             "type": "object",
             "properties": {
-              "id": {"type": "number"},
-              "email": {"type": "string", "format": "email"}
+              "id": {
+                "type": "number"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
             },
             "description": "Recruiter information"
           },
           "coordinator": {
             "type": "object",
             "properties": {
-              "id": {"type": "number"},
-              "email": {"type": "string", "format": "email"}
+              "id": {
+                "type": "number"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
             },
             "description": "Coordinator information"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Tags"
           },
           "custom_fields": {
@@ -261,7 +346,9 @@
             "description": "Custom field values"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -307,7 +394,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["open", "closed", "draft"],
+            "enum": [
+              "open",
+              "closed",
+              "draft"
+            ],
             "description": "Filter by job status"
           }
         },
@@ -327,7 +418,9 @@
             "description": "Job ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -368,7 +461,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "rejected", "hired"],
+            "enum": [
+              "active",
+              "rejected",
+              "hired"
+            ],
             "description": "Filter by application status"
           },
           "job_id": {
@@ -392,7 +489,9 @@
             "description": "Application ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -416,7 +515,9 @@
             "description": "Target stage ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -442,13 +543,20 @@
           "rejection_email": {
             "type": "object",
             "properties": {
-              "send_email_at": {"type": "string", "format": "date-time"},
-              "email_template_id": {"type": "number"}
+              "send_email_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "email_template_id": {
+                "type": "number"
+              }
             },
             "description": "Email to send to candidate"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -464,7 +572,9 @@
             "description": "Application ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     }
@@ -484,13 +594,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "first_name": {"type": "string"},
-          "last_name": {"type": "string"},
-          "company": {"type": "string"},
-          "title": {"type": "string"},
-          "email_addresses": {"type": "array"},
-          "phone_numbers": {"type": "array"}
+          "id": {
+            "type": "number"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "company": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "email_addresses": {
+            "type": "array"
+          },
+          "phone_numbers": {
+            "type": "array"
+          }
         }
       }
     },
@@ -513,9 +637,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "application": {"type": "object"},
-          "previous_stage": {"type": "object"},
-          "current_stage": {"type": "object"}
+          "application": {
+            "type": "object"
+          },
+          "previous_stage": {
+            "type": "object"
+          },
+          "current_stage": {
+            "type": "object"
+          }
         }
       }
     },
@@ -533,9 +663,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "application": {"type": "object"},
-          "candidate": {"type": "object"},
-          "job": {"type": "object"}
+          "application": {
+            "type": "object"
+          },
+          "candidate": {
+            "type": "object"
+          },
+          "job": {
+            "type": "object"
+          }
         }
       }
     }
@@ -543,5 +679,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/guru/definition.json
+++ b/connectors/guru/definition.json
@@ -43,23 +43,36 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by tags"
           },
           "verificationState": {
             "type": "string",
-            "enum": ["VERIFIED", "NEEDS_VERIFICATION", "UNVERIFIED"],
+            "enum": [
+              "VERIFIED",
+              "NEEDS_VERIFICATION",
+              "UNVERIFIED"
+            ],
             "description": "Verification state filter"
           },
           "sort": {
             "type": "string",
-            "enum": ["lastModified", "verificationDate", "title"],
+            "enum": [
+              "lastModified",
+              "verificationDate",
+              "title"
+            ],
             "default": "lastModified",
             "description": "Sort field"
           },
           "sortDirection": {
             "type": "string",
-            "enum": ["ASC", "DESC"],
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
             "default": "DESC",
             "description": "Sort direction"
           },
@@ -93,7 +106,9 @@
             "description": "Card ID"
           }
         },
-        "required": ["cardId"],
+        "required": [
+          "cardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -115,13 +130,18 @@
           "collection": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"}
+              "id": {
+                "type": "string"
+              }
             },
             "description": "Collection to add card to"
           },
           "verificationState": {
             "type": "string",
-            "enum": ["NEEDS_VERIFICATION", "VERIFIED"],
+            "enum": [
+              "NEEDS_VERIFICATION",
+              "VERIFIED"
+            ],
             "default": "NEEDS_VERIFICATION",
             "description": "Verification state"
           },
@@ -132,17 +152,26 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Tags to add to the card"
           },
           "shareStatus": {
             "type": "string",
-            "enum": ["TEAM", "PRIVATE"],
+            "enum": [
+              "TEAM",
+              "PRIVATE"
+            ],
             "default": "TEAM",
             "description": "Share status"
           }
         },
-        "required": ["preferredPhrase", "content", "collection"],
+        "required": [
+          "preferredPhrase",
+          "content",
+          "collection"
+        ],
         "additionalProperties": false
       }
     },
@@ -167,21 +196,31 @@
           },
           "verificationState": {
             "type": "string",
-            "enum": ["NEEDS_VERIFICATION", "VERIFIED"],
+            "enum": [
+              "NEEDS_VERIFICATION",
+              "VERIFIED"
+            ],
             "description": "Verification state"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Tags for the card"
           },
           "shareStatus": {
             "type": "string",
-            "enum": ["TEAM", "PRIVATE"],
+            "enum": [
+              "TEAM",
+              "PRIVATE"
+            ],
             "description": "Share status"
           }
         },
-        "required": ["cardId"],
+        "required": [
+          "cardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -197,7 +236,9 @@
             "description": "Card ID"
           }
         },
-        "required": ["cardId"],
+        "required": [
+          "cardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -210,13 +251,20 @@
         "properties": {
           "sort": {
             "type": "string",
-            "enum": ["name", "dateCreated", "dateModified"],
+            "enum": [
+              "name",
+              "dateCreated",
+              "dateModified"
+            ],
             "default": "name",
             "description": "Sort field"
           },
           "sortDirection": {
             "type": "string",
-            "enum": ["ASC", "DESC"],
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
             "default": "ASC",
             "description": "Sort direction"
           }
@@ -237,7 +285,9 @@
             "description": "Collection ID"
           }
         },
-        "required": ["collectionId"],
+        "required": [
+          "collectionId"
+        ],
         "additionalProperties": false
       }
     },
@@ -258,7 +308,9 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by tags"
           },
           "limit": {
@@ -275,7 +327,9 @@
             "description": "Number of results to skip"
           }
         },
-        "required": ["searchTerm"],
+        "required": [
+          "searchTerm"
+        ],
         "additionalProperties": false
       }
     },
@@ -338,12 +392,18 @@
           },
           "role": {
             "type": "string",
-            "enum": ["CORE_USER", "LIGHT_USER", "ADMIN"],
+            "enum": [
+              "CORE_USER",
+              "LIGHT_USER",
+              "ADMIN"
+            ],
             "default": "CORE_USER",
             "description": "User role"
           }
         },
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "additionalProperties": false
       }
     }
@@ -363,7 +423,9 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by tags"
           }
         },
@@ -373,14 +435,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "preferredPhrase": {"type": "string"},
-          "content": {"type": "string"},
-          "collection": {"type": "object"},
-          "dateCreated": {"type": "string"},
-          "owner": {"type": "object"},
-          "verificationState": {"type": "string"},
-          "tags": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "preferredPhrase": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "collection": {
+            "type": "object"
+          },
+          "dateCreated": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "object"
+          },
+          "verificationState": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array"
+          }
         }
       }
     },
@@ -403,12 +481,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "preferredPhrase": {"type": "string"},
-          "content": {"type": "string"},
-          "dateModified": {"type": "string"},
-          "lastModifiedBy": {"type": "object"},
-          "verificationState": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "preferredPhrase": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "dateModified": {
+            "type": "string"
+          },
+          "lastModifiedBy": {
+            "type": "object"
+          },
+          "verificationState": {
+            "type": "string"
+          }
         }
       }
     },
@@ -431,11 +521,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "preferredPhrase": {"type": "string"},
-          "verificationState": {"type": "string"},
-          "verificationDate": {"type": "string"},
-          "verifiedBy": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "preferredPhrase": {
+            "type": "string"
+          },
+          "verificationState": {
+            "type": "string"
+          },
+          "verificationDate": {
+            "type": "string"
+          },
+          "verifiedBy": {
+            "type": "object"
+          }
         }
       }
     }
@@ -443,5 +543,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/teams/whoami"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/hashicorp-vault/definition.json
+++ b/connectors/hashicorp-vault/definition.json
@@ -52,7 +52,9 @@
             "description": "Secret version (for KV v2)"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -77,7 +79,10 @@
             "description": "Check-and-set parameter for KV v2"
           }
         },
-        "required": ["path", "data"],
+        "required": [
+          "path",
+          "data"
+        ],
         "additionalProperties": false
       }
     },
@@ -94,7 +99,9 @@
             "description": "Secret path to delete"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       }
     },
@@ -115,7 +122,10 @@
             "description": "Policy rules in HCL format"
           }
         },
-        "required": ["name", "policy"],
+        "required": [
+          "name",
+          "policy"
+        ],
         "additionalProperties": false
       }
     },
@@ -167,5 +177,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/hellosign/definition.json
+++ b/connectors/hellosign/definition.json
@@ -62,27 +62,45 @@
             "items": {
               "type": "object",
               "properties": {
-                "email_address": {"type": "string", "format": "email"},
-                "name": {"type": "string"},
-                "order": {"type": "number", "minimum": 0}
+                "email_address": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number",
+                  "minimum": 0
+                }
               },
-              "required": ["email_address", "name"]
+              "required": [
+                "email_address",
+                "name"
+              ]
             },
             "description": "List of signers"
           },
           "cc_email_addresses": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "CC email addresses"
           },
           "files": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "File URLs or base64 encoded files"
           },
           "file_urls": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "URLs of files to be signed"
           },
           "use_text_tags": {
@@ -108,8 +126,13 @@
           "reminders": {
             "type": "object",
             "properties": {
-              "days": {"type": "number", "minimum": 1},
-              "enabled": {"type": "boolean"}
+              "days": {
+                "type": "number",
+                "minimum": 1
+              },
+              "enabled": {
+                "type": "boolean"
+              }
             },
             "description": "Reminder settings"
           },
@@ -122,23 +145,68 @@
             "items": {
               "type": "object",
               "properties": {
-                "document_index": {"type": "number", "minimum": 0},
+                "document_index": {
+                  "type": "number",
+                  "minimum": 0
+                },
                 "form_fields": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "properties": {
-                      "api_id": {"type": "string"},
-                      "name": {"type": "string"},
-                      "type": {"type": "string", "enum": ["signature", "text", "date", "checkbox", "dropdown", "hyperlink", "initials", "radio"]},
-                      "x": {"type": "number", "minimum": 0},
-                      "y": {"type": "number", "minimum": 0},
-                      "width": {"type": "number", "minimum": 1},
-                      "height": {"type": "number", "minimum": 1},
-                      "required": {"type": "boolean"},
-                      "signer": {"type": "number", "minimum": 0}
+                      "api_id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "signature",
+                          "text",
+                          "date",
+                          "checkbox",
+                          "dropdown",
+                          "hyperlink",
+                          "initials",
+                          "radio"
+                        ]
+                      },
+                      "x": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "y": {
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "width": {
+                        "type": "number",
+                        "minimum": 1
+                      },
+                      "height": {
+                        "type": "number",
+                        "minimum": 1
+                      },
+                      "required": {
+                        "type": "boolean"
+                      },
+                      "signer": {
+                        "type": "number",
+                        "minimum": 0
+                      }
                     },
-                    "required": ["api_id", "name", "type", "x", "y", "width", "height", "signer"]
+                    "required": [
+                      "api_id",
+                      "name",
+                      "type",
+                      "x",
+                      "y",
+                      "width",
+                      "height",
+                      "signer"
+                    ]
                   }
                 }
               }
@@ -150,14 +218,20 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {"type": "string"},
-                "value": {"type": "string"}
+                "name": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
               }
             },
             "description": "Custom fields"
           }
         },
-        "required": ["signers"],
+        "required": [
+          "signers"
+        ],
         "additionalProperties": false
       }
     },
@@ -173,7 +247,9 @@
             "description": "Signature request ID"
           }
         },
-        "required": ["signature_request_id"],
+        "required": [
+          "signature_request_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -227,7 +303,10 @@
             "description": "Email address to remind"
           }
         },
-        "required": ["signature_request_id", "email_address"],
+        "required": [
+          "signature_request_id",
+          "email_address"
+        ],
         "additionalProperties": false
       }
     },
@@ -243,7 +322,9 @@
             "description": "Signature request ID"
           }
         },
-        "required": ["signature_request_id"],
+        "required": [
+          "signature_request_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -260,12 +341,17 @@
           },
           "file_type": {
             "type": "string",
-            "enum": ["pdf", "zip"],
+            "enum": [
+              "pdf",
+              "zip"
+            ],
             "default": "pdf",
             "description": "File type to download"
           }
         },
-        "required": ["signature_request_id"],
+        "required": [
+          "signature_request_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -289,16 +375,26 @@
             "items": {
               "type": "object",
               "properties": {
-                "email_address": {"type": "string", "format": "email"},
-                "name": {"type": "string"}
+                "email_address": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "name": {
+                  "type": "string"
+                }
               },
-              "required": ["email_address", "name"]
+              "required": [
+                "email_address",
+                "name"
+              ]
             },
             "description": "List of signers"
           },
           "files": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "File URLs or base64 encoded files"
           },
           "test_mode": {
@@ -307,7 +403,10 @@
             "description": "Test mode"
           }
         },
-        "required": ["client_id", "signers"],
+        "required": [
+          "client_id",
+          "signers"
+        ],
         "additionalProperties": false
       }
     },
@@ -323,7 +422,9 @@
             "description": "Signature ID"
           }
         },
-        "required": ["signature_id"],
+        "required": [
+          "signature_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -343,10 +444,17 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {"type": "string"},
-                "order": {"type": "number", "minimum": 0}
+                "name": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number",
+                  "minimum": 0
+                }
               },
-              "required": ["name"]
+              "required": [
+                "name"
+              ]
             },
             "description": "Signer roles"
           },
@@ -355,15 +463,21 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {"type": "string"}
+                "name": {
+                  "type": "string"
+                }
               },
-              "required": ["name"]
+              "required": [
+                "name"
+              ]
             },
             "description": "CC roles"
           },
           "files": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "File URLs or base64 encoded files"
           },
           "merge_fields": {
@@ -371,14 +485,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {"type": "string"},
-                "type": {"type": "string", "enum": ["text", "checkbox"]}
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "text",
+                    "checkbox"
+                  ]
+                }
               }
             },
             "description": "Merge fields"
           }
         },
-        "required": ["title", "signer_roles"],
+        "required": [
+          "title",
+          "signer_roles"
+        ],
         "additionalProperties": false
       }
     },
@@ -394,7 +519,9 @@
             "description": "Template ID"
           }
         },
-        "required": ["template_id"],
+        "required": [
+          "template_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -434,14 +561,21 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {"type": "string"},
-                "value": {"type": "string"}
+                "name": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
               }
             },
             "description": "Custom field values"
           }
         },
-        "required": ["template_id", "signers"],
+        "required": [
+          "template_id",
+          "signers"
+        ],
         "additionalProperties": false
       }
     }
@@ -466,14 +600,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "signature_request_id": {"type": "string"},
-          "title": {"type": "string"},
-          "subject": {"type": "string"},
-          "message": {"type": "string"},
-          "is_complete": {"type": "boolean"},
-          "has_error": {"type": "boolean"},
-          "custom_fields": {"type": "array"},
-          "response_data": {"type": "array"}
+          "signature_request_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "is_complete": {
+            "type": "boolean"
+          },
+          "has_error": {
+            "type": "boolean"
+          },
+          "custom_fields": {
+            "type": "array"
+          },
+          "response_data": {
+            "type": "array"
+          }
         }
       }
     },
@@ -496,13 +646,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "signature_request_id": {"type": "string"},
-          "title": {"type": "string"},
-          "is_complete": {"type": "boolean"},
-          "final_copy_uri": {"type": "string"},
-          "files_url": {"type": "string"},
-          "signing_url": {"type": "string"},
-          "details_url": {"type": "string"}
+          "signature_request_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "is_complete": {
+            "type": "boolean"
+          },
+          "final_copy_uri": {
+            "type": "string"
+          },
+          "files_url": {
+            "type": "string"
+          },
+          "signing_url": {
+            "type": "string"
+          },
+          "details_url": {
+            "type": "string"
+          }
         }
       }
     },
@@ -525,11 +689,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "signature_request_id": {"type": "string"},
-          "title": {"type": "string"},
-          "is_complete": {"type": "boolean"},
-          "declined_by": {"type": "string"},
-          "decline_reason": {"type": "string"}
+          "signature_request_id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "is_complete": {
+            "type": "boolean"
+          },
+          "declined_by": {
+            "type": "string"
+          },
+          "decline_reason": {
+            "type": "string"
+          }
         }
       }
     }
@@ -537,5 +711,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/account"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/helm/definition.json
+++ b/connectors/helm/definition.json
@@ -64,7 +64,10 @@
             "description": "Helm repository URL"
           }
         },
-        "required": ["release_name", "chart"],
+        "required": [
+          "release_name",
+          "chart"
+        ],
         "additionalProperties": false
       }
     },
@@ -98,7 +101,10 @@
             "description": "Chart version"
           }
         },
-        "required": ["release_name", "chart"],
+        "required": [
+          "release_name",
+          "chart"
+        ],
         "additionalProperties": false
       }
     },
@@ -125,7 +131,9 @@
             "description": "Keep release history"
           }
         },
-        "required": ["release_name"],
+        "required": [
+          "release_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -148,7 +156,15 @@
           },
           "status": {
             "type": "string",
-            "enum": ["deployed", "uninstalled", "superseded", "failed", "pending-install", "pending-upgrade", "pending-rollback"],
+            "enum": [
+              "deployed",
+              "uninstalled",
+              "superseded",
+              "failed",
+              "pending-install",
+              "pending-upgrade",
+              "pending-rollback"
+            ],
             "description": "Filter by release status"
           }
         },
@@ -212,5 +228,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/hubspot-enhanced/definition.json
+++ b/connectors/hubspot-enhanced/definition.json
@@ -11,7 +11,14 @@
     "config": {
       "authUrl": "https://app.hubspot.com/oauth/authorize",
       "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
-      "scopes": ["crm.objects.contacts.read", "crm.objects.contacts.write", "crm.objects.companies.read", "crm.objects.companies.write", "crm.objects.deals.read", "crm.objects.deals.write"]
+      "scopes": [
+        "crm.objects.contacts.read",
+        "crm.objects.contacts.write",
+        "crm.objects.companies.read",
+        "crm.objects.companies.write",
+        "crm.objects.deals.read",
+        "crm.objects.deals.write"
+      ]
     }
   },
   "baseUrl": "https://api.hubapi.com",
@@ -37,22 +44,66 @@
           "properties": {
             "type": "object",
             "properties": {
-              "email": {"type": "string", "format": "email"},
-              "firstname": {"type": "string"},
-              "lastname": {"type": "string"},
-              "phone": {"type": "string"},
-              "company": {"type": "string"},
-              "jobtitle": {"type": "string"},
-              "website": {"type": "string", "format": "uri"},
-              "lifecyclestage": {"type": "string", "enum": ["subscriber", "lead", "marketingqualifiedlead", "salesqualifiedlead", "opportunity", "customer", "evangelist", "other"]},
-              "leadstatus": {"type": "string"},
-              "hs_lead_status": {"type": "string"},
-              "hubspot_owner_id": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "country": {"type": "string"},
-              "zip": {"type": "string"},
-              "address": {"type": "string"}
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "firstname": {
+                "type": "string"
+              },
+              "lastname": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "company": {
+                "type": "string"
+              },
+              "jobtitle": {
+                "type": "string"
+              },
+              "website": {
+                "type": "string",
+                "format": "uri"
+              },
+              "lifecyclestage": {
+                "type": "string",
+                "enum": [
+                  "subscriber",
+                  "lead",
+                  "marketingqualifiedlead",
+                  "salesqualifiedlead",
+                  "opportunity",
+                  "customer",
+                  "evangelist",
+                  "other"
+                ]
+              },
+              "leadstatus": {
+                "type": "string"
+              },
+              "hs_lead_status": {
+                "type": "string"
+              },
+              "hubspot_owner_id": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              },
+              "zip": {
+                "type": "string"
+              },
+              "address": {
+                "type": "string"
+              }
             },
             "description": "Contact properties"
           },
@@ -61,8 +112,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "to": {"type": "object"},
-                "types": {"type": "array"}
+                "to": {
+                  "type": "object"
+                },
+                "types": {
+                  "type": "array"
+                }
               }
             },
             "description": "Associations to other objects"
@@ -86,21 +141,45 @@
           "properties": {
             "type": "object",
             "properties": {
-              "email": {"type": "string", "format": "email"},
-              "firstname": {"type": "string"},
-              "lastname": {"type": "string"},
-              "phone": {"type": "string"},
-              "company": {"type": "string"},
-              "jobtitle": {"type": "string"},
-              "website": {"type": "string", "format": "uri"},
-              "lifecyclestage": {"type": "string"},
-              "leadstatus": {"type": "string"},
-              "hubspot_owner_id": {"type": "string"}
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "firstname": {
+                "type": "string"
+              },
+              "lastname": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "company": {
+                "type": "string"
+              },
+              "jobtitle": {
+                "type": "string"
+              },
+              "website": {
+                "type": "string",
+                "format": "uri"
+              },
+              "lifecyclestage": {
+                "type": "string"
+              },
+              "leadstatus": {
+                "type": "string"
+              },
+              "hubspot_owner_id": {
+                "type": "string"
+              }
             },
             "description": "Properties to update"
           }
         },
-        "required": ["contactId"],
+        "required": [
+          "contactId"
+        ],
         "additionalProperties": false
       }
     },
@@ -117,16 +196,22 @@
           },
           "properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Properties to retrieve"
           },
           "associations": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Associations to retrieve"
           }
         },
-        "required": ["contactId"],
+        "required": [
+          "contactId"
+        ],
         "additionalProperties": false
       }
     },
@@ -157,20 +242,32 @@
             "items": {
               "type": "object",
               "properties": {
-                "propertyName": {"type": "string"},
-                "direction": {"type": "string", "enum": ["ASCENDING", "DESCENDING"]}
+                "propertyName": {
+                  "type": "string"
+                },
+                "direction": {
+                  "type": "string",
+                  "enum": [
+                    "ASCENDING",
+                    "DESCENDING"
+                  ]
+                }
               }
             },
             "description": "Sort criteria"
           },
           "properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Properties to retrieve"
           },
           "filterGroups": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Filter groups for advanced search"
           }
         },
@@ -188,25 +285,64 @@
           "properties": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "domain": {"type": "string"},
-              "industry": {"type": "string"},
-              "phone": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "country": {"type": "string"},
-              "zip": {"type": "string"},
-              "address": {"type": "string"},
-              "address2": {"type": "string"},
-              "description": {"type": "string"},
-              "founded_year": {"type": "string"},
-              "hubspot_owner_id": {"type": "string"},
-              "is_public": {"type": "boolean"},
-              "numberofemployees": {"type": "number"},
-              "annualrevenue": {"type": "number"},
-              "lifecyclestage": {"type": "string"},
-              "type": {"type": "string"},
-              "website": {"type": "string", "format": "uri"}
+              "name": {
+                "type": "string"
+              },
+              "domain": {
+                "type": "string"
+              },
+              "industry": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              },
+              "zip": {
+                "type": "string"
+              },
+              "address": {
+                "type": "string"
+              },
+              "address2": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "founded_year": {
+                "type": "string"
+              },
+              "hubspot_owner_id": {
+                "type": "string"
+              },
+              "is_public": {
+                "type": "boolean"
+              },
+              "numberofemployees": {
+                "type": "number"
+              },
+              "annualrevenue": {
+                "type": "number"
+              },
+              "lifecyclestage": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "website": {
+                "type": "string",
+                "format": "uri"
+              }
             },
             "description": "Company properties"
           },
@@ -215,8 +351,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "to": {"type": "object"},
-                "types": {"type": "array"}
+                "to": {
+                  "type": "object"
+                },
+                "types": {
+                  "type": "array"
+                }
               }
             },
             "description": "Associations to other objects"
@@ -240,19 +380,37 @@
           "properties": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "domain": {"type": "string"},
-              "industry": {"type": "string"},
-              "phone": {"type": "string"},
-              "description": {"type": "string"},
-              "hubspot_owner_id": {"type": "string"},
-              "numberofemployees": {"type": "number"},
-              "annualrevenue": {"type": "number"}
+              "name": {
+                "type": "string"
+              },
+              "domain": {
+                "type": "string"
+              },
+              "industry": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "hubspot_owner_id": {
+                "type": "string"
+              },
+              "numberofemployees": {
+                "type": "number"
+              },
+              "annualrevenue": {
+                "type": "number"
+              }
             },
             "description": "Properties to update"
           }
         },
-        "required": ["companyId"],
+        "required": [
+          "companyId"
+        ],
         "additionalProperties": false
       }
     },
@@ -266,18 +424,49 @@
           "properties": {
             "type": "object",
             "properties": {
-              "dealname": {"type": "string"},
-              "amount": {"type": "number"},
-              "dealstage": {"type": "string"},
-              "pipeline": {"type": "string"},
-              "closedate": {"type": "string", "format": "date"},
-              "hubspot_owner_id": {"type": "string"},
-              "dealtype": {"type": "string"},
-              "description": {"type": "string"},
-              "hs_priority": {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]},
-              "hs_forecast_amount": {"type": "number"},
-              "hs_forecast_probability": {"type": "number"},
-              "createdate": {"type": "string", "format": "date-time"}
+              "dealname": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "number"
+              },
+              "dealstage": {
+                "type": "string"
+              },
+              "pipeline": {
+                "type": "string"
+              },
+              "closedate": {
+                "type": "string",
+                "format": "date"
+              },
+              "hubspot_owner_id": {
+                "type": "string"
+              },
+              "dealtype": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "hs_priority": {
+                "type": "string",
+                "enum": [
+                  "HIGH",
+                  "MEDIUM",
+                  "LOW"
+                ]
+              },
+              "hs_forecast_amount": {
+                "type": "number"
+              },
+              "hs_forecast_probability": {
+                "type": "number"
+              },
+              "createdate": {
+                "type": "string",
+                "format": "date-time"
+              }
             },
             "description": "Deal properties"
           },
@@ -286,8 +475,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "to": {"type": "object"},
-                "types": {"type": "array"}
+                "to": {
+                  "type": "object"
+                },
+                "types": {
+                  "type": "array"
+                }
               }
             },
             "description": "Associations to contacts and companies"
@@ -311,19 +504,43 @@
           "properties": {
             "type": "object",
             "properties": {
-              "dealname": {"type": "string"},
-              "amount": {"type": "number"},
-              "dealstage": {"type": "string"},
-              "closedate": {"type": "string", "format": "date"},
-              "hubspot_owner_id": {"type": "string"},
-              "dealtype": {"type": "string"},
-              "description": {"type": "string"},
-              "hs_priority": {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]}
+              "dealname": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "number"
+              },
+              "dealstage": {
+                "type": "string"
+              },
+              "closedate": {
+                "type": "string",
+                "format": "date"
+              },
+              "hubspot_owner_id": {
+                "type": "string"
+              },
+              "dealtype": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "hs_priority": {
+                "type": "string",
+                "enum": [
+                  "HIGH",
+                  "MEDIUM",
+                  "LOW"
+                ]
+              }
             },
             "description": "Properties to update"
           }
         },
-        "required": ["dealId"],
+        "required": [
+          "dealId"
+        ],
         "additionalProperties": false
       }
     },
@@ -337,14 +554,50 @@
           "properties": {
             "type": "object",
             "properties": {
-              "hs_task_subject": {"type": "string"},
-              "hs_task_body": {"type": "string"},
-              "hs_task_status": {"type": "string", "enum": ["NOT_STARTED", "IN_PROGRESS", "COMPLETED", "WAITING", "DEFERRED"]},
-              "hs_task_priority": {"type": "string", "enum": ["HIGH", "MEDIUM", "LOW"]},
-              "hs_task_type": {"type": "string", "enum": ["CALL", "EMAIL", "TODO", "MEETING", "FOLLOW_UP"]},
-              "hs_timestamp": {"type": "string", "format": "date-time"},
-              "hubspot_owner_id": {"type": "string"},
-              "hs_task_reminders": {"type": "string"}
+              "hs_task_subject": {
+                "type": "string"
+              },
+              "hs_task_body": {
+                "type": "string"
+              },
+              "hs_task_status": {
+                "type": "string",
+                "enum": [
+                  "NOT_STARTED",
+                  "IN_PROGRESS",
+                  "COMPLETED",
+                  "WAITING",
+                  "DEFERRED"
+                ]
+              },
+              "hs_task_priority": {
+                "type": "string",
+                "enum": [
+                  "HIGH",
+                  "MEDIUM",
+                  "LOW"
+                ]
+              },
+              "hs_task_type": {
+                "type": "string",
+                "enum": [
+                  "CALL",
+                  "EMAIL",
+                  "TODO",
+                  "MEETING",
+                  "FOLLOW_UP"
+                ]
+              },
+              "hs_timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "hubspot_owner_id": {
+                "type": "string"
+              },
+              "hs_task_reminders": {
+                "type": "string"
+              }
             },
             "description": "Task properties"
           },
@@ -353,8 +606,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "to": {"type": "object"},
-                "types": {"type": "array"}
+                "to": {
+                  "type": "object"
+                },
+                "types": {
+                  "type": "array"
+                }
               }
             },
             "description": "Associations to contacts, companies, or deals"
@@ -374,9 +631,16 @@
           "properties": {
             "type": "object",
             "properties": {
-              "hs_note_body": {"type": "string"},
-              "hs_timestamp": {"type": "string", "format": "date-time"},
-              "hubspot_owner_id": {"type": "string"}
+              "hs_note_body": {
+                "type": "string"
+              },
+              "hs_timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "hubspot_owner_id": {
+                "type": "string"
+              }
             },
             "description": "Note properties"
           },
@@ -385,8 +649,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "to": {"type": "object"},
-                "types": {"type": "array"}
+                "to": {
+                  "type": "object"
+                },
+                "types": {
+                  "type": "array"
+                }
               }
             },
             "description": "Associations to contacts, companies, or deals"
@@ -408,14 +676,20 @@
             "items": {
               "type": "object",
               "properties": {
-                "properties": {"type": "object"},
-                "associations": {"type": "array"}
+                "properties": {
+                  "type": "object"
+                },
+                "associations": {
+                  "type": "array"
+                }
               }
             },
             "description": "Array of contacts to create"
           }
         },
-        "required": ["inputs"],
+        "required": [
+          "inputs"
+        ],
         "additionalProperties": false
       }
     }
@@ -441,17 +715,39 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "objectId": {"type": "number"},
-          "propertyName": {"type": "string"},
-          "propertyValue": {"type": "string"},
-          "changeSource": {"type": "string"},
-          "eventId": {"type": "number"},
-          "subscriptionId": {"type": "number"},
-          "portalId": {"type": "number"},
-          "appId": {"type": "number"},
-          "occurredAt": {"type": "number"},
-          "subscriptionType": {"type": "string"},
-          "attemptNumber": {"type": "number"}
+          "objectId": {
+            "type": "number"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "propertyValue": {
+            "type": "string"
+          },
+          "changeSource": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "number"
+          },
+          "subscriptionId": {
+            "type": "number"
+          },
+          "portalId": {
+            "type": "number"
+          },
+          "appId": {
+            "type": "number"
+          },
+          "occurredAt": {
+            "type": "number"
+          },
+          "subscriptionType": {
+            "type": "string"
+          },
+          "attemptNumber": {
+            "type": "number"
+          }
         }
       }
     },
@@ -474,11 +770,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "objectId": {"type": "number"},
-          "propertyName": {"type": "string"},
-          "propertyValue": {"type": "string"},
-          "changeSource": {"type": "string"},
-          "eventId": {"type": "number"}
+          "objectId": {
+            "type": "number"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "propertyValue": {
+            "type": "string"
+          },
+          "changeSource": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "number"
+          }
         }
       }
     },
@@ -501,10 +807,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "objectId": {"type": "number"},
-          "propertyName": {"type": "string"},
-          "propertyValue": {"type": "string"},
-          "changeSource": {"type": "string"}
+          "objectId": {
+            "type": "number"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "propertyValue": {
+            "type": "string"
+          },
+          "changeSource": {
+            "type": "string"
+          }
         }
       }
     },
@@ -522,10 +836,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "objectId": {"type": "number"},
-          "propertyName": {"type": "string"},
-          "propertyValue": {"type": "string"},
-          "changeSource": {"type": "string"}
+          "objectId": {
+            "type": "number"
+          },
+          "propertyName": {
+            "type": "string"
+          },
+          "propertyValue": {
+            "type": "string"
+          },
+          "changeSource": {
+            "type": "string"
+          }
         }
       }
     }
@@ -533,5 +855,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/crm/v3/objects/contacts?limit=1"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/hubspot/definition.json
+++ b/connectors/hubspot/definition.json
@@ -46,7 +46,24 @@
       "description": "Get a deal by ID",
       "endpoint": "/crm/v3/objects/deals/{dealId}",
       "method": "GET",
-      "parameters": { "type":"object", "properties": { "dealId": {"type":"string"}, "properties": {"type":"array", "items": {"type":"string"} } }, "required": ["dealId"], "additionalProperties": false }
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "dealId": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "dealId"
+        ],
+        "additionalProperties": false
+      }
     },
     {
       "id": "search_deals",
@@ -54,7 +71,23 @@
       "description": "Search deals using filters",
       "endpoint": "/crm/v3/objects/deals/search",
       "method": "POST",
-      "parameters": { "type":"object", "properties": { "query": {"type":"string"}, "filters": {"type":"object"}, "limit": {"type":"number","default":10} }, "required": [], "additionalProperties": false }
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "filters": {
+            "type": "object"
+          },
+          "limit": {
+            "type": "number",
+            "default": 10
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
     },
     {
       "id": "list_deals",
@@ -65,9 +98,20 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "limit": { "type": "number", "default": 50, "maximum": 100 },
-          "after": { "type": "string" },
-          "properties": { "type": "array", "items": { "type": "string" } }
+          "limit": {
+            "type": "number",
+            "default": 50,
+            "maximum": 100
+          },
+          "after": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         },
         "required": [],
         "additionalProperties": false
@@ -82,10 +126,17 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "dealId": { "type": "string" },
-          "properties": { "type": "object" }
+          "dealId": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object"
+          }
         },
-        "required": ["dealId", "properties"],
+        "required": [
+          "dealId",
+          "properties"
+        ],
         "additionalProperties": false
       }
     },
@@ -125,16 +176,36 @@
           },
           "lifecyclestage": {
             "type": "string",
-            "enum": ["subscriber", "lead", "marketingqualifiedlead", "salesqualifiedlead", "opportunity", "customer", "evangelist", "other"],
+            "enum": [
+              "subscriber",
+              "lead",
+              "marketingqualifiedlead",
+              "salesqualifiedlead",
+              "opportunity",
+              "customer",
+              "evangelist",
+              "other"
+            ],
             "description": "Contact's lifecycle stage"
           },
           "hs_lead_status": {
             "type": "string",
-            "enum": ["NEW", "OPEN", "IN_PROGRESS", "OPEN_DEAL", "UNQUALIFIED", "ATTEMPTED_TO_CONTACT", "CONNECTED", "BAD_TIMING"],
+            "enum": [
+              "NEW",
+              "OPEN",
+              "IN_PROGRESS",
+              "OPEN_DEAL",
+              "UNQUALIFIED",
+              "ATTEMPTED_TO_CONTACT",
+              "CONNECTED",
+              "BAD_TIMING"
+            ],
             "description": "Lead status"
           }
         },
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "additionalProperties": false
       }
     },
@@ -174,11 +245,22 @@
           },
           "lifecyclestage": {
             "type": "string",
-            "enum": ["subscriber", "lead", "marketingqualifiedlead", "salesqualifiedlead", "opportunity", "customer", "evangelist", "other"],
+            "enum": [
+              "subscriber",
+              "lead",
+              "marketingqualifiedlead",
+              "salesqualifiedlead",
+              "opportunity",
+              "customer",
+              "evangelist",
+              "other"
+            ],
             "description": "Contact's lifecycle stage"
           }
         },
-        "required": ["contactId"],
+        "required": [
+          "contactId"
+        ],
         "additionalProperties": false
       }
     },
@@ -202,7 +284,9 @@
           },
           "properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of properties to retrieve"
           }
         },
@@ -225,7 +309,9 @@
           },
           "properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Properties to return"
           },
           "limit": {
@@ -279,11 +365,17 @@
           },
           "dealtype": {
             "type": "string",
-            "enum": ["newbusiness", "existingbusiness", "renewal"],
+            "enum": [
+              "newbusiness",
+              "existingbusiness",
+              "renewal"
+            ],
             "description": "Type of deal"
           }
         },
-        "required": ["dealname"],
+        "required": [
+          "dealname"
+        ],
         "additionalProperties": false
       }
     },
@@ -318,7 +410,9 @@
             "description": "Expected close date (YYYY-MM-DD)"
           }
         },
-        "required": ["dealId"],
+        "required": [
+          "dealId"
+        ],
         "additionalProperties": false
       }
     },
@@ -368,7 +462,9 @@
             "description": "Annual revenue"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -399,7 +495,11 @@
           },
           "hs_ticket_priority": {
             "type": "string",
-            "enum": ["LOW", "MEDIUM", "HIGH"],
+            "enum": [
+              "LOW",
+              "MEDIUM",
+              "HIGH"
+            ],
             "description": "Ticket priority"
           },
           "hubspot_owner_id": {
@@ -407,7 +507,9 @@
             "description": "Owner ID for the ticket"
           }
         },
-        "required": ["subject"],
+        "required": [
+          "subject"
+        ],
         "additionalProperties": false
       }
     },
@@ -438,14 +540,20 @@
             "items": {
               "type": "object",
               "properties": {
-                "to": {"type": "object"},
-                "types": {"type": "array"}
+                "to": {
+                  "type": "object"
+                },
+                "types": {
+                  "type": "array"
+                }
               }
             },
             "description": "Objects to associate the note with"
           }
         },
-        "required": ["hs_note_body"],
+        "required": [
+          "hs_note_body"
+        ],
         "additionalProperties": false
       }
     },
@@ -476,7 +584,10 @@
             "description": "Custom properties for personalization"
           }
         },
-        "required": ["emailId", "to"],
+        "required": [
+          "emailId",
+          "to"
+        ],
         "additionalProperties": false
       }
     }
@@ -492,7 +603,9 @@
         "properties": {
           "properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Contact properties to include in webhook"
           }
         },
@@ -502,11 +615,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "contactId": {"type": "string"},
-          "email": {"type": "string"},
-          "firstname": {"type": "string"},
-          "lastname": {"type": "string"},
-          "createdate": {"type": "string"}
+          "contactId": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstname": {
+            "type": "string"
+          },
+          "lastname": {
+            "type": "string"
+          },
+          "createdate": {
+            "type": "string"
+          }
         }
       }
     },
@@ -520,7 +643,9 @@
         "properties": {
           "properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Properties to monitor for changes"
           }
         },
@@ -530,10 +655,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "contactId": {"type": "string"},
-          "email": {"type": "string"},
-          "changedProperties": {"type": "array", "items": {"type": "string"}},
-          "modifieddate": {"type": "string"}
+          "contactId": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "changedProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "modifieddate": {
+            "type": "string"
+          }
         }
       }
     },
@@ -556,11 +692,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "dealId": {"type": "string"},
-          "dealname": {"type": "string"},
-          "amount": {"type": "number"},
-          "dealstage": {"type": "string"},
-          "createdate": {"type": "string"}
+          "dealId": {
+            "type": "string"
+          },
+          "dealname": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "dealstage": {
+            "type": "string"
+          },
+          "createdate": {
+            "type": "string"
+          }
         }
       }
     },
@@ -587,11 +733,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "dealId": {"type": "string"},
-          "dealname": {"type": "string"},
-          "oldStage": {"type": "string"},
-          "newStage": {"type": "string"},
-          "modifieddate": {"type": "string"}
+          "dealId": {
+            "type": "string"
+          },
+          "dealname": {
+            "type": "string"
+          },
+          "oldStage": {
+            "type": "string"
+          },
+          "newStage": {
+            "type": "string"
+          },
+          "modifieddate": {
+            "type": "string"
+          }
         }
       }
     }
@@ -599,5 +755,20 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/account-info/v3/api-usage"
+  },
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/intercom/definition.json
+++ b/connectors/intercom/definition.json
@@ -36,7 +36,10 @@
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["user", "lead"],
+            "enum": [
+              "user",
+              "lead"
+            ],
             "default": "user",
             "description": "Contact role"
           },
@@ -56,8 +59,16 @@
           "avatar": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["avatar"]},
-              "image_url": {"type": "string", "format": "uri"}
+              "type": {
+                "type": "string",
+                "enum": [
+                  "avatar"
+                ]
+              },
+              "image_url": {
+                "type": "string",
+                "format": "uri"
+              }
             },
             "description": "Avatar information"
           },
@@ -68,8 +79,15 @@
           "social_profiles": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["social_profile.list"]},
-              "social_profiles": {"type": "array"}
+              "type": {
+                "type": "string",
+                "enum": [
+                  "social_profile.list"
+                ]
+              },
+              "social_profiles": {
+                "type": "array"
+              }
             },
             "description": "Social profiles"
           },
@@ -139,7 +157,9 @@
             "description": "Custom attributes to update"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -155,7 +175,9 @@
             "description": "Contact ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -197,24 +219,47 @@
           "query": {
             "type": "object",
             "properties": {
-              "operator": {"type": "string", "enum": ["AND", "OR"]},
-              "value": {"type": "array"}
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "AND",
+                  "OR"
+                ]
+              },
+              "value": {
+                "type": "array"
+              }
             },
             "description": "Search query object"
           },
           "pagination": {
             "type": "object",
             "properties": {
-              "per_page": {"type": "number", "minimum": 1, "maximum": 150, "default": 50},
-              "starting_after": {"type": "string"}
+              "per_page": {
+                "type": "number",
+                "minimum": 1,
+                "maximum": 150,
+                "default": 50
+              },
+              "starting_after": {
+                "type": "string"
+              }
             },
             "description": "Pagination options"
           },
           "sort": {
             "type": "object",
             "properties": {
-              "field": {"type": "string"},
-              "order": {"type": "string", "enum": ["ascending", "descending"]}
+              "field": {
+                "type": "string"
+              },
+              "order": {
+                "type": "string",
+                "enum": [
+                  "ascending",
+                  "descending"
+                ]
+              }
             },
             "description": "Sort options"
           }
@@ -235,7 +280,9 @@
             "description": "Contact ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -249,8 +296,16 @@
           "from": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["user", "contact"]},
-              "id": {"type": "string"}
+              "type": {
+                "type": "string",
+                "enum": [
+                  "user",
+                  "contact"
+                ]
+              },
+              "id": {
+                "type": "string"
+              }
             },
             "description": "Conversation initiator"
           },
@@ -264,12 +319,20 @@
           },
           "message_type": {
             "type": "string",
-            "enum": ["email", "inapp", "facebook", "twitter"],
+            "enum": [
+              "email",
+              "inapp",
+              "facebook",
+              "twitter"
+            ],
             "default": "email",
             "description": "Message type"
           }
         },
-        "required": ["from", "body"],
+        "required": [
+          "from",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -290,12 +353,18 @@
           },
           "type": {
             "type": "string",
-            "enum": ["user", "admin"],
+            "enum": [
+              "user",
+              "admin"
+            ],
             "description": "Reply type"
           },
           "message_type": {
             "type": "string",
-            "enum": ["comment", "note"],
+            "enum": [
+              "comment",
+              "note"
+            ],
             "default": "comment",
             "description": "Message type"
           },
@@ -304,7 +373,11 @@
             "description": "Admin ID for admin replies"
           }
         },
-        "required": ["id", "body", "type"],
+        "required": [
+          "id",
+          "body",
+          "type"
+        ],
         "additionalProperties": false
       }
     },
@@ -328,7 +401,10 @@
             "description": "Assignee ID"
           }
         },
-        "required": ["id", "admin_id"],
+        "required": [
+          "id",
+          "admin_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -348,7 +424,10 @@
             "description": "Admin ID closing the conversation"
           }
         },
-        "required": ["id", "admin_id"],
+        "required": [
+          "id",
+          "admin_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -372,7 +451,10 @@
             "description": "Admin ID creating the note"
           }
         },
-        "required": ["contact_id", "body"],
+        "required": [
+          "contact_id",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -403,16 +485,36 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "id": {"type": "string"},
-          "workspace_id": {"type": "string"},
-          "external_id": {"type": "string"},
-          "role": {"type": "string"},
-          "email": {"type": "string"},
-          "phone": {"type": "string"},
-          "name": {"type": "string"},
-          "created_at": {"type": "number"},
-          "updated_at": {"type": "number"}
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          },
+          "external_id": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "number"
+          },
+          "updated_at": {
+            "type": "number"
+          }
         }
       }
     },
@@ -430,12 +532,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "id": {"type": "string"},
-          "subject": {"type": "string"},
-          "state": {"type": "string"},
-          "created_at": {"type": "number"},
-          "updated_at": {"type": "number"}
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "number"
+          },
+          "updated_at": {
+            "type": "number"
+          }
         }
       }
     },
@@ -453,10 +567,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "id": {"type": "string"},
-          "state": {"type": "string"},
-          "assignee": {"type": "object"}
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "assignee": {
+            "type": "object"
+          }
         }
       }
     }
@@ -464,5 +586,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/iterable/definition.json
+++ b/connectors/iterable/definition.json
@@ -144,7 +144,9 @@
             "description": "Event ID for deduplication"
           }
         },
-        "required": ["eventName"],
+        "required": [
+          "eventName"
+        ],
         "additionalProperties": false
       }
     },
@@ -158,9 +160,16 @@
           "user": {
             "type": "object",
             "properties": {
-              "email": {"type": "string", "format": "email"},
-              "userId": {"type": "string"},
-              "dataFields": {"type": "object"}
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "userId": {
+                "type": "string"
+              },
+              "dataFields": {
+                "type": "object"
+              }
             },
             "description": "User information"
           },
@@ -169,13 +178,27 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"},
-                "sku": {"type": "string"},
-                "name": {"type": "string"},
-                "categories": {"type": "array"},
-                "price": {"type": "number"},
-                "quantity": {"type": "number"},
-                "dataFields": {"type": "object"}
+                "id": {
+                  "type": "string"
+                },
+                "sku": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "categories": {
+                  "type": "array"
+                },
+                "price": {
+                  "type": "number"
+                },
+                "quantity": {
+                  "type": "number"
+                },
+                "dataFields": {
+                  "type": "object"
+                }
               }
             },
             "description": "Purchased items"
@@ -201,7 +224,9 @@
             "description": "Additional purchase data"
           }
         },
-        "required": ["items"],
+        "required": [
+          "items"
+        ],
         "additionalProperties": false
       }
     },
@@ -244,7 +269,9 @@
             "description": "Additional metadata"
           }
         },
-        "required": ["campaignId"],
+        "required": [
+          "campaignId"
+        ],
         "additionalProperties": false
       }
     },
@@ -264,15 +291,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "email": {"type": "string", "format": "email"},
-                "userId": {"type": "string"},
-                "dataFields": {"type": "object"}
+                "email": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "userId": {
+                  "type": "string"
+                },
+                "dataFields": {
+                  "type": "object"
+                }
               }
             },
             "description": "Users to subscribe"
           }
         },
-        "required": ["listId", "subscribers"],
+        "required": [
+          "listId",
+          "subscribers"
+        ],
         "additionalProperties": false
       }
     },
@@ -292,8 +329,13 @@
             "items": {
               "type": "object",
               "properties": {
-                "email": {"type": "string", "format": "email"},
-                "userId": {"type": "string"}
+                "email": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "userId": {
+                  "type": "string"
+                }
               }
             },
             "description": "Users to unsubscribe"
@@ -308,7 +350,10 @@
             "description": "Unsubscribe from entire channel"
           }
         },
-        "required": ["listId", "subscribers"],
+        "required": [
+          "listId",
+          "subscribers"
+        ],
         "additionalProperties": false
       }
     },
@@ -339,7 +384,9 @@
             "description": "List description"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -352,7 +399,11 @@
         "properties": {
           "campaignType": {
             "type": "string",
-            "enum": ["Blast", "Triggered", "Workflow"],
+            "enum": [
+              "Blast",
+              "Triggered",
+              "Workflow"
+            ],
             "description": "Filter by campaign type"
           }
         },
@@ -369,12 +420,22 @@
         "properties": {
           "templateType": {
             "type": "string",
-            "enum": ["Base", "Blast", "Triggered", "Workflow"],
+            "enum": [
+              "Base",
+              "Blast",
+              "Triggered",
+              "Workflow"
+            ],
             "description": "Filter by template type"
           },
           "messageMedium": {
             "type": "string",
-            "enum": ["Email", "Push", "InApp", "SMS"],
+            "enum": [
+              "Email",
+              "Push",
+              "InApp",
+              "SMS"
+            ],
             "description": "Filter by message medium"
           }
         },
@@ -391,12 +452,40 @@
         "properties": {
           "dataTypeName": {
             "type": "string",
-            "enum": ["user", "emailSend", "emailOpen", "emailClick", "emailBounce", "emailComplaint", "emailUnSubscribe", "emailSubscribe", "pushSend", "pushOpen", "pushUninstall", "pushBounce", "inAppSend", "inAppOpen", "inAppClick", "inAppDelete", "smsSend", "smsReceived", "smsBounce", "smsClick", "purchase", "customEvent", "hostedUnsubscribeClick"],
+            "enum": [
+              "user",
+              "emailSend",
+              "emailOpen",
+              "emailClick",
+              "emailBounce",
+              "emailComplaint",
+              "emailUnSubscribe",
+              "emailSubscribe",
+              "pushSend",
+              "pushOpen",
+              "pushUninstall",
+              "pushBounce",
+              "inAppSend",
+              "inAppOpen",
+              "inAppClick",
+              "inAppDelete",
+              "smsSend",
+              "smsReceived",
+              "smsBounce",
+              "smsClick",
+              "purchase",
+              "customEvent",
+              "hostedUnsubscribeClick"
+            ],
             "description": "Type of data to export"
           },
           "range": {
             "type": "string",
-            "enum": ["Today", "Yesterday", "BeforeToday"],
+            "enum": [
+              "Today",
+              "Yesterday",
+              "BeforeToday"
+            ],
             "description": "Date range for export"
           },
           "startDateTime": {
@@ -411,7 +500,10 @@
           },
           "format": {
             "type": "string",
-            "enum": ["csv", "json"],
+            "enum": [
+              "csv",
+              "json"
+            ],
             "default": "csv",
             "description": "Export format"
           },
@@ -422,16 +514,22 @@
           },
           "onlyFields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Only include specific fields"
           },
           "omitFields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Omit specific fields"
           }
         },
-        "required": ["dataTypeName"],
+        "required": [
+          "dataTypeName"
+        ],
         "additionalProperties": false
       }
     }
@@ -456,12 +554,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "email": {"type": "string"},
-          "userId": {"type": "string"},
-          "campaignId": {"type": "number"},
-          "templateId": {"type": "number"},
-          "createdAt": {"type": "string"},
-          "eventName": {"type": "string"}
+          "email": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "campaignId": {
+            "type": "number"
+          },
+          "templateId": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "eventName": {
+            "type": "string"
+          }
         }
       }
     },
@@ -484,13 +594,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "email": {"type": "string"},
-          "userId": {"type": "string"},
-          "campaignId": {"type": "number"},
-          "templateId": {"type": "number"},
-          "createdAt": {"type": "string"},
-          "userAgent": {"type": "string"},
-          "ip": {"type": "string"}
+          "email": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "campaignId": {
+            "type": "number"
+          },
+          "templateId": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "userAgent": {
+            "type": "string"
+          },
+          "ip": {
+            "type": "string"
+          }
         }
       }
     },
@@ -513,14 +637,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "email": {"type": "string"},
-          "userId": {"type": "string"},
-          "campaignId": {"type": "number"},
-          "templateId": {"type": "number"},
-          "createdAt": {"type": "string"},
-          "url": {"type": "string"},
-          "userAgent": {"type": "string"},
-          "ip": {"type": "string"}
+          "email": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "campaignId": {
+            "type": "number"
+          },
+          "templateId": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "userAgent": {
+            "type": "string"
+          },
+          "ip": {
+            "type": "string"
+          }
         }
       }
     },
@@ -538,12 +678,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "email": {"type": "string"},
-          "userId": {"type": "string"},
-          "campaignId": {"type": "number"},
-          "listId": {"type": "number"},
-          "createdAt": {"type": "string"},
-          "channelUnsubscribe": {"type": "boolean"}
+          "email": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "campaignId": {
+            "type": "number"
+          },
+          "listId": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "channelUnsubscribe": {
+            "type": "boolean"
+          }
         }
       }
     }
@@ -551,5 +703,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/lists"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/jenkins/definition.json
+++ b/connectors/jenkins/definition.json
@@ -50,7 +50,9 @@
             "description": "Build cause description"
           }
         },
-        "required": ["job_name"],
+        "required": [
+          "job_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -70,7 +72,10 @@
             "description": "Build number"
           }
         },
-        "required": ["job_name", "build_number"],
+        "required": [
+          "job_name",
+          "build_number"
+        ],
         "additionalProperties": false
       }
     },
@@ -86,7 +91,9 @@
             "description": "Job name"
           }
         },
-        "required": ["job_name"],
+        "required": [
+          "job_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -110,7 +117,10 @@
             "description": "Start position for log output"
           }
         },
-        "required": ["job_name", "build_number"],
+        "required": [
+          "job_name",
+          "build_number"
+        ],
         "additionalProperties": false
       }
     },
@@ -149,7 +159,9 @@
             "description": "Job name"
           }
         },
-        "required": ["job_name"],
+        "required": [
+          "job_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -173,7 +185,10 @@
             "description": "Folder to create job in"
           }
         },
-        "required": ["job_name", "config_xml"],
+        "required": [
+          "job_name",
+          "config_xml"
+        ],
         "additionalProperties": false
       }
     },
@@ -193,7 +208,10 @@
             "description": "Updated job configuration XML"
           }
         },
-        "required": ["job_name", "config_xml"],
+        "required": [
+          "job_name",
+          "config_xml"
+        ],
         "additionalProperties": false
       }
     },
@@ -209,7 +227,9 @@
             "description": "Job name"
           }
         },
-        "required": ["job_name"],
+        "required": [
+          "job_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -225,7 +245,9 @@
             "description": "Job name"
           }
         },
-        "required": ["job_name"],
+        "required": [
+          "job_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -241,7 +263,9 @@
             "description": "Job name"
           }
         },
-        "required": ["job_name"],
+        "required": [
+          "job_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -265,7 +289,10 @@
             "description": "Destination folder"
           }
         },
-        "required": ["from_job", "to_job"],
+        "required": [
+          "from_job",
+          "to_job"
+        ],
         "additionalProperties": false
       }
     },
@@ -285,7 +312,10 @@
             "description": "Build number"
           }
         },
-        "required": ["job_name", "build_number"],
+        "required": [
+          "job_name",
+          "build_number"
+        ],
         "additionalProperties": false
       }
     },
@@ -312,7 +342,9 @@
             "description": "Queue item ID"
           }
         },
-        "required": ["queue_id"],
+        "required": [
+          "queue_id"
+        ],
         "additionalProperties": false
       }
     }
@@ -332,7 +364,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["SUCCESS", "FAILURE", "UNSTABLE", "ABORTED"],
+            "enum": [
+              "SUCCESS",
+              "FAILURE",
+              "UNSTABLE",
+              "ABORTED"
+            ],
             "description": "Filter by build status"
           }
         },
@@ -342,18 +379,36 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "url": {"type": "string"},
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
           "build": {
             "type": "object",
             "properties": {
-              "number": {"type": "number"},
-              "queue_id": {"type": "number"},
-              "url": {"type": "string"},
-              "phase": {"type": "string"},
-              "status": {"type": "string"},
-              "full_url": {"type": "string"},
-              "parameters": {"type": "object"}
+              "number": {
+                "type": "number"
+              },
+              "queue_id": {
+                "type": "number"
+              },
+              "url": {
+                "type": "string"
+              },
+              "phase": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "full_url": {
+                "type": "string"
+              },
+              "parameters": {
+                "type": "object"
+              }
             }
           }
         }
@@ -378,15 +433,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "url": {"type": "string"},
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
           "build": {
             "type": "object",
             "properties": {
-              "number": {"type": "number"},
-              "queue_id": {"type": "number"},
-              "url": {"type": "string"},
-              "phase": {"type": "string"}
+              "number": {
+                "type": "number"
+              },
+              "queue_id": {
+                "type": "number"
+              },
+              "url": {
+                "type": "string"
+              },
+              "phase": {
+                "type": "string"
+              }
             }
           }
         }
@@ -411,14 +478,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "url": {"type": "string"},
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
           "build": {
             "type": "object",
             "properties": {
-              "number": {"type": "number"},
-              "status": {"type": "string"},
-              "url": {"type": "string"}
+              "number": {
+                "type": "number"
+              },
+              "status": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
             }
           }
         }
@@ -428,5 +505,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/api/json"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/jira-service-management/definition.json
+++ b/connectors/jira-service-management/definition.json
@@ -63,7 +63,9 @@
             "description": "Service desk ID"
           }
         },
-        "required": ["serviceDeskId"],
+        "required": [
+          "serviceDeskId"
+        ],
         "additionalProperties": false
       }
     },
@@ -96,7 +98,9 @@
             "description": "Search query to filter request types"
           }
         },
-        "required": ["serviceDeskId"],
+        "required": [
+          "serviceDeskId"
+        ],
         "additionalProperties": false
       }
     },
@@ -125,17 +129,27 @@
           },
           "requestParticipants": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of participant email addresses"
           },
           "channel": {
             "type": "string",
-            "enum": ["email", "portal", "api"],
+            "enum": [
+              "email",
+              "portal",
+              "api"
+            ],
             "default": "api",
             "description": "Channel through which request was created"
           }
         },
-        "required": ["serviceDeskId", "requestTypeId", "requestFieldValues"],
+        "required": [
+          "serviceDeskId",
+          "requestTypeId",
+          "requestFieldValues"
+        ],
         "additionalProperties": false
       }
     },
@@ -154,12 +168,23 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["participant", "status", "sla", "requestType", "serviceDesk", "attachment", "action", "comment"]
+              "enum": [
+                "participant",
+                "status",
+                "sla",
+                "requestType",
+                "serviceDesk",
+                "attachment",
+                "action",
+                "comment"
+              ]
             },
             "description": "Additional data to include"
           }
         },
-        "required": ["issueIdOrKey"],
+        "required": [
+          "issueIdOrKey"
+        ],
         "additionalProperties": false
       }
     },
@@ -176,7 +201,12 @@
           },
           "requestStatus": {
             "type": "string",
-            "enum": ["OPEN", "WAITING_FOR_SUPPORT", "WAITING_FOR_CUSTOMER", "CLOSED"],
+            "enum": [
+              "OPEN",
+              "WAITING_FOR_SUPPORT",
+              "WAITING_FOR_CUSTOMER",
+              "CLOSED"
+            ],
             "description": "Request status filter"
           },
           "requestTypeId": {
@@ -185,7 +215,10 @@
           },
           "requestOwnership": {
             "type": "string",
-            "enum": ["OWNED", "PARTICIPATED"],
+            "enum": [
+              "OWNED",
+              "PARTICIPATED"
+            ],
             "description": "Request ownership filter"
           },
           "searchTerm": {
@@ -207,7 +240,9 @@
           },
           "expand": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Additional data to include"
           }
         },
@@ -237,13 +272,20 @@
           "additionalComment": {
             "type": "object",
             "properties": {
-              "body": {"type": "string"},
-              "public": {"type": "boolean"}
+              "body": {
+                "type": "string"
+              },
+              "public": {
+                "type": "boolean"
+              }
             },
             "description": "Additional comment details"
           }
         },
-        "required": ["issueIdOrKey", "id"],
+        "required": [
+          "issueIdOrKey",
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -268,7 +310,10 @@
             "description": "Whether comment is public"
           }
         },
-        "required": ["issueIdOrKey", "body"],
+        "required": [
+          "issueIdOrKey",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -305,7 +350,9 @@
             "description": "Number of results to return"
           }
         },
-        "required": ["issueIdOrKey"],
+        "required": [
+          "issueIdOrKey"
+        ],
         "additionalProperties": false
       }
     },
@@ -342,7 +389,12 @@
             "description": "Comment for the attachment"
           }
         },
-        "required": ["issueIdOrKey", "serviceDeskId", "fileName", "fileContent"],
+        "required": [
+          "issueIdOrKey",
+          "serviceDeskId",
+          "fileName",
+          "fileContent"
+        ],
         "additionalProperties": false
       }
     },
@@ -371,7 +423,9 @@
             "description": "Number of results to return"
           }
         },
-        "required": ["issueIdOrKey"],
+        "required": [
+          "issueIdOrKey"
+        ],
         "additionalProperties": false
       }
     },
@@ -421,7 +475,10 @@
             "description": "Customer display name"
           }
         },
-        "required": ["email", "displayName"],
+        "required": [
+          "email",
+          "displayName"
+        ],
         "additionalProperties": false
       }
     },
@@ -454,7 +511,10 @@
             "description": "Number of results to return"
           }
         },
-        "required": ["serviceDeskId", "queueId"],
+        "required": [
+          "serviceDeskId",
+          "queueId"
+        ],
         "additionalProperties": false
       }
     }
@@ -483,14 +543,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "issueId": {"type": "string"},
-          "issueKey": {"type": "string"},
-          "requestTypeId": {"type": "string"},
-          "serviceDeskId": {"type": "string"},
-          "createdDate": {"type": "string"},
-          "reporter": {"type": "object"},
-          "requestFieldValues": {"type": "object"},
-          "currentStatus": {"type": "object"}
+          "issueId": {
+            "type": "string"
+          },
+          "issueKey": {
+            "type": "string"
+          },
+          "requestTypeId": {
+            "type": "string"
+          },
+          "serviceDeskId": {
+            "type": "string"
+          },
+          "createdDate": {
+            "type": "string"
+          },
+          "reporter": {
+            "type": "object"
+          },
+          "requestFieldValues": {
+            "type": "object"
+          },
+          "currentStatus": {
+            "type": "object"
+          }
         }
       }
     },
@@ -508,7 +584,12 @@
           },
           "statusCategory": {
             "type": "string",
-            "enum": ["OPEN", "WAITING_FOR_SUPPORT", "WAITING_FOR_CUSTOMER", "CLOSED"],
+            "enum": [
+              "OPEN",
+              "WAITING_FOR_SUPPORT",
+              "WAITING_FOR_CUSTOMER",
+              "CLOSED"
+            ],
             "description": "Filter by status category"
           }
         },
@@ -518,12 +599,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "issueId": {"type": "string"},
-          "issueKey": {"type": "string"},
-          "currentStatus": {"type": "object"},
-          "previousStatus": {"type": "object"},
-          "transitionDate": {"type": "string"},
-          "serviceDeskId": {"type": "string"}
+          "issueId": {
+            "type": "string"
+          },
+          "issueKey": {
+            "type": "string"
+          },
+          "currentStatus": {
+            "type": "object"
+          },
+          "previousStatus": {
+            "type": "object"
+          },
+          "transitionDate": {
+            "type": "string"
+          },
+          "serviceDeskId": {
+            "type": "string"
+          }
         }
       }
     },
@@ -550,14 +643,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "issueId": {"type": "string"},
-          "issueKey": {"type": "string"},
-          "commentId": {"type": "string"},
-          "commentBody": {"type": "string"},
-          "isPublic": {"type": "boolean"},
-          "author": {"type": "object"},
-          "created": {"type": "string"},
-          "serviceDeskId": {"type": "string"}
+          "issueId": {
+            "type": "string"
+          },
+          "issueKey": {
+            "type": "string"
+          },
+          "commentId": {
+            "type": "string"
+          },
+          "commentBody": {
+            "type": "string"
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "author": {
+            "type": "object"
+          },
+          "created": {
+            "type": "string"
+          },
+          "serviceDeskId": {
+            "type": "string"
+          }
         }
       }
     },
@@ -584,13 +693,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "issueId": {"type": "string"},
-          "issueKey": {"type": "string"},
-          "slaId": {"type": "string"},
-          "slaName": {"type": "string"},
-          "breachTime": {"type": "string"},
-          "remainingTime": {"type": "object"},
-          "serviceDeskId": {"type": "string"}
+          "issueId": {
+            "type": "string"
+          },
+          "issueKey": {
+            "type": "string"
+          },
+          "slaId": {
+            "type": "string"
+          },
+          "slaName": {
+            "type": "string"
+          },
+          "breachTime": {
+            "type": "string"
+          },
+          "remainingTime": {
+            "type": "object"
+          },
+          "serviceDeskId": {
+            "type": "string"
+          }
         }
       }
     }
@@ -598,5 +721,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/info"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/jira/definition.json
+++ b/connectors/jira/definition.json
@@ -63,12 +63,24 @@
           },
           "issueType": {
             "type": "string",
-            "enum": ["Bug", "Task", "Story", "Epic", "Subtask"],
+            "enum": [
+              "Bug",
+              "Task",
+              "Story",
+              "Epic",
+              "Subtask"
+            ],
             "description": "Type of issue to create"
           },
           "priority": {
             "type": "string",
-            "enum": ["Highest", "High", "Medium", "Low", "Lowest"],
+            "enum": [
+              "Highest",
+              "High",
+              "Medium",
+              "Low",
+              "Lowest"
+            ],
             "default": "Medium",
             "description": "Issue priority"
           },
@@ -82,17 +94,23 @@
           },
           "labels": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Issue labels"
           },
           "components": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Component IDs or names"
           },
           "fixVersions": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fix version IDs or names"
           },
           "customFields": {
@@ -100,7 +118,11 @@
             "description": "Custom field values as key-value pairs"
           }
         },
-        "required": ["projectKey", "summary", "issueType"],
+        "required": [
+          "projectKey",
+          "summary",
+          "issueType"
+        ],
         "additionalProperties": false
       }
     },
@@ -131,7 +153,13 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["Highest", "High", "Medium", "Low", "Lowest"],
+            "enum": [
+              "Highest",
+              "High",
+              "Medium",
+              "Low",
+              "Lowest"
+            ],
             "description": "Issue priority"
           },
           "status": {
@@ -140,7 +168,9 @@
           },
           "labels": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Issue labels"
           },
           "customFields": {
@@ -148,7 +178,9 @@
             "description": "Custom field values as key-value pairs"
           }
         },
-        "required": ["issueIdOrKey"],
+        "required": [
+          "issueIdOrKey"
+        ],
         "additionalProperties": false
       }
     },
@@ -174,7 +206,9 @@
             "description": "Comma-separated list of parameters to expand"
           }
         },
-        "required": ["issueIdOrKey"],
+        "required": [
+          "issueIdOrKey"
+        ],
         "additionalProperties": false
       }
     },
@@ -193,12 +227,16 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to return for each issue"
           },
           "expand": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Parameters to expand"
           },
           "maxResults": {
@@ -213,7 +251,9 @@
             "description": "Index of the first result to return"
           }
         },
-        "required": ["jql"],
+        "required": [
+          "jql"
+        ],
         "additionalProperties": false
       }
     },
@@ -237,13 +277,24 @@
           "visibility": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["group", "role"]},
-              "value": {"type": "string"}
+              "type": {
+                "type": "string",
+                "enum": [
+                  "group",
+                  "role"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
             },
             "description": "Comment visibility restrictions"
           }
         },
-        "required": ["issueIdOrKey", "body"],
+        "required": [
+          "issueIdOrKey",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -273,7 +324,10 @@
             "description": "Field values to set during transition"
           }
         },
-        "required": ["issueIdOrKey", "transitionId"],
+        "required": [
+          "issueIdOrKey",
+          "transitionId"
+        ],
         "additionalProperties": false
       }
     },
@@ -295,7 +349,10 @@
             "description": "Account ID of the user to assign"
           }
         },
-        "required": ["issueIdOrKey", "accountId"],
+        "required": [
+          "issueIdOrKey",
+          "accountId"
+        ],
         "additionalProperties": false
       }
     },
@@ -318,7 +375,11 @@
           },
           "projectTypeKey": {
             "type": "string",
-            "enum": ["software", "service_desk", "business"],
+            "enum": [
+              "software",
+              "service_desk",
+              "business"
+            ],
             "description": "Type of project to create"
           },
           "projectTemplateKey": {
@@ -334,7 +395,11 @@
             "description": "Account ID of the project lead"
           }
         },
-        "required": ["key", "name", "projectTypeKey"],
+        "required": [
+          "key",
+          "name",
+          "projectTypeKey"
+        ],
         "additionalProperties": false
       }
     },
@@ -356,7 +421,9 @@
             "description": "Comma-separated list of parameters to expand"
           }
         },
-        "required": ["projectIdOrKey"],
+        "required": [
+          "projectIdOrKey"
+        ],
         "additionalProperties": false
       }
     },
@@ -379,7 +446,9 @@
           },
           "properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Project properties to filter by"
           }
         },
@@ -424,7 +493,10 @@
             "description": "Release date (YYYY-MM-DD)"
           }
         },
-        "required": ["name", "projectId"],
+        "required": [
+          "name",
+          "projectId"
+        ],
         "additionalProperties": false
       }
     }
@@ -457,17 +529,39 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "issueId": {"type": "string"},
-          "key": {"type": "string"},
-          "summary": {"type": "string"},
-          "description": {"type": "string"},
-          "issueType": {"type": "string"},
-          "priority": {"type": "string"},
-          "status": {"type": "string"},
-          "assignee": {"type": "string"},
-          "reporter": {"type": "string"},
-          "created": {"type": "string"},
-          "projectKey": {"type": "string"}
+          "issueId": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "issueType": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "assignee": {
+            "type": "string"
+          },
+          "reporter": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string"
+          },
+          "projectKey": {
+            "type": "string"
+          }
         }
       }
     },
@@ -485,7 +579,9 @@
           },
           "fieldsToWatch": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Specific fields to watch for changes"
           }
         },
@@ -495,11 +591,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "issueId": {"type": "string"},
-          "key": {"type": "string"},
-          "changelog": {"type": "object"},
-          "updated": {"type": "string"},
-          "user": {"type": "string"}
+          "issueId": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "changelog": {
+            "type": "object"
+          },
+          "updated": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          }
         }
       }
     },
@@ -530,12 +636,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "issueId": {"type": "string"},
-          "key": {"type": "string"},
-          "fromStatus": {"type": "string"},
-          "toStatus": {"type": "string"},
-          "transitionDate": {"type": "string"},
-          "user": {"type": "string"}
+          "issueId": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "fromStatus": {
+            "type": "string"
+          },
+          "toStatus": {
+            "type": "string"
+          },
+          "transitionDate": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          }
         }
       }
     },
@@ -562,12 +680,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "issueId": {"type": "string"},
-          "key": {"type": "string"},
-          "commentId": {"type": "string"},
-          "commentBody": {"type": "string"},
-          "author": {"type": "string"},
-          "created": {"type": "string"}
+          "issueId": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "commentId": {
+            "type": "string"
+          },
+          "commentBody": {
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string"
+          }
         }
       }
     }
@@ -575,5 +705,20 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/rest/api/3/myself"
+  },
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/jotform/definition.json
+++ b/connectors/jotform/definition.json
@@ -59,7 +59,15 @@
           },
           "orderby": {
             "type": "string",
-            "enum": ["id", "username", "title", "status", "created_at", "updated_at", "count"],
+            "enum": [
+              "id",
+              "username",
+              "title",
+              "status",
+              "created_at",
+              "updated_at",
+              "count"
+            ],
             "description": "Field to order by"
           },
           "filter": {
@@ -83,7 +91,9 @@
             "description": "Form ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -99,7 +109,9 @@
             "description": "Form ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -115,7 +127,9 @@
             "description": "Form ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -149,11 +163,17 @@
           },
           "orderby": {
             "type": "string",
-            "enum": ["id", "created_at", "updated_at"],
+            "enum": [
+              "id",
+              "created_at",
+              "updated_at"
+            ],
             "description": "Field to order by"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -169,7 +189,9 @@
             "description": "Submission ID"
           }
         },
-        "required": ["sid"],
+        "required": [
+          "sid"
+        ],
         "additionalProperties": false
       }
     },
@@ -185,7 +207,9 @@
             "description": "Submission ID"
           }
         },
-        "required": ["sid"],
+        "required": [
+          "sid"
+        ],
         "additionalProperties": false
       }
     },
@@ -205,7 +229,10 @@
             "description": "Updated submission data"
           }
         },
-        "required": ["sid", "submission"],
+        "required": [
+          "sid",
+          "submission"
+        ],
         "additionalProperties": false
       }
     },
@@ -219,14 +246,22 @@
           "form": {
             "type": "object",
             "properties": {
-              "title": {"type": "string"},
-              "questions": {"type": "object"},
-              "properties": {"type": "object"}
+              "title": {
+                "type": "string"
+              },
+              "questions": {
+                "type": "object"
+              },
+              "properties": {
+                "type": "object"
+              }
             },
             "description": "Form configuration"
           }
         },
-        "required": ["form"],
+        "required": [
+          "form"
+        ],
         "additionalProperties": false
       }
     },
@@ -242,7 +277,9 @@
             "description": "Form ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -258,7 +295,9 @@
             "description": "Form ID to clone"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -274,7 +313,9 @@
             "description": "Form ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -290,7 +331,9 @@
             "description": "Form ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -308,14 +351,23 @@
           "report": {
             "type": "object",
             "properties": {
-              "title": {"type": "string"},
-              "list_type": {"type": "string"},
-              "fields": {"type": "string"}
+              "title": {
+                "type": "string"
+              },
+              "list_type": {
+                "type": "string"
+              },
+              "fields": {
+                "type": "string"
+              }
             },
             "description": "Report configuration"
           }
         },
-        "required": ["id", "report"],
+        "required": [
+          "id",
+          "report"
+        ],
         "additionalProperties": false
       }
     }
@@ -340,12 +392,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "submissionID": {"type": "string"},
-          "formID": {"type": "string"},
-          "rawRequest": {"type": "array"},
-          "prettyRequest": {"type": "object"},
-          "formTitle": {"type": "string"},
-          "submissionDate": {"type": "string"}
+          "submissionID": {
+            "type": "string"
+          },
+          "formID": {
+            "type": "string"
+          },
+          "rawRequest": {
+            "type": "array"
+          },
+          "prettyRequest": {
+            "type": "object"
+          },
+          "formTitle": {
+            "type": "string"
+          },
+          "submissionDate": {
+            "type": "string"
+          }
         }
       }
     },
@@ -363,10 +427,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "formID": {"type": "string"},
-          "formTitle": {"type": "string"},
-          "formURL": {"type": "string"},
-          "created_at": {"type": "string"}
+          "formID": {
+            "type": "string"
+          },
+          "formTitle": {
+            "type": "string"
+          },
+          "formURL": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          }
         }
       }
     }
@@ -374,5 +446,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/klaviyo/definition.json
+++ b/connectors/klaviyo/definition.json
@@ -39,36 +39,76 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["profile"],
+                "enum": [
+                  "profile"
+                ],
                 "default": "profile",
                 "description": "Resource type"
               },
               "attributes": {
                 "type": "object",
                 "properties": {
-                  "email": {"type": "string", "format": "email"},
-                  "phone_number": {"type": "string"},
-                  "external_id": {"type": "string"},
-                  "first_name": {"type": "string"},
-                  "last_name": {"type": "string"},
-                  "organization": {"type": "string"},
-                  "title": {"type": "string"},
-                  "image": {"type": "string", "format": "uri"},
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "phone_number": {
+                    "type": "string"
+                  },
+                  "external_id": {
+                    "type": "string"
+                  },
+                  "first_name": {
+                    "type": "string"
+                  },
+                  "last_name": {
+                    "type": "string"
+                  },
+                  "organization": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "image": {
+                    "type": "string",
+                    "format": "uri"
+                  },
                   "location": {
                     "type": "object",
                     "properties": {
-                      "address1": {"type": "string"},
-                      "address2": {"type": "string"},
-                      "city": {"type": "string"},
-                      "country": {"type": "string"},
-                      "latitude": {"type": "number"},
-                      "longitude": {"type": "number"},
-                      "region": {"type": "string"},
-                      "zip": {"type": "string"},
-                      "timezone": {"type": "string"}
+                      "address1": {
+                        "type": "string"
+                      },
+                      "address2": {
+                        "type": "string"
+                      },
+                      "city": {
+                        "type": "string"
+                      },
+                      "country": {
+                        "type": "string"
+                      },
+                      "latitude": {
+                        "type": "number"
+                      },
+                      "longitude": {
+                        "type": "number"
+                      },
+                      "region": {
+                        "type": "string"
+                      },
+                      "zip": {
+                        "type": "string"
+                      },
+                      "timezone": {
+                        "type": "string"
+                      }
                     }
                   },
-                  "properties": {"type": "object"}
+                  "properties": {
+                    "type": "object"
+                  }
                 },
                 "description": "Profile attributes"
               }
@@ -96,26 +136,47 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["profile"],
+                "enum": [
+                  "profile"
+                ],
                 "default": "profile"
               },
-              "id": {"type": "string"},
+              "id": {
+                "type": "string"
+              },
               "attributes": {
                 "type": "object",
                 "properties": {
-                  "email": {"type": "string", "format": "email"},
-                  "phone_number": {"type": "string"},
-                  "first_name": {"type": "string"},
-                  "last_name": {"type": "string"},
-                  "organization": {"type": "string"},
-                  "title": {"type": "string"},
-                  "properties": {"type": "object"}
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "phone_number": {
+                    "type": "string"
+                  },
+                  "first_name": {
+                    "type": "string"
+                  },
+                  "last_name": {
+                    "type": "string"
+                  },
+                  "organization": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "properties": {
+                    "type": "object"
+                  }
                 }
               }
             }
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -132,11 +193,15 @@
           },
           "additional_fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Additional fields to include"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -168,7 +233,9 @@
           },
           "additional_fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Additional fields to include"
           }
         },
@@ -188,7 +255,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["event"],
+                "enum": [
+                  "event"
+                ],
                 "default": "event"
               },
               "attributes": {
@@ -200,13 +269,25 @@
                       "data": {
                         "type": "object",
                         "properties": {
-                          "type": {"type": "string", "enum": ["profile"]},
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "profile"
+                            ]
+                          },
                           "attributes": {
                             "type": "object",
                             "properties": {
-                              "email": {"type": "string", "format": "email"},
-                              "phone_number": {"type": "string"},
-                              "external_id": {"type": "string"}
+                              "email": {
+                                "type": "string",
+                                "format": "email"
+                              },
+                              "phone_number": {
+                                "type": "string"
+                              },
+                              "external_id": {
+                                "type": "string"
+                              }
                             }
                           }
                         }
@@ -219,21 +300,37 @@
                       "data": {
                         "type": "object",
                         "properties": {
-                          "type": {"type": "string", "enum": ["metric"]},
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "metric"
+                            ]
+                          },
                           "attributes": {
                             "type": "object",
                             "properties": {
-                              "name": {"type": "string"}
+                              "name": {
+                                "type": "string"
+                              }
                             }
                           }
                         }
                       }
                     }
                   },
-                  "properties": {"type": "object"},
-                  "time": {"type": "string", "format": "date-time"},
-                  "value": {"type": "number"},
-                  "unique_id": {"type": "string"}
+                  "properties": {
+                    "type": "object"
+                  },
+                  "time": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "value": {
+                    "type": "number"
+                  },
+                  "unique_id": {
+                    "type": "string"
+                  }
                 },
                 "description": "Event attributes"
               }
@@ -279,14 +376,24 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["list"],
+                "enum": [
+                  "list"
+                ],
                 "default": "list"
               },
               "attributes": {
                 "type": "object",
                 "properties": {
-                  "name": {"type": "string"},
-                  "opt_in_process": {"type": "string", "enum": ["single_opt_in", "double_opt_in"]}
+                  "name": {
+                    "type": "string"
+                  },
+                  "opt_in_process": {
+                    "type": "string",
+                    "enum": [
+                      "single_opt_in",
+                      "double_opt_in"
+                    ]
+                  }
                 }
               }
             }
@@ -312,12 +419,22 @@
             "items": {
               "type": "object",
               "properties": {
-                "type": {"type": "string", "enum": ["profile"]},
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "profile"
+                  ]
+                },
                 "attributes": {
                   "type": "object",
                   "properties": {
-                    "email": {"type": "string", "format": "email"},
-                    "phone_number": {"type": "string"},
+                    "email": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "phone_number": {
+                      "type": "string"
+                    },
                     "subscriptions": {
                       "type": "object",
                       "properties": {
@@ -327,7 +444,13 @@
                             "marketing": {
                               "type": "object",
                               "properties": {
-                                "consent": {"type": "string", "enum": ["SUBSCRIBED", "UNSUBSCRIBED"]}
+                                "consent": {
+                                  "type": "string",
+                                  "enum": [
+                                    "SUBSCRIBED",
+                                    "UNSUBSCRIBED"
+                                  ]
+                                }
                               }
                             }
                           }
@@ -338,7 +461,13 @@
                             "marketing": {
                               "type": "object",
                               "properties": {
-                                "consent": {"type": "string", "enum": ["SUBSCRIBED", "UNSUBSCRIBED"]}
+                                "consent": {
+                                  "type": "string",
+                                  "enum": [
+                                    "SUBSCRIBED",
+                                    "UNSUBSCRIBED"
+                                  ]
+                                }
                               }
                             }
                           }
@@ -352,7 +481,9 @@
             "description": "Array of profiles to subscribe"
           }
         },
-        "required": ["list_id"],
+        "required": [
+          "list_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -372,12 +503,22 @@
             "items": {
               "type": "object",
               "properties": {
-                "type": {"type": "string", "enum": ["profile"]},
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "profile"
+                  ]
+                },
                 "attributes": {
                   "type": "object",
                   "properties": {
-                    "email": {"type": "string", "format": "email"},
-                    "phone_number": {"type": "string"}
+                    "email": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "phone_number": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -385,7 +526,9 @@
             "description": "Array of profiles to unsubscribe"
           }
         },
-        "required": ["list_id"],
+        "required": [
+          "list_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -467,17 +610,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "id": {"type": "string"},
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
           "attributes": {
             "type": "object",
             "properties": {
-              "email": {"type": "string"},
-              "phone_number": {"type": "string"},
-              "first_name": {"type": "string"},
-              "last_name": {"type": "string"},
-              "created": {"type": "string"},
-              "updated": {"type": "string"}
+              "email": {
+                "type": "string"
+              },
+              "phone_number": {
+                "type": "string"
+              },
+              "first_name": {
+                "type": "string"
+              },
+              "last_name": {
+                "type": "string"
+              },
+              "created": {
+                "type": "string"
+              },
+              "updated": {
+                "type": "string"
+              }
             }
           }
         }
@@ -502,9 +661,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "profile": {"type": "object"},
-          "list": {"type": "object"},
-          "datetime": {"type": "string"}
+          "profile": {
+            "type": "object"
+          },
+          "list": {
+            "type": "object"
+          },
+          "datetime": {
+            "type": "string"
+          }
         }
       }
     },
@@ -527,9 +692,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "profile": {"type": "object"},
-          "list": {"type": "object"},
-          "datetime": {"type": "string"}
+          "profile": {
+            "type": "object"
+          },
+          "list": {
+            "type": "object"
+          },
+          "datetime": {
+            "type": "string"
+          }
         }
       }
     }
@@ -537,5 +708,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/accounts/"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/kubernetes/definition.json
+++ b/connectors/kubernetes/definition.json
@@ -68,7 +68,10 @@
             "description": "Container port"
           }
         },
-        "required": ["name", "image"],
+        "required": [
+          "name",
+          "image"
+        ],
         "additionalProperties": false
       }
     },
@@ -98,21 +101,39 @@
             "items": {
               "type": "object",
               "properties": {
-                "port": {"type": "number"},
-                "targetPort": {"type": "number"},
-                "protocol": {"type": "string", "enum": ["TCP", "UDP"]}
+                "port": {
+                  "type": "number"
+                },
+                "targetPort": {
+                  "type": "number"
+                },
+                "protocol": {
+                  "type": "string",
+                  "enum": [
+                    "TCP",
+                    "UDP"
+                  ]
+                }
               }
             },
             "description": "Service ports"
           },
           "type": {
             "type": "string",
-            "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
+            "enum": [
+              "ClusterIP",
+              "NodePort",
+              "LoadBalancer"
+            ],
             "default": "ClusterIP",
             "description": "Service type"
           }
         },
-        "required": ["name", "selector", "ports"],
+        "required": [
+          "name",
+          "selector",
+          "ports"
+        ],
         "additionalProperties": false
       }
     },
@@ -139,7 +160,10 @@
             "description": "Target replica count"
           }
         },
-        "required": ["name", "replicas"],
+        "required": [
+          "name",
+          "replicas"
+        ],
         "additionalProperties": false
       }
     },
@@ -170,7 +194,9 @@
             "description": "Number of lines to tail"
           }
         },
-        "required": ["pod_name"],
+        "required": [
+          "pod_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -230,5 +256,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/kustomer/definition.json
+++ b/connectors/kustomer/definition.json
@@ -76,7 +76,9 @@
             "description": "Customer ID"
           }
         },
-        "required": ["customerId"],
+        "required": [
+          "customerId"
+        ],
         "additionalProperties": false
       }
     },
@@ -113,7 +115,9 @@
             "description": "Custom attributes"
           }
         },
-        "required": ["customerId"],
+        "required": [
+          "customerId"
+        ],
         "additionalProperties": false
       }
     },
@@ -176,24 +180,43 @@
           },
           "channel": {
             "type": "string",
-            "enum": ["email", "chat", "phone", "social", "api"],
+            "enum": [
+              "email",
+              "chat",
+              "phone",
+              "social",
+              "api"
+            ],
             "description": "Conversation channel"
           },
           "priority": {
             "type": "string",
-            "enum": ["lowest", "low", "normal", "high", "highest"],
+            "enum": [
+              "lowest",
+              "low",
+              "normal",
+              "high",
+              "highest"
+            ],
             "default": "normal",
             "description": "Conversation priority"
           },
           "status": {
             "type": "string",
-            "enum": ["open", "snoozed", "closed"],
+            "enum": [
+              "open",
+              "snoozed",
+              "closed"
+            ],
             "default": "open",
             "description": "Conversation status"
           },
           "direction": {
             "type": "string",
-            "enum": ["in", "out"],
+            "enum": [
+              "in",
+              "out"
+            ],
             "default": "in",
             "description": "Conversation direction"
           },
@@ -202,7 +225,9 @@
             "description": "Custom attributes"
           }
         },
-        "required": ["customerId"],
+        "required": [
+          "customerId"
+        ],
         "additionalProperties": false
       }
     },
@@ -218,7 +243,9 @@
             "description": "Conversation ID"
           }
         },
-        "required": ["conversationId"],
+        "required": [
+          "conversationId"
+        ],
         "additionalProperties": false
       }
     },
@@ -239,12 +266,22 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["lowest", "low", "normal", "high", "highest"],
+            "enum": [
+              "lowest",
+              "low",
+              "normal",
+              "high",
+              "highest"
+            ],
             "description": "Conversation priority"
           },
           "status": {
             "type": "string",
-            "enum": ["open", "snoozed", "closed"],
+            "enum": [
+              "open",
+              "snoozed",
+              "closed"
+            ],
             "description": "Conversation status"
           },
           "assignedTeamId": {
@@ -260,7 +297,9 @@
             "description": "Custom attributes"
           }
         },
-        "required": ["conversationId"],
+        "required": [
+          "conversationId"
+        ],
         "additionalProperties": false
       }
     },
@@ -281,13 +320,22 @@
           },
           "direction": {
             "type": "string",
-            "enum": ["in", "out"],
+            "enum": [
+              "in",
+              "out"
+            ],
             "default": "out",
             "description": "Message direction"
           },
           "channel": {
             "type": "string",
-            "enum": ["email", "chat", "phone", "social", "api"],
+            "enum": [
+              "email",
+              "chat",
+              "phone",
+              "social",
+              "api"
+            ],
             "description": "Message channel"
           },
           "attachments": {
@@ -295,15 +343,24 @@
             "items": {
               "type": "object",
               "properties": {
-                "url": {"type": "string"},
-                "name": {"type": "string"},
-                "contentType": {"type": "string"}
+                "url": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "contentType": {
+                  "type": "string"
+                }
               }
             },
             "description": "Message attachments"
           }
         },
-        "required": ["conversationId", "body"],
+        "required": [
+          "conversationId",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -332,7 +389,9 @@
             "description": "Number of results per page"
           }
         },
-        "required": ["conversationId"],
+        "required": [
+          "conversationId"
+        ],
         "additionalProperties": false
       }
     },
@@ -349,12 +408,22 @@
           },
           "status": {
             "type": "string",
-            "enum": ["open", "snoozed", "closed"],
+            "enum": [
+              "open",
+              "snoozed",
+              "closed"
+            ],
             "description": "Filter by status"
           },
           "priority": {
             "type": "string",
-            "enum": ["lowest", "low", "normal", "high", "highest"],
+            "enum": [
+              "lowest",
+              "low",
+              "normal",
+              "high",
+              "highest"
+            ],
             "description": "Filter by priority"
           },
           "assignedUserId": {
@@ -367,7 +436,13 @@
           },
           "channel": {
             "type": "string",
-            "enum": ["email", "chat", "phone", "social", "api"],
+            "enum": [
+              "email",
+              "chat",
+              "phone",
+              "social",
+              "api"
+            ],
             "description": "Filter by channel"
           },
           "createdAfter": {
@@ -414,7 +489,10 @@
             "description": "Note content"
           }
         },
-        "required": ["customerId", "body"],
+        "required": [
+          "customerId",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -493,13 +571,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "customerId": {"type": "string"},
-          "title": {"type": "string"},
-          "status": {"type": "string"},
-          "priority": {"type": "string"},
-          "channel": {"type": "string"},
-          "createdAt": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          }
         }
       }
     },
@@ -526,12 +618,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "customerId": {"type": "string"},
-          "title": {"type": "string"},
-          "status": {"type": "string"},
-          "priority": {"type": "string"},
-          "updatedAt": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
         }
       }
     },
@@ -545,12 +649,21 @@
         "properties": {
           "direction": {
             "type": "string",
-            "enum": ["in", "out"],
+            "enum": [
+              "in",
+              "out"
+            ],
             "description": "Filter by message direction"
           },
           "channel": {
             "type": "string",
-            "enum": ["email", "chat", "phone", "social", "api"],
+            "enum": [
+              "email",
+              "chat",
+              "phone",
+              "social",
+              "api"
+            ],
             "description": "Filter by channel"
           }
         },
@@ -560,13 +673,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "conversationId": {"type": "string"},
-          "customerId": {"type": "string"},
-          "body": {"type": "string"},
-          "direction": {"type": "string"},
-          "channel": {"type": "string"},
-          "createdAt": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "direction": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          }
         }
       }
     },
@@ -584,12 +711,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "email": {"type": "string"},
-          "phone": {"type": "string"},
-          "company": {"type": "string"},
-          "createdAt": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "company": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          }
         }
       }
     }
@@ -597,5 +736,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/customers?page[size]=1"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/lever/definition.json
+++ b/connectors/lever/definition.json
@@ -79,7 +79,10 @@
           },
           "confidentiality": {
             "type": "string",
-            "enum": ["confidential", "non-confidential"],
+            "enum": [
+              "confidential",
+              "non-confidential"
+            ],
             "description": "Filter by confidentiality"
           },
           "email": {
@@ -105,11 +108,23 @@
           },
           "expand": {
             "type": "array",
-            "items": {"type": "string", "enum": ["applications", "stage", "owner", "followers", "sourcedBy", "origin"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "applications",
+                "stage",
+                "owner",
+                "followers",
+                "sourcedBy",
+                "origin"
+              ]
+            },
             "description": "Additional data to include"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -139,34 +154,61 @@
           "phone": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["home", "work", "mobile", "other"]},
-              "value": {"type": "string"}
+              "type": {
+                "type": "string",
+                "enum": [
+                  "home",
+                  "work",
+                  "mobile",
+                  "other"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
             },
             "description": "Phone number"
           },
           "emails": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "Email addresses"
           },
           "links": {
             "type": "array",
-            "items": {"type": "string", "format": "uri"},
+            "items": {
+              "type": "string",
+              "format": "uri"
+            },
             "description": "URLs (LinkedIn, portfolio, etc.)"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Tags to apply"
           },
           "sources": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Source IDs"
           },
           "origin": {
             "type": "string",
-            "enum": ["agency", "applied", "internal", "referred", "sourced", "university"],
+            "enum": [
+              "agency",
+              "applied",
+              "internal",
+              "referred",
+              "sourced",
+              "university"
+            ],
             "description": "Origin of candidate"
           },
           "owner": {
@@ -175,7 +217,9 @@
           },
           "followers": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "User IDs of followers"
           },
           "stage": {
@@ -185,18 +229,32 @@
           "archived": {
             "type": "object",
             "properties": {
-              "archivedAt": {"type": "number"},
-              "reason": {"type": "string", "enum": ["hired", "passed", "lost", "other"]}
+              "archivedAt": {
+                "type": "number"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "hired",
+                  "passed",
+                  "lost",
+                  "other"
+                ]
+              }
             },
             "description": "Archive information"
           },
           "postings": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Posting IDs to apply to"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -230,19 +288,34 @@
           "phone": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["home", "work", "mobile", "other"]},
-              "value": {"type": "string"}
+              "type": {
+                "type": "string",
+                "enum": [
+                  "home",
+                  "work",
+                  "mobile",
+                  "other"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
             },
             "description": "Phone number"
           },
           "emails": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "Email addresses"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Tags to apply"
           },
           "owner": {
@@ -251,7 +324,9 @@
           },
           "followers": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "User IDs of followers"
           },
           "stage": {
@@ -259,7 +334,9 @@
             "description": "Stage ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -276,11 +353,19 @@
           },
           "reason": {
             "type": "string",
-            "enum": ["hired", "passed", "lost", "other"],
+            "enum": [
+              "hired",
+              "passed",
+              "lost",
+              "other"
+            ],
             "description": "Archive reason"
           }
         },
-        "required": ["id", "reason"],
+        "required": [
+          "id",
+          "reason"
+        ],
         "additionalProperties": false
       }
     },
@@ -341,7 +426,9 @@
             "description": "Posting ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -385,7 +472,9 @@
             "description": "User ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -406,12 +495,18 @@
           },
           "visibility": {
             "type": "string",
-            "enum": ["public", "private"],
+            "enum": [
+              "public",
+              "private"
+            ],
             "default": "public",
             "description": "Note visibility"
           }
         },
-        "required": ["opportunity_id", "value"],
+        "required": [
+          "opportunity_id",
+          "value"
+        ],
         "additionalProperties": false
       }
     },
@@ -431,7 +526,10 @@
             "description": "Target stage ID"
           }
         },
-        "required": ["id", "stage"],
+        "required": [
+          "id",
+          "stage"
+        ],
         "additionalProperties": false
       }
     }
@@ -451,15 +549,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "headline": {"type": "string"},
-          "stage": {"type": "string"},
-          "location": {"type": "string"},
-          "emails": {"type": "array"},
-          "phones": {"type": "array"},
-          "createdAt": {"type": "number"},
-          "updatedAt": {"type": "number"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "headline": {
+            "type": "string"
+          },
+          "stage": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "emails": {
+            "type": "array"
+          },
+          "phones": {
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "updatedAt": {
+            "type": "number"
+          }
         }
       }
     },
@@ -482,10 +598,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "opportunityId": {"type": "string"},
-          "fromStage": {"type": "object"},
-          "toStage": {"type": "object"},
-          "changedAt": {"type": "number"}
+          "opportunityId": {
+            "type": "string"
+          },
+          "fromStage": {
+            "type": "object"
+          },
+          "toStage": {
+            "type": "object"
+          },
+          "changedAt": {
+            "type": "number"
+          }
         }
       }
     },
@@ -503,10 +627,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "archivedAt": {"type": "number"},
-          "reason": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "archivedAt": {
+            "type": "number"
+          },
+          "reason": {
+            "type": "string"
+          }
         }
       }
     }
@@ -514,5 +646,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/linear/definition.json
+++ b/connectors/linear/definition.json
@@ -62,7 +62,9 @@
           },
           "labelIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of label IDs"
           },
           "projectId": {
@@ -83,7 +85,10 @@
             "description": "Due date"
           }
         },
-        "required": ["title", "teamId"],
+        "required": [
+          "title",
+          "teamId"
+        ],
         "additionalProperties": false
       }
     },
@@ -122,7 +127,9 @@
           },
           "labelIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of label IDs"
           },
           "projectId": {
@@ -139,7 +146,9 @@
             "description": "Due date"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -155,7 +164,9 @@
             "description": "Issue ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -205,7 +216,12 @@
           },
           "orderBy": {
             "type": "string",
-            "enum": ["createdAt", "updatedAt", "priority", "title"],
+            "enum": [
+              "createdAt",
+              "updatedAt",
+              "priority",
+              "title"
+            ],
             "description": "Sort field"
           }
         },
@@ -229,7 +245,10 @@
             "description": "Comment body"
           }
         },
-        "required": ["issueId", "body"],
+        "required": [
+          "issueId",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -293,7 +312,9 @@
           },
           "teamIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of team IDs"
           },
           "leadId": {
@@ -307,12 +328,20 @@
           },
           "state": {
             "type": "string",
-            "enum": ["planned", "started", "paused", "completed", "canceled"],
+            "enum": [
+              "planned",
+              "started",
+              "paused",
+              "completed",
+              "canceled"
+            ],
             "default": "planned",
             "description": "Project state"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -411,18 +440,42 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "description": {"type": "string"},
-          "identifier": {"type": "string"},
-          "priority": {"type": "number"},
-          "estimate": {"type": "number"},
-          "team": {"type": "object"},
-          "assignee": {"type": "object"},
-          "state": {"type": "object"},
-          "labels": {"type": "array"},
-          "createdAt": {"type": "string"},
-          "updatedAt": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "number"
+          },
+          "estimate": {
+            "type": "number"
+          },
+          "team": {
+            "type": "object"
+          },
+          "assignee": {
+            "type": "object"
+          },
+          "state": {
+            "type": "object"
+          },
+          "labels": {
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
         }
       }
     },
@@ -445,11 +498,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "updatedAt": {"type": "string"},
-          "previousValues": {"type": "object"},
-          "changedValues": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "previousValues": {
+            "type": "object"
+          },
+          "changedValues": {
+            "type": "object"
+          }
         }
       }
     },
@@ -472,12 +535,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "identifier": {"type": "string"},
-          "completedAt": {"type": "string"},
-          "assignee": {"type": "object"},
-          "team": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "completedAt": {
+            "type": "string"
+          },
+          "assignee": {
+            "type": "object"
+          },
+          "team": {
+            "type": "object"
+          }
         }
       }
     }
@@ -488,5 +563,19 @@
     "body": {
       "query": "query { viewer { id name } }"
     }
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/llm/definition.json
+++ b/connectors/llm/definition.json
@@ -29,7 +29,13 @@
           },
           "model": {
             "type": "string",
-            "enum": ["gpt-4", "gpt-4-turbo", "gpt-3.5-turbo", "claude-3-opus", "claude-3-sonnet"],
+            "enum": [
+              "gpt-4",
+              "gpt-4-turbo",
+              "gpt-3.5-turbo",
+              "claude-3-opus",
+              "claude-3-sonnet"
+            ],
             "default": "gpt-3.5-turbo",
             "description": "Language model to use"
           },
@@ -70,7 +76,9 @@
           },
           "stop_sequences": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Stop sequences to end generation"
           },
           "system_message": {
@@ -78,7 +86,9 @@
             "description": "System message to set behavior"
           }
         },
-        "required": ["prompt"],
+        "required": [
+          "prompt"
+        ],
         "additionalProperties": false
       }
     },
@@ -94,16 +104,34 @@
             "items": {
               "type": "object",
               "properties": {
-                "role": {"type": "string", "enum": ["system", "user", "assistant"]},
-                "content": {"type": "string"}
+                "role": {
+                  "type": "string",
+                  "enum": [
+                    "system",
+                    "user",
+                    "assistant"
+                  ]
+                },
+                "content": {
+                  "type": "string"
+                }
               },
-              "required": ["role", "content"]
+              "required": [
+                "role",
+                "content"
+              ]
             },
             "description": "Conversation messages"
           },
           "model": {
             "type": "string",
-            "enum": ["gpt-4", "gpt-4-turbo", "gpt-3.5-turbo", "claude-3-opus", "claude-3-sonnet"],
+            "enum": [
+              "gpt-4",
+              "gpt-4-turbo",
+              "gpt-3.5-turbo",
+              "claude-3-opus",
+              "claude-3-sonnet"
+            ],
             "default": "gpt-3.5-turbo",
             "description": "Language model to use"
           },
@@ -127,7 +155,9 @@
             "description": "Stream the response"
           }
         },
-        "required": ["messages"],
+        "required": [
+          "messages"
+        ],
         "additionalProperties": false
       }
     }
@@ -152,11 +182,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "model": {"type": "string"},
-          "generated_text": {"type": "string"},
-          "usage": {"type": "object"},
-          "created": {"type": "number"}
+          "id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "generated_text": {
+            "type": "string"
+          },
+          "usage": {
+            "type": "object"
+          },
+          "created": {
+            "type": "number"
+          }
         }
       }
     }
@@ -164,5 +204,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/models"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/looker/definition.json
+++ b/connectors/looker/definition.json
@@ -40,7 +40,15 @@
           },
           "resultFormat": {
             "type": "string",
-            "enum": ["json", "csv", "txt", "html", "xlsx", "png", "jpg"],
+            "enum": [
+              "json",
+              "csv",
+              "txt",
+              "html",
+              "xlsx",
+              "png",
+              "jpg"
+            ],
             "default": "json",
             "description": "Format for results"
           },
@@ -61,7 +69,9 @@
             "description": "Perform table calculations on server"
           }
         },
-        "required": ["lookId"],
+        "required": [
+          "lookId"
+        ],
         "additionalProperties": false
       }
     },
@@ -78,7 +88,16 @@
           },
           "resultFormat": {
             "type": "string",
-            "enum": ["json", "csv", "txt", "html", "xlsx", "png", "jpg", "pdf"],
+            "enum": [
+              "json",
+              "csv",
+              "txt",
+              "html",
+              "xlsx",
+              "png",
+              "jpg",
+              "pdf"
+            ],
             "default": "json",
             "description": "Format for results"
           },
@@ -95,7 +114,9 @@
             "description": "Height for image/PDF output"
           }
         },
-        "required": ["dashboardId"],
+        "required": [
+          "dashboardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -116,12 +137,16 @@
           },
           "dimensions": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Dimensions to include"
           },
           "measures": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Measures to include"
           },
           "filters": {
@@ -130,7 +155,9 @@
           },
           "sorts": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Sort order"
           },
           "limit": {
@@ -147,12 +174,21 @@
           },
           "resultFormat": {
             "type": "string",
-            "enum": ["json", "csv", "txt", "html", "xlsx"],
+            "enum": [
+              "json",
+              "csv",
+              "txt",
+              "html",
+              "xlsx"
+            ],
             "default": "json",
             "description": "Format for results"
           }
         },
-        "required": ["model", "explore"],
+        "required": [
+          "model",
+          "explore"
+        ],
         "additionalProperties": false
       }
     },
@@ -173,12 +209,16 @@
           },
           "dimensions": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Dimensions to include"
           },
           "measures": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Measures to include"
           },
           "filters": {
@@ -187,7 +227,9 @@
           },
           "sorts": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Sort order"
           },
           "limit": {
@@ -203,7 +245,10 @@
             "description": "Column limit for results"
           }
         },
-        "required": ["model", "explore"],
+        "required": [
+          "model",
+          "explore"
+        ],
         "additionalProperties": false
       }
     },
@@ -219,7 +264,9 @@
             "description": "Look ID"
           }
         },
-        "required": ["lookId"],
+        "required": [
+          "lookId"
+        ],
         "additionalProperties": false
       }
     },
@@ -264,7 +311,9 @@
             "description": "Dashboard ID"
           }
         },
-        "required": ["dashboardId"],
+        "required": [
+          "dashboardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -309,7 +358,9 @@
             "description": "User ID"
           }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       }
     },
@@ -376,17 +427,31 @@
           },
           "destinationAddresses": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Email addresses for delivery"
           },
           "format": {
             "type": "string",
-            "enum": ["json", "csv", "txt", "html", "xlsx", "png", "jpg", "pdf"],
+            "enum": [
+              "json",
+              "csv",
+              "txt",
+              "html",
+              "xlsx",
+              "png",
+              "jpg",
+              "pdf"
+            ],
             "default": "pdf",
             "description": "Format for delivery"
           }
         },
-        "required": ["name", "crontab"],
+        "required": [
+          "name",
+          "crontab"
+        ],
         "additionalProperties": false
       }
     },
@@ -439,7 +504,10 @@
             "description": "Comma-separated list of fields to return"
           }
         },
-        "required": ["model", "explore"],
+        "required": [
+          "model",
+          "explore"
+        ],
         "additionalProperties": false
       }
     }
@@ -464,11 +532,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "planId": {"type": "string"},
-          "planName": {"type": "string"},
-          "runAt": {"type": "string"},
-          "status": {"type": "string"},
-          "resultUrl": {"type": "string"}
+          "planId": {
+            "type": "string"
+          },
+          "planName": {
+            "type": "string"
+          },
+          "runAt": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "resultUrl": {
+            "type": "string"
+          }
         }
       }
     },
@@ -491,12 +569,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "alertId": {"type": "string"},
-          "alertName": {"type": "string"},
-          "triggeredAt": {"type": "string"},
-          "value": {"type": "number"},
-          "threshold": {"type": "number"},
-          "condition": {"type": "string"}
+          "alertId": {
+            "type": "string"
+          },
+          "alertName": {
+            "type": "string"
+          },
+          "triggeredAt": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          },
+          "threshold": {
+            "type": "number"
+          },
+          "condition": {
+            "type": "string"
+          }
         }
       }
     }
@@ -504,5 +594,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/luma/definition.json
+++ b/connectors/luma/definition.json
@@ -60,11 +60,21 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["venue", "online", "hybrid"]
+                "enum": [
+                  "venue",
+                  "online",
+                  "hybrid"
+                ]
               },
-              "venue": {"type": "string"},
-              "address": {"type": "string"},
-              "url": {"type": "string"}
+              "venue": {
+                "type": "string"
+              },
+              "address": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
             },
             "description": "Event location details"
           },
@@ -84,17 +94,26 @@
           },
           "visibility": {
             "type": "string",
-            "enum": ["public", "private", "unlisted"],
+            "enum": [
+              "public",
+              "private",
+              "unlisted"
+            ],
             "default": "public",
             "description": "Event visibility"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Event tags"
           }
         },
-        "required": ["name", "startAt"],
+        "required": [
+          "name",
+          "startAt"
+        ],
         "additionalProperties": false
       }
     },
@@ -110,7 +129,9 @@
             "description": "Event ID"
           }
         },
-        "required": ["eventId"],
+        "required": [
+          "eventId"
+        ],
         "additionalProperties": false
       }
     },
@@ -152,11 +173,21 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["venue", "online", "hybrid"]
+                "enum": [
+                  "venue",
+                  "online",
+                  "hybrid"
+                ]
               },
-              "venue": {"type": "string"},
-              "address": {"type": "string"},
-              "url": {"type": "string"}
+              "venue": {
+                "type": "string"
+              },
+              "address": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
             },
             "description": "Event location details"
           },
@@ -175,16 +206,24 @@
           },
           "visibility": {
             "type": "string",
-            "enum": ["public", "private", "unlisted"],
+            "enum": [
+              "public",
+              "private",
+              "unlisted"
+            ],
             "description": "Event visibility"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Event tags"
           }
         },
-        "required": ["eventId"],
+        "required": [
+          "eventId"
+        ],
         "additionalProperties": false
       }
     },
@@ -210,7 +249,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["upcoming", "past", "live"],
+            "enum": [
+              "upcoming",
+              "past",
+              "live"
+            ],
             "description": "Filter by event status"
           },
           "seriesId": {
@@ -234,7 +277,9 @@
             "description": "Event ID"
           }
         },
-        "required": ["eventId"],
+        "required": [
+          "eventId"
+        ],
         "additionalProperties": false
       }
     },
@@ -264,11 +309,17 @@
           },
           "status": {
             "type": "string",
-            "enum": ["registered", "waitlisted", "cancelled"],
+            "enum": [
+              "registered",
+              "waitlisted",
+              "cancelled"
+            ],
             "description": "Filter by registration status"
           }
         },
-        "required": ["eventId"],
+        "required": [
+          "eventId"
+        ],
         "additionalProperties": false
       }
     },
@@ -297,7 +348,10 @@
             "description": "Additional registration information"
           }
         },
-        "required": ["eventId", "email"],
+        "required": [
+          "eventId",
+          "email"
+        ],
         "additionalProperties": false
       }
     },
@@ -313,7 +367,9 @@
             "description": "Registration ID"
           }
         },
-        "required": ["registrationId"],
+        "required": [
+          "registrationId"
+        ],
         "additionalProperties": false
       }
     },
@@ -338,17 +394,25 @@
           },
           "visibility": {
             "type": "string",
-            "enum": ["public", "private", "unlisted"],
+            "enum": [
+              "public",
+              "private",
+              "unlisted"
+            ],
             "default": "public",
             "description": "Series visibility"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Series tags"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -364,7 +428,9 @@
             "description": "Series ID"
           }
         },
-        "required": ["seriesId"],
+        "required": [
+          "seriesId"
+        ],
         "additionalProperties": false
       }
     },
@@ -414,12 +480,20 @@
           },
           "recipients": {
             "type": "string",
-            "enum": ["all", "registered", "waitlisted"],
+            "enum": [
+              "all",
+              "registered",
+              "waitlisted"
+            ],
             "default": "registered",
             "description": "Message recipients"
           }
         },
-        "required": ["eventId", "subject", "body"],
+        "required": [
+          "eventId",
+          "subject",
+          "body"
+        ],
         "additionalProperties": false
       }
     }
@@ -444,12 +518,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventId": {"type": "string"},
-          "name": {"type": "string"},
-          "startAt": {"type": "string"},
-          "endAt": {"type": "string"},
-          "createdAt": {"type": "string"},
-          "seriesId": {"type": "string"}
+          "eventId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "startAt": {
+            "type": "string"
+          },
+          "endAt": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "seriesId": {
+            "type": "string"
+          }
         }
       }
     },
@@ -472,12 +558,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "registrationId": {"type": "string"},
-          "eventId": {"type": "string"},
-          "email": {"type": "string"},
-          "name": {"type": "string"},
-          "status": {"type": "string"},
-          "registeredAt": {"type": "string"}
+          "registrationId": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "registeredAt": {
+            "type": "string"
+          }
         }
       }
     },
@@ -500,11 +598,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "registrationId": {"type": "string"},
-          "eventId": {"type": "string"},
-          "email": {"type": "string"},
-          "name": {"type": "string"},
-          "cancelledAt": {"type": "string"}
+          "registrationId": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "cancelledAt": {
+            "type": "string"
+          }
         }
       }
     },
@@ -527,10 +635,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventId": {"type": "string"},
-          "name": {"type": "string"},
-          "startAt": {"type": "string"},
-          "registrationCount": {"type": "number"}
+          "eventId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "startAt": {
+            "type": "string"
+          },
+          "registrationCount": {
+            "type": "number"
+          }
         }
       }
     }
@@ -538,5 +654,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/magento/definition.json
+++ b/connectors/magento/definition.json
@@ -55,17 +55,32 @@
               },
               "status": {
                 "type": "number",
-                "enum": [1, 2],
+                "enum": [
+                  1,
+                  2
+                ],
                 "description": "Product status (1=enabled, 2=disabled)"
               },
               "visibility": {
                 "type": "number",
-                "enum": [1, 2, 3, 4],
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4
+                ],
                 "description": "Product visibility"
               },
               "type_id": {
                 "type": "string",
-                "enum": ["simple", "configurable", "grouped", "virtual", "bundle", "downloadable"],
+                "enum": [
+                  "simple",
+                  "configurable",
+                  "grouped",
+                  "virtual",
+                  "bundle",
+                  "downloadable"
+                ],
                 "description": "Product type"
               },
               "weight": {
@@ -77,17 +92,25 @@
                 "properties": {
                   "website_ids": {
                     "type": "array",
-                    "items": {"type": "number"}
+                    "items": {
+                      "type": "number"
+                    }
                   },
                   "category_links": {
                     "type": "array",
-                    "items": {"type": "object"}
+                    "items": {
+                      "type": "object"
+                    }
                   },
                   "stock_item": {
                     "type": "object",
                     "properties": {
-                      "qty": {"type": "number"},
-                      "is_in_stock": {"type": "boolean"}
+                      "qty": {
+                        "type": "number"
+                      },
+                      "is_in_stock": {
+                        "type": "boolean"
+                      }
                     },
                     "additionalProperties": false
                   }
@@ -99,18 +122,31 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "attribute_code": {"type": "string"},
-                    "value": {"type": "string"}
+                    "attribute_code": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
                   },
                   "additionalProperties": false
                 }
               }
             },
-            "required": ["sku", "name", "attribute_set_id", "price", "status", "type_id"],
+            "required": [
+              "sku",
+              "name",
+              "attribute_set_id",
+              "price",
+              "status",
+              "type_id"
+            ],
             "additionalProperties": false
           }
         },
-        "required": ["product"],
+        "required": [
+          "product"
+        ],
         "additionalProperties": false
       }
     },
@@ -138,7 +174,9 @@
             "description": "Whether to force reload"
           }
         },
-        "required": ["sku"],
+        "required": [
+          "sku"
+        ],
         "additionalProperties": false
       }
     },
@@ -156,12 +194,34 @@
           "product": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "price": {"type": "number"},
-              "status": {"type": "number", "enum": [1, 2]},
-              "visibility": {"type": "number", "enum": [1, 2, 3, 4]},
-              "weight": {"type": "number"},
-              "custom_attributes": {"type": "array"}
+              "name": {
+                "type": "string"
+              },
+              "price": {
+                "type": "number"
+              },
+              "status": {
+                "type": "number",
+                "enum": [
+                  1,
+                  2
+                ]
+              },
+              "visibility": {
+                "type": "number",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4
+                ]
+              },
+              "weight": {
+                "type": "number"
+              },
+              "custom_attributes": {
+                "type": "array"
+              }
             },
             "additionalProperties": false
           },
@@ -170,7 +230,10 @@
             "description": "Whether to save options"
           }
         },
-        "required": ["sku", "product"],
+        "required": [
+          "sku",
+          "product"
+        ],
         "additionalProperties": false
       }
     },
@@ -186,7 +249,9 @@
             "description": "Product SKU"
           }
         },
-        "required": ["sku"],
+        "required": [
+          "sku"
+        ],
         "additionalProperties": false
       }
     },
@@ -202,14 +267,24 @@
             "properties": {
               "filterGroups": {
                 "type": "array",
-                "items": {"type": "object"}
+                "items": {
+                  "type": "object"
+                }
               },
               "sortOrders": {
                 "type": "array",
-                "items": {"type": "object"}
+                "items": {
+                  "type": "object"
+                }
               },
-              "pageSize": {"type": "number", "minimum": 1},
-              "currentPage": {"type": "number", "minimum": 1}
+              "pageSize": {
+                "type": "number",
+                "minimum": 1
+              },
+              "currentPage": {
+                "type": "number",
+                "minimum": 1
+              }
             },
             "additionalProperties": false
           }
@@ -228,29 +303,53 @@
           "entity": {
             "type": "object",
             "properties": {
-              "customer_email": {"type": "string", "format": "email"},
-              "customer_firstname": {"type": "string"},
-              "customer_lastname": {"type": "string"},
-              "billing_address": {"type": "object"},
+              "customer_email": {
+                "type": "string",
+                "format": "email"
+              },
+              "customer_firstname": {
+                "type": "string"
+              },
+              "customer_lastname": {
+                "type": "string"
+              },
+              "billing_address": {
+                "type": "object"
+              },
               "items": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "sku": {"type": "string"},
-                    "qty": {"type": "number", "minimum": 1},
-                    "price": {"type": "number"}
+                    "sku": {
+                      "type": "string"
+                    },
+                    "qty": {
+                      "type": "number",
+                      "minimum": 1
+                    },
+                    "price": {
+                      "type": "number"
+                    }
                   },
-                  "required": ["sku", "qty"],
+                  "required": [
+                    "sku",
+                    "qty"
+                  ],
                   "additionalProperties": false
                 }
               }
             },
-            "required": ["customer_email", "items"],
+            "required": [
+              "customer_email",
+              "items"
+            ],
             "additionalProperties": false
           }
         },
-        "required": ["entity"],
+        "required": [
+          "entity"
+        ],
         "additionalProperties": false
       }
     },
@@ -266,7 +365,9 @@
             "description": "Order ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -280,17 +381,34 @@
           "customer": {
             "type": "object",
             "properties": {
-              "email": {"type": "string", "format": "email"},
-              "firstname": {"type": "string"},
-              "lastname": {"type": "string"},
-              "store_id": {"type": "number"},
-              "website_id": {"type": "number"},
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "firstname": {
+                "type": "string"
+              },
+              "lastname": {
+                "type": "string"
+              },
+              "store_id": {
+                "type": "number"
+              },
+              "website_id": {
+                "type": "number"
+              },
               "addresses": {
                 "type": "array",
-                "items": {"type": "object"}
+                "items": {
+                  "type": "object"
+                }
               }
             },
-            "required": ["email", "firstname", "lastname"],
+            "required": [
+              "email",
+              "firstname",
+              "lastname"
+            ],
             "additionalProperties": false
           },
           "password": {
@@ -302,7 +420,9 @@
             "description": "Redirect URL after creation"
           }
         },
-        "required": ["customer"],
+        "required": [
+          "customer"
+        ],
         "additionalProperties": false
       }
     }
@@ -327,15 +447,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "sku": {"type": "string"},
-          "name": {"type": "string"},
-          "attribute_set_id": {"type": "number"},
-          "price": {"type": "number"},
-          "status": {"type": "number"},
-          "visibility": {"type": "number"},
-          "type_id": {"type": "string"},
-          "created_at": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "attribute_set_id": {
+            "type": "number"
+          },
+          "price": {
+            "type": "number"
+          },
+          "status": {
+            "type": "number"
+          },
+          "visibility": {
+            "type": "number"
+          },
+          "type_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          }
         }
       }
     },
@@ -358,14 +496,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "entity_id": {"type": "number"},
-          "increment_id": {"type": "string"},
-          "customer_email": {"type": "string"},
-          "customer_firstname": {"type": "string"},
-          "customer_lastname": {"type": "string"},
-          "grand_total": {"type": "number"},
-          "status": {"type": "string"},
-          "created_at": {"type": "string"}
+          "entity_id": {
+            "type": "number"
+          },
+          "increment_id": {
+            "type": "string"
+          },
+          "customer_email": {
+            "type": "string"
+          },
+          "customer_firstname": {
+            "type": "string"
+          },
+          "customer_lastname": {
+            "type": "string"
+          },
+          "grand_total": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          }
         }
       }
     }
@@ -373,5 +527,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/modules"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/mailchimp-enhanced/definition.json
+++ b/connectors/mailchimp-enhanced/definition.json
@@ -45,22 +45,33 @@
           },
           "status": {
             "type": "string",
-            "enum": ["subscribed", "unsubscribed", "cleaned", "pending"],
+            "enum": [
+              "subscribed",
+              "unsubscribed",
+              "cleaned",
+              "pending"
+            ],
             "default": "subscribed",
             "description": "Subscriber status"
           },
           "merge_fields": {
             "type": "object",
             "properties": {
-              "FNAME": {"type": "string"},
-              "LNAME": {"type": "string"}
+              "FNAME": {
+                "type": "string"
+              },
+              "LNAME": {
+                "type": "string"
+              }
             },
             "additionalProperties": true,
             "description": "Merge fields"
           },
           "interests": {
             "type": "object",
-            "additionalProperties": {"type": "boolean"},
+            "additionalProperties": {
+              "type": "boolean"
+            },
             "description": "Interest categories"
           },
           "language": {
@@ -74,8 +85,12 @@
           "location": {
             "type": "object",
             "properties": {
-              "latitude": {"type": "number"},
-              "longitude": {"type": "number"}
+              "latitude": {
+                "type": "number"
+              },
+              "longitude": {
+                "type": "number"
+              }
             },
             "additionalProperties": false
           },
@@ -84,8 +99,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "marketing_permission_id": {"type": "string"},
-                "enabled": {"type": "boolean"}
+                "marketing_permission_id": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
               },
               "additionalProperties": false
             }
@@ -110,11 +129,16 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Tags for the subscriber"
           }
         },
-        "required": ["list_id", "email_address"],
+        "required": [
+          "list_id",
+          "email_address"
+        ],
         "additionalProperties": false
       }
     },
@@ -140,7 +164,12 @@
           },
           "status_if_new": {
             "type": "string",
-            "enum": ["subscribed", "unsubscribed", "cleaned", "pending"],
+            "enum": [
+              "subscribed",
+              "unsubscribed",
+              "cleaned",
+              "pending"
+            ],
             "description": "Status if subscriber is new"
           },
           "merge_fields": {
@@ -150,7 +179,9 @@
           },
           "interests": {
             "type": "object",
-            "additionalProperties": {"type": "boolean"},
+            "additionalProperties": {
+              "type": "boolean"
+            },
             "description": "Interest categories"
           },
           "language": {
@@ -164,13 +195,20 @@
           "location": {
             "type": "object",
             "properties": {
-              "latitude": {"type": "number"},
-              "longitude": {"type": "number"}
+              "latitude": {
+                "type": "number"
+              },
+              "longitude": {
+                "type": "number"
+              }
             },
             "additionalProperties": false
           }
         },
-        "required": ["list_id", "subscriber_hash"],
+        "required": [
+          "list_id",
+          "subscriber_hash"
+        ],
         "additionalProperties": false
       }
     },
@@ -191,16 +229,23 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to include"
           },
           "exclude_fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to exclude"
           }
         },
-        "required": ["list_id", "subscriber_hash"],
+        "required": [
+          "list_id",
+          "subscriber_hash"
+        ],
         "additionalProperties": false
       }
     },
@@ -220,7 +265,10 @@
             "description": "MD5 hash of subscriber email"
           }
         },
-        "required": ["list_id", "subscriber_hash"],
+        "required": [
+          "list_id",
+          "subscriber_hash"
+        ],
         "additionalProperties": false
       }
     },
@@ -233,86 +281,180 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["regular", "plaintext", "absplit", "rss", "variate"],
+            "enum": [
+              "regular",
+              "plaintext",
+              "absplit",
+              "rss",
+              "variate"
+            ],
             "default": "regular",
             "description": "Campaign type"
           },
           "recipients": {
             "type": "object",
             "properties": {
-              "list_id": {"type": "string"},
-              "segment_opts": {"type": "object"}
+              "list_id": {
+                "type": "string"
+              },
+              "segment_opts": {
+                "type": "object"
+              }
             },
-            "required": ["list_id"],
+            "required": [
+              "list_id"
+            ],
             "additionalProperties": false
           },
           "settings": {
             "type": "object",
             "properties": {
-              "subject_line": {"type": "string"},
-              "preview_text": {"type": "string"},
-              "title": {"type": "string"},
-              "from_name": {"type": "string"},
-              "reply_to": {"type": "string", "format": "email"},
-              "use_conversation": {"type": "boolean"},
-              "to_name": {"type": "string"},
-              "folder_id": {"type": "string"},
-              "authenticate": {"type": "boolean"},
-              "auto_footer": {"type": "boolean"},
-              "inline_css": {"type": "boolean"},
-              "auto_tweet": {"type": "boolean"},
-              "auto_fb_post": {"type": "array"},
-              "fb_comments": {"type": "boolean"},
-              "timewarp": {"type": "boolean"},
-              "template_id": {"type": "number"},
-              "drag_and_drop": {"type": "boolean"}
+              "subject_line": {
+                "type": "string"
+              },
+              "preview_text": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "from_name": {
+                "type": "string"
+              },
+              "reply_to": {
+                "type": "string",
+                "format": "email"
+              },
+              "use_conversation": {
+                "type": "boolean"
+              },
+              "to_name": {
+                "type": "string"
+              },
+              "folder_id": {
+                "type": "string"
+              },
+              "authenticate": {
+                "type": "boolean"
+              },
+              "auto_footer": {
+                "type": "boolean"
+              },
+              "inline_css": {
+                "type": "boolean"
+              },
+              "auto_tweet": {
+                "type": "boolean"
+              },
+              "auto_fb_post": {
+                "type": "array"
+              },
+              "fb_comments": {
+                "type": "boolean"
+              },
+              "timewarp": {
+                "type": "boolean"
+              },
+              "template_id": {
+                "type": "number"
+              },
+              "drag_and_drop": {
+                "type": "boolean"
+              }
             },
-            "required": ["subject_line", "from_name", "reply_to"],
+            "required": [
+              "subject_line",
+              "from_name",
+              "reply_to"
+            ],
             "additionalProperties": false
           },
           "variate_settings": {
             "type": "object",
             "properties": {
-              "winning_criteria": {"type": "string"},
-              "wait_time": {"type": "number"},
-              "test_size": {"type": "number"},
-              "subject_lines": {"type": "array"}
+              "winning_criteria": {
+                "type": "string"
+              },
+              "wait_time": {
+                "type": "number"
+              },
+              "test_size": {
+                "type": "number"
+              },
+              "subject_lines": {
+                "type": "array"
+              }
             },
             "additionalProperties": false
           },
           "tracking": {
             "type": "object",
             "properties": {
-              "opens": {"type": "boolean", "default": true},
-              "html_clicks": {"type": "boolean", "default": true},
-              "text_clicks": {"type": "boolean", "default": false},
-              "goal_tracking": {"type": "boolean", "default": false},
-              "ecomm360": {"type": "boolean", "default": false},
-              "google_analytics": {"type": "string"},
-              "clicktale": {"type": "string"}
+              "opens": {
+                "type": "boolean",
+                "default": true
+              },
+              "html_clicks": {
+                "type": "boolean",
+                "default": true
+              },
+              "text_clicks": {
+                "type": "boolean",
+                "default": false
+              },
+              "goal_tracking": {
+                "type": "boolean",
+                "default": false
+              },
+              "ecomm360": {
+                "type": "boolean",
+                "default": false
+              },
+              "google_analytics": {
+                "type": "string"
+              },
+              "clicktale": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           },
           "rss_opts": {
             "type": "object",
             "properties": {
-              "feed_url": {"type": "string"},
-              "frequency": {"type": "string"},
-              "schedule": {"type": "object"}
+              "feed_url": {
+                "type": "string"
+              },
+              "frequency": {
+                "type": "string"
+              },
+              "schedule": {
+                "type": "object"
+              }
             },
             "additionalProperties": false
           },
           "social_card": {
             "type": "object",
             "properties": {
-              "image_url": {"type": "string"},
-              "description": {"type": "string"},
-              "title": {"type": "string"}
+              "image_url": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           }
         },
-        "required": ["type", "recipients", "settings"],
+        "required": [
+          "type",
+          "recipients",
+          "settings"
+        ],
         "additionalProperties": false
       }
     },
@@ -328,7 +470,9 @@
             "description": "Campaign ID"
           }
         },
-        "required": ["campaign_id"],
+        "required": [
+          "campaign_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -355,13 +499,20 @@
           "batch_delivery": {
             "type": "object",
             "properties": {
-              "batch_delay": {"type": "number"},
-              "batch_count": {"type": "number"}
+              "batch_delay": {
+                "type": "number"
+              },
+              "batch_count": {
+                "type": "number"
+              }
             },
             "additionalProperties": false
           }
         },
-        "required": ["campaign_id", "schedule_time"],
+        "required": [
+          "campaign_id",
+          "schedule_time"
+        ],
         "additionalProperties": false
       }
     },
@@ -375,52 +526,109 @@
           "recipients": {
             "type": "object",
             "properties": {
-              "list_id": {"type": "string"},
-              "store_id": {"type": "string"}
+              "list_id": {
+                "type": "string"
+              },
+              "store_id": {
+                "type": "string"
+              }
             },
-            "required": ["list_id"],
+            "required": [
+              "list_id"
+            ],
             "additionalProperties": false
           },
           "settings": {
             "type": "object",
             "properties": {
-              "title": {"type": "string"},
-              "from_name": {"type": "string"},
-              "reply_to": {"type": "string", "format": "email"},
-              "use_conversation": {"type": "boolean"},
-              "to_name": {"type": "string"},
-              "authenticate": {"type": "boolean"},
-              "auto_footer": {"type": "boolean"},
-              "inline_css": {"type": "boolean"}
+              "title": {
+                "type": "string"
+              },
+              "from_name": {
+                "type": "string"
+              },
+              "reply_to": {
+                "type": "string",
+                "format": "email"
+              },
+              "use_conversation": {
+                "type": "boolean"
+              },
+              "to_name": {
+                "type": "string"
+              },
+              "authenticate": {
+                "type": "boolean"
+              },
+              "auto_footer": {
+                "type": "boolean"
+              },
+              "inline_css": {
+                "type": "boolean"
+              }
             },
-            "required": ["title", "from_name", "reply_to"],
+            "required": [
+              "title",
+              "from_name",
+              "reply_to"
+            ],
             "additionalProperties": false
           },
           "tracking": {
             "type": "object",
             "properties": {
-              "opens": {"type": "boolean", "default": true},
-              "html_clicks": {"type": "boolean", "default": true},
-              "text_clicks": {"type": "boolean", "default": false},
-              "goal_tracking": {"type": "boolean", "default": false},
-              "ecomm360": {"type": "boolean", "default": false},
-              "google_analytics": {"type": "string"},
-              "clicktale": {"type": "string"}
+              "opens": {
+                "type": "boolean",
+                "default": true
+              },
+              "html_clicks": {
+                "type": "boolean",
+                "default": true
+              },
+              "text_clicks": {
+                "type": "boolean",
+                "default": false
+              },
+              "goal_tracking": {
+                "type": "boolean",
+                "default": false
+              },
+              "ecomm360": {
+                "type": "boolean",
+                "default": false
+              },
+              "google_analytics": {
+                "type": "string"
+              },
+              "clicktale": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           },
           "trigger_settings": {
             "type": "object",
             "properties": {
-              "workflow_type": {"type": "string"},
-              "send_immediately": {"type": "boolean"},
-              "trigger_on_import": {"type": "boolean"},
-              "runtime": {"type": "object"}
+              "workflow_type": {
+                "type": "string"
+              },
+              "send_immediately": {
+                "type": "boolean"
+              },
+              "trigger_on_import": {
+                "type": "boolean"
+              },
+              "runtime": {
+                "type": "object"
+              }
             },
             "additionalProperties": false
           }
         },
-        "required": ["recipients", "settings"],
+        "required": [
+          "recipients",
+          "settings"
+        ],
         "additionalProperties": false
       }
     },
@@ -441,7 +649,10 @@
             "description": "Subscriber email address"
           }
         },
-        "required": ["workflow_id", "email_address"],
+        "required": [
+          "workflow_id",
+          "email_address"
+        ],
         "additionalProperties": false
       }
     },
@@ -458,16 +669,22 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to include"
           },
           "exclude_fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to exclude"
           }
         },
-        "required": ["campaign_id"],
+        "required": [
+          "campaign_id"
+        ],
         "additionalProperties": false
       }
     }
@@ -492,30 +709,72 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "fired_at": {"type": "string"},
+          "type": {
+            "type": "string"
+          },
+          "fired_at": {
+            "type": "string"
+          },
           "data": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"},
-              "email": {"type": "string"},
-              "email_type": {"type": "string"},
-              "status": {"type": "string"},
-              "merge_fields": {"type": "object"},
-              "interests": {"type": "object"},
-              "stats": {"type": "object"},
-              "ip_signup": {"type": "string"},
-              "timestamp_signup": {"type": "string"},
-              "ip_opt": {"type": "string"},
-              "timestamp_opt": {"type": "string"},
-              "member_rating": {"type": "number"},
-              "last_changed": {"type": "string"},
-              "language": {"type": "string"},
-              "vip": {"type": "boolean"},
-              "email_client": {"type": "string"},
-              "location": {"type": "object"},
-              "list_id": {"type": "string"},
-              "unique_email_id": {"type": "string"}
+              "id": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "email_type": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "merge_fields": {
+                "type": "object"
+              },
+              "interests": {
+                "type": "object"
+              },
+              "stats": {
+                "type": "object"
+              },
+              "ip_signup": {
+                "type": "string"
+              },
+              "timestamp_signup": {
+                "type": "string"
+              },
+              "ip_opt": {
+                "type": "string"
+              },
+              "timestamp_opt": {
+                "type": "string"
+              },
+              "member_rating": {
+                "type": "number"
+              },
+              "last_changed": {
+                "type": "string"
+              },
+              "language": {
+                "type": "string"
+              },
+              "vip": {
+                "type": "boolean"
+              },
+              "email_client": {
+                "type": "string"
+              },
+              "location": {
+                "type": "object"
+              },
+              "list_id": {
+                "type": "string"
+              },
+              "unique_email_id": {
+                "type": "string"
+              }
             }
           }
         }
@@ -540,9 +799,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "fired_at": {"type": "string"},
-          "data": {"type": "object"}
+          "type": {
+            "type": "string"
+          },
+          "fired_at": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
+          }
         }
       }
     },
@@ -565,37 +830,90 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "fired_at": {"type": "string"},
+          "type": {
+            "type": "string"
+          },
+          "fired_at": {
+            "type": "string"
+          },
           "data": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"},
-              "web_id": {"type": "number"},
-              "list_id": {"type": "string"},
-              "folder_id": {"type": "string"},
-              "template_id": {"type": "number"},
-              "content_type": {"type": "string"},
-              "title": {"type": "string"},
-              "type": {"type": "string"},
-              "create_time": {"type": "string"},
-              "archive_url": {"type": "string"},
-              "long_archive_url": {"type": "string"},
-              "status": {"type": "string"},
-              "emails_sent": {"type": "number"},
-              "send_time": {"type": "string"},
-              "content_type": {"type": "string"},
-              "needs_block_refresh": {"type": "boolean"},
-              "resendable": {"type": "boolean"},
-              "recipients": {"type": "object"},
-              "settings": {"type": "object"},
-              "variate_settings": {"type": "object"},
-              "tracking": {"type": "object"},
-              "rss_opts": {"type": "object"},
-              "ab_split_opts": {"type": "object"},
-              "social_card": {"type": "object"},
-              "report_summary": {"type": "object"},
-              "delivery_status": {"type": "object"}
+              "id": {
+                "type": "string"
+              },
+              "web_id": {
+                "type": "number"
+              },
+              "list_id": {
+                "type": "string"
+              },
+              "folder_id": {
+                "type": "string"
+              },
+              "template_id": {
+                "type": "number"
+              },
+              "content_type": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "create_time": {
+                "type": "string"
+              },
+              "archive_url": {
+                "type": "string"
+              },
+              "long_archive_url": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "emails_sent": {
+                "type": "number"
+              },
+              "send_time": {
+                "type": "string"
+              },
+              "needs_block_refresh": {
+                "type": "boolean"
+              },
+              "resendable": {
+                "type": "boolean"
+              },
+              "recipients": {
+                "type": "object"
+              },
+              "settings": {
+                "type": "object"
+              },
+              "variate_settings": {
+                "type": "object"
+              },
+              "tracking": {
+                "type": "object"
+              },
+              "rss_opts": {
+                "type": "object"
+              },
+              "ab_split_opts": {
+                "type": "object"
+              },
+              "social_card": {
+                "type": "object"
+              },
+              "report_summary": {
+                "type": "object"
+              },
+              "delivery_status": {
+                "type": "object"
+              }
             }
           }
         }
@@ -605,5 +923,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/ping"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/mailchimp/definition.json
+++ b/connectors/mailchimp/definition.json
@@ -74,7 +74,9 @@
             "description": "The unique ID for the list"
           }
         },
-        "required": ["listId"],
+        "required": [
+          "listId"
+        ],
         "additionalProperties": false
       }
     },
@@ -92,14 +94,30 @@
           "contact": {
             "type": "object",
             "properties": {
-              "company": {"type": "string"},
-              "address1": {"type": "string"},
-              "address2": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "zip": {"type": "string"},
-              "country": {"type": "string"},
-              "phone": {"type": "string"}
+              "company": {
+                "type": "string"
+              },
+              "address1": {
+                "type": "string"
+              },
+              "address2": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "zip": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              }
             },
             "description": "Contact information for the list"
           },
@@ -110,10 +128,19 @@
           "campaignDefaults": {
             "type": "object",
             "properties": {
-              "fromName": {"type": "string"},
-              "fromEmail": {"type": "string", "format": "email"},
-              "subject": {"type": "string"},
-              "language": {"type": "string"}
+              "fromName": {
+                "type": "string"
+              },
+              "fromEmail": {
+                "type": "string",
+                "format": "email"
+              },
+              "subject": {
+                "type": "string"
+              },
+              "language": {
+                "type": "string"
+              }
             },
             "description": "Default values for campaigns"
           },
@@ -132,11 +159,16 @@
             "description": "Email to notify when someone subscribes"
           },
           "notifyOnUnsubscribe": {
-            "type": "string", 
+            "type": "string",
             "description": "Email to notify when someone unsubscribes"
           }
         },
-        "required": ["name", "contact", "permissionReminder", "campaignDefaults"],
+        "required": [
+          "name",
+          "contact",
+          "permissionReminder",
+          "campaignDefaults"
+        ],
         "additionalProperties": false
       }
     },
@@ -158,7 +190,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["subscribed", "unsubscribed", "cleaned", "pending"],
+            "enum": [
+              "subscribed",
+              "unsubscribed",
+              "cleaned",
+              "pending"
+            ],
             "description": "Subscriber's current status"
           },
           "mergeFields": {
@@ -180,8 +217,12 @@
           "location": {
             "type": "object",
             "properties": {
-              "latitude": {"type": "number"},
-              "longitude": {"type": "number"}
+              "latitude": {
+                "type": "number"
+              },
+              "longitude": {
+                "type": "number"
+              }
             },
             "description": "Subscriber location information"
           },
@@ -204,7 +245,11 @@
             "description": "The date and time the subscriber confirmed"
           }
         },
-        "required": ["listId", "emailAddress", "status"],
+        "required": [
+          "listId",
+          "emailAddress",
+          "status"
+        ],
         "additionalProperties": false
       }
     },
@@ -224,7 +269,10 @@
             "description": "The MD5 hash of the lowercase version of the list member's email address"
           }
         },
-        "required": ["listId", "subscriberHash"],
+        "required": [
+          "listId",
+          "subscriberHash"
+        ],
         "additionalProperties": false
       }
     },
@@ -250,7 +298,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["subscribed", "unsubscribed", "cleaned", "pending"],
+            "enum": [
+              "subscribed",
+              "unsubscribed",
+              "cleaned",
+              "pending"
+            ],
             "description": "Subscriber's current status"
           },
           "mergeFields": {
@@ -272,13 +325,20 @@
           "location": {
             "type": "object",
             "properties": {
-              "latitude": {"type": "number"},
-              "longitude": {"type": "number"}
+              "latitude": {
+                "type": "number"
+              },
+              "longitude": {
+                "type": "number"
+              }
             },
             "description": "Subscriber location information"
           }
         },
-        "required": ["listId", "subscriberHash"],
+        "required": [
+          "listId",
+          "subscriberHash"
+        ],
         "additionalProperties": false
       }
     },
@@ -298,7 +358,10 @@
             "description": "The MD5 hash of the lowercase version of the list member's email address"
           }
         },
-        "required": ["listId", "subscriberHash"],
+        "required": [
+          "listId",
+          "subscriberHash"
+        ],
         "additionalProperties": false
       }
     },
@@ -328,7 +391,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["subscribed", "unsubscribed", "cleaned", "pending"],
+            "enum": [
+              "subscribed",
+              "unsubscribed",
+              "cleaned",
+              "pending"
+            ],
             "description": "Filter by subscriber status"
           },
           "sinceLastChanged": {
@@ -352,7 +420,9 @@
             "description": "Filter by opt-in time"
           }
         },
-        "required": ["listId"],
+        "required": [
+          "listId"
+        ],
         "additionalProperties": false
       }
     },
@@ -365,49 +435,106 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["regular", "plaintext", "absplit", "rss", "variate"],
+            "enum": [
+              "regular",
+              "plaintext",
+              "absplit",
+              "rss",
+              "variate"
+            ],
             "description": "The campaign type"
           },
           "recipients": {
             "type": "object",
             "properties": {
-              "listId": {"type": "string"},
-              "segmentOpts": {"type": "object"}
+              "listId": {
+                "type": "string"
+              },
+              "segmentOpts": {
+                "type": "object"
+              }
             },
             "description": "List settings for the campaign"
           },
           "settings": {
             "type": "object",
             "properties": {
-              "subjectLine": {"type": "string"},
-              "previewText": {"type": "string"},
-              "title": {"type": "string"},
-              "fromName": {"type": "string"},
-              "replyTo": {"type": "string", "format": "email"},
-              "useConversation": {"type": "boolean"},
-              "toName": {"type": "string"},
-              "folderId": {"type": "string"},
-              "authenticate": {"type": "boolean"},
-              "autoFooter": {"type": "boolean"},
-              "inlineCss": {"type": "boolean"},
-              "autoTweet": {"type": "boolean"},
-              "fbComments": {"type": "boolean"},
-              "timewarp": {"type": "boolean"},
-              "templateId": {"type": "number"},
-              "dragAndDrop": {"type": "boolean"}
+              "subjectLine": {
+                "type": "string"
+              },
+              "previewText": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "fromName": {
+                "type": "string"
+              },
+              "replyTo": {
+                "type": "string",
+                "format": "email"
+              },
+              "useConversation": {
+                "type": "boolean"
+              },
+              "toName": {
+                "type": "string"
+              },
+              "folderId": {
+                "type": "string"
+              },
+              "authenticate": {
+                "type": "boolean"
+              },
+              "autoFooter": {
+                "type": "boolean"
+              },
+              "inlineCss": {
+                "type": "boolean"
+              },
+              "autoTweet": {
+                "type": "boolean"
+              },
+              "fbComments": {
+                "type": "boolean"
+              },
+              "timewarp": {
+                "type": "boolean"
+              },
+              "templateId": {
+                "type": "number"
+              },
+              "dragAndDrop": {
+                "type": "boolean"
+              }
             },
             "description": "The settings for your campaign"
           },
           "tracking": {
             "type": "object",
             "properties": {
-              "opens": {"type": "boolean"},
-              "htmlClicks": {"type": "boolean"},
-              "textClicks": {"type": "boolean"},
-              "goalTracking": {"type": "boolean"},
-              "ecomm360": {"type": "boolean"},
-              "googleAnalytics": {"type": "string"},
-              "clicktale": {"type": "string"}
+              "opens": {
+                "type": "boolean"
+              },
+              "htmlClicks": {
+                "type": "boolean"
+              },
+              "textClicks": {
+                "type": "boolean"
+              },
+              "goalTracking": {
+                "type": "boolean"
+              },
+              "ecomm360": {
+                "type": "boolean"
+              },
+              "googleAnalytics": {
+                "type": "string"
+              },
+              "clicktale": {
+                "type": "string"
+              }
             },
             "description": "The tracking options for a campaign"
           },
@@ -420,7 +547,9 @@
             "description": "The preview for the campaign in social networks"
           }
         },
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "additionalProperties": false
       }
     },
@@ -446,12 +575,24 @@
           },
           "type": {
             "type": "string",
-            "enum": ["regular", "plaintext", "absplit", "rss", "variate"],
+            "enum": [
+              "regular",
+              "plaintext",
+              "absplit",
+              "rss",
+              "variate"
+            ],
             "description": "Filter by campaign type"
           },
           "status": {
             "type": "string",
-            "enum": ["save", "paused", "schedule", "sending", "sent"],
+            "enum": [
+              "save",
+              "paused",
+              "schedule",
+              "sending",
+              "sent"
+            ],
             "description": "Filter by campaign status"
           },
           "beforeSendTime": {
@@ -484,12 +625,18 @@
           },
           "sortField": {
             "type": "string",
-            "enum": ["create_time", "send_time"],
+            "enum": [
+              "create_time",
+              "send_time"
+            ],
             "description": "Field to sort by"
           },
           "sortDir": {
             "type": "string",
-            "enum": ["ASC", "DESC"],
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
             "description": "Sort direction"
           }
         },
@@ -509,7 +656,9 @@
             "description": "The unique ID for the campaign"
           }
         },
-        "required": ["campaignId"],
+        "required": [
+          "campaignId"
+        ],
         "additionalProperties": false
       }
     },
@@ -525,7 +674,9 @@
             "description": "The unique ID for the campaign"
           }
         },
-        "required": ["campaignId"],
+        "required": [
+          "campaignId"
+        ],
         "additionalProperties": false
       }
     },
@@ -551,8 +702,12 @@
           "template": {
             "type": "object",
             "properties": {
-              "id": {"type": "number"},
-              "sections": {"type": "object"}
+              "id": {
+                "type": "number"
+              },
+              "sections": {
+                "type": "object"
+              }
             },
             "description": "Content for the campaign using a template"
           },
@@ -565,7 +720,9 @@
             "description": "A URL to import content from"
           }
         },
-        "required": ["campaignId"],
+        "required": [
+          "campaignId"
+        ],
         "additionalProperties": false
       }
     }
@@ -590,12 +747,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "emailAddress": {"type": "string"},
-          "status": {"type": "string"},
-          "mergeFields": {"type": "object"},
-          "listId": {"type": "string"},
-          "timestampSignup": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "emailAddress": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "mergeFields": {
+            "type": "object"
+          },
+          "listId": {
+            "type": "string"
+          },
+          "timestampSignup": {
+            "type": "string"
+          }
         }
       }
     },
@@ -618,12 +787,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "emailAddress": {"type": "string"},
-          "status": {"type": "string"},
-          "mergeFields": {"type": "object"},
-          "listId": {"type": "string"},
-          "lastChanged": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "emailAddress": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "mergeFields": {
+            "type": "object"
+          },
+          "listId": {
+            "type": "string"
+          },
+          "lastChanged": {
+            "type": "string"
+          }
         }
       }
     },
@@ -646,11 +827,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "emailAddress": {"type": "string"},
-          "listId": {"type": "string"},
-          "reason": {"type": "string"},
-          "campaignId": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "emailAddress": {
+            "type": "string"
+          },
+          "listId": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "campaignId": {
+            "type": "string"
+          }
         }
       }
     },
@@ -673,14 +864,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "webId": {"type": "number"},
-          "type": {"type": "string"},
-          "createTime": {"type": "string"},
-          "archiveUrl": {"type": "string"},
-          "status": {"type": "string"},
-          "emailsSent": {"type": "number"},
-          "sendTime": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "webId": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string"
+          },
+          "archiveUrl": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "emailsSent": {
+            "type": "number"
+          },
+          "sendTime": {
+            "type": "string"
+          }
         }
       }
     }
@@ -688,5 +895,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/ping"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/mailgun/definition.json
+++ b/connectors/mailgun/definition.json
@@ -44,17 +44,23 @@
           },
           "to": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Email address(es) of the recipient(s)"
           },
           "cc": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Same as To but for CC"
           },
           "bcc": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Same as To but for BCC"
           },
           "subject": {
@@ -71,17 +77,23 @@
           },
           "attachment": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "File attachment URLs"
           },
           "inline": {
-            "type": "array", 
-            "items": {"type": "string"},
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
             "description": "Attachment with inline disposition"
           },
           "tag": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Tag string for tracking purposes"
           },
           "dkim": {
@@ -108,7 +120,7 @@
             "description": "Toggles clicks tracking on a per-message basis"
           },
           "tracking-opens": {
-            "type": "boolean", 
+            "type": "boolean",
             "description": "Toggles opens tracking on a per-message basis"
           },
           "require-tls": {
@@ -122,7 +134,11 @@
             "description": "Skip recipient verification"
           }
         },
-        "required": ["domain", "from", "to"],
+        "required": [
+          "domain",
+          "from",
+          "to"
+        ],
         "additionalProperties": false
       }
     },
@@ -138,7 +154,9 @@
             "description": "Domain name"
           }
         },
-        "required": ["domain"],
+        "required": [
+          "domain"
+        ],
         "additionalProperties": false
       }
     },
@@ -179,7 +197,9 @@
             "description": "Domain name to verify"
           }
         },
-        "required": ["domain"],
+        "required": [
+          "domain"
+        ],
         "additionalProperties": false
       }
     },
@@ -205,12 +225,18 @@
           },
           "access_level": {
             "type": "string",
-            "enum": ["readonly", "members", "everyone"],
+            "enum": [
+              "readonly",
+              "members",
+              "everyone"
+            ],
             "default": "readonly",
             "description": "List access level"
           }
         },
-        "required": ["address"],
+        "required": [
+          "address"
+        ],
         "additionalProperties": false
       }
     },
@@ -227,7 +253,9 @@
             "description": "Mailing list address"
           }
         },
-        "required": ["address"],
+        "required": [
+          "address"
+        ],
         "additionalProperties": false
       }
     },
@@ -292,7 +320,10 @@
             "description": "Update member if it already exists"
           }
         },
-        "required": ["listAddress", "address"],
+        "required": [
+          "listAddress",
+          "address"
+        ],
         "additionalProperties": false
       }
     },
@@ -314,7 +345,10 @@
             "description": "Member's email address"
           }
         },
-        "required": ["listAddress", "memberAddress"],
+        "required": [
+          "listAddress",
+          "memberAddress"
+        ],
         "additionalProperties": false
       }
     },
@@ -336,7 +370,9 @@
             "description": "Enable mailbox verification"
           }
         },
-        "required": ["address"],
+        "required": [
+          "address"
+        ],
         "additionalProperties": false
       }
     },
@@ -355,7 +391,16 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["accepted", "delivered", "failed", "opened", "clicked", "unsubscribed", "complained", "stored"]
+              "enum": [
+                "accepted",
+                "delivered",
+                "failed",
+                "opened",
+                "clicked",
+                "unsubscribed",
+                "complained",
+                "stored"
+              ]
             },
             "description": "Name of the event to receive the stats for"
           },
@@ -371,7 +416,11 @@
           },
           "resolution": {
             "type": "string",
-            "enum": ["hour", "day", "month"],
+            "enum": [
+              "hour",
+              "day",
+              "month"
+            ],
             "default": "day",
             "description": "Time resolution"
           },
@@ -380,7 +429,9 @@
             "description": "Duration like '1d', '1w', '1m'"
           }
         },
-        "required": ["domain"],
+        "required": [
+          "domain"
+        ],
         "additionalProperties": false
       }
     },
@@ -407,7 +458,10 @@
           },
           "ascending": {
             "type": "string",
-            "enum": ["yes", "no"],
+            "enum": [
+              "yes",
+              "no"
+            ],
             "default": "yes",
             "description": "Sort order"
           },
@@ -422,12 +476,24 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["accepted", "rejected", "delivered", "failed", "opened", "clicked", "unsubscribed", "complained", "stored"]
+              "enum": [
+                "accepted",
+                "rejected",
+                "delivered",
+                "failed",
+                "opened",
+                "clicked",
+                "unsubscribed",
+                "complained",
+                "stored"
+              ]
             },
             "description": "Event types to filter by"
           }
         },
-        "required": ["domain"],
+        "required": [
+          "domain"
+        ],
         "additionalProperties": false
       }
     }
@@ -452,13 +518,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
-          "recipient": {"type": "string"},
-          "domain": {"type": "string"},
-          "timestamp": {"type": "number"},
-          "token": {"type": "string"},
-          "signature": {"type": "string"},
-          "message-headers": {"type": "string"}
+          "event": {
+            "type": "string"
+          },
+          "recipient": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "token": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          },
+          "message-headers": {
+            "type": "string"
+          }
         }
       }
     },
@@ -481,17 +561,39 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
-          "recipient": {"type": "string"},
-          "domain": {"type": "string"},
-          "timestamp": {"type": "number"},
-          "token": {"type": "string"},
-          "signature": {"type": "string"},
-          "ip": {"type": "string"},
-          "country": {"type": "string"},
-          "region": {"type": "string"},
-          "city": {"type": "string"},
-          "user-agent": {"type": "string"}
+          "event": {
+            "type": "string"
+          },
+          "recipient": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "token": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          },
+          "ip": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "user-agent": {
+            "type": "string"
+          }
         }
       }
     },
@@ -514,18 +616,42 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
-          "recipient": {"type": "string"},
-          "domain": {"type": "string"},
-          "timestamp": {"type": "number"},
-          "token": {"type": "string"},
-          "signature": {"type": "string"},
-          "url": {"type": "string"},
-          "ip": {"type": "string"},
-          "country": {"type": "string"},
-          "region": {"type": "string"},
-          "city": {"type": "string"},
-          "user-agent": {"type": "string"}
+          "event": {
+            "type": "string"
+          },
+          "recipient": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "token": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "ip": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "user-agent": {
+            "type": "string"
+          }
         }
       }
     },
@@ -548,15 +674,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
-          "recipient": {"type": "string"},
-          "domain": {"type": "string"},
-          "timestamp": {"type": "number"},
-          "token": {"type": "string"},
-          "signature": {"type": "string"},
-          "code": {"type": "string"},
-          "error": {"type": "string"},
-          "notification": {"type": "string"}
+          "event": {
+            "type": "string"
+          },
+          "recipient": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "token": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          },
+          "notification": {
+            "type": "string"
+          }
         }
       }
     },
@@ -579,12 +723,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
-          "recipient": {"type": "string"},
-          "domain": {"type": "string"},
-          "timestamp": {"type": "number"},
-          "token": {"type": "string"},
-          "signature": {"type": "string"}
+          "event": {
+            "type": "string"
+          },
+          "recipient": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "token": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          }
         }
       }
     },
@@ -607,13 +763,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
-          "recipient": {"type": "string"},
-          "domain": {"type": "string"},
-          "timestamp": {"type": "number"},
-          "token": {"type": "string"},
-          "signature": {"type": "string"},
-          "tag": {"type": "string"}
+          "event": {
+            "type": "string"
+          },
+          "recipient": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "token": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
         }
       }
     }
@@ -621,5 +791,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/domains"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/marketo/definition.json
+++ b/connectors/marketo/definition.json
@@ -105,12 +105,19 @@
           },
           "action": {
             "type": "string",
-            "enum": ["createOnly", "updateOnly", "createOrUpdate", "createDuplicate"],
+            "enum": [
+              "createOnly",
+              "updateOnly",
+              "createOrUpdate",
+              "createDuplicate"
+            ],
             "default": "createOrUpdate",
             "description": "Action to take"
           }
         },
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "additionalProperties": false
       }
     },
@@ -127,11 +134,15 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of field names to return"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -144,17 +155,32 @@
         "properties": {
           "filterType": {
             "type": "string",
-            "enum": ["email", "cookie", "twitterId", "facebookId", "linkedInId", "sfdcAccountId", "sfdcContactId", "sfdcLeadId", "sfdcLeadOwnerId", "sfdcOpptyId"],
+            "enum": [
+              "email",
+              "cookie",
+              "twitterId",
+              "facebookId",
+              "linkedInId",
+              "sfdcAccountId",
+              "sfdcContactId",
+              "sfdcLeadId",
+              "sfdcLeadOwnerId",
+              "sfdcOpptyId"
+            ],
             "description": "Filter type"
           },
           "filterValues": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter values"
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of field names to return"
           },
           "batchSize": {
@@ -169,7 +195,10 @@
             "description": "Token for next page of results"
           }
         },
-        "required": ["filterType", "filterValues"],
+        "required": [
+          "filterType",
+          "filterValues"
+        ],
         "additionalProperties": false
       }
     },
@@ -218,7 +247,9 @@
             "description": "Lead score"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -234,7 +265,9 @@
             "description": "Lead ID to delete"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -251,11 +284,16 @@
           },
           "leadIds": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Array of lead IDs"
           }
         },
-        "required": ["listId", "leadIds"],
+        "required": [
+          "listId",
+          "leadIds"
+        ],
         "additionalProperties": false
       }
     },
@@ -272,11 +310,16 @@
           },
           "leadIds": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Array of lead IDs"
           }
         },
-        "required": ["listId", "leadIds"],
+        "required": [
+          "listId",
+          "leadIds"
+        ],
         "additionalProperties": false
       }
     },
@@ -301,7 +344,10 @@
           },
           "type": {
             "type": "string",
-            "enum": ["batch", "trigger"],
+            "enum": [
+              "batch",
+              "trigger"
+            ],
             "description": "Campaign type"
           },
           "isActive": {
@@ -310,7 +356,10 @@
             "description": "Whether campaign is active"
           }
         },
-        "required": ["name", "programId"],
+        "required": [
+          "name",
+          "programId"
+        ],
         "additionalProperties": false
       }
     },
@@ -361,7 +410,9 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "number"}
+                "id": {
+                  "type": "number"
+                }
               }
             },
             "description": "Array of lead objects"
@@ -371,14 +422,21 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {"type": "string"},
-                "value": {"type": "string"}
+                "name": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
               }
             },
             "description": "My tokens for the campaign"
           }
         },
-        "required": ["campaignId", "leads"],
+        "required": [
+          "campaignId",
+          "leads"
+        ],
         "additionalProperties": false
       }
     },
@@ -424,7 +482,10 @@
             "description": "Reply-to email address"
           }
         },
-        "required": ["name", "folderId"],
+        "required": [
+          "name",
+          "folderId"
+        ],
         "additionalProperties": false
       }
     },
@@ -437,7 +498,11 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["draft", "approved", "unapproved"],
+            "enum": [
+              "draft",
+              "approved",
+              "unapproved"
+            ],
             "description": "Filter by status"
           },
           "folderId": {
@@ -488,7 +553,10 @@
             "description": "Lead ID to use for personalization"
           }
         },
-        "required": ["emailId", "emailAddress"],
+        "required": [
+          "emailId",
+          "emailAddress"
+        ],
         "additionalProperties": false
       }
     },
@@ -501,7 +569,11 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["completed", "on", "off"],
+            "enum": [
+              "completed",
+              "on",
+              "off"
+            ],
             "description": "Filter by status"
           },
           "maxReturn": {
@@ -539,7 +611,16 @@
           },
           "type": {
             "type": "string",
-            "enum": ["Default", "Email", "Event", "Webinar", "Nurture", "Content", "Engagement", "Social"],
+            "enum": [
+              "Default",
+              "Email",
+              "Event",
+              "Webinar",
+              "Nurture",
+              "Content",
+              "Engagement",
+              "Social"
+            ],
             "description": "Program type"
           },
           "channel": {
@@ -555,15 +636,27 @@
             "items": {
               "type": "object",
               "properties": {
-                "startDate": {"type": "string", "format": "date"},
-                "cost": {"type": "number"},
-                "note": {"type": "string"}
+                "startDate": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "cost": {
+                  "type": "number"
+                },
+                "note": {
+                  "type": "string"
+                }
               }
             },
             "description": "Program costs"
           }
         },
-        "required": ["name", "type", "channel", "folderId"],
+        "required": [
+          "name",
+          "type",
+          "channel",
+          "folderId"
+        ],
         "additionalProperties": false
       }
     }
@@ -588,13 +681,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "email": {"type": "string"},
-          "firstName": {"type": "string"},
-          "lastName": {"type": "string"},
-          "company": {"type": "string"},
-          "createdAt": {"type": "string"},
-          "updatedAt": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "company": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
         }
       }
     },
@@ -617,12 +724,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "email": {"type": "string"},
-          "firstName": {"type": "string"},
-          "lastName": {"type": "string"},
-          "company": {"type": "string"},
-          "updatedAt": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "company": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
         }
       }
     },
@@ -645,13 +764,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "leadId": {"type": "number"},
-          "activityDate": {"type": "string"},
-          "activityTypeId": {"type": "number"},
-          "campaignId": {"type": "number"},
-          "primaryAttributeValue": {"type": "string"},
-          "primaryAttributeValueId": {"type": "number"},
-          "attributes": {"type": "array"}
+          "leadId": {
+            "type": "number"
+          },
+          "activityDate": {
+            "type": "string"
+          },
+          "activityTypeId": {
+            "type": "number"
+          },
+          "campaignId": {
+            "type": "number"
+          },
+          "primaryAttributeValue": {
+            "type": "string"
+          },
+          "primaryAttributeValueId": {
+            "type": "number"
+          },
+          "attributes": {
+            "type": "array"
+          }
         }
       }
     },
@@ -674,10 +807,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "leadId": {"type": "number"},
-          "emailId": {"type": "number"},
-          "campaignId": {"type": "number"},
-          "activityDate": {"type": "string"}
+          "leadId": {
+            "type": "number"
+          },
+          "emailId": {
+            "type": "number"
+          },
+          "campaignId": {
+            "type": "number"
+          },
+          "activityDate": {
+            "type": "string"
+          }
         }
       }
     },
@@ -700,14 +841,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "leadId": {"type": "number"},
-          "emailId": {"type": "number"},
-          "campaignId": {"type": "number"},
-          "activityDate": {"type": "string"},
-          "isPrimary": {"type": "boolean"},
-          "device": {"type": "string"},
-          "platform": {"type": "string"},
-          "userAgent": {"type": "string"}
+          "leadId": {
+            "type": "number"
+          },
+          "emailId": {
+            "type": "number"
+          },
+          "campaignId": {
+            "type": "number"
+          },
+          "activityDate": {
+            "type": "string"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "device": {
+            "type": "string"
+          },
+          "platform": {
+            "type": "string"
+          },
+          "userAgent": {
+            "type": "string"
+          }
         }
       }
     }
@@ -715,5 +872,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/identity/oauth/token?grant_type=client_credentials&client_id={client_id}&client_secret={client_secret}"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/microsoft-teams/definition.json
+++ b/connectors/microsoft-teams/definition.json
@@ -11,7 +11,11 @@
     "config": {
       "authUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-      "scopes": ["https://graph.microsoft.com/Team.ReadBasic.All", "https://graph.microsoft.com/Channel.ReadWrite.All", "https://graph.microsoft.com/ChatMessage.Send"]
+      "scopes": [
+        "https://graph.microsoft.com/Team.ReadBasic.All",
+        "https://graph.microsoft.com/Channel.ReadWrite.All",
+        "https://graph.microsoft.com/ChatMessage.Send"
+      ]
     }
   },
   "baseUrl": "https://graph.microsoft.com/v1.0",
@@ -53,28 +57,43 @@
           },
           "message_type": {
             "type": "string",
-            "enum": ["message", "systemEventMessage"],
+            "enum": [
+              "message",
+              "systemEventMessage"
+            ],
             "default": "message",
             "description": "Type of message"
           },
           "importance": {
             "type": "string",
-            "enum": ["normal", "high", "urgent"],
+            "enum": [
+              "normal",
+              "high",
+              "urgent"
+            ],
             "default": "normal",
             "description": "Message importance"
           },
           "attachments": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Message attachments"
           },
           "mentions": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "User mentions in the message"
           }
         },
-        "required": ["team_id", "channel_id", "message"],
+        "required": [
+          "team_id",
+          "channel_id",
+          "message"
+        ],
         "additionalProperties": false
       }
     },
@@ -95,18 +114,28 @@
           },
           "content_type": {
             "type": "string",
-            "enum": ["text", "html"],
+            "enum": [
+              "text",
+              "html"
+            ],
             "default": "text",
             "description": "Content type of the message"
           },
           "importance": {
             "type": "string",
-            "enum": ["normal", "high", "urgent"],
+            "enum": [
+              "normal",
+              "high",
+              "urgent"
+            ],
             "default": "normal",
             "description": "Message importance"
           }
         },
-        "required": ["chat_id", "message"],
+        "required": [
+          "chat_id",
+          "message"
+        ],
         "additionalProperties": false
       }
     },
@@ -127,7 +156,10 @@
           },
           "visibility": {
             "type": "string",
-            "enum": ["private", "public"],
+            "enum": [
+              "private",
+              "public"
+            ],
             "default": "private",
             "description": "Team visibility"
           },
@@ -140,14 +172,23 @@
             "items": {
               "type": "object",
               "properties": {
-                "user_id": {"type": "string"},
-                "roles": {"type": "array", "items": {"type": "string"}}
+                "user_id": {
+                  "type": "string"
+                },
+                "roles": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               }
             },
             "description": "Initial team members"
           }
         },
-        "required": ["display_name"],
+        "required": [
+          "display_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -172,12 +213,18 @@
           },
           "membership_type": {
             "type": "string",
-            "enum": ["standard", "private"],
+            "enum": [
+              "standard",
+              "private"
+            ],
             "default": "standard",
             "description": "Channel membership type"
           }
         },
-        "required": ["team_id", "display_name"],
+        "required": [
+          "team_id",
+          "display_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -225,7 +272,9 @@
             "description": "OData filter expression"
           }
         },
-        "required": ["team_id"],
+        "required": [
+          "team_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -246,12 +295,19 @@
           },
           "roles": {
             "type": "array",
-            "items": {"type": "string"},
-            "default": ["member"],
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "member"
+            ],
             "description": "Roles to assign to the user"
           }
         },
-        "required": ["team_id", "user_id"],
+        "required": [
+          "team_id",
+          "user_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -281,8 +337,16 @@
             "items": {
               "type": "object",
               "properties": {
-                "email": {"type": "string"},
-                "type": {"type": "string", "enum": ["required", "optional"]}
+                "email": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "required",
+                    "optional"
+                  ]
+                }
               }
             },
             "description": "Meeting attendees"
@@ -296,7 +360,11 @@
             "description": "Meeting body/description"
           }
         },
-        "required": ["subject", "start_time", "end_time"],
+        "required": [
+          "subject",
+          "start_time",
+          "end_time"
+        ],
         "additionalProperties": false
       }
     }
@@ -325,12 +393,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "messageType": {"type": "string"},
-          "createdDateTime": {"type": "string"},
-          "from": {"type": "object"},
-          "body": {"type": "object"},
-          "attachments": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "messageType": {
+            "type": "string"
+          },
+          "createdDateTime": {
+            "type": "string"
+          },
+          "from": {
+            "type": "object"
+          },
+          "body": {
+            "type": "object"
+          },
+          "attachments": {
+            "type": "array"
+          }
         }
       }
     },
@@ -348,10 +428,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "displayName": {"type": "string"},
-          "description": {"type": "string"},
-          "createdDateTime": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "createdDateTime": {
+            "type": "string"
+          }
         }
       }
     },
@@ -374,10 +462,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "userId": {"type": "string"},
-          "displayName": {"type": "string"},
-          "roles": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "roles": {
+            "type": "array"
+          }
         }
       }
     }
@@ -385,5 +481,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/microsoft-todo/definition.json
+++ b/connectors/microsoft-todo/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-      "scopes": ["https://graph.microsoft.com/Tasks.ReadWrite"]
+      "scopes": [
+        "https://graph.microsoft.com/Tasks.ReadWrite"
+      ]
     }
   },
   "baseUrl": "https://graph.microsoft.com/v1.0/me/todo",
@@ -70,7 +72,9 @@
             "description": "Task list name"
           }
         },
-        "required": ["displayName"],
+        "required": [
+          "displayName"
+        ],
         "additionalProperties": false
       }
     },
@@ -105,7 +109,9 @@
             "description": "OData order by expression"
           }
         },
-        "required": ["listId"],
+        "required": [
+          "listId"
+        ],
         "additionalProperties": false
       }
     },
@@ -127,40 +133,67 @@
           "body": {
             "type": "object",
             "properties": {
-              "content": {"type": "string"},
-              "contentType": {"type": "string", "enum": ["text", "html"]}
+              "content": {
+                "type": "string"
+              },
+              "contentType": {
+                "type": "string",
+                "enum": [
+                  "text",
+                  "html"
+                ]
+              }
             },
             "description": "Task body content"
           },
           "dueDateTime": {
             "type": "object",
             "properties": {
-              "dateTime": {"type": "string", "format": "date-time"},
-              "timeZone": {"type": "string"}
+              "dateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "timeZone": {
+                "type": "string"
+              }
             },
             "description": "Due date and time"
           },
           "reminderDateTime": {
             "type": "object",
             "properties": {
-              "dateTime": {"type": "string", "format": "date-time"},
-              "timeZone": {"type": "string"}
+              "dateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "timeZone": {
+                "type": "string"
+              }
             },
             "description": "Reminder date and time"
           },
           "importance": {
             "type": "string",
-            "enum": ["low", "normal", "high"],
+            "enum": [
+              "low",
+              "normal",
+              "high"
+            ],
             "default": "normal",
             "description": "Task importance"
           },
           "categories": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Task categories"
           }
         },
-        "required": ["listId", "title"],
+        "required": [
+          "listId",
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -186,31 +219,57 @@
           "body": {
             "type": "object",
             "properties": {
-              "content": {"type": "string"},
-              "contentType": {"type": "string", "enum": ["text", "html"]}
+              "content": {
+                "type": "string"
+              },
+              "contentType": {
+                "type": "string",
+                "enum": [
+                  "text",
+                  "html"
+                ]
+              }
             },
             "description": "Task body content"
           },
           "status": {
             "type": "string",
-            "enum": ["notStarted", "inProgress", "completed", "waitingOnOthers", "deferred"],
+            "enum": [
+              "notStarted",
+              "inProgress",
+              "completed",
+              "waitingOnOthers",
+              "deferred"
+            ],
             "description": "Task status"
           },
           "importance": {
             "type": "string",
-            "enum": ["low", "normal", "high"],
+            "enum": [
+              "low",
+              "normal",
+              "high"
+            ],
             "description": "Task importance"
           },
           "dueDateTime": {
             "type": "object",
             "properties": {
-              "dateTime": {"type": "string", "format": "date-time"},
-              "timeZone": {"type": "string"}
+              "dateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "timeZone": {
+                "type": "string"
+              }
             },
             "description": "Due date and time"
           }
         },
-        "required": ["listId", "taskId"],
+        "required": [
+          "listId",
+          "taskId"
+        ],
         "additionalProperties": false
       }
     },
@@ -230,7 +289,10 @@
             "description": "Task ID"
           }
         },
-        "required": ["listId", "taskId"],
+        "required": [
+          "listId",
+          "taskId"
+        ],
         "additionalProperties": false
       }
     },
@@ -250,7 +312,10 @@
             "description": "Task ID"
           }
         },
-        "required": ["listId", "taskId"],
+        "required": [
+          "listId",
+          "taskId"
+        ],
         "additionalProperties": false
       }
     }
@@ -275,11 +340,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "status": {"type": "string"},
-          "importance": {"type": "string"},
-          "createdDateTime": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "importance": {
+            "type": "string"
+          },
+          "createdDateTime": {
+            "type": "string"
+          }
         }
       }
     },
@@ -302,9 +377,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "completedDateTime": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "completedDateTime": {
+            "type": "string"
+          }
         }
       }
     }
@@ -312,5 +393,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/lists"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/miro/definition.json
+++ b/connectors/miro/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://miro.com/oauth/authorize",
       "tokenUrl": "https://api.miro.com/v1/oauth/token",
-      "scopes": ["boards:read", "boards:write"]
+      "scopes": [
+        "boards:read",
+        "boards:write"
+      ]
     }
   },
   "baseUrl": "https://api.miro.com/v2",
@@ -66,7 +69,9 @@
             "description": "Board ID"
           }
         },
-        "required": ["boardId"],
+        "required": [
+          "boardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -97,15 +102,27 @@
                 "properties": {
                   "collaborationToolsStartAccess": {
                     "type": "string",
-                    "enum": ["all_editors", "board_owners_and_coowners"]
+                    "enum": [
+                      "all_editors",
+                      "board_owners_and_coowners"
+                    ]
                   },
                   "copyAccess": {
                     "type": "string",
-                    "enum": ["anyone", "team_members", "team_editors", "board_owners_and_coowners"]
+                    "enum": [
+                      "anyone",
+                      "team_members",
+                      "team_editors",
+                      "board_owners_and_coowners"
+                    ]
                   },
                   "sharingAccess": {
                     "type": "string",
-                    "enum": ["team_members", "team_editors", "board_owners_and_coowners"]
+                    "enum": [
+                      "team_members",
+                      "team_editors",
+                      "board_owners_and_coowners"
+                    ]
                   }
                 }
               },
@@ -114,20 +131,40 @@
                 "properties": {
                   "access": {
                     "type": "string",
-                    "enum": ["private", "view", "comment", "edit"],
+                    "enum": [
+                      "private",
+                      "view",
+                      "comment",
+                      "edit"
+                    ],
                     "default": "private"
                   },
                   "inviteToAccountAndBoardLinkAccess": {
                     "type": "string",
-                    "enum": ["no_access", "view", "comment", "edit"]
+                    "enum": [
+                      "no_access",
+                      "view",
+                      "comment",
+                      "edit"
+                    ]
                   },
                   "organizationAccess": {
                     "type": "string",
-                    "enum": ["no_access", "view", "comment", "edit"]
+                    "enum": [
+                      "no_access",
+                      "view",
+                      "comment",
+                      "edit"
+                    ]
                   },
                   "teamAccess": {
                     "type": "string",
-                    "enum": ["no_access", "view", "comment", "edit"]
+                    "enum": [
+                      "no_access",
+                      "view",
+                      "comment",
+                      "edit"
+                    ]
                   }
                 }
               }
@@ -135,7 +172,9 @@
             "description": "Board policy settings"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -159,7 +198,9 @@
             "description": "Board description"
           }
         },
-        "required": ["boardId"],
+        "required": [
+          "boardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -175,7 +216,9 @@
             "description": "Board ID"
           }
         },
-        "required": ["boardId"],
+        "required": [
+          "boardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -192,7 +235,19 @@
           },
           "type": {
             "type": "string",
-            "enum": ["app_card", "card", "connector", "document", "embed", "frame", "image", "mindmap", "shape", "sticky_note", "text"],
+            "enum": [
+              "app_card",
+              "card",
+              "connector",
+              "document",
+              "embed",
+              "frame",
+              "image",
+              "mindmap",
+              "shape",
+              "sticky_note",
+              "text"
+            ],
             "description": "Filter by item type"
           },
           "cursor": {
@@ -207,7 +262,9 @@
             "description": "Number of items to return"
           }
         },
-        "required": ["boardId"],
+        "required": [
+          "boardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -231,15 +288,42 @@
             "properties": {
               "fillColor": {
                 "type": "string",
-                "enum": ["yellow", "light_yellow", "orange", "light_orange", "light_green", "green", "dark_green", "cyan", "light_pink", "pink", "violet", "red", "light_blue", "blue", "dark_blue", "gray", "light_gray", "black"]
+                "enum": [
+                  "yellow",
+                  "light_yellow",
+                  "orange",
+                  "light_orange",
+                  "light_green",
+                  "green",
+                  "dark_green",
+                  "cyan",
+                  "light_pink",
+                  "pink",
+                  "violet",
+                  "red",
+                  "light_blue",
+                  "blue",
+                  "dark_blue",
+                  "gray",
+                  "light_gray",
+                  "black"
+                ]
               },
               "textAlign": {
                 "type": "string",
-                "enum": ["left", "center", "right"]
+                "enum": [
+                  "left",
+                  "center",
+                  "right"
+                ]
               },
               "textAlignVertical": {
                 "type": "string",
-                "enum": ["top", "middle", "bottom"]
+                "enum": [
+                  "top",
+                  "middle",
+                  "bottom"
+                ]
               }
             },
             "description": "Note styling"
@@ -247,26 +331,39 @@
           "geometry": {
             "type": "object",
             "properties": {
-              "width": {"type": "number"},
-              "height": {"type": "number"}
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              }
             },
             "description": "Note dimensions"
           },
           "position": {
             "type": "object",
             "properties": {
-              "x": {"type": "number"},
-              "y": {"type": "number"},
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
               "origin": {
                 "type": "string",
-                "enum": ["center"],
+                "enum": [
+                  "center"
+                ],
                 "default": "center"
               }
             },
             "description": "Note position on board"
           }
         },
-        "required": ["boardId", "content"],
+        "required": [
+          "boardId",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -294,7 +391,18 @@
             "properties": {
               "cardTheme": {
                 "type": "string",
-                "enum": ["#2d7ff9", "#18a0fb", "#0ca789", "#8fd14f", "#fac710", "#f24726", "#da3782", "#9510ac", "#c1c1c1", "#767676"]
+                "enum": [
+                  "#2d7ff9",
+                  "#18a0fb",
+                  "#0ca789",
+                  "#8fd14f",
+                  "#fac710",
+                  "#f24726",
+                  "#da3782",
+                  "#9510ac",
+                  "#c1c1c1",
+                  "#767676"
+                ]
               }
             },
             "description": "Card styling"
@@ -302,26 +410,38 @@
           "geometry": {
             "type": "object",
             "properties": {
-              "width": {"type": "number"},
-              "height": {"type": "number"}
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              }
             },
             "description": "Card dimensions"
           },
           "position": {
             "type": "object",
             "properties": {
-              "x": {"type": "number"},
-              "y": {"type": "number"},
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
               "origin": {
                 "type": "string",
-                "enum": ["center"],
+                "enum": [
+                  "center"
+                ],
                 "default": "center"
               }
             },
             "description": "Card position on board"
           }
         },
-        "required": ["boardId"],
+        "required": [
+          "boardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -353,7 +473,12 @@
               },
               "fontFamily": {
                 "type": "string",
-                "enum": ["arial", "cursive", "impact", "times_new_roman"]
+                "enum": [
+                  "arial",
+                  "cursive",
+                  "impact",
+                  "times_new_roman"
+                ]
               },
               "fontSize": {
                 "type": "number",
@@ -362,7 +487,11 @@
               },
               "textAlign": {
                 "type": "string",
-                "enum": ["left", "center", "right"]
+                "enum": [
+                  "left",
+                  "center",
+                  "right"
+                ]
               }
             },
             "description": "Text styling"
@@ -370,26 +499,39 @@
           "geometry": {
             "type": "object",
             "properties": {
-              "width": {"type": "number"},
-              "height": {"type": "number"}
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              }
             },
             "description": "Text dimensions"
           },
           "position": {
             "type": "object",
             "properties": {
-              "x": {"type": "number"},
-              "y": {"type": "number"},
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
               "origin": {
                 "type": "string",
-                "enum": ["center"],
+                "enum": [
+                  "center"
+                ],
                 "default": "center"
               }
             },
             "description": "Text position on board"
           }
         },
-        "required": ["boardId", "content"],
+        "required": [
+          "boardId",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -410,32 +552,80 @@
           },
           "shape": {
             "type": "string",
-            "enum": ["rectangle", "round_rectangle", "circle", "triangle", "rhombus", "parallelogram", "trapezoid", "pentagon", "hexagon", "octagon", "wedge_round_rectangle_callout", "star", "flow_chart_predefined_process", "cloud", "cross", "can", "right_arrow", "left_arrow", "left_right_arrow", "left_right_up_arrow"],
+            "enum": [
+              "rectangle",
+              "round_rectangle",
+              "circle",
+              "triangle",
+              "rhombus",
+              "parallelogram",
+              "trapezoid",
+              "pentagon",
+              "hexagon",
+              "octagon",
+              "wedge_round_rectangle_callout",
+              "star",
+              "flow_chart_predefined_process",
+              "cloud",
+              "cross",
+              "can",
+              "right_arrow",
+              "left_arrow",
+              "left_right_arrow",
+              "left_right_up_arrow"
+            ],
             "description": "Shape type"
           },
           "style": {
             "type": "object",
             "properties": {
-              "color": {"type": "string"},
-              "fillColor": {"type": "string"},
+              "color": {
+                "type": "string"
+              },
+              "fillColor": {
+                "type": "string"
+              },
               "fontFamily": {
                 "type": "string",
-                "enum": ["arial", "cursive", "impact", "times_new_roman"]
+                "enum": [
+                  "arial",
+                  "cursive",
+                  "impact",
+                  "times_new_roman"
+                ]
               },
-              "fontSize": {"type": "number"},
+              "fontSize": {
+                "type": "number"
+              },
               "textAlign": {
                 "type": "string",
-                "enum": ["left", "center", "right"]
+                "enum": [
+                  "left",
+                  "center",
+                  "right"
+                ]
               },
               "textAlignVertical": {
                 "type": "string",
-                "enum": ["top", "middle", "bottom"]
+                "enum": [
+                  "top",
+                  "middle",
+                  "bottom"
+                ]
               },
-              "borderColor": {"type": "string"},
-              "borderWidth": {"type": "number"},
+              "borderColor": {
+                "type": "string"
+              },
+              "borderWidth": {
+                "type": "number"
+              },
               "borderStyle": {
                 "type": "string",
-                "enum": ["normal", "dotted", "dashed"]
+                "enum": [
+                  "normal",
+                  "dotted",
+                  "dashed"
+                ]
               }
             },
             "description": "Shape styling"
@@ -443,26 +633,39 @@
           "geometry": {
             "type": "object",
             "properties": {
-              "width": {"type": "number"},
-              "height": {"type": "number"}
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              }
             },
             "description": "Shape dimensions"
           },
           "position": {
             "type": "object",
             "properties": {
-              "x": {"type": "number"},
-              "y": {"type": "number"},
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
               "origin": {
                 "type": "string",
-                "enum": ["center"],
+                "enum": [
+                  "center"
+                ],
                 "default": "center"
               }
             },
             "description": "Shape position on board"
           }
         },
-        "required": ["boardId", "shape"],
+        "required": [
+          "boardId",
+          "shape"
+        ],
         "additionalProperties": false
       }
     },
@@ -492,21 +695,32 @@
           "geometry": {
             "type": "object",
             "properties": {
-              "width": {"type": "number"},
-              "height": {"type": "number"}
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              }
             },
             "description": "Updated dimensions"
           },
           "position": {
             "type": "object",
             "properties": {
-              "x": {"type": "number"},
-              "y": {"type": "number"}
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              }
             },
             "description": "Updated position"
           }
         },
-        "required": ["boardId", "itemId"],
+        "required": [
+          "boardId",
+          "itemId"
+        ],
         "additionalProperties": false
       }
     },
@@ -526,7 +740,10 @@
             "description": "Item ID"
           }
         },
-        "required": ["boardId", "itemId"],
+        "required": [
+          "boardId",
+          "itemId"
+        ],
         "additionalProperties": false
       }
     },
@@ -553,7 +770,9 @@
             "description": "Number of members to return"
           }
         },
-        "required": ["boardId"],
+        "required": [
+          "boardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -570,12 +789,20 @@
           },
           "emails": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "Email addresses to share with"
           },
           "role": {
             "type": "string",
-            "enum": ["viewer", "commenter", "editor", "co_owner"],
+            "enum": [
+              "viewer",
+              "commenter",
+              "editor",
+              "co_owner"
+            ],
             "default": "editor",
             "description": "Access role"
           },
@@ -584,7 +811,10 @@
             "description": "Optional message"
           }
         },
-        "required": ["boardId", "emails"],
+        "required": [
+          "boardId",
+          "emails"
+        ],
         "additionalProperties": false
       }
     }
@@ -609,12 +839,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "teamId": {"type": "string"},
-          "createdAt": {"type": "string"},
-          "createdBy": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "teamId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "createdBy": {
+            "type": "object"
+          }
         }
       }
     },
@@ -637,11 +879,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "modifiedAt": {"type": "string"},
-          "modifiedBy": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "modifiedAt": {
+            "type": "string"
+          },
+          "modifiedBy": {
+            "type": "object"
+          }
         }
       }
     },
@@ -659,7 +911,12 @@
           },
           "itemType": {
             "type": "string",
-            "enum": ["sticky_note", "card", "text", "shape"],
+            "enum": [
+              "sticky_note",
+              "card",
+              "text",
+              "shape"
+            ],
             "description": "Filter by item type"
           }
         },
@@ -669,12 +926,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "type": {"type": "string"},
-          "boardId": {"type": "string"},
-          "content": {"type": "string"},
-          "createdAt": {"type": "string"},
-          "createdBy": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "boardId": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "createdBy": {
+            "type": "object"
+          }
         }
       }
     },
@@ -692,7 +961,12 @@
           },
           "itemType": {
             "type": "string",
-            "enum": ["sticky_note", "card", "text", "shape"],
+            "enum": [
+              "sticky_note",
+              "card",
+              "text",
+              "shape"
+            ],
             "description": "Filter by item type"
           }
         },
@@ -702,12 +976,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "type": {"type": "string"},
-          "boardId": {"type": "string"},
-          "content": {"type": "string"},
-          "modifiedAt": {"type": "string"},
-          "modifiedBy": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "boardId": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "modifiedAt": {
+            "type": "string"
+          },
+          "modifiedBy": {
+            "type": "object"
+          }
         }
       }
     }
@@ -715,5 +1001,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/boards"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/mixpanel/definition.json
+++ b/connectors/mixpanel/definition.json
@@ -63,7 +63,10 @@
             "description": "Library name"
           }
         },
-        "required": ["event", "properties"],
+        "required": [
+          "event",
+          "properties"
+        ],
         "additionalProperties": false
       }
     },
@@ -101,7 +104,10 @@
             "description": "If true, Mixpanel will not alias the distinct_id"
           }
         },
-        "required": ["distinct_id", "properties"],
+        "required": [
+          "distinct_id",
+          "properties"
+        ],
         "additionalProperties": false
       }
     },
@@ -129,7 +135,10 @@
             "description": "Unix timestamp"
           }
         },
-        "required": ["distinct_id", "properties"],
+        "required": [
+          "distinct_id",
+          "properties"
+        ],
         "additionalProperties": false
       }
     },
@@ -157,7 +166,10 @@
             "description": "Unix timestamp"
           }
         },
-        "required": ["distinct_id", "properties"],
+        "required": [
+          "distinct_id",
+          "properties"
+        ],
         "additionalProperties": false
       }
     },
@@ -185,7 +197,10 @@
             "description": "Unix timestamp"
           }
         },
-        "required": ["distinct_id", "properties"],
+        "required": [
+          "distinct_id",
+          "properties"
+        ],
         "additionalProperties": false
       }
     },
@@ -213,7 +228,10 @@
             "description": "Unix timestamp"
           }
         },
-        "required": ["distinct_id", "properties"],
+        "required": [
+          "distinct_id",
+          "properties"
+        ],
         "additionalProperties": false
       }
     },
@@ -241,7 +259,10 @@
             "description": "Unix timestamp"
           }
         },
-        "required": ["distinct_id", "properties"],
+        "required": [
+          "distinct_id",
+          "properties"
+        ],
         "additionalProperties": false
       }
     },
@@ -258,7 +279,9 @@
           },
           "properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of property names to remove"
           },
           "ip": {
@@ -270,7 +293,10 @@
             "description": "Unix timestamp"
           }
         },
-        "required": ["distinct_id", "properties"],
+        "required": [
+          "distinct_id",
+          "properties"
+        ],
         "additionalProperties": false
       }
     },
@@ -294,7 +320,9 @@
             "description": "Unix timestamp"
           }
         },
-        "required": ["distinct_id"],
+        "required": [
+          "distinct_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -322,7 +350,10 @@
             "description": "Unix timestamp"
           }
         },
-        "required": ["distinct_id", "alias"],
+        "required": [
+          "distinct_id",
+          "alias"
+        ],
         "additionalProperties": false
       }
     },
@@ -338,10 +369,17 @@
             "items": {
               "type": "object",
               "properties": {
-                "event": {"type": "string"},
-                "properties": {"type": "object"}
+                "event": {
+                  "type": "string"
+                },
+                "properties": {
+                  "type": "object"
+                }
               },
-              "required": ["event", "properties"]
+              "required": [
+                "event",
+                "properties"
+              ]
             },
             "description": "Array of events to import"
           },
@@ -351,7 +389,9 @@
             "description": "If true, import will fail if any event is invalid"
           }
         },
-        "required": ["events"],
+        "required": [
+          "events"
+        ],
         "additionalProperties": false
       }
     },
@@ -374,7 +414,9 @@
           },
           "event": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of event names to export"
           },
           "where": {
@@ -386,7 +428,10 @@
             "description": "Data bucket"
           }
         },
-        "required": ["from_date", "to_date"],
+        "required": [
+          "from_date",
+          "to_date"
+        ],
         "additionalProperties": false
       }
     },
@@ -399,18 +444,30 @@
         "properties": {
           "event": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of event names to query"
           },
           "type": {
             "type": "string",
-            "enum": ["general", "unique", "average"],
+            "enum": [
+              "general",
+              "unique",
+              "average"
+            ],
             "default": "general",
             "description": "Query type"
           },
           "unit": {
             "type": "string",
-            "enum": ["minute", "hour", "day", "week", "month"],
+            "enum": [
+              "minute",
+              "hour",
+              "day",
+              "week",
+              "month"
+            ],
             "default": "day",
             "description": "Time unit"
           },
@@ -446,7 +503,9 @@
             "description": "Limit number of results"
           }
         },
-        "required": ["event"],
+        "required": [
+          "event"
+        ],
         "additionalProperties": false
       }
     },
@@ -459,12 +518,20 @@
         "properties": {
           "events": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of event names for the funnel steps"
           },
           "unit": {
             "type": "string",
-            "enum": ["minute", "hour", "day", "week", "month"],
+            "enum": [
+              "minute",
+              "hour",
+              "day",
+              "week",
+              "month"
+            ],
             "default": "day",
             "description": "Time unit"
           },
@@ -500,7 +567,9 @@
             "description": "Limit number of results"
           }
         },
-        "required": ["events"],
+        "required": [
+          "events"
+        ],
         "additionalProperties": false
       }
     },
@@ -521,7 +590,11 @@
           },
           "unit": {
             "type": "string",
-            "enum": ["day", "week", "month"],
+            "enum": [
+              "day",
+              "week",
+              "month"
+            ],
             "default": "day",
             "description": "Time unit"
           },
@@ -551,7 +624,9 @@
             "description": "Expression to filter birth events"
           }
         },
-        "required": ["born_event"],
+        "required": [
+          "born_event"
+        ],
         "additionalProperties": false
       }
     }
@@ -580,11 +655,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
-          "distinct_id": {"type": "string"},
-          "properties": {"type": "object"},
-          "time": {"type": "number"},
-          "mp_lib": {"type": "string"}
+          "event": {
+            "type": "string"
+          },
+          "distinct_id": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object"
+          },
+          "time": {
+            "type": "number"
+          },
+          "mp_lib": {
+            "type": "string"
+          }
         }
       }
     },
@@ -607,10 +692,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "distinct_id": {"type": "string"},
-          "operation": {"type": "string"},
-          "properties": {"type": "object"},
-          "time": {"type": "number"}
+          "distinct_id": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object"
+          },
+          "time": {
+            "type": "number"
+          }
         }
       }
     },
@@ -633,11 +726,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "distinct_id": {"type": "string"},
-          "funnel_id": {"type": "string"},
-          "steps": {"type": "array"},
-          "completion_time": {"type": "number"},
-          "time_to_complete": {"type": "number"}
+          "distinct_id": {
+            "type": "string"
+          },
+          "funnel_id": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array"
+          },
+          "completion_time": {
+            "type": "number"
+          },
+          "time_to_complete": {
+            "type": "number"
+          }
         }
       }
     },
@@ -660,10 +763,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "distinct_id": {"type": "string"},
-          "cohort_id": {"type": "string"},
-          "cohort_name": {"type": "string"},
-          "entered_at": {"type": "number"}
+          "distinct_id": {
+            "type": "string"
+          },
+          "cohort_id": {
+            "type": "string"
+          },
+          "cohort_name": {
+            "type": "string"
+          },
+          "entered_at": {
+            "type": "number"
+          }
         }
       }
     }
@@ -671,5 +782,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/2.0/engage"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/monday-enhanced/definition.json
+++ b/connectors/monday-enhanced/definition.json
@@ -49,17 +49,27 @@
           },
           "ids": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Specific board IDs to retrieve"
           },
           "board_kind": {
             "type": "string",
-            "enum": ["public", "private", "share"],
+            "enum": [
+              "public",
+              "private",
+              "share"
+            ],
             "description": "Filter by board kind"
           },
           "state": {
             "type": "string",
-            "enum": ["active", "archived", "deleted"],
+            "enum": [
+              "active",
+              "archived",
+              "deleted"
+            ],
             "default": "active",
             "description": "Filter by board state"
           }
@@ -81,7 +91,11 @@
           },
           "board_kind": {
             "type": "string",
-            "enum": ["public", "private", "share"],
+            "enum": [
+              "public",
+              "private",
+              "share"
+            ],
             "default": "public",
             "description": "Board visibility"
           },
@@ -102,7 +116,9 @@
             "description": "Template ID to create board from"
           }
         },
-        "required": ["board_name"],
+        "required": [
+          "board_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -132,7 +148,9 @@
           },
           "ids": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Specific item IDs to retrieve"
           },
           "newest_first": {
@@ -141,7 +159,9 @@
             "description": "Sort by newest first"
           }
         },
-        "required": ["board_id"],
+        "required": [
+          "board_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -174,7 +194,10 @@
             "description": "Create status labels if they don't exist"
           }
         },
-        "required": ["board_id", "item_name"],
+        "required": [
+          "board_id",
+          "item_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -203,7 +226,11 @@
             "description": "Create status labels if they don't exist"
           }
         },
-        "required": ["board_id", "item_id", "column_values"],
+        "required": [
+          "board_id",
+          "item_id",
+          "column_values"
+        ],
         "additionalProperties": false
       }
     },
@@ -219,7 +246,9 @@
             "description": "Item ID"
           }
         },
-        "required": ["item_id"],
+        "required": [
+          "item_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -239,7 +268,10 @@
             "description": "Update content"
           }
         },
-        "required": ["item_id", "body"],
+        "required": [
+          "item_id",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -265,12 +297,19 @@
           },
           "ids": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Specific user IDs to retrieve"
           },
           "kind": {
             "type": "string",
-            "enum": ["all", "non_guests", "guests", "non_pending"],
+            "enum": [
+              "all",
+              "non_guests",
+              "guests",
+              "non_pending"
+            ],
             "default": "all",
             "description": "Filter by user kind"
           },
@@ -306,18 +345,27 @@
           },
           "ids": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Specific workspace IDs to retrieve"
           },
           "state": {
             "type": "string",
-            "enum": ["active", "archived", "deleted"],
+            "enum": [
+              "active",
+              "archived",
+              "deleted"
+            ],
             "default": "active",
             "description": "Filter by workspace state"
           },
           "kind": {
             "type": "string",
-            "enum": ["open", "closed"],
+            "enum": [
+              "open",
+              "closed"
+            ],
             "description": "Filter by workspace kind"
           }
         },
@@ -343,7 +391,14 @@
           },
           "event": {
             "type": "string",
-            "enum": ["create_item", "change_column_value", "change_status_column_value", "change_name", "create_update", "edit_update"],
+            "enum": [
+              "create_item",
+              "change_column_value",
+              "change_status_column_value",
+              "change_name",
+              "create_update",
+              "edit_update"
+            ],
             "description": "Event to subscribe to"
           },
           "config": {
@@ -351,7 +406,11 @@
             "description": "JSON configuration string"
           }
         },
-        "required": ["board_id", "url", "event"],
+        "required": [
+          "board_id",
+          "url",
+          "event"
+        ],
         "additionalProperties": false
       }
     },
@@ -371,7 +430,9 @@
             "description": "GraphQL variables"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     }
@@ -396,13 +457,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "name": {"type": "string"},
-          "board": {"type": "object"},
-          "group": {"type": "object"},
-          "column_values": {"type": "array"},
-          "created_at": {"type": "string"},
-          "creator": {"type": "object"}
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "board": {
+            "type": "object"
+          },
+          "group": {
+            "type": "object"
+          },
+          "column_values": {
+            "type": "array"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "creator": {
+            "type": "object"
+          }
         }
       }
     },
@@ -429,13 +504,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "item_id": {"type": "number"},
-          "item_name": {"type": "string"},
-          "column_id": {"type": "string"},
-          "column_title": {"type": "string"},
-          "previous_value": {"type": "object"},
-          "value": {"type": "object"},
-          "changed_at": {"type": "string"}
+          "item_id": {
+            "type": "number"
+          },
+          "item_name": {
+            "type": "string"
+          },
+          "column_id": {
+            "type": "string"
+          },
+          "column_title": {
+            "type": "string"
+          },
+          "previous_value": {
+            "type": "object"
+          },
+          "value": {
+            "type": "object"
+          },
+          "changed_at": {
+            "type": "string"
+          }
         }
       }
     }
@@ -446,5 +535,19 @@
     "body": {
       "query": "query { me { id name email } }"
     }
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/monday/definition.json
+++ b/connectors/monday/definition.json
@@ -56,7 +56,10 @@
             "description": "Create labels if they don't exist"
           }
         },
-        "required": ["board_id", "item_name"],
+        "required": [
+          "board_id",
+          "item_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -81,7 +84,9 @@
             "description": "Create labels if they don't exist"
           }
         },
-        "required": ["item_id"],
+        "required": [
+          "item_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -120,7 +125,9 @@
             "description": "Exclude non-active items"
           }
         },
-        "required": ["board_id"],
+        "required": [
+          "board_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -137,7 +144,11 @@
           },
           "board_kind": {
             "type": "string",
-            "enum": ["public", "private", "share"],
+            "enum": [
+              "public",
+              "private",
+              "share"
+            ],
             "default": "public",
             "description": "Board visibility"
           },
@@ -158,7 +169,9 @@
             "description": "Board description"
           }
         },
-        "required": ["board_name"],
+        "required": [
+          "board_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -171,7 +184,9 @@
         "properties": {
           "workspace_ids": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Workspace IDs to filter by"
           },
           "limit": {
@@ -189,7 +204,10 @@
           },
           "order_by": {
             "type": "string",
-            "enum": ["created_at", "used_at"],
+            "enum": [
+              "created_at",
+              "used_at"
+            ],
             "description": "Order by field"
           }
         },
@@ -214,7 +232,27 @@
           },
           "group_color": {
             "type": "string",
-            "enum": ["#037f4c", "#00c875", "#9cd326", "#cab641", "#ffcb00", "#784bd1", "#a25ddc", "#0086c0", "#579bfc", "#66ccff", "#bb3354", "#e2445c", "#ff158a", "#ff5ac4", "#ff642e", "#fdab3d", "#7f5347", "#c4c4c4", "#808080"],
+            "enum": [
+              "#037f4c",
+              "#00c875",
+              "#9cd326",
+              "#cab641",
+              "#ffcb00",
+              "#784bd1",
+              "#a25ddc",
+              "#0086c0",
+              "#579bfc",
+              "#66ccff",
+              "#bb3354",
+              "#e2445c",
+              "#ff158a",
+              "#ff5ac4",
+              "#ff642e",
+              "#fdab3d",
+              "#7f5347",
+              "#c4c4c4",
+              "#808080"
+            ],
             "description": "Group color"
           },
           "relative_position_after": {
@@ -222,7 +260,10 @@
             "description": "Position after this group ID"
           }
         },
-        "required": ["board_id", "group_name"],
+        "required": [
+          "board_id",
+          "group_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -243,7 +284,35 @@
           },
           "column_type": {
             "type": "string",
-            "enum": ["text", "long_text", "numbers", "rating", "status", "dropdown", "people", "timeline", "date", "checkbox", "email", "phone", "link", "file", "tags", "hour", "week", "location", "creation_log", "country", "auto_number", "last_updated", "formula", "dependency", "progress", "mirror", "button"],
+            "enum": [
+              "text",
+              "long_text",
+              "numbers",
+              "rating",
+              "status",
+              "dropdown",
+              "people",
+              "timeline",
+              "date",
+              "checkbox",
+              "email",
+              "phone",
+              "link",
+              "file",
+              "tags",
+              "hour",
+              "week",
+              "location",
+              "creation_log",
+              "country",
+              "auto_number",
+              "last_updated",
+              "formula",
+              "dependency",
+              "progress",
+              "mirror",
+              "button"
+            ],
             "description": "Column type"
           },
           "description": {
@@ -255,7 +324,11 @@
             "description": "Default column settings"
           }
         },
-        "required": ["board_id", "title", "column_type"],
+        "required": [
+          "board_id",
+          "title",
+          "column_type"
+        ],
         "additionalProperties": false
       }
     },
@@ -279,7 +352,10 @@
             "description": "Parent update ID for replies"
           }
         },
-        "required": ["item_id", "body"],
+        "required": [
+          "item_id",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -340,7 +416,9 @@
           },
           "order_by": {
             "type": "string",
-            "enum": ["created_at"],
+            "enum": [
+              "created_at"
+            ],
             "description": "Order by field"
           }
         },
@@ -369,7 +447,10 @@
             "description": "Include updates in duplication"
           }
         },
-        "required": ["board_id", "item_id"],
+        "required": [
+          "board_id",
+          "item_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -385,7 +466,9 @@
             "description": "Item ID"
           }
         },
-        "required": ["item_id"],
+        "required": [
+          "item_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -401,7 +484,9 @@
             "description": "Item ID"
           }
         },
-        "required": ["item_id"],
+        "required": [
+          "item_id"
+        ],
         "additionalProperties": false
       }
     }
@@ -426,13 +511,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "item_id": {"type": "number"},
-          "item_name": {"type": "string"},
-          "board_id": {"type": "number"},
-          "group_id": {"type": "string"},
-          "column_values": {"type": "array"},
-          "created_at": {"type": "string"},
-          "creator_id": {"type": "number"}
+          "item_id": {
+            "type": "number"
+          },
+          "item_name": {
+            "type": "string"
+          },
+          "board_id": {
+            "type": "number"
+          },
+          "group_id": {
+            "type": "string"
+          },
+          "column_values": {
+            "type": "array"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "creator_id": {
+            "type": "number"
+          }
         }
       }
     },
@@ -459,12 +558,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "item_id": {"type": "number"},
-          "board_id": {"type": "number"},
-          "column_id": {"type": "string"},
-          "previous_value": {"type": "object"},
-          "value": {"type": "object"},
-          "changed_at": {"type": "string"}
+          "item_id": {
+            "type": "number"
+          },
+          "board_id": {
+            "type": "number"
+          },
+          "column_id": {
+            "type": "string"
+          },
+          "previous_value": {
+            "type": "object"
+          },
+          "value": {
+            "type": "object"
+          },
+          "changed_at": {
+            "type": "string"
+          }
         }
       }
     },
@@ -487,10 +598,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "item_id": {"type": "number"},
-          "board_id": {"type": "number"},
-          "item_name": {"type": "string"},
-          "deleted_at": {"type": "string"}
+          "item_id": {
+            "type": "number"
+          },
+          "board_id": {
+            "type": "number"
+          },
+          "item_name": {
+            "type": "string"
+          },
+          "deleted_at": {
+            "type": "string"
+          }
         }
       }
     },
@@ -517,12 +636,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "item_id": {"type": "number"},
-          "board_id": {"type": "number"},
-          "column_id": {"type": "string"},
-          "column_type": {"type": "string"},
-          "previous_value": {"type": "object"},
-          "value": {"type": "object"}
+          "item_id": {
+            "type": "number"
+          },
+          "board_id": {
+            "type": "number"
+          },
+          "column_id": {
+            "type": "string"
+          },
+          "column_type": {
+            "type": "string"
+          },
+          "previous_value": {
+            "type": "object"
+          },
+          "value": {
+            "type": "object"
+          }
         }
       }
     }
@@ -533,5 +664,19 @@
     "body": {
       "query": "query { me { id name } }"
     }
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/navan/definition.json
+++ b/connectors/navan/definition.json
@@ -53,7 +53,13 @@
           },
           "status": {
             "type": "string",
-            "enum": ["DRAFT", "SUBMITTED", "APPROVED", "REJECTED", "PAID"],
+            "enum": [
+              "DRAFT",
+              "SUBMITTED",
+              "APPROVED",
+              "REJECTED",
+              "PAID"
+            ],
             "description": "Filter by expense status"
           },
           "start_date": {
@@ -113,7 +119,13 @@
             "description": "Receipt image URL"
           }
         },
-        "required": ["user_id", "amount", "currency", "merchant", "category"],
+        "required": [
+          "user_id",
+          "amount",
+          "currency",
+          "merchant",
+          "category"
+        ],
         "additionalProperties": false
       }
     },
@@ -143,7 +155,13 @@
           },
           "status": {
             "type": "string",
-            "enum": ["REQUESTED", "APPROVED", "IN_PROGRESS", "COMPLETED", "CANCELLED"],
+            "enum": [
+              "REQUESTED",
+              "APPROVED",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "CANCELLED"
+            ],
             "description": "Filter by trip status"
           }
         },
@@ -185,7 +203,12 @@
             "description": "Trip destination"
           }
         },
-        "required": ["user_id", "title", "start_date", "end_date"],
+        "required": [
+          "user_id",
+          "title",
+          "start_date",
+          "end_date"
+        ],
         "additionalProperties": false
       }
     },
@@ -235,11 +258,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "user_id": {"type": "string"},
-          "amount": {"type": "number"},
-          "currency": {"type": "string"},
-          "status": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
         }
       }
     }
@@ -247,5 +280,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/netsuite/definition.json
+++ b/connectors/netsuite/definition.json
@@ -11,14 +11,17 @@
     "config": {
       "authUrl": "https://system.netsuite.com/app/login/oauth2/authorize.nl",
       "tokenUrl": "https://system.netsuite.com/app/login/oauth2/token.nl",
-      "scopes": ["restlets", "rest_webservices"]
+      "scopes": [
+        "restlets",
+        "rest_webservices"
+      ]
     }
   },
   "baseUrl": "https://{account}.suitetalk.api.netsuite.com/services/rest",
   "actions": [
     {
       "id": "test_connection",
-      "name": "Test Connection", 
+      "name": "Test Connection",
       "description": "Test the connection to NetSuite",
       "parameters": {
         "type": "object",
@@ -79,19 +82,25 @@
           "subsidiary": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"}
+              "id": {
+                "type": "string"
+              }
             },
             "description": "Subsidiary reference"
           },
           "currency": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"}
+              "id": {
+                "type": "string"
+              }
             },
             "description": "Currency reference"
           }
         },
-        "required": ["companyName"],
+        "required": [
+          "companyName"
+        ],
         "additionalProperties": false
       }
     },
@@ -134,7 +143,9 @@
           "entity": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"}
+              "id": {
+                "type": "string"
+              }
             },
             "description": "Customer reference"
           },
@@ -151,17 +162,25 @@
                 "item": {
                   "type": "object",
                   "properties": {
-                    "id": {"type": "string"}
+                    "id": {
+                      "type": "string"
+                    }
                   }
                 },
-                "quantity": {"type": "number"},
-                "rate": {"type": "number"}
+                "quantity": {
+                  "type": "number"
+                },
+                "rate": {
+                  "type": "number"
+                }
               }
             },
             "description": "Line items"
           }
         },
-        "required": ["entity"],
+        "required": [
+          "entity"
+        ],
         "additionalProperties": false
       }
     },
@@ -210,9 +229,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "companyName": {"type": "string"},
-          "email": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
         }
       }
     }
@@ -220,5 +245,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/record/v1/customer"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/newrelic/definition.json
+++ b/connectors/newrelic/definition.json
@@ -36,10 +36,21 @@
           "filter": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "host": {"type": "string"},
-              "language": {"type": "string"},
-              "ids": {"type": "array", "items": {"type": "number"}}
+              "name": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "language": {
+                "type": "string"
+              },
+              "ids": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
             },
             "description": "Filter criteria"
           },
@@ -55,7 +66,7 @@
     },
     {
       "id": "get_application_metrics",
-      "name": "Get Application Metrics", 
+      "name": "Get Application Metrics",
       "description": "Get metrics for an application",
       "parameters": {
         "type": "object",
@@ -66,12 +77,16 @@
           },
           "names": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Metric names to retrieve"
           },
           "values": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Metric values to retrieve"
           },
           "from": {
@@ -89,7 +104,9 @@
             "description": "Period in seconds"
           }
         },
-        "required": ["application_id"],
+        "required": [
+          "application_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -103,9 +120,18 @@
           "filter": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "enabled": {"type": "boolean"},
-              "ids": {"type": "array", "items": {"type": "number"}}
+              "name": {
+                "type": "string"
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "ids": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
             },
             "description": "Filter criteria"
           },
@@ -129,15 +155,28 @@
           "policy": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "incident_preference": {"type": "string", "enum": ["PER_POLICY", "PER_CONDITION", "PER_CONDITION_AND_TARGET"]}
+              "name": {
+                "type": "string"
+              },
+              "incident_preference": {
+                "type": "string",
+                "enum": [
+                  "PER_POLICY",
+                  "PER_CONDITION",
+                  "PER_CONDITION_AND_TARGET"
+                ]
+              }
             },
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "additionalProperties": false,
             "description": "Alert policy details"
           }
         },
-        "required": ["policy"],
+        "required": [
+          "policy"
+        ],
         "additionalProperties": false
       }
     },
@@ -151,9 +190,17 @@
           "filter": {
             "type": "object",
             "properties": {
-              "start_date": {"type": "string", "format": "date-time"},
-              "end_date": {"type": "string", "format": "date-time"},
-              "only_open": {"type": "boolean"}
+              "start_date": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "end_date": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "only_open": {
+                "type": "boolean"
+              }
             },
             "description": "Filter criteria"
           },
@@ -186,7 +233,9 @@
             "description": "Query timeout in seconds"
           }
         },
-        "required": ["nrql"],
+        "required": [
+          "nrql"
+        ],
         "additionalProperties": false
       }
     }
@@ -211,11 +260,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "account_id": {"type": "number"},
-          "policy_name": {"type": "string"},
-          "condition_name": {"type": "string"},
-          "incident_url": {"type": "string"},
-          "severity": {"type": "string"}
+          "account_id": {
+            "type": "number"
+          },
+          "policy_name": {
+            "type": "string"
+          },
+          "condition_name": {
+            "type": "string"
+          },
+          "incident_url": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          }
         }
       }
     }
@@ -223,5 +282,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/applications.json"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/nexus/definition.json
+++ b/connectors/nexus/definition.json
@@ -49,7 +49,13 @@
           },
           "format": {
             "type": "string",
-            "enum": ["maven2", "npm", "docker", "pypi", "nuget"],
+            "enum": [
+              "maven2",
+              "npm",
+              "docker",
+              "pypi",
+              "nuget"
+            ],
             "description": "Repository format"
           },
           "group": {
@@ -83,7 +89,13 @@
           },
           "format": {
             "type": "string",
-            "enum": ["maven2", "npm", "docker", "pypi", "nuget"],
+            "enum": [
+              "maven2",
+              "npm",
+              "docker",
+              "pypi",
+              "nuget"
+            ],
             "description": "Repository format"
           },
           "group": {
@@ -103,7 +115,12 @@
             "description": "Base64 encoded file content"
           }
         },
-        "required": ["repository", "format", "artifact_id", "version"],
+        "required": [
+          "repository",
+          "format",
+          "artifact_id",
+          "version"
+        ],
         "additionalProperties": false
       }
     },
@@ -120,7 +137,9 @@
             "description": "Component ID"
           }
         },
-        "required": ["component_id"],
+        "required": [
+          "component_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -134,7 +153,13 @@
         "properties": {
           "format": {
             "type": "string",
-            "enum": ["maven2", "npm", "docker", "pypi", "nuget"],
+            "enum": [
+              "maven2",
+              "npm",
+              "docker",
+              "pypi",
+              "nuget"
+            ],
             "description": "Filter by repository format"
           }
         },
@@ -170,7 +195,13 @@
           },
           "format": {
             "type": "string",
-            "enum": ["maven2", "npm", "docker", "pypi", "nuget"],
+            "enum": [
+              "maven2",
+              "npm",
+              "docker",
+              "pypi",
+              "nuget"
+            ],
             "description": "Filter by format"
           }
         },
@@ -188,7 +219,12 @@
         "properties": {
           "severity": {
             "type": "string",
-            "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
+            "enum": [
+              "CRITICAL",
+              "HIGH",
+              "MEDIUM",
+              "LOW"
+            ],
             "description": "Filter by vulnerability severity"
           }
         },
@@ -196,5 +232,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/notion-enhanced/definition.json
+++ b/connectors/notion-enhanced/definition.json
@@ -37,9 +37,19 @@
           "parent": {
             "type": "object",
             "properties": {
-              "database_id": {"type": "string"},
-              "page_id": {"type": "string"},
-              "type": {"type": "string", "enum": ["database_id", "page_id"]}
+              "database_id": {
+                "type": "string"
+              },
+              "page_id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "database_id",
+                  "page_id"
+                ]
+              }
             },
             "description": "Parent database or page"
           },
@@ -54,24 +64,49 @@
           "icon": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["emoji", "external", "file"]},
-              "emoji": {"type": "string"},
-              "external": {"type": "object"},
-              "file": {"type": "object"}
+              "type": {
+                "type": "string",
+                "enum": [
+                  "emoji",
+                  "external",
+                  "file"
+                ]
+              },
+              "emoji": {
+                "type": "string"
+              },
+              "external": {
+                "type": "object"
+              },
+              "file": {
+                "type": "object"
+              }
             },
             "description": "Page icon"
           },
           "cover": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["external", "file"]},
-              "external": {"type": "object"},
-              "file": {"type": "object"}
+              "type": {
+                "type": "string",
+                "enum": [
+                  "external",
+                  "file"
+                ]
+              },
+              "external": {
+                "type": "object"
+              },
+              "file": {
+                "type": "object"
+              }
             },
             "description": "Page cover"
           }
         },
-        "required": ["parent"],
+        "required": [
+          "parent"
+        ],
         "additionalProperties": false
       }
     },
@@ -103,7 +138,9 @@
             "description": "Update page cover"
           }
         },
-        "required": ["page_id"],
+        "required": [
+          "page_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -120,11 +157,15 @@
           },
           "filter_properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Specific properties to retrieve"
           }
         },
-        "required": ["page_id"],
+        "required": [
+          "page_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -159,7 +200,9 @@
             "description": "Number of results per page"
           }
         },
-        "required": ["database_id"],
+        "required": [
+          "database_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -175,7 +218,9 @@
             "description": "Database ID"
           }
         },
-        "required": ["database_id"],
+        "required": [
+          "database_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -207,7 +252,9 @@
             "description": "Whether database is inline"
           }
         },
-        "required": ["database_id"],
+        "required": [
+          "database_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -221,8 +268,15 @@
           "parent": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["page_id"]},
-              "page_id": {"type": "string"}
+              "type": {
+                "type": "string",
+                "enum": [
+                  "page_id"
+                ]
+              },
+              "page_id": {
+                "type": "string"
+              }
             },
             "description": "Parent page"
           },
@@ -244,7 +298,11 @@
             "description": "Whether database is inline"
           }
         },
-        "required": ["parent", "title", "properties"],
+        "required": [
+          "parent",
+          "title",
+          "properties"
+        ],
         "additionalProperties": false
       }
     },
@@ -271,7 +329,9 @@
             "description": "Number of blocks per page"
           }
         },
-        "required": ["block_id"],
+        "required": [
+          "block_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -295,7 +355,10 @@
             "description": "Block ID to insert after"
           }
         },
-        "required": ["block_id", "children"],
+        "required": [
+          "block_id",
+          "children"
+        ],
         "additionalProperties": false
       }
     },
@@ -319,7 +382,9 @@
             "description": "Block content to update"
           }
         },
-        "required": ["block_id"],
+        "required": [
+          "block_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -335,7 +400,9 @@
             "description": "Block ID to delete"
           }
         },
-        "required": ["block_id"],
+        "required": [
+          "block_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -353,16 +420,38 @@
           "filter": {
             "type": "object",
             "properties": {
-              "value": {"type": "string", "enum": ["page", "database"]},
-              "property": {"type": "string", "enum": ["object"]}
+              "value": {
+                "type": "string",
+                "enum": [
+                  "page",
+                  "database"
+                ]
+              },
+              "property": {
+                "type": "string",
+                "enum": [
+                  "object"
+                ]
+              }
             },
             "description": "Filter by object type"
           },
           "sort": {
             "type": "object",
             "properties": {
-              "direction": {"type": "string", "enum": ["ascending", "descending"]},
-              "timestamp": {"type": "string", "enum": ["last_edited_time"]}
+              "direction": {
+                "type": "string",
+                "enum": [
+                  "ascending",
+                  "descending"
+                ]
+              },
+              "timestamp": {
+                "type": "string",
+                "enum": [
+                  "last_edited_time"
+                ]
+              }
             },
             "description": "Sort options"
           },
@@ -417,7 +506,9 @@
             "description": "User ID"
           }
         },
-        "required": ["user_id"],
+        "required": [
+          "user_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -444,7 +535,9 @@
             "description": "Number of comments per page"
           }
         },
-        "required": ["block_id"],
+        "required": [
+          "block_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -458,8 +551,12 @@
           "parent": {
             "type": "object",
             "properties": {
-              "page_id": {"type": "string"},
-              "block_id": {"type": "string"}
+              "page_id": {
+                "type": "string"
+              },
+              "block_id": {
+                "type": "string"
+              }
             },
             "description": "Parent page or block"
           },
@@ -472,7 +569,10 @@
             "description": "Discussion thread ID"
           }
         },
-        "required": ["parent", "rich_text"],
+        "required": [
+          "parent",
+          "rich_text"
+        ],
         "additionalProperties": false
       }
     }
@@ -501,12 +601,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "created_time": {"type": "string"},
-          "last_edited_time": {"type": "string"},
-          "parent": {"type": "object"},
-          "properties": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "created_time": {
+            "type": "string"
+          },
+          "last_edited_time": {
+            "type": "string"
+          },
+          "parent": {
+            "type": "object"
+          },
+          "properties": {
+            "type": "object"
+          }
         }
       }
     },
@@ -533,11 +645,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "last_edited_time": {"type": "string"},
-          "parent": {"type": "object"},
-          "properties": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "last_edited_time": {
+            "type": "string"
+          },
+          "parent": {
+            "type": "object"
+          },
+          "properties": {
+            "type": "object"
+          }
         }
       }
     },
@@ -560,11 +682,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "created_time": {"type": "string"},
-          "title": {"type": "array"},
-          "properties": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "created_time": {
+            "type": "string"
+          },
+          "title": {
+            "type": "array"
+          },
+          "properties": {
+            "type": "object"
+          }
         }
       }
     },
@@ -587,11 +719,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "last_edited_time": {"type": "string"},
-          "title": {"type": "array"},
-          "properties": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "last_edited_time": {
+            "type": "string"
+          },
+          "title": {
+            "type": "array"
+          },
+          "properties": {
+            "type": "object"
+          }
         }
       }
     }
@@ -599,5 +741,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/notion/definition.json
+++ b/connectors/notion/definition.json
@@ -12,7 +12,11 @@
     "config": {
       "authUrl": "https://api.notion.com/v1/oauth/authorize",
       "tokenUrl": "https://api.notion.com/v1/oauth/token",
-      "scopes": ["read_content", "update_content", "insert_content"]
+      "scopes": [
+        "read_content",
+        "update_content",
+        "insert_content"
+      ]
     }
   },
   "baseUrl": "https://api.notion.com/v1",
@@ -44,7 +48,11 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["database_id", "page_id", "workspace"],
+                "enum": [
+                  "database_id",
+                  "page_id",
+                  "workspace"
+                ],
                 "description": "Type of parent"
               },
               "database_id": {
@@ -64,16 +72,31 @@
           },
           "children": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Array of block objects for page content"
           },
           "icon": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["emoji", "external", "file"]},
-              "emoji": {"type": "string"},
-              "external": {"type": "object"},
-              "file": {"type": "object"}
+              "type": {
+                "type": "string",
+                "enum": [
+                  "emoji",
+                  "external",
+                  "file"
+                ]
+              },
+              "emoji": {
+                "type": "string"
+              },
+              "external": {
+                "type": "object"
+              },
+              "file": {
+                "type": "object"
+              }
             },
             "description": "Page icon"
           },
@@ -82,7 +105,9 @@
             "description": "Page cover image"
           }
         },
-        "required": ["parent"],
+        "required": [
+          "parent"
+        ],
         "additionalProperties": false
       }
     },
@@ -114,7 +139,9 @@
             "description": "Updated page cover"
           }
         },
-        "required": ["page_id"],
+        "required": [
+          "page_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -131,11 +158,15 @@
           },
           "filter_properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Specific properties to retrieve"
           }
         },
-        "required": ["page_id"],
+        "required": [
+          "page_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -156,11 +187,16 @@
           },
           "children": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Array of block objects for entry content"
           }
         },
-        "required": ["database_id", "properties"],
+        "required": [
+          "database_id",
+          "properties"
+        ],
         "additionalProperties": false
       }
     },
@@ -181,7 +217,9 @@
           },
           "sorts": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Sort conditions for the query"
           },
           "start_cursor": {
@@ -196,7 +234,9 @@
             "description": "Number of results to return"
           }
         },
-        "required": ["database_id"],
+        "required": [
+          "database_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -213,11 +253,16 @@
           },
           "children": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Array of block objects to append"
           }
         },
-        "required": ["block_id", "children"],
+        "required": [
+          "block_id",
+          "children"
+        ],
         "additionalProperties": false
       }
     },
@@ -237,7 +282,9 @@
             "description": "Whether to archive the block"
           }
         },
-        "required": ["block_id"],
+        "required": [
+          "block_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -264,7 +311,9 @@
             "description": "Number of results to return"
           }
         },
-        "required": ["block_id"],
+        "required": [
+          "block_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -284,12 +333,17 @@
             "properties": {
               "value": {
                 "type": "string",
-                "enum": ["page", "database"],
+                "enum": [
+                  "page",
+                  "database"
+                ],
                 "description": "Filter by object type"
               },
               "property": {
                 "type": "string",
-                "enum": ["object"],
+                "enum": [
+                  "object"
+                ],
                 "description": "Property to filter on"
               }
             },
@@ -300,12 +354,17 @@
             "properties": {
               "direction": {
                 "type": "string",
-                "enum": ["ascending", "descending"],
+                "enum": [
+                  "ascending",
+                  "descending"
+                ],
                 "description": "Sort direction"
               },
               "timestamp": {
                 "type": "string",
-                "enum": ["last_edited_time"],
+                "enum": [
+                  "last_edited_time"
+                ],
                 "description": "Sort by timestamp"
               }
             },
@@ -352,12 +411,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "object": {"type": "string"},
-          "id": {"type": "string"},
-          "created_time": {"type": "string"},
-          "last_edited_time": {"type": "string"},
-          "properties": {"type": "object"},
-          "parent": {"type": "object"}
+          "object": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "created_time": {
+            "type": "string"
+          },
+          "last_edited_time": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object"
+          },
+          "parent": {
+            "type": "object"
+          }
         }
       }
     },
@@ -375,7 +446,9 @@
           },
           "properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Specific properties to watch for changes"
           }
         },
@@ -385,10 +458,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "object": {"type": "string"},
-          "id": {"type": "string"},
-          "last_edited_time": {"type": "string"},
-          "properties": {"type": "object"}
+          "object": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "last_edited_time": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object"
+          }
         }
       }
     },
@@ -411,11 +492,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "object": {"type": "string"},
-          "id": {"type": "string"},
-          "created_time": {"type": "string"},
-          "properties": {"type": "object"},
-          "parent": {"type": "object"}
+          "object": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "created_time": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object"
+          },
+          "parent": {
+            "type": "object"
+          }
         }
       }
     }
@@ -423,5 +514,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/okta/definition.json
+++ b/connectors/okta/definition.json
@@ -37,39 +37,108 @@
           "profile": {
             "type": "object",
             "properties": {
-              "firstName": {"type": "string"},
-              "lastName": {"type": "string"},
-              "email": {"type": "string", "format": "email"},
-              "login": {"type": "string"},
-              "mobilePhone": {"type": "string"},
-              "secondEmail": {"type": "string", "format": "email"},
-              "middleName": {"type": "string"},
-              "honorificPrefix": {"type": "string"},
-              "honorificSuffix": {"type": "string"},
-              "title": {"type": "string"},
-              "displayName": {"type": "string"},
-              "nickName": {"type": "string"},
-              "profileUrl": {"type": "string"},
-              "primaryPhone": {"type": "string"},
-              "streetAddress": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "zipCode": {"type": "string"},
-              "countryCode": {"type": "string"},
-              "postalAddress": {"type": "string"},
-              "preferredLanguage": {"type": "string"},
-              "locale": {"type": "string"},
-              "timezone": {"type": "string"},
-              "userType": {"type": "string"},
-              "employeeNumber": {"type": "string"},
-              "costCenter": {"type": "string"},
-              "organization": {"type": "string"},
-              "division": {"type": "string"},
-              "department": {"type": "string"},
-              "managerId": {"type": "string"},
-              "manager": {"type": "string"}
+              "firstName": {
+                "type": "string"
+              },
+              "lastName": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "login": {
+                "type": "string"
+              },
+              "mobilePhone": {
+                "type": "string"
+              },
+              "secondEmail": {
+                "type": "string",
+                "format": "email"
+              },
+              "middleName": {
+                "type": "string"
+              },
+              "honorificPrefix": {
+                "type": "string"
+              },
+              "honorificSuffix": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "nickName": {
+                "type": "string"
+              },
+              "profileUrl": {
+                "type": "string"
+              },
+              "primaryPhone": {
+                "type": "string"
+              },
+              "streetAddress": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "zipCode": {
+                "type": "string"
+              },
+              "countryCode": {
+                "type": "string"
+              },
+              "postalAddress": {
+                "type": "string"
+              },
+              "preferredLanguage": {
+                "type": "string"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "timezone": {
+                "type": "string"
+              },
+              "userType": {
+                "type": "string"
+              },
+              "employeeNumber": {
+                "type": "string"
+              },
+              "costCenter": {
+                "type": "string"
+              },
+              "organization": {
+                "type": "string"
+              },
+              "division": {
+                "type": "string"
+              },
+              "department": {
+                "type": "string"
+              },
+              "managerId": {
+                "type": "string"
+              },
+              "manager": {
+                "type": "string"
+              }
             },
-            "required": ["firstName", "lastName", "email", "login"],
+            "required": [
+              "firstName",
+              "lastName",
+              "email",
+              "login"
+            ],
             "additionalProperties": false
           },
           "credentials": {
@@ -78,23 +147,40 @@
               "password": {
                 "type": "object",
                 "properties": {
-                  "value": {"type": "string"}
+                  "value": {
+                    "type": "string"
+                  }
                 },
                 "additionalProperties": false
               },
               "recovery_question": {
                 "type": "object",
                 "properties": {
-                  "question": {"type": "string"},
-                  "answer": {"type": "string"}
+                  "question": {
+                    "type": "string"
+                  },
+                  "answer": {
+                    "type": "string"
+                  }
                 },
                 "additionalProperties": false
               },
               "provider": {
                 "type": "object",
                 "properties": {
-                  "type": {"type": "string", "enum": ["OKTA", "ACTIVE_DIRECTORY", "LDAP", "FEDERATION", "SOCIAL"]},
-                  "name": {"type": "string"}
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "OKTA",
+                      "ACTIVE_DIRECTORY",
+                      "LDAP",
+                      "FEDERATION",
+                      "SOCIAL"
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  }
                 },
                 "additionalProperties": false
               }
@@ -103,7 +189,9 @@
           },
           "groupIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Group IDs to assign user to"
           },
           "activate": {
@@ -117,11 +205,15 @@
           },
           "nextLogin": {
             "type": "string",
-            "enum": ["changePassword"],
+            "enum": [
+              "changePassword"
+            ],
             "description": "Action to take on next login"
           }
         },
-        "required": ["profile"],
+        "required": [
+          "profile"
+        ],
         "additionalProperties": false
       }
     },
@@ -137,7 +229,9 @@
             "description": "User ID or login"
           }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       }
     },
@@ -155,27 +249,50 @@
           "profile": {
             "type": "object",
             "properties": {
-              "firstName": {"type": "string"},
-              "lastName": {"type": "string"},
-              "email": {"type": "string", "format": "email"},
-              "login": {"type": "string"},
-              "mobilePhone": {"type": "string"},
-              "title": {"type": "string"},
-              "department": {"type": "string"},
-              "manager": {"type": "string"}
+              "firstName": {
+                "type": "string"
+              },
+              "lastName": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "login": {
+                "type": "string"
+              },
+              "mobilePhone": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "department": {
+                "type": "string"
+              },
+              "manager": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           },
           "credentials": {
             "type": "object",
             "properties": {
-              "password": {"type": "object"},
-              "recovery_question": {"type": "object"}
+              "password": {
+                "type": "object"
+              },
+              "recovery_question": {
+                "type": "object"
+              }
             },
             "additionalProperties": false
           }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       }
     },
@@ -196,7 +313,9 @@
             "description": "Whether to send deactivation email"
           }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       }
     },
@@ -217,7 +336,9 @@
             "description": "Whether to send activation email"
           }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       }
     },
@@ -233,7 +354,9 @@
             "description": "User ID"
           }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       }
     },
@@ -249,7 +372,9 @@
             "description": "User ID"
           }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       }
     },
@@ -289,7 +414,10 @@
           },
           "sortOrder": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "description": "Sort order"
           }
         },
@@ -313,7 +441,10 @@
             "description": "User ID"
           }
         },
-        "required": ["groupId", "userId"],
+        "required": [
+          "groupId",
+          "userId"
+        ],
         "additionalProperties": false
       }
     },
@@ -333,7 +464,10 @@
             "description": "User ID"
           }
         },
-        "required": ["groupId", "userId"],
+        "required": [
+          "groupId",
+          "userId"
+        ],
         "additionalProperties": false
       }
     },
@@ -347,14 +481,22 @@
           "profile": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "description": {"type": "string"}
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "additionalProperties": false
           }
         },
-        "required": ["profile"],
+        "required": [
+          "profile"
+        ],
         "additionalProperties": false
       }
     },
@@ -394,7 +536,10 @@
           },
           "sortOrder": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "description": "Sort order"
           },
           "expand": {
@@ -423,7 +568,9 @@
             "description": "Whether to send reset email"
           }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       }
     },
@@ -443,7 +590,9 @@
             "description": "Whether to generate temporary password"
           }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       }
     }
@@ -468,11 +617,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventType": {"type": "string"},
-          "version": {"type": "string"},
-          "source": {"type": "string"},
-          "eventId": {"type": "string"},
-          "published": {"type": "string"},
+          "eventType": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "published": {
+            "type": "string"
+          },
           "data": {
             "type": "object",
             "properties": {
@@ -481,22 +640,54 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "uuid": {"type": "string"},
-                    "published": {"type": "string"},
-                    "eventType": {"type": "string"},
-                    "version": {"type": "string"},
-                    "displayMessage": {"type": "string"},
-                    "severity": {"type": "string"},
-                    "client": {"type": "object"},
-                    "actor": {"type": "object"},
-                    "outcome": {"type": "object"},
-                    "target": {"type": "array"},
-                    "transaction": {"type": "object"},
-                    "debugContext": {"type": "object"},
-                    "legacyEventType": {"type": "string"},
-                    "authenticationContext": {"type": "object"},
-                    "securityContext": {"type": "object"},
-                    "insertionTimestamp": {"type": "string"}
+                    "uuid": {
+                      "type": "string"
+                    },
+                    "published": {
+                      "type": "string"
+                    },
+                    "eventType": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "displayMessage": {
+                      "type": "string"
+                    },
+                    "severity": {
+                      "type": "string"
+                    },
+                    "client": {
+                      "type": "object"
+                    },
+                    "actor": {
+                      "type": "object"
+                    },
+                    "outcome": {
+                      "type": "object"
+                    },
+                    "target": {
+                      "type": "array"
+                    },
+                    "transaction": {
+                      "type": "object"
+                    },
+                    "debugContext": {
+                      "type": "object"
+                    },
+                    "legacyEventType": {
+                      "type": "string"
+                    },
+                    "authenticationContext": {
+                      "type": "object"
+                    },
+                    "securityContext": {
+                      "type": "object"
+                    },
+                    "insertionTimestamp": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -519,8 +710,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventType": {"type": "string"},
-          "data": {"type": "object"}
+          "eventType": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
+          }
         }
       }
     },
@@ -538,8 +733,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventType": {"type": "string"},
-          "data": {"type": "object"}
+          "eventType": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
+          }
         }
       }
     }
@@ -547,5 +746,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/onedrive/definition.json
+++ b/connectors/onedrive/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-      "scopes": ["https://graph.microsoft.com/Files.ReadWrite"]
+      "scopes": [
+        "https://graph.microsoft.com/Files.ReadWrite"
+      ]
     }
   },
   "baseUrl": "https://graph.microsoft.com/v1.0/me/drive",
@@ -83,12 +85,19 @@
           },
           "conflictBehavior": {
             "type": "string",
-            "enum": ["rename", "replace", "fail"],
+            "enum": [
+              "rename",
+              "replace",
+              "fail"
+            ],
             "default": "rename",
             "description": "Behavior when file exists"
           }
         },
-        "required": ["fileName", "content"],
+        "required": [
+          "fileName",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -104,7 +113,9 @@
             "description": "File ID"
           }
         },
-        "required": ["fileId"],
+        "required": [
+          "fileId"
+        ],
         "additionalProperties": false
       }
     },
@@ -124,7 +135,9 @@
             "description": "Parent folder ID"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -140,7 +153,9 @@
             "description": "File or folder ID"
           }
         },
-        "required": ["itemId"],
+        "required": [
+          "itemId"
+        ],
         "additionalProperties": false
       }
     },
@@ -157,18 +172,26 @@
           },
           "type": {
             "type": "string",
-            "enum": ["view", "edit"],
+            "enum": [
+              "view",
+              "edit"
+            ],
             "default": "view",
             "description": "Permission type"
           },
           "scope": {
             "type": "string",
-            "enum": ["anonymous", "organization"],
+            "enum": [
+              "anonymous",
+              "organization"
+            ],
             "default": "anonymous",
             "description": "Link scope"
           }
         },
-        "required": ["itemId"],
+        "required": [
+          "itemId"
+        ],
         "additionalProperties": false
       }
     }
@@ -193,10 +216,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "size": {"type": "number"},
-          "createdDateTime": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "createdDateTime": {
+            "type": "string"
+          }
         }
       }
     }
@@ -204,5 +235,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/opsgenie/definition.json
+++ b/connectors/opsgenie/definition.json
@@ -48,7 +48,13 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["P1", "P2", "P3", "P4", "P5"],
+            "enum": [
+              "P1",
+              "P2",
+              "P3",
+              "P4",
+              "P5"
+            ],
             "default": "P3",
             "description": "Alert priority"
           },
@@ -58,7 +64,9 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Alert tags"
           },
           "details": {
@@ -78,7 +86,9 @@
             "description": "Additional note"
           }
         },
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "additionalProperties": false
       }
     },
@@ -95,12 +105,18 @@
           },
           "identifierType": {
             "type": "string",
-            "enum": ["id", "tiny", "alias"],
+            "enum": [
+              "id",
+              "tiny",
+              "alias"
+            ],
             "default": "id",
             "description": "Identifier type"
           }
         },
-        "required": ["identifier"],
+        "required": [
+          "identifier"
+        ],
         "additionalProperties": false
       }
     },
@@ -117,7 +133,11 @@
           },
           "identifierType": {
             "type": "string",
-            "enum": ["id", "tiny", "alias"],
+            "enum": [
+              "id",
+              "tiny",
+              "alias"
+            ],
             "default": "id",
             "description": "Identifier type"
           },
@@ -134,7 +154,9 @@
             "description": "Source of the close action"
           }
         },
-        "required": ["identifier"],
+        "required": [
+          "identifier"
+        ],
         "additionalProperties": false
       }
     },
@@ -151,7 +173,11 @@
           },
           "identifierType": {
             "type": "string",
-            "enum": ["id", "tiny", "alias"],
+            "enum": [
+              "id",
+              "tiny",
+              "alias"
+            ],
             "default": "id",
             "description": "Identifier type"
           },
@@ -168,7 +194,9 @@
             "description": "Source of the acknowledge action"
           }
         },
-        "required": ["identifier"],
+        "required": [
+          "identifier"
+        ],
         "additionalProperties": false
       }
     },
@@ -189,7 +217,11 @@
           },
           "searchIdentifierType": {
             "type": "string",
-            "enum": ["id", "tiny", "alias"],
+            "enum": [
+              "id",
+              "tiny",
+              "alias"
+            ],
             "description": "Search identifier type"
           },
           "offset": {
@@ -207,13 +239,26 @@
           },
           "sort": {
             "type": "string",
-            "enum": ["createdAt", "updatedAt", "tinyId", "alias", "message", "status", "acknowledged", "isSeen", "snoozed"],
+            "enum": [
+              "createdAt",
+              "updatedAt",
+              "tinyId",
+              "alias",
+              "message",
+              "status",
+              "acknowledged",
+              "isSeen",
+              "snoozed"
+            ],
             "default": "createdAt",
             "description": "Sort field"
           },
           "order": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "default": "desc",
             "description": "Sort order"
           }
@@ -235,7 +280,11 @@
           },
           "identifierType": {
             "type": "string",
-            "enum": ["id", "tiny", "alias"],
+            "enum": [
+              "id",
+              "tiny",
+              "alias"
+            ],
             "default": "id",
             "description": "Identifier type"
           },
@@ -252,7 +301,10 @@
             "description": "Source of the note"
           }
         },
-        "required": ["identifier", "note"],
+        "required": [
+          "identifier",
+          "note"
+        ],
         "additionalProperties": false
       }
     },
@@ -269,15 +321,23 @@
           },
           "identifierType": {
             "type": "string",
-            "enum": ["id", "tiny", "alias"],
+            "enum": [
+              "id",
+              "tiny",
+              "alias"
+            ],
             "default": "id",
             "description": "Identifier type"
           },
           "owner": {
             "type": "object",
             "properties": {
-              "username": {"type": "string"},
-              "id": {"type": "string"}
+              "username": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              }
             },
             "description": "Owner to assign alert to"
           },
@@ -294,7 +354,10 @@
             "description": "Source of the assignment"
           }
         },
-        "required": ["identifier", "owner"],
+        "required": [
+          "identifier",
+          "owner"
+        ],
         "additionalProperties": false
       }
     },
@@ -361,7 +424,10 @@
           },
           "scheduleIdentifierType": {
             "type": "string",
-            "enum": ["id", "name"],
+            "enum": [
+              "id",
+              "name"
+            ],
             "default": "id",
             "description": "Schedule identifier type"
           },
@@ -392,12 +458,20 @@
         "properties": {
           "priority": {
             "type": "string",
-            "enum": ["P1", "P2", "P3", "P4", "P5"],
+            "enum": [
+              "P1",
+              "P2",
+              "P3",
+              "P4",
+              "P5"
+            ],
             "description": "Filter by priority"
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by tags"
           }
         },
@@ -407,22 +481,54 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "tinyId": {"type": "string"},
-          "alias": {"type": "string"},
-          "message": {"type": "string"},
-          "status": {"type": "string"},
-          "acknowledged": {"type": "boolean"},
-          "isSeen": {"type": "boolean"},
-          "tags": {"type": "array"},
-          "snoozed": {"type": "boolean"},
-          "count": {"type": "number"},
-          "lastOccurredAt": {"type": "string"},
-          "createdAt": {"type": "string"},
-          "updatedAt": {"type": "string"},
-          "source": {"type": "string"},
-          "owner": {"type": "string"},
-          "priority": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "tinyId": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "acknowledged": {
+            "type": "boolean"
+          },
+          "isSeen": {
+            "type": "boolean"
+          },
+          "tags": {
+            "type": "array"
+          },
+          "snoozed": {
+            "type": "boolean"
+          },
+          "count": {
+            "type": "number"
+          },
+          "lastOccurredAt": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          }
         }
       }
     },
@@ -436,7 +542,13 @@
         "properties": {
           "priority": {
             "type": "string",
-            "enum": ["P1", "P2", "P3", "P4", "P5"],
+            "enum": [
+              "P1",
+              "P2",
+              "P3",
+              "P4",
+              "P5"
+            ],
             "description": "Filter by priority"
           }
         },
@@ -446,12 +558,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "tinyId": {"type": "string"},
-          "alias": {"type": "string"},
-          "message": {"type": "string"},
-          "acknowledgedBy": {"type": "string"},
-          "acknowledgedAt": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "tinyId": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "acknowledgedBy": {
+            "type": "string"
+          },
+          "acknowledgedAt": {
+            "type": "string"
+          }
         }
       }
     },
@@ -465,7 +589,13 @@
         "properties": {
           "priority": {
             "type": "string",
-            "enum": ["P1", "P2", "P3", "P4", "P5"],
+            "enum": [
+              "P1",
+              "P2",
+              "P3",
+              "P4",
+              "P5"
+            ],
             "description": "Filter by priority"
           }
         },
@@ -475,12 +605,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "tinyId": {"type": "string"},
-          "alias": {"type": "string"},
-          "message": {"type": "string"},
-          "closedBy": {"type": "string"},
-          "closedAt": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "tinyId": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "closedBy": {
+            "type": "string"
+          },
+          "closedAt": {
+            "type": "string"
+          }
         }
       }
     }
@@ -488,5 +630,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/account"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/outlook/definition.json
+++ b/connectors/outlook/definition.json
@@ -43,14 +43,27 @@
           "message": {
             "type": "object",
             "properties": {
-              "subject": {"type": "string"},
+              "subject": {
+                "type": "string"
+              },
               "body": {
                 "type": "object",
                 "properties": {
-                  "contentType": {"type": "string", "enum": ["Text", "HTML"], "default": "HTML"},
-                  "content": {"type": "string"}
+                  "contentType": {
+                    "type": "string",
+                    "enum": [
+                      "Text",
+                      "HTML"
+                    ],
+                    "default": "HTML"
+                  },
+                  "content": {
+                    "type": "string"
+                  }
                 },
-                "required": ["content"],
+                "required": [
+                  "content"
+                ],
                 "additionalProperties": false
               },
               "toRecipients": {
@@ -61,14 +74,23 @@
                     "emailAddress": {
                       "type": "object",
                       "properties": {
-                        "address": {"type": "string", "format": "email"},
-                        "name": {"type": "string"}
+                        "address": {
+                          "type": "string",
+                          "format": "email"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
                       },
-                      "required": ["address"],
+                      "required": [
+                        "address"
+                      ],
                       "additionalProperties": false
                     }
                   },
-                  "required": ["emailAddress"],
+                  "required": [
+                    "emailAddress"
+                  ],
                   "additionalProperties": false
                 }
               },
@@ -80,10 +102,17 @@
                     "emailAddress": {
                       "type": "object",
                       "properties": {
-                        "address": {"type": "string", "format": "email"},
-                        "name": {"type": "string"}
+                        "address": {
+                          "type": "string",
+                          "format": "email"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
                       },
-                      "required": ["address"],
+                      "required": [
+                        "address"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -98,10 +127,17 @@
                     "emailAddress": {
                       "type": "object",
                       "properties": {
-                        "address": {"type": "string", "format": "email"},
-                        "name": {"type": "string"}
+                        "address": {
+                          "type": "string",
+                          "format": "email"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
                       },
-                      "required": ["address"],
+                      "required": [
+                        "address"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -116,8 +152,13 @@
                     "emailAddress": {
                       "type": "object",
                       "properties": {
-                        "address": {"type": "string", "format": "email"},
-                        "name": {"type": "string"}
+                        "address": {
+                          "type": "string",
+                          "format": "email"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
                       },
                       "additionalProperties": false
                     }
@@ -130,38 +171,65 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "@odata.type": {"type": "string"},
-                    "name": {"type": "string"},
-                    "contentBytes": {"type": "string"},
-                    "contentType": {"type": "string"},
-                    "contentId": {"type": "string"},
-                    "isInline": {"type": "boolean"}
+                    "@odata.type": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "contentBytes": {
+                      "type": "string"
+                    },
+                    "contentType": {
+                      "type": "string"
+                    },
+                    "contentId": {
+                      "type": "string"
+                    },
+                    "isInline": {
+                      "type": "boolean"
+                    }
                   },
                   "additionalProperties": false
                 }
               },
               "importance": {
                 "type": "string",
-                "enum": ["Low", "Normal", "High"],
+                "enum": [
+                  "Low",
+                  "Normal",
+                  "High"
+                ],
                 "default": "Normal"
               },
               "inferenceClassification": {
                 "type": "string",
-                "enum": ["Focused", "Other"]
+                "enum": [
+                  "Focused",
+                  "Other"
+                ]
               },
               "internetMessageHeaders": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "name": {"type": "string"},
-                    "value": {"type": "string"}
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
                   },
                   "additionalProperties": false
                 }
               }
             },
-            "required": ["subject", "body", "toRecipients"],
+            "required": [
+              "subject",
+              "body",
+              "toRecipients"
+            ],
             "additionalProperties": false
           },
           "saveToSentItems": {
@@ -169,7 +237,9 @@
             "default": true
           }
         },
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "additionalProperties": false
       }
     },
@@ -241,7 +311,9 @@
             "description": "Expand related data"
           }
         },
-        "required": ["messageId"],
+        "required": [
+          "messageId"
+        ],
         "additionalProperties": false
       }
     },
@@ -262,18 +334,32 @@
               "body": {
                 "type": "object",
                 "properties": {
-                  "contentType": {"type": "string", "enum": ["Text", "HTML"]},
-                  "content": {"type": "string"}
+                  "contentType": {
+                    "type": "string",
+                    "enum": [
+                      "Text",
+                      "HTML"
+                    ]
+                  },
+                  "content": {
+                    "type": "string"
+                  }
                 },
-                "required": ["content"],
+                "required": [
+                  "content"
+                ],
                 "additionalProperties": false
               },
               "toRecipients": {
                 "type": "array",
-                "items": {"type": "object"}
+                "items": {
+                  "type": "object"
+                }
               }
             },
-            "required": ["body"],
+            "required": [
+              "body"
+            ],
             "additionalProperties": false
           },
           "comment": {
@@ -281,7 +367,9 @@
             "description": "Reply comment"
           }
         },
-        "required": ["messageId"],
+        "required": [
+          "messageId"
+        ],
         "additionalProperties": false
       }
     },
@@ -297,7 +385,9 @@
             "description": "Message ID"
           }
         },
-        "required": ["messageId"],
+        "required": [
+          "messageId"
+        ],
         "additionalProperties": false
       }
     },
@@ -315,35 +405,63 @@
           "body": {
             "type": "object",
             "properties": {
-              "contentType": {"type": "string", "enum": ["Text", "HTML"]},
-              "content": {"type": "string"}
+              "contentType": {
+                "type": "string",
+                "enum": [
+                  "Text",
+                  "HTML"
+                ]
+              },
+              "content": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           },
           "start": {
             "type": "object",
             "properties": {
-              "dateTime": {"type": "string", "format": "date-time"},
-              "timeZone": {"type": "string"}
+              "dateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "timeZone": {
+                "type": "string"
+              }
             },
-            "required": ["dateTime"],
+            "required": [
+              "dateTime"
+            ],
             "additionalProperties": false
           },
           "end": {
             "type": "object",
             "properties": {
-              "dateTime": {"type": "string", "format": "date-time"},
-              "timeZone": {"type": "string"}
+              "dateTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "timeZone": {
+                "type": "string"
+              }
             },
-            "required": ["dateTime"],
+            "required": [
+              "dateTime"
+            ],
             "additionalProperties": false
           },
           "location": {
             "type": "object",
             "properties": {
-              "displayName": {"type": "string"},
-              "address": {"type": "object"},
-              "coordinates": {"type": "object"}
+              "displayName": {
+                "type": "string"
+              },
+              "address": {
+                "type": "object"
+              },
+              "coordinates": {
+                "type": "object"
+              }
             },
             "additionalProperties": false
           },
@@ -355,15 +473,31 @@
                 "emailAddress": {
                   "type": "object",
                   "properties": {
-                    "address": {"type": "string", "format": "email"},
-                    "name": {"type": "string"}
+                    "address": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["address"],
+                  "required": [
+                    "address"
+                  ],
                   "additionalProperties": false
                 },
-                "type": {"type": "string", "enum": ["required", "optional", "resource"]}
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "required",
+                    "optional",
+                    "resource"
+                  ]
+                }
               },
-              "required": ["emailAddress"],
+              "required": [
+                "emailAddress"
+              ],
               "additionalProperties": false
             }
           },
@@ -374,8 +508,12 @@
           "recurrence": {
             "type": "object",
             "properties": {
-              "pattern": {"type": "object"},
-              "range": {"type": "object"}
+              "pattern": {
+                "type": "object"
+              },
+              "range": {
+                "type": "object"
+              }
             },
             "additionalProperties": false
           },
@@ -385,21 +523,41 @@
           },
           "importance": {
             "type": "string",
-            "enum": ["Low", "Normal", "High"],
+            "enum": [
+              "Low",
+              "Normal",
+              "High"
+            ],
             "default": "Normal"
           },
           "sensitivity": {
             "type": "string",
-            "enum": ["Normal", "Personal", "Private", "Confidential"],
+            "enum": [
+              "Normal",
+              "Personal",
+              "Private",
+              "Confidential"
+            ],
             "default": "Normal"
           },
           "showAs": {
             "type": "string",
-            "enum": ["Free", "Tentative", "Busy", "Oof", "WorkingElsewhere", "Unknown"],
+            "enum": [
+              "Free",
+              "Tentative",
+              "Busy",
+              "Oof",
+              "WorkingElsewhere",
+              "Unknown"
+            ],
             "default": "Busy"
           }
         },
-        "required": ["subject", "start", "end"],
+        "required": [
+          "subject",
+          "start",
+          "end"
+        ],
         "additionalProperties": false
       }
     },
@@ -466,19 +624,28 @@
             "items": {
               "type": "object",
               "properties": {
-                "address": {"type": "string", "format": "email"},
-                "name": {"type": "string"}
+                "address": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "name": {
+                  "type": "string"
+                }
               },
               "additionalProperties": false
             }
           },
           "businessPhones": {
             "type": "array",
-            "items": {"type": "string"}
+            "items": {
+              "type": "string"
+            }
           },
           "homePhones": {
             "type": "array",
-            "items": {"type": "string"}
+            "items": {
+              "type": "string"
+            }
           },
           "mobilePhone": {
             "type": "string"
@@ -498,22 +665,42 @@
           "homeAddress": {
             "type": "object",
             "properties": {
-              "street": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "postalCode": {"type": "string"},
-              "countryOrRegion": {"type": "string"}
+              "street": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "postalCode": {
+                "type": "string"
+              },
+              "countryOrRegion": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           },
           "businessAddress": {
             "type": "object",
             "properties": {
-              "street": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "postalCode": {"type": "string"},
-              "countryOrRegion": {"type": "string"}
+              "street": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "postalCode": {
+                "type": "string"
+              },
+              "countryOrRegion": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           }
@@ -548,35 +735,93 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"},
-                "createdDateTime": {"type": "string"},
-                "lastModifiedDateTime": {"type": "string"},
-                "changeKey": {"type": "string"},
-                "categories": {"type": "array"},
-                "receivedDateTime": {"type": "string"},
-                "sentDateTime": {"type": "string"},
-                "hasAttachments": {"type": "boolean"},
-                "internetMessageId": {"type": "string"},
-                "subject": {"type": "string"},
-                "bodyPreview": {"type": "string"},
-                "importance": {"type": "string"},
-                "parentFolderId": {"type": "string"},
-                "conversationId": {"type": "string"},
-                "conversationIndex": {"type": "string"},
-                "isDeliveryReceiptRequested": {"type": "boolean"},
-                "isReadReceiptRequested": {"type": "boolean"},
-                "isRead": {"type": "boolean"},
-                "isDraft": {"type": "boolean"},
-                "webLink": {"type": "string"},
-                "inferenceClassification": {"type": "string"},
-                "body": {"type": "object"},
-                "sender": {"type": "object"},
-                "from": {"type": "object"},
-                "toRecipients": {"type": "array"},
-                "ccRecipients": {"type": "array"},
-                "bccRecipients": {"type": "array"},
-                "replyTo": {"type": "array"},
-                "flag": {"type": "object"}
+                "id": {
+                  "type": "string"
+                },
+                "createdDateTime": {
+                  "type": "string"
+                },
+                "lastModifiedDateTime": {
+                  "type": "string"
+                },
+                "changeKey": {
+                  "type": "string"
+                },
+                "categories": {
+                  "type": "array"
+                },
+                "receivedDateTime": {
+                  "type": "string"
+                },
+                "sentDateTime": {
+                  "type": "string"
+                },
+                "hasAttachments": {
+                  "type": "boolean"
+                },
+                "internetMessageId": {
+                  "type": "string"
+                },
+                "subject": {
+                  "type": "string"
+                },
+                "bodyPreview": {
+                  "type": "string"
+                },
+                "importance": {
+                  "type": "string"
+                },
+                "parentFolderId": {
+                  "type": "string"
+                },
+                "conversationId": {
+                  "type": "string"
+                },
+                "conversationIndex": {
+                  "type": "string"
+                },
+                "isDeliveryReceiptRequested": {
+                  "type": "boolean"
+                },
+                "isReadReceiptRequested": {
+                  "type": "boolean"
+                },
+                "isRead": {
+                  "type": "boolean"
+                },
+                "isDraft": {
+                  "type": "boolean"
+                },
+                "webLink": {
+                  "type": "string"
+                },
+                "inferenceClassification": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "object"
+                },
+                "sender": {
+                  "type": "object"
+                },
+                "from": {
+                  "type": "object"
+                },
+                "toRecipients": {
+                  "type": "array"
+                },
+                "ccRecipients": {
+                  "type": "array"
+                },
+                "bccRecipients": {
+                  "type": "array"
+                },
+                "replyTo": {
+                  "type": "array"
+                },
+                "flag": {
+                  "type": "object"
+                }
               }
             }
           }
@@ -607,46 +852,126 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"},
-                "createdDateTime": {"type": "string"},
-                "lastModifiedDateTime": {"type": "string"},
-                "changeKey": {"type": "string"},
-                "categories": {"type": "array"},
-                "originalStartTimeZone": {"type": "string"},
-                "originalEndTimeZone": {"type": "string"},
-                "iCalUId": {"type": "string"},
-                "reminderMinutesBeforeStart": {"type": "number"},
-                "isReminderOn": {"type": "boolean"},
-                "hasAttachments": {"type": "boolean"},
-                "subject": {"type": "string"},
-                "bodyPreview": {"type": "string"},
-                "importance": {"type": "string"},
-                "sensitivity": {"type": "string"},
-                "isAllDay": {"type": "boolean"},
-                "isCancelled": {"type": "boolean"},
-                "isOrganizer": {"type": "boolean"},
-                "responseRequested": {"type": "boolean"},
-                "seriesMasterId": {"type": "string"},
-                "showAs": {"type": "string"},
-                "type": {"type": "string"},
-                "webLink": {"type": "string"},
-                "onlineMeetingUrl": {"type": "string"},
-                "isOnlineMeeting": {"type": "boolean"},
-                "onlineMeetingProvider": {"type": "string"},
-                "allowNewTimeProposals": {"type": "boolean"},
-                "occurrenceId": {"type": "string"},
-                "isDraft": {"type": "boolean"},
-                "hideAttendees": {"type": "boolean"},
-                "responseStatus": {"type": "object"},
-                "body": {"type": "object"},
-                "start": {"type": "object"},
-                "end": {"type": "object"},
-                "location": {"type": "object"},
-                "locations": {"type": "array"},
-                "recurrence": {"type": "object"},
-                "attendees": {"type": "array"},
-                "organizer": {"type": "object"},
-                "onlineMeeting": {"type": "object"}
+                "id": {
+                  "type": "string"
+                },
+                "createdDateTime": {
+                  "type": "string"
+                },
+                "lastModifiedDateTime": {
+                  "type": "string"
+                },
+                "changeKey": {
+                  "type": "string"
+                },
+                "categories": {
+                  "type": "array"
+                },
+                "originalStartTimeZone": {
+                  "type": "string"
+                },
+                "originalEndTimeZone": {
+                  "type": "string"
+                },
+                "iCalUId": {
+                  "type": "string"
+                },
+                "reminderMinutesBeforeStart": {
+                  "type": "number"
+                },
+                "isReminderOn": {
+                  "type": "boolean"
+                },
+                "hasAttachments": {
+                  "type": "boolean"
+                },
+                "subject": {
+                  "type": "string"
+                },
+                "bodyPreview": {
+                  "type": "string"
+                },
+                "importance": {
+                  "type": "string"
+                },
+                "sensitivity": {
+                  "type": "string"
+                },
+                "isAllDay": {
+                  "type": "boolean"
+                },
+                "isCancelled": {
+                  "type": "boolean"
+                },
+                "isOrganizer": {
+                  "type": "boolean"
+                },
+                "responseRequested": {
+                  "type": "boolean"
+                },
+                "seriesMasterId": {
+                  "type": "string"
+                },
+                "showAs": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "webLink": {
+                  "type": "string"
+                },
+                "onlineMeetingUrl": {
+                  "type": "string"
+                },
+                "isOnlineMeeting": {
+                  "type": "boolean"
+                },
+                "onlineMeetingProvider": {
+                  "type": "string"
+                },
+                "allowNewTimeProposals": {
+                  "type": "boolean"
+                },
+                "occurrenceId": {
+                  "type": "string"
+                },
+                "isDraft": {
+                  "type": "boolean"
+                },
+                "hideAttendees": {
+                  "type": "boolean"
+                },
+                "responseStatus": {
+                  "type": "object"
+                },
+                "body": {
+                  "type": "object"
+                },
+                "start": {
+                  "type": "object"
+                },
+                "end": {
+                  "type": "object"
+                },
+                "location": {
+                  "type": "object"
+                },
+                "locations": {
+                  "type": "array"
+                },
+                "recurrence": {
+                  "type": "object"
+                },
+                "attendees": {
+                  "type": "array"
+                },
+                "organizer": {
+                  "type": "object"
+                },
+                "onlineMeeting": {
+                  "type": "object"
+                }
               }
             }
           }
@@ -657,5 +982,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/pagerduty/definition.json
+++ b/connectors/pagerduty/definition.json
@@ -40,7 +40,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["incident"],
+                "enum": [
+                  "incident"
+                ],
                 "default": "incident"
               },
               "title": {
@@ -50,23 +52,43 @@
               "service": {
                 "type": "object",
                 "properties": {
-                  "id": {"type": "string"},
-                  "type": {"type": "string", "enum": ["service_reference"]}
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "service_reference"
+                    ]
+                  }
                 },
-                "required": ["id", "type"],
+                "required": [
+                  "id",
+                  "type"
+                ],
                 "additionalProperties": false
               },
               "priority": {
                 "type": "object",
                 "properties": {
-                  "id": {"type": "string"},
-                  "type": {"type": "string", "enum": ["priority_reference"]}
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "priority_reference"
+                    ]
+                  }
                 },
                 "additionalProperties": false
               },
               "urgency": {
                 "type": "string",
-                "enum": ["high", "low"],
+                "enum": [
+                  "high",
+                  "low"
+                ],
                 "description": "Incident urgency"
               },
               "incident_key": {
@@ -76,16 +98,30 @@
               "body": {
                 "type": "object",
                 "properties": {
-                  "type": {"type": "string", "enum": ["incident_body"]},
-                  "details": {"type": "string"}
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "incident_body"
+                    ]
+                  },
+                  "details": {
+                    "type": "string"
+                  }
                 },
                 "additionalProperties": false
               },
               "escalation_policy": {
                 "type": "object",
                 "properties": {
-                  "id": {"type": "string"},
-                  "type": {"type": "string", "enum": ["escalation_policy_reference"]}
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "escalation_policy_reference"
+                    ]
+                  }
                 },
                 "additionalProperties": false
               },
@@ -97,8 +133,15 @@
                     "assignee": {
                       "type": "object",
                       "properties": {
-                        "id": {"type": "string"},
-                        "type": {"type": "string", "enum": ["user_reference"]}
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "user_reference"
+                          ]
+                        }
                       },
                       "additionalProperties": false
                     }
@@ -107,11 +150,17 @@
                 }
               }
             },
-            "required": ["type", "title", "service"],
+            "required": [
+              "type",
+              "title",
+              "service"
+            ],
             "additionalProperties": false
           }
         },
-        "required": ["incident"],
+        "required": [
+          "incident"
+        ],
         "additionalProperties": false
       }
     },
@@ -128,11 +177,15 @@
           },
           "include": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Additional data to include"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -150,37 +203,80 @@
           "incident": {
             "type": "object",
             "properties": {
-              "type": {"type": "string", "enum": ["incident"]},
-              "title": {"type": "string"},
-              "status": {"type": "string", "enum": ["triggered", "acknowledged", "resolved"]},
+              "type": {
+                "type": "string",
+                "enum": [
+                  "incident"
+                ]
+              },
+              "title": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "triggered",
+                  "acknowledged",
+                  "resolved"
+                ]
+              },
               "priority": {
                 "type": "object",
                 "properties": {
-                  "id": {"type": "string"},
-                  "type": {"type": "string", "enum": ["priority_reference"]}
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "priority_reference"
+                    ]
+                  }
                 },
                 "additionalProperties": false
               },
-              "escalation_level": {"type": "number"},
+              "escalation_level": {
+                "type": "number"
+              },
               "assignments": {
                 "type": "array",
-                "items": {"type": "object"}
+                "items": {
+                  "type": "object"
+                }
               },
               "escalation_policy": {
                 "type": "object",
                 "properties": {
-                  "id": {"type": "string"},
-                  "type": {"type": "string", "enum": ["escalation_policy_reference"]}
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "escalation_policy_reference"
+                    ]
+                  }
                 },
                 "additionalProperties": false
               },
-              "urgency": {"type": "string", "enum": ["high", "low"]},
-              "resolution": {"type": "string"}
+              "urgency": {
+                "type": "string",
+                "enum": [
+                  "high",
+                  "low"
+                ]
+              },
+              "resolution": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           }
         },
-        "required": ["id", "incident"],
+        "required": [
+          "id",
+          "incident"
+        ],
         "additionalProperties": false
       }
     },
@@ -210,7 +306,9 @@
           },
           "date_range": {
             "type": "string",
-            "enum": ["all"],
+            "enum": [
+              "all"
+            ],
             "description": "Date range filter"
           },
           "incident_key": {
@@ -219,22 +317,34 @@
           },
           "service_ids": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by service IDs"
           },
           "team_ids": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by team IDs"
           },
           "user_ids": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by user IDs"
           },
           "urgencies": {
             "type": "array",
-            "items": {"type": "string", "enum": ["high", "low"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "high",
+                "low"
+              ]
+            },
             "description": "Filter by urgencies"
           },
           "time_zone": {
@@ -243,17 +353,35 @@
           },
           "statuses": {
             "type": "array",
-            "items": {"type": "string", "enum": ["triggered", "acknowledged", "resolved"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "triggered",
+                "acknowledged",
+                "resolved"
+              ]
+            },
             "description": "Filter by statuses"
           },
           "sort_by": {
             "type": "string",
-            "enum": ["incident_number:asc", "incident_number:desc", "created_at:asc", "created_at:desc", "resolved_at:asc", "resolved_at:desc", "urgency:asc", "urgency:desc"],
+            "enum": [
+              "incident_number:asc",
+              "incident_number:desc",
+              "created_at:asc",
+              "created_at:desc",
+              "resolved_at:asc",
+              "resolved_at:desc",
+              "urgency:asc",
+              "urgency:desc"
+            ],
             "description": "Sort order"
           },
           "include": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Additional data to include"
           }
         },
@@ -278,7 +406,10 @@
             "description": "Email of the user acknowledging"
           }
         },
-        "required": ["id", "from"],
+        "required": [
+          "id",
+          "from"
+        ],
         "additionalProperties": false
       }
     },
@@ -303,7 +434,10 @@
             "description": "Resolution notes"
           }
         },
-        "required": ["id", "from"],
+        "required": [
+          "id",
+          "from"
+        ],
         "additionalProperties": false
       }
     },
@@ -321,9 +455,13 @@
           "note": {
             "type": "object",
             "properties": {
-              "content": {"type": "string"}
+              "content": {
+                "type": "string"
+              }
             },
-            "required": ["content"],
+            "required": [
+              "content"
+            ],
             "additionalProperties": false
           },
           "from": {
@@ -332,7 +470,11 @@
             "description": "Email of the user adding note"
           }
         },
-        "required": ["id", "note", "from"],
+        "required": [
+          "id",
+          "note",
+          "from"
+        ],
         "additionalProperties": false
       }
     },
@@ -349,11 +491,15 @@
           },
           "include": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Additional data to include"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -380,14 +526,21 @@
           },
           "team_ids": {
             "type": "array",
-            "items": {"type": "string"}
+            "items": {
+              "type": "string"
+            }
           },
           "time_zone": {
             "type": "string"
           },
           "sort_by": {
             "type": "string",
-            "enum": ["name:asc", "name:desc", "created_at:asc", "created_at:desc"]
+            "enum": [
+              "name:asc",
+              "name:desc",
+              "created_at:asc",
+              "created_at:desc"
+            ]
           },
           "query": {
             "type": "string",
@@ -395,7 +548,9 @@
           },
           "include": {
             "type": "array",
-            "items": {"type": "string"}
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [],
@@ -415,11 +570,15 @@
           },
           "include": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Additional data to include"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -450,11 +609,15 @@
           },
           "team_ids": {
             "type": "array",
-            "items": {"type": "string"}
+            "items": {
+              "type": "string"
+            }
           },
           "include": {
             "type": "array",
-            "items": {"type": "string"}
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [],
@@ -473,7 +636,9 @@
         "properties": {
           "service_ids": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by service IDs"
           }
         },
@@ -486,40 +651,102 @@
           "event": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"},
-              "event_type": {"type": "string"},
-              "resource_type": {"type": "string"},
-              "occurred_at": {"type": "string"},
-              "agent": {"type": "object"},
-              "client": {"type": "object"},
+              "id": {
+                "type": "string"
+              },
+              "event_type": {
+                "type": "string"
+              },
+              "resource_type": {
+                "type": "string"
+              },
+              "occurred_at": {
+                "type": "string"
+              },
+              "agent": {
+                "type": "object"
+              },
+              "client": {
+                "type": "object"
+              },
               "data": {
                 "type": "object",
                 "properties": {
-                  "id": {"type": "string"},
-                  "type": {"type": "string"},
-                  "self": {"type": "string"},
-                  "html_url": {"type": "string"},
-                  "number": {"type": "number"},
-                  "status": {"type": "string"},
-                  "incident_key": {"type": "string"},
-                  "created_at": {"type": "string"},
-                  "updated_at": {"type": "string"},
-                  "summary": {"type": "string"},
-                  "description": {"type": "string"},
-                  "urgency": {"type": "string"},
-                  "service": {"type": "object"},
-                  "escalation_policy": {"type": "object"},
-                  "assignments": {"type": "array"},
-                  "acknowledgements": {"type": "array"},
-                  "priority": {"type": "object"},
-                  "incident_number": {"type": "number"},
-                  "title": {"type": "string"},
-                  "pending_actions": {"type": "array"},
-                  "alert_counts": {"type": "object"},
-                  "body": {"type": "object"},
-                  "is_mergeable": {"type": "boolean"},
-                  "basic_alert_grouping": {"type": "object"},
-                  "alert_grouping": {"type": "object"}
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "self": {
+                    "type": "string"
+                  },
+                  "html_url": {
+                    "type": "string"
+                  },
+                  "number": {
+                    "type": "number"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "incident_key": {
+                    "type": "string"
+                  },
+                  "created_at": {
+                    "type": "string"
+                  },
+                  "updated_at": {
+                    "type": "string"
+                  },
+                  "summary": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "urgency": {
+                    "type": "string"
+                  },
+                  "service": {
+                    "type": "object"
+                  },
+                  "escalation_policy": {
+                    "type": "object"
+                  },
+                  "assignments": {
+                    "type": "array"
+                  },
+                  "acknowledgements": {
+                    "type": "array"
+                  },
+                  "priority": {
+                    "type": "object"
+                  },
+                  "incident_number": {
+                    "type": "number"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "pending_actions": {
+                    "type": "array"
+                  },
+                  "alert_counts": {
+                    "type": "object"
+                  },
+                  "body": {
+                    "type": "object"
+                  },
+                  "is_mergeable": {
+                    "type": "boolean"
+                  },
+                  "basic_alert_grouping": {
+                    "type": "object"
+                  },
+                  "alert_grouping": {
+                    "type": "object"
+                  }
                 }
               }
             }
@@ -537,7 +764,9 @@
         "properties": {
           "service_ids": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by service IDs"
           }
         },
@@ -547,7 +776,9 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "object"}
+          "event": {
+            "type": "object"
+          }
         }
       }
     },
@@ -561,7 +792,9 @@
         "properties": {
           "service_ids": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by service IDs"
           }
         },
@@ -571,7 +804,9 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "object"}
+          "event": {
+            "type": "object"
+          }
         }
       }
     }
@@ -579,5 +814,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/pardot/definition.json
+++ b/connectors/pardot/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://login.salesforce.com/services/oauth2/authorize",
       "tokenUrl": "https://login.salesforce.com/services/oauth2/token",
-      "scopes": ["pardot_api"]
+      "scopes": [
+        "pardot_api"
+      ]
     }
   },
   "baseUrl": "https://pi.pardot.com/api",
@@ -69,12 +71,20 @@
           },
           "sort_by": {
             "type": "string",
-            "enum": ["created_at", "id", "probability", "value"],
+            "enum": [
+              "created_at",
+              "id",
+              "probability",
+              "value"
+            ],
             "description": "Sort field"
           },
           "sort_order": {
             "type": "string",
-            "enum": ["ascending", "descending"],
+            "enum": [
+              "ascending",
+              "descending"
+            ],
             "description": "Sort order"
           }
         },
@@ -195,7 +205,9 @@
             "description": "Do not call flag"
           }
         },
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "additionalProperties": false
       }
     },
@@ -240,7 +252,9 @@
             "description": "Prospect score"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -310,7 +324,10 @@
             "description": "Prospect ID"
           }
         },
-        "required": ["list_id", "prospect_id"],
+        "required": [
+          "list_id",
+          "prospect_id"
+        ],
         "additionalProperties": false
       }
     }
@@ -330,12 +347,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "email": {"type": "string"},
-          "first_name": {"type": "string"},
-          "last_name": {"type": "string"},
-          "company": {"type": "string"},
-          "created_at": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "email": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "company": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          }
         }
       }
     }
@@ -343,5 +372,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/prospect/version/4/do/query"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/paypal/definition.json
+++ b/connectors/paypal/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://www.paypal.com/signin/authorize",
       "tokenUrl": "https://api-m.paypal.com/v1/oauth2/token",
-      "scopes": ["https://uri.paypal.com/services/payments/payment", "https://uri.paypal.com/services/payments/refund"]
+      "scopes": [
+        "https://uri.paypal.com/services/payments/payment",
+        "https://uri.paypal.com/services/payments/refund"
+      ]
     }
   },
   "baseUrl": "https://api-m.paypal.com",
@@ -40,7 +43,10 @@
         "properties": {
           "intent": {
             "type": "string",
-            "enum": ["CAPTURE", "AUTHORIZE"],
+            "enum": [
+              "CAPTURE",
+              "AUTHORIZE"
+            ],
             "description": "Order intent - CAPTURE for immediate payment, AUTHORIZE for delayed capture"
           },
           "purchase_units": {
@@ -51,70 +57,131 @@
                 "amount": {
                   "type": "object",
                   "properties": {
-                    "currency_code": {"type": "string"},
-                    "value": {"type": "string"}
+                    "currency_code": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["currency_code", "value"]
+                  "required": [
+                    "currency_code",
+                    "value"
+                  ]
                 },
-                "description": {"type": "string"},
-                "custom_id": {"type": "string"},
-                "invoice_id": {"type": "string"},
-                "soft_descriptor": {"type": "string"},
+                "description": {
+                  "type": "string"
+                },
+                "custom_id": {
+                  "type": "string"
+                },
+                "invoice_id": {
+                  "type": "string"
+                },
+                "soft_descriptor": {
+                  "type": "string"
+                },
                 "items": {
                   "type": "array",
-                  "items": {"type": "object"}
+                  "items": {
+                    "type": "object"
+                  }
                 },
-                "shipping": {"type": "object"},
-                "payments": {"type": "object"}
+                "shipping": {
+                  "type": "object"
+                },
+                "payments": {
+                  "type": "object"
+                }
               },
-              "required": ["amount"]
+              "required": [
+                "amount"
+              ]
             },
             "description": "Array of purchase units for the order"
           },
           "application_context": {
             "type": "object",
             "properties": {
-              "brand_name": {"type": "string"},
-              "locale": {"type": "string"},
+              "brand_name": {
+                "type": "string"
+              },
+              "locale": {
+                "type": "string"
+              },
               "landing_page": {
                 "type": "string",
-                "enum": ["LOGIN", "BILLING", "NO_PREFERENCE"]
+                "enum": [
+                  "LOGIN",
+                  "BILLING",
+                  "NO_PREFERENCE"
+                ]
               },
               "shipping_preference": {
                 "type": "string",
-                "enum": ["GET_FROM_FILE", "NO_SHIPPING", "SET_PROVIDED_ADDRESS"]
+                "enum": [
+                  "GET_FROM_FILE",
+                  "NO_SHIPPING",
+                  "SET_PROVIDED_ADDRESS"
+                ]
               },
               "user_action": {
                 "type": "string",
-                "enum": ["CONTINUE", "PAY_NOW"]
+                "enum": [
+                  "CONTINUE",
+                  "PAY_NOW"
+                ]
               },
               "payment_method": {
                 "type": "object",
                 "properties": {
-                  "payer_selected": {"type": "string"},
+                  "payer_selected": {
+                    "type": "string"
+                  },
                   "payee_preferred": {
                     "type": "string",
-                    "enum": ["UNRESTRICTED", "IMMEDIATE_PAYMENT_REQUIRED"]
+                    "enum": [
+                      "UNRESTRICTED",
+                      "IMMEDIATE_PAYMENT_REQUIRED"
+                    ]
                   }
                 }
               },
-              "return_url": {"type": "string", "format": "uri"},
-              "cancel_url": {"type": "string", "format": "uri"}
+              "return_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "cancel_url": {
+                "type": "string",
+                "format": "uri"
+              }
             },
             "description": "Application context for the order"
           },
           "payer": {
             "type": "object",
             "properties": {
-              "name": {"type": "object"},
-              "email_address": {"type": "string", "format": "email"},
-              "payer_id": {"type": "string"},
-              "address": {"type": "object"}
+              "name": {
+                "type": "object"
+              },
+              "email_address": {
+                "type": "string",
+                "format": "email"
+              },
+              "payer_id": {
+                "type": "string"
+              },
+              "address": {
+                "type": "object"
+              }
             },
             "description": "Payer information"
           }
         },
-        "required": ["intent", "purchase_units"],
+        "required": [
+          "intent",
+          "purchase_units"
+        ],
         "additionalProperties": false
       }
     },
@@ -134,7 +201,9 @@
             "description": "Payment source information"
           }
         },
-        "required": ["order_id"],
+        "required": [
+          "order_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -154,7 +223,9 @@
             "description": "Comma-separated list of fields to return"
           }
         },
-        "required": ["order_id"],
+        "required": [
+          "order_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -172,8 +243,12 @@
           "amount": {
             "type": "object",
             "properties": {
-              "currency_code": {"type": "string"},
-              "value": {"type": "string"}
+              "currency_code": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
             },
             "description": "Refund amount (omit for full refund)"
           },
@@ -186,7 +261,9 @@
             "description": "Invoice ID for the refund"
           }
         },
-        "required": ["capture_id"],
+        "required": [
+          "capture_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -199,7 +276,11 @@
         "properties": {
           "intent": {
             "type": "string",
-            "enum": ["sale", "authorize", "order"],
+            "enum": [
+              "sale",
+              "authorize",
+              "order"
+            ],
             "description": "Payment intent"
           },
           "payer": {
@@ -207,9 +288,14 @@
             "properties": {
               "payment_method": {
                 "type": "string",
-                "enum": ["credit_card", "paypal"]
+                "enum": [
+                  "credit_card",
+                  "paypal"
+                ]
               },
-              "funding_instruments": {"type": "array"}
+              "funding_instruments": {
+                "type": "array"
+              }
             },
             "description": "Payer information"
           },
@@ -218,13 +304,27 @@
             "items": {
               "type": "object",
               "properties": {
-                "amount": {"type": "object"},
-                "description": {"type": "string"},
-                "invoice_number": {"type": "string"},
-                "custom": {"type": "string"},
-                "payment_options": {"type": "object"},
-                "soft_descriptor": {"type": "string"},
-                "item_list": {"type": "object"}
+                "amount": {
+                  "type": "object"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "invoice_number": {
+                  "type": "string"
+                },
+                "custom": {
+                  "type": "string"
+                },
+                "payment_options": {
+                  "type": "object"
+                },
+                "soft_descriptor": {
+                  "type": "string"
+                },
+                "item_list": {
+                  "type": "object"
+                }
               }
             },
             "description": "Transaction details"
@@ -232,13 +332,23 @@
           "redirect_urls": {
             "type": "object",
             "properties": {
-              "return_url": {"type": "string", "format": "uri"},
-              "cancel_url": {"type": "string", "format": "uri"}
+              "return_url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "cancel_url": {
+                "type": "string",
+                "format": "uri"
+              }
             },
             "description": "Redirect URLs for payment completion"
           }
         },
-        "required": ["intent", "payer", "transactions"],
+        "required": [
+          "intent",
+          "payer",
+          "transactions"
+        ],
         "additionalProperties": false
       }
     },
@@ -254,7 +364,9 @@
             "description": "Payment ID to retrieve"
           }
         },
-        "required": ["payment_id"],
+        "required": [
+          "payment_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -292,12 +404,18 @@
           },
           "sort_by": {
             "type": "string",
-            "enum": ["create_time", "update_time"],
+            "enum": [
+              "create_time",
+              "update_time"
+            ],
             "description": "Sort field"
           },
           "sort_order": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "description": "Sort order"
           }
         },
@@ -330,12 +448,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "event_type": {"type": "string"},
-          "create_time": {"type": "string"},
-          "resource_type": {"type": "string"},
-          "resource": {"type": "object"},
-          "summary": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "create_time": {
+            "type": "string"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "object"
+          },
+          "summary": {
+            "type": "string"
+          }
         }
       }
     },
@@ -358,11 +488,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "event_type": {"type": "string"},
-          "create_time": {"type": "string"},
-          "resource_type": {"type": "string"},
-          "resource": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "create_time": {
+            "type": "string"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "object"
+          }
         }
       }
     },
@@ -376,7 +516,10 @@
         "properties": {
           "intent": {
             "type": "string",
-            "enum": ["CAPTURE", "AUTHORIZE"],
+            "enum": [
+              "CAPTURE",
+              "AUTHORIZE"
+            ],
             "description": "Filter by order intent"
           }
         },
@@ -386,10 +529,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "event_type": {"type": "string"},
-          "resource": {"type": "object"},
-          "links": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "object"
+          },
+          "links": {
+            "type": "array"
+          }
         }
       }
     },
@@ -407,10 +558,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "event_type": {"type": "string"},
-          "resource": {"type": "object"},
-          "links": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "object"
+          },
+          "links": {
+            "type": "array"
+          }
         }
       }
     }
@@ -418,5 +577,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/v1/identity/oauth2/userinfo?schema=paypalv1.1"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/pipedrive/definition.json
+++ b/connectors/pipedrive/definition.json
@@ -47,7 +47,13 @@
           },
           "status": {
             "type": "string",
-            "enum": ["open", "won", "lost", "deleted", "all_not_deleted"],
+            "enum": [
+              "open",
+              "won",
+              "lost",
+              "deleted",
+              "all_not_deleted"
+            ],
             "default": "all_not_deleted",
             "description": "Filter by status"
           },
@@ -69,7 +75,10 @@
           },
           "owned_by_you": {
             "type": "string",
-            "enum": ["0", "1"],
+            "enum": [
+              "0",
+              "1"
+            ],
             "description": "Filter for deals owned by authenticated user"
           }
         },
@@ -114,7 +123,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["open", "won", "lost", "deleted"],
+            "enum": [
+              "open",
+              "won",
+              "lost",
+              "deleted"
+            ],
             "default": "open",
             "description": "Deal status"
           },
@@ -135,11 +149,18 @@
           },
           "visible_to": {
             "type": "string",
-            "enum": ["1", "3", "5", "7"],
+            "enum": [
+              "1",
+              "3",
+              "5",
+              "7"
+            ],
             "description": "Visibility setting"
           }
         },
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -184,7 +205,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["open", "won", "lost", "deleted"],
+            "enum": [
+              "open",
+              "won",
+              "lost",
+              "deleted"
+            ],
             "description": "Deal status"
           },
           "probability": {
@@ -194,7 +220,9 @@
             "description": "Probability percentage"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -262,9 +290,16 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string", "format": "email"},
-                "primary": {"type": "boolean"},
-                "label": {"type": "string"}
+                "value": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "primary": {
+                  "type": "boolean"
+                },
+                "label": {
+                  "type": "string"
+                }
               }
             },
             "description": "Email addresses"
@@ -274,20 +309,33 @@
             "items": {
               "type": "object",
               "properties": {
-                "value": {"type": "string"},
-                "primary": {"type": "boolean"},
-                "label": {"type": "string"}
+                "value": {
+                  "type": "string"
+                },
+                "primary": {
+                  "type": "boolean"
+                },
+                "label": {
+                  "type": "string"
+                }
               }
             },
             "description": "Phone numbers"
           },
           "visible_to": {
             "type": "string",
-            "enum": ["1", "3", "5", "7"],
+            "enum": [
+              "1",
+              "3",
+              "5",
+              "7"
+            ],
             "description": "Visibility setting"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -348,7 +396,12 @@
           },
           "visible_to": {
             "type": "string",
-            "enum": ["1", "3", "5", "7"],
+            "enum": [
+              "1",
+              "3",
+              "5",
+              "7"
+            ],
             "description": "Visibility setting"
           },
           "address": {
@@ -396,7 +449,9 @@
             "description": "Formatted address"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -443,7 +498,10 @@
           },
           "done": {
             "type": "string",
-            "enum": ["0", "1"],
+            "enum": [
+              "0",
+              "1"
+            ],
             "description": "Filter by completion status"
           }
         },
@@ -501,12 +559,18 @@
           },
           "done": {
             "type": "string",
-            "enum": ["0", "1"],
+            "enum": [
+              "0",
+              "1"
+            ],
             "default": "0",
             "description": "Mark as done"
           }
         },
-        "required": ["subject", "type"],
+        "required": [
+          "subject",
+          "type"
+        ],
         "additionalProperties": false
       }
     }
@@ -531,16 +595,36 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "title": {"type": "string"},
-          "value": {"type": "number"},
-          "currency": {"type": "string"},
-          "add_time": {"type": "string"},
-          "update_time": {"type": "string"},
-          "stage_id": {"type": "number"},
-          "status": {"type": "string"},
-          "probability": {"type": "number"},
-          "user_id": {"type": "number"}
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "add_time": {
+            "type": "string"
+          },
+          "update_time": {
+            "type": "string"
+          },
+          "stage_id": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          },
+          "probability": {
+            "type": "number"
+          },
+          "user_id": {
+            "type": "number"
+          }
         }
       }
     },
@@ -563,12 +647,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "title": {"type": "string"},
-          "value": {"type": "number"},
-          "update_time": {"type": "string"},
-          "stage_id": {"type": "number"},
-          "status": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number"
+          },
+          "update_time": {
+            "type": "string"
+          },
+          "stage_id": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          }
         }
       }
     }
@@ -576,5 +672,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/powerbi-enhanced/definition.json
+++ b/connectors/powerbi-enhanced/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-      "scopes": ["https://analysis.windows.net/powerbi/api/.default"]
+      "scopes": [
+        "https://analysis.windows.net/powerbi/api/.default"
+      ]
     }
   },
   "baseUrl": "https://api.powerbi.com/v1.0/myorg",
@@ -66,7 +68,9 @@
             "description": "Workspace ID"
           }
         },
-        "required": ["groupId"],
+        "required": [
+          "groupId"
+        ],
         "additionalProperties": false
       }
     },
@@ -87,7 +91,9 @@
             "description": "Create as workspace v2"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -134,7 +140,9 @@
             "description": "Workspace ID (optional)"
           }
         },
-        "required": ["datasetId"],
+        "required": [
+          "datasetId"
+        ],
         "additionalProperties": false
       }
     },
@@ -155,7 +163,11 @@
           },
           "notifyOption": {
             "type": "string",
-            "enum": ["MailOnCompletion", "MailOnFailure", "NoNotification"],
+            "enum": [
+              "MailOnCompletion",
+              "MailOnFailure",
+              "NoNotification"
+            ],
             "default": "NoNotification",
             "description": "Notification option"
           },
@@ -167,13 +179,24 @@
           },
           "type": {
             "type": "string",
-            "enum": ["Full", "ClearValues", "Calculate", "DataOnly", "Automatic", "Add", "Defragment"],
+            "enum": [
+              "Full",
+              "ClearValues",
+              "Calculate",
+              "DataOnly",
+              "Automatic",
+              "Add",
+              "Defragment"
+            ],
             "default": "Full",
             "description": "Refresh type"
           },
           "commitMode": {
             "type": "string",
-            "enum": ["Transactional", "PartialBatch"],
+            "enum": [
+              "Transactional",
+              "PartialBatch"
+            ],
             "description": "Commit mode"
           },
           "maxParallelism": {
@@ -186,14 +209,20 @@
             "items": {
               "type": "object",
               "properties": {
-                "table": {"type": "string"},
-                "partition": {"type": "string"}
+                "table": {
+                  "type": "string"
+                },
+                "partition": {
+                  "type": "string"
+                }
               }
             },
             "description": "Specific objects to refresh"
           }
         },
-        "required": ["datasetId"],
+        "required": [
+          "datasetId"
+        ],
         "additionalProperties": false
       }
     },
@@ -220,7 +249,9 @@
             "description": "Number of refresh entries to return"
           }
         },
-        "required": ["datasetId"],
+        "required": [
+          "datasetId"
+        ],
         "additionalProperties": false
       }
     },
@@ -271,7 +302,9 @@
             "description": "Workspace ID (optional)"
           }
         },
-        "required": ["reportId"],
+        "required": [
+          "reportId"
+        ],
         "additionalProperties": false
       }
     },
@@ -303,7 +336,10 @@
             "description": "Target workspace ID"
           }
         },
-        "required": ["reportId", "name"],
+        "required": [
+          "reportId",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -324,7 +360,14 @@
           },
           "format": {
             "type": "string",
-            "enum": ["PDF", "PNG", "PPTX", "XLSX", "XML", "CSV"],
+            "enum": [
+              "PDF",
+              "PNG",
+              "PPTX",
+              "XLSX",
+              "XML",
+              "CSV"
+            ],
             "description": "Export format"
           },
           "pages": {
@@ -332,12 +375,18 @@
             "items": {
               "type": "object",
               "properties": {
-                "pageName": {"type": "string"},
+                "pageName": {
+                  "type": "string"
+                },
                 "bookmark": {
                   "type": "object",
                   "properties": {
-                    "name": {"type": "string"},
-                    "state": {"type": "string"}
+                    "name": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -350,8 +399,12 @@
               "settings": {
                 "type": "object",
                 "properties": {
-                  "includeHiddenPages": {"type": "boolean"},
-                  "locale": {"type": "string"}
+                  "includeHiddenPages": {
+                    "type": "boolean"
+                  },
+                  "locale": {
+                    "type": "string"
+                  }
                 }
               },
               "identities": {
@@ -359,9 +412,21 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "username": {"type": "string"},
-                    "datasets": {"type": "array", "items": {"type": "string"}},
-                    "roles": {"type": "array", "items": {"type": "string"}}
+                    "username": {
+                      "type": "string"
+                    },
+                    "datasets": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "roles": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -369,7 +434,10 @@
             "description": "Export configuration"
           }
         },
-        "required": ["reportId", "format"],
+        "required": [
+          "reportId",
+          "format"
+        ],
         "additionalProperties": false
       }
     },
@@ -416,7 +484,9 @@
             "description": "Workspace ID (optional)"
           }
         },
-        "required": ["dashboardId"],
+        "required": [
+          "dashboardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -436,7 +506,9 @@
             "description": "Workspace ID (optional)"
           }
         },
-        "required": ["dashboardId"],
+        "required": [
+          "dashboardId"
+        ],
         "additionalProperties": false
       }
     },
@@ -456,10 +528,16 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"},
-                "allowEdit": {"type": "boolean"}
+                "id": {
+                  "type": "string"
+                },
+                "allowEdit": {
+                  "type": "boolean"
+                }
               },
-              "required": ["id"]
+              "required": [
+                "id"
+              ]
             },
             "description": "Reports to include in token"
           },
@@ -468,9 +546,13 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"}
+                "id": {
+                  "type": "string"
+                }
               },
-              "required": ["id"]
+              "required": [
+                "id"
+              ]
             },
             "description": "Datasets to include in token"
           },
@@ -479,9 +561,13 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"}
+                "id": {
+                  "type": "string"
+                }
               },
-              "required": ["id"]
+              "required": [
+                "id"
+              ]
             },
             "description": "Target workspaces"
           },
@@ -490,11 +576,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "username": {"type": "string"},
-                "datasets": {"type": "array", "items": {"type": "string"}},
-                "roles": {"type": "array", "items": {"type": "string"}}
+                "username": {
+                  "type": "string"
+                },
+                "datasets": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "roles": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
-              "required": ["username"]
+              "required": [
+                "username"
+              ]
             },
             "description": "Row-level security identities"
           }
@@ -525,7 +625,9 @@
           "serializerSettings": {
             "type": "object",
             "properties": {
-              "includeNulls": {"type": "boolean"}
+              "includeNulls": {
+                "type": "boolean"
+              }
             },
             "description": "Serializer settings"
           },
@@ -534,7 +636,10 @@
             "description": "Impersonated user name for RLS"
           }
         },
-        "required": ["datasetId", "query"],
+        "required": [
+          "datasetId",
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -582,12 +687,18 @@
           },
           "notifyOption": {
             "type": "string",
-            "enum": ["MailOnCompletion", "MailOnFailure", "NoNotification"],
+            "enum": [
+              "MailOnCompletion",
+              "MailOnFailure",
+              "NoNotification"
+            ],
             "default": "NoNotification",
             "description": "Notification option"
           }
         },
-        "required": ["dataflowId"],
+        "required": [
+          "dataflowId"
+        ],
         "additionalProperties": false
       }
     }
@@ -611,7 +722,11 @@
           },
           "refreshStatus": {
             "type": "string",
-            "enum": ["Completed", "Failed", "Disabled"],
+            "enum": [
+              "Completed",
+              "Failed",
+              "Disabled"
+            ],
             "description": "Filter by refresh status"
           }
         },
@@ -621,15 +736,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "datasetId": {"type": "string"},
-          "datasetName": {"type": "string"},
-          "groupId": {"type": "string"},
-          "refreshId": {"type": "string"},
-          "refreshType": {"type": "string"},
-          "status": {"type": "string"},
-          "startTime": {"type": "string"},
-          "endTime": {"type": "string"},
-          "serviceExceptionJson": {"type": "string"}
+          "datasetId": {
+            "type": "string"
+          },
+          "datasetName": {
+            "type": "string"
+          },
+          "groupId": {
+            "type": "string"
+          },
+          "refreshId": {
+            "type": "string"
+          },
+          "refreshType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "serviceExceptionJson": {
+            "type": "string"
+          }
         }
       }
     },
@@ -652,13 +785,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "reportId": {"type": "string"},
-          "reportName": {"type": "string"},
-          "groupId": {"type": "string"},
-          "datasetId": {"type": "string"},
-          "createdDateTime": {"type": "string"},
-          "modifiedDateTime": {"type": "string"},
-          "createdBy": {"type": "string"}
+          "reportId": {
+            "type": "string"
+          },
+          "reportName": {
+            "type": "string"
+          },
+          "groupId": {
+            "type": "string"
+          },
+          "datasetId": {
+            "type": "string"
+          },
+          "createdDateTime": {
+            "type": "string"
+          },
+          "modifiedDateTime": {
+            "type": "string"
+          },
+          "createdBy": {
+            "type": "string"
+          }
         }
       }
     },
@@ -685,13 +832,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "dataflowId": {"type": "string"},
-          "dataflowName": {"type": "string"},
-          "groupId": {"type": "string"},
-          "refreshId": {"type": "string"},
-          "status": {"type": "string"},
-          "startTime": {"type": "string"},
-          "endTime": {"type": "string"}
+          "dataflowId": {
+            "type": "string"
+          },
+          "dataflowName": {
+            "type": "string"
+          },
+          "groupId": {
+            "type": "string"
+          },
+          "refreshId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          }
         }
       }
     }
@@ -699,5 +860,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/groups"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/powerbi/definition.json
+++ b/connectors/powerbi/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-      "scopes": ["https://analysis.windows.net/powerbi/api/.default"]
+      "scopes": [
+        "https://analysis.windows.net/powerbi/api/.default"
+      ]
     }
   },
   "baseUrl": "https://api.powerbi.com/v1.0/myorg",
@@ -59,7 +61,9 @@
             "description": "Workspace ID (optional)"
           }
         },
-        "required": ["datasetId"],
+        "required": [
+          "datasetId"
+        ],
         "additionalProperties": false
       }
     },
@@ -116,9 +120,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "datasetId": {"type": "string"},
-          "refreshType": {"type": "string"},
-          "status": {"type": "string"}
+          "datasetId": {
+            "type": "string"
+          },
+          "refreshType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
         }
       }
     }
@@ -126,5 +136,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/groups"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/prometheus/definition.json
+++ b/connectors/prometheus/definition.json
@@ -56,7 +56,9 @@
             "description": "Query timeout duration"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -85,7 +87,12 @@
             "description": "Query resolution step width"
           }
         },
-        "required": ["query", "start", "end", "step"],
+        "required": [
+          "query",
+          "start",
+          "end",
+          "step"
+        ],
         "additionalProperties": false
       }
     },
@@ -99,7 +106,11 @@
         "properties": {
           "state": {
             "type": "string",
-            "enum": ["active", "dropped", "any"],
+            "enum": [
+              "active",
+              "dropped",
+              "any"
+            ],
             "default": "active",
             "description": "Target state filter"
           }
@@ -153,7 +164,11 @@
           },
           "severity": {
             "type": "string",
-            "enum": ["critical", "warning", "info"],
+            "enum": [
+              "critical",
+              "warning",
+              "info"
+            ],
             "description": "Filter by alert severity"
           }
         },
@@ -182,5 +197,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/qualtrics/definition.json
+++ b/connectors/qualtrics/definition.json
@@ -63,7 +63,9 @@
             "description": "Survey ID"
           }
         },
-        "required": ["surveyId"],
+        "required": [
+          "surveyId"
+        ],
         "additionalProperties": false
       }
     },
@@ -89,7 +91,9 @@
             "description": "Project category"
           }
         },
-        "required": ["SurveyName"],
+        "required": [
+          "SurveyName"
+        ],
         "additionalProperties": false
       }
     },
@@ -122,7 +126,9 @@
           },
           "includedQuestionIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Include specific question IDs"
           },
           "startDate": {
@@ -136,7 +142,9 @@
             "description": "End date filter"
           }
         },
-        "required": ["surveyId"],
+        "required": [
+          "surveyId"
+        ],
         "additionalProperties": false
       }
     },
@@ -153,7 +161,11 @@
           },
           "linkType": {
             "type": "string",
-            "enum": ["Individual", "Multiple", "Anonymous"],
+            "enum": [
+              "Individual",
+              "Multiple",
+              "Anonymous"
+            ],
             "description": "Link type"
           },
           "description": {
@@ -162,12 +174,17 @@
           },
           "action": {
             "type": "string",
-            "enum": ["CreateDistribution"],
+            "enum": [
+              "CreateDistribution"
+            ],
             "default": "CreateDistribution",
             "description": "Action type"
           }
         },
-        "required": ["surveyId", "linkType"],
+        "required": [
+          "surveyId",
+          "linkType"
+        ],
         "additionalProperties": false
       }
     },
@@ -196,7 +213,9 @@
             "description": "Number of contacts to return"
           }
         },
-        "required": ["directoryId"],
+        "required": [
+          "directoryId"
+        ],
         "additionalProperties": false
       }
     },
@@ -242,7 +261,10 @@
             "description": "Additional embedded data"
           }
         },
-        "required": ["directoryId", "email"],
+        "required": [
+          "directoryId",
+          "email"
+        ],
         "additionalProperties": false
       }
     },
@@ -292,7 +314,9 @@
             "description": "Embedded data"
           }
         },
-        "required": ["surveyId"],
+        "required": [
+          "surveyId"
+        ],
         "additionalProperties": false
       }
     }
@@ -317,14 +341,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "responseId": {"type": "string"},
-          "surveyId": {"type": "string"},
-          "ipAddress": {"type": "string"},
-          "progress": {"type": "number"},
-          "duration": {"type": "number"},
-          "finished": {"type": "boolean"},
-          "recordedDate": {"type": "string"},
-          "responses": {"type": "object"}
+          "responseId": {
+            "type": "string"
+          },
+          "surveyId": {
+            "type": "string"
+          },
+          "ipAddress": {
+            "type": "string"
+          },
+          "progress": {
+            "type": "number"
+          },
+          "duration": {
+            "type": "number"
+          },
+          "finished": {
+            "type": "boolean"
+          },
+          "recordedDate": {
+            "type": "string"
+          },
+          "responses": {
+            "type": "object"
+          }
         }
       }
     }
@@ -332,5 +372,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/whoami"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/quickbooks/definition.json
+++ b/connectors/quickbooks/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://appcenter.intuit.com/connect/oauth2",
       "tokenUrl": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
-      "scopes": ["com.intuit.quickbooks.accounting"]
+      "scopes": [
+        "com.intuit.quickbooks.accounting"
+      ]
     }
   },
   "baseUrl": "https://sandbox-quickbooks.api.intuit.com/v3/company",
@@ -39,7 +41,9 @@
             "description": "Company ID"
           }
         },
-        "required": ["companyId"],
+        "required": [
+          "companyId"
+        ],
         "additionalProperties": false
       }
     },
@@ -65,38 +69,67 @@
           "primaryEmailAddr": {
             "type": "object",
             "properties": {
-              "address": {"type": "string", "format": "email"}
+              "address": {
+                "type": "string",
+                "format": "email"
+              }
             },
             "description": "Primary email address"
           },
           "primaryPhone": {
             "type": "object",
             "properties": {
-              "freeFormNumber": {"type": "string"}
+              "freeFormNumber": {
+                "type": "string"
+              }
             },
             "description": "Primary phone number"
           },
           "billAddr": {
             "type": "object",
             "properties": {
-              "line1": {"type": "string"},
-              "line2": {"type": "string"},
-              "city": {"type": "string"},
-              "countrySubDivisionCode": {"type": "string"},
-              "postalCode": {"type": "string"},
-              "country": {"type": "string"}
+              "line1": {
+                "type": "string"
+              },
+              "line2": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "countrySubDivisionCode": {
+                "type": "string"
+              },
+              "postalCode": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              }
             },
             "description": "Billing address"
           },
           "shipAddr": {
             "type": "object",
             "properties": {
-              "line1": {"type": "string"},
-              "line2": {"type": "string"},
-              "city": {"type": "string"},
-              "countrySubDivisionCode": {"type": "string"},
-              "postalCode": {"type": "string"},
-              "country": {"type": "string"}
+              "line1": {
+                "type": "string"
+              },
+              "line2": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "countrySubDivisionCode": {
+                "type": "string"
+              },
+              "postalCode": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              }
             },
             "description": "Shipping address"
           },
@@ -112,29 +145,44 @@
           "currencyRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Currency reference"
           },
           "paymentMethodRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Payment method reference"
           },
           "salesTermRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Sales terms reference"
           }
         },
-        "required": ["companyId", "name"],
+        "required": [
+          "companyId",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -154,7 +202,10 @@
             "description": "Customer ID"
           }
         },
-        "required": ["companyId", "customerId"],
+        "required": [
+          "companyId",
+          "customerId"
+        ],
         "additionalProperties": false
       }
     },
@@ -188,17 +239,28 @@
           "primaryEmailAddr": {
             "type": "object",
             "properties": {
-              "address": {"type": "string", "format": "email"}
+              "address": {
+                "type": "string",
+                "format": "email"
+              }
             },
             "description": "Primary email address"
           },
           "billAddr": {
             "type": "object",
             "properties": {
-              "line1": {"type": "string"},
-              "city": {"type": "string"},
-              "countrySubDivisionCode": {"type": "string"},
-              "postalCode": {"type": "string"}
+              "line1": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "countrySubDivisionCode": {
+                "type": "string"
+              },
+              "postalCode": {
+                "type": "string"
+              }
             },
             "description": "Billing address"
           },
@@ -207,7 +269,11 @@
             "description": "Customer notes"
           }
         },
-        "required": ["companyId", "customerId", "syncToken"],
+        "required": [
+          "companyId",
+          "customerId",
+          "syncToken"
+        ],
         "additionalProperties": false
       }
     },
@@ -240,7 +306,9 @@
             "description": "Start position for pagination"
           }
         },
-        "required": ["companyId"],
+        "required": [
+          "companyId"
+        ],
         "additionalProperties": false
       }
     },
@@ -265,7 +333,11 @@
           },
           "type": {
             "type": "string",
-            "enum": ["Inventory", "NonInventory", "Service"],
+            "enum": [
+              "Inventory",
+              "NonInventory",
+              "Service"
+            ],
             "description": "Item type"
           },
           "trackQtyOnHand": {
@@ -280,24 +352,36 @@
           "incomeAccountRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Income account reference"
           },
           "expenseAccountRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Expense account reference"
           },
           "assetAccountRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Asset account reference"
           },
@@ -309,21 +393,33 @@
           "salesTaxCodeRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Sales tax code reference"
           },
           "purchaseTaxCodeRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Purchase tax code reference"
           }
         },
-        "required": ["companyId", "name", "type"],
+        "required": [
+          "companyId",
+          "name",
+          "type"
+        ],
         "additionalProperties": false
       }
     },
@@ -341,8 +437,12 @@
           "customerRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Customer reference"
           },
@@ -361,76 +461,126 @@
             "items": {
               "type": "object",
               "properties": {
-                "amount": {"type": "number", "minimum": 0},
-                "detailType": {"type": "string", "enum": ["SalesItemLineDetail"]},
+                "amount": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "detailType": {
+                  "type": "string",
+                  "enum": [
+                    "SalesItemLineDetail"
+                  ]
+                },
                 "salesItemLineDetail": {
                   "type": "object",
                   "properties": {
                     "itemRef": {
                       "type": "object",
                       "properties": {
-                        "value": {"type": "string"},
-                        "name": {"type": "string"}
+                        "value": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
                       }
                     },
-                    "qty": {"type": "number", "minimum": 0},
-                    "unitPrice": {"type": "number", "minimum": 0},
+                    "qty": {
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    "unitPrice": {
+                      "type": "number",
+                      "minimum": 0
+                    },
                     "taxCodeRef": {
                       "type": "object",
                       "properties": {
-                        "value": {"type": "string"}
+                        "value": {
+                          "type": "string"
+                        }
                       }
                     }
                   }
                 }
               },
-              "required": ["amount", "detailType"]
+              "required": [
+                "amount",
+                "detailType"
+              ]
             },
             "description": "Invoice line items"
           },
           "billAddr": {
             "type": "object",
             "properties": {
-              "line1": {"type": "string"},
-              "city": {"type": "string"},
-              "countrySubDivisionCode": {"type": "string"},
-              "postalCode": {"type": "string"}
+              "line1": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "countrySubDivisionCode": {
+                "type": "string"
+              },
+              "postalCode": {
+                "type": "string"
+              }
             },
             "description": "Billing address"
           },
           "shipAddr": {
             "type": "object",
             "properties": {
-              "line1": {"type": "string"},
-              "city": {"type": "string"},
-              "countrySubDivisionCode": {"type": "string"},
-              "postalCode": {"type": "string"}
+              "line1": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "countrySubDivisionCode": {
+                "type": "string"
+              },
+              "postalCode": {
+                "type": "string"
+              }
             },
             "description": "Shipping address"
           },
           "emailStatus": {
             "type": "string",
-            "enum": ["NotSet", "NeedToSend", "EmailSent"],
+            "enum": [
+              "NotSet",
+              "NeedToSend",
+              "EmailSent"
+            ],
             "description": "Email status"
           },
           "billEmail": {
             "type": "object",
             "properties": {
-              "address": {"type": "string", "format": "email"}
+              "address": {
+                "type": "string",
+                "format": "email"
+              }
             },
             "description": "Bill email address"
           },
           "salesTermRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"}
+              "value": {
+                "type": "string"
+              }
             },
             "description": "Sales terms reference"
           },
           "customerMemo": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"}
+              "value": {
+                "type": "string"
+              }
             },
             "description": "Customer memo"
           },
@@ -439,7 +589,11 @@
             "description": "Private note"
           }
         },
-        "required": ["companyId", "customerRef", "line"],
+        "required": [
+          "companyId",
+          "customerRef",
+          "line"
+        ],
         "additionalProperties": false
       }
     },
@@ -459,7 +613,10 @@
             "description": "Invoice ID"
           }
         },
-        "required": ["companyId", "invoiceId"],
+        "required": [
+          "companyId",
+          "invoiceId"
+        ],
         "additionalProperties": false
       }
     },
@@ -483,7 +640,10 @@
             "description": "Request ID for tracking"
           }
         },
-        "required": ["companyId", "invoiceId"],
+        "required": [
+          "companyId",
+          "invoiceId"
+        ],
         "additionalProperties": false
       }
     },
@@ -501,8 +661,12 @@
           "customerRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Customer reference"
           },
@@ -519,16 +683,24 @@
           "paymentMethodRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Payment method reference"
           },
           "depositToAccountRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Deposit to account reference"
           },
@@ -537,14 +709,21 @@
             "items": {
               "type": "object",
               "properties": {
-                "amount": {"type": "number", "minimum": 0},
+                "amount": {
+                  "type": "number",
+                  "minimum": 0
+                },
                 "linkedTxn": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "properties": {
-                      "txnId": {"type": "string"},
-                      "txnType": {"type": "string"}
+                      "txnId": {
+                        "type": "string"
+                      },
+                      "txnType": {
+                        "type": "string"
+                      }
                     }
                   }
                 }
@@ -557,7 +736,11 @@
             "description": "Private note"
           }
         },
-        "required": ["companyId", "customerRef", "totalAmt"],
+        "required": [
+          "companyId",
+          "customerRef",
+          "totalAmt"
+        ],
         "additionalProperties": false
       }
     },
@@ -584,7 +767,9 @@
             "description": "Maximum number of results"
           }
         },
-        "required": ["companyId"],
+        "required": [
+          "companyId"
+        ],
         "additionalProperties": false
       }
     },
@@ -602,14 +787,22 @@
           "accountRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Expense account reference"
           },
           "paymentType": {
             "type": "string",
-            "enum": ["Cash", "Check", "CreditCard"],
+            "enum": [
+              "Cash",
+              "Check",
+              "CreditCard"
+            ],
             "description": "Payment type"
           },
           "totalAmt": {
@@ -625,9 +818,15 @@
           "entityRef": {
             "type": "object",
             "properties": {
-              "value": {"type": "string"},
-              "name": {"type": "string"},
-              "type": {"type": "string"}
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
             },
             "description": "Vendor or employee reference"
           },
@@ -636,28 +835,41 @@
             "items": {
               "type": "object",
               "properties": {
-                "amount": {"type": "number", "minimum": 0},
-                "detailType": {"type": "string"},
+                "amount": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "detailType": {
+                  "type": "string"
+                },
                 "accountBasedExpenseLineDetail": {
                   "type": "object",
                   "properties": {
                     "accountRef": {
                       "type": "object",
                       "properties": {
-                        "value": {"type": "string"}
+                        "value": {
+                          "type": "string"
+                        }
                       }
                     },
                     "customerRef": {
                       "type": "object",
                       "properties": {
-                        "value": {"type": "string"}
+                        "value": {
+                          "type": "string"
+                        }
                       }
                     },
-                    "billableStatus": {"type": "string"},
+                    "billableStatus": {
+                      "type": "string"
+                    },
                     "taxCodeRef": {
                       "type": "object",
                       "properties": {
-                        "value": {"type": "string"}
+                        "value": {
+                          "type": "string"
+                        }
                       }
                     }
                   }
@@ -671,7 +883,12 @@
             "description": "Private note"
           }
         },
-        "required": ["companyId", "accountRef", "paymentType", "totalAmt"],
+        "required": [
+          "companyId",
+          "accountRef",
+          "paymentType",
+          "totalAmt"
+        ],
         "additionalProperties": false
       }
     },
@@ -688,7 +905,15 @@
           },
           "reportType": {
             "type": "string",
-            "enum": ["ProfitAndLoss", "BalanceSheet", "CashFlow", "TrialBalance", "GeneralLedger", "CustomerSales", "VendorExpenses"],
+            "enum": [
+              "ProfitAndLoss",
+              "BalanceSheet",
+              "CashFlow",
+              "TrialBalance",
+              "GeneralLedger",
+              "CustomerSales",
+              "VendorExpenses"
+            ],
             "description": "Report type"
           },
           "start_date": {
@@ -703,16 +928,26 @@
           },
           "accounting_method": {
             "type": "string",
-            "enum": ["Cash", "Accrual"],
+            "enum": [
+              "Cash",
+              "Accrual"
+            ],
             "description": "Accounting method"
           },
           "summarize_column_by": {
             "type": "string",
-            "enum": ["Month", "Quarter", "Year"],
+            "enum": [
+              "Month",
+              "Quarter",
+              "Year"
+            ],
             "description": "Summarize columns by period"
           }
         },
-        "required": ["companyId", "reportType"],
+        "required": [
+          "companyId",
+          "reportType"
+        ],
         "additionalProperties": false
       }
     }
@@ -741,15 +976,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "docNumber": {"type": "string"},
-          "customerId": {"type": "string"},
-          "customerName": {"type": "string"},
-          "txnDate": {"type": "string"},
-          "dueDate": {"type": "string"},
-          "totalAmt": {"type": "number"},
-          "balance": {"type": "number"},
-          "emailStatus": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "docNumber": {
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string"
+          },
+          "customerName": {
+            "type": "string"
+          },
+          "txnDate": {
+            "type": "string"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "totalAmt": {
+            "type": "number"
+          },
+          "balance": {
+            "type": "number"
+          },
+          "emailStatus": {
+            "type": "string"
+          }
         }
       }
     },
@@ -780,13 +1033,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "customerId": {"type": "string"},
-          "customerName": {"type": "string"},
-          "totalAmt": {"type": "number"},
-          "txnDate": {"type": "string"},
-          "paymentMethodName": {"type": "string"},
-          "privateNote": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string"
+          },
+          "customerName": {
+            "type": "string"
+          },
+          "totalAmt": {
+            "type": "number"
+          },
+          "txnDate": {
+            "type": "string"
+          },
+          "paymentMethodName": {
+            "type": "string"
+          },
+          "privateNote": {
+            "type": "string"
+          }
         }
       }
     },
@@ -809,13 +1076,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "companyName": {"type": "string"},
-          "emailAddress": {"type": "string"},
-          "phone": {"type": "string"},
-          "createTime": {"type": "string"},
-          "balance": {"type": "number"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "emailAddress": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string"
+          },
+          "balance": {
+            "type": "number"
+          }
         }
       }
     }
@@ -823,5 +1104,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/{companyId}/companyinfo/{companyId}"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/ramp/definition.json
+++ b/connectors/ramp/definition.json
@@ -136,11 +136,20 @@
           },
           "role": {
             "type": "string",
-            "enum": ["CARDHOLDER", "ADMIN", "BOOKKEEPER"],
+            "enum": [
+              "CARDHOLDER",
+              "ADMIN",
+              "BOOKKEEPER"
+            ],
             "description": "User role"
           }
         },
-        "required": ["first_name", "last_name", "email", "role"],
+        "required": [
+          "first_name",
+          "last_name",
+          "email",
+          "role"
+        ],
         "additionalProperties": false
       }
     }
@@ -165,10 +174,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "amount": {"type": "number"},
-          "card_id": {"type": "string"},
-          "user_transaction_date": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "card_id": {
+            "type": "string"
+          },
+          "user_transaction_date": {
+            "type": "string"
+          }
         }
       }
     }
@@ -176,5 +193,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/razorpay/definition.json
+++ b/connectors/razorpay/definition.json
@@ -52,7 +52,9 @@
             "description": "Additional notes"
           }
         },
-        "required": ["amount"],
+        "required": [
+          "amount"
+        ],
         "additionalProperties": false
       }
     },
@@ -144,7 +146,10 @@
             "description": "Currency code"
           }
         },
-        "required": ["payment_id", "amount"],
+        "required": [
+          "payment_id",
+          "amount"
+        ],
         "additionalProperties": false
       }
     },
@@ -166,7 +171,10 @@
           },
           "speed": {
             "type": "string",
-            "enum": ["normal", "optimum"],
+            "enum": [
+              "normal",
+              "optimum"
+            ],
             "default": "normal",
             "description": "Refund speed"
           },
@@ -179,7 +187,9 @@
             "description": "Receipt identifier"
           }
         },
-        "required": ["payment_id"],
+        "required": [
+          "payment_id"
+        ],
         "additionalProperties": false
       }
     }
@@ -199,10 +209,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "amount": {"type": "number"},
-          "currency": {"type": "string"},
-          "status": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
         }
       }
     },
@@ -220,12 +238,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "amount": {"type": "number"},
-          "currency": {"type": "string"},
-          "status": {"type": "string"},
-          "error_code": {"type": "string"},
-          "error_description": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "error_description": {
+            "type": "string"
+          }
         }
       }
     }
@@ -233,5 +263,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/payments"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/ringcentral/definition.json
+++ b/connectors/ringcentral/definition.json
@@ -11,7 +11,18 @@
     "config": {
       "authUrl": "https://platform.ringcentral.com/restapi/oauth/authorize",
       "tokenUrl": "https://platform.ringcentral.com/restapi/oauth/token",
-      "scopes": ["ReadMessages", "SMS", "InternalMessages", "ReadAccounts", "ReadCallLog", "ReadContacts", "RingOut", "EditCallLog", "Meetings", "ReadCallRecording"]
+      "scopes": [
+        "ReadMessages",
+        "SMS",
+        "InternalMessages",
+        "ReadAccounts",
+        "ReadCallLog",
+        "ReadContacts",
+        "RingOut",
+        "EditCallLog",
+        "Meetings",
+        "ReadCallRecording"
+      ]
     }
   },
   "baseUrl": "https://platform.ringcentral.com/restapi/v1.0",
@@ -37,9 +48,13 @@
           "from": {
             "type": "object",
             "properties": {
-              "phoneNumber": {"type": "string"}
+              "phoneNumber": {
+                "type": "string"
+              }
             },
-            "required": ["phoneNumber"],
+            "required": [
+              "phoneNumber"
+            ],
             "additionalProperties": false
           },
           "to": {
@@ -47,9 +62,13 @@
             "items": {
               "type": "object",
               "properties": {
-                "phoneNumber": {"type": "string"}
+                "phoneNumber": {
+                  "type": "string"
+                }
               },
-              "required": ["phoneNumber"],
+              "required": [
+                "phoneNumber"
+              ],
               "additionalProperties": false
             }
           },
@@ -58,7 +77,11 @@
             "description": "Message text"
           }
         },
-        "required": ["from", "to", "text"],
+        "required": [
+          "from",
+          "to",
+          "text"
+        ],
         "additionalProperties": false
       }
     },
@@ -71,12 +94,27 @@
         "properties": {
           "messageType": {
             "type": "array",
-            "items": {"type": "string", "enum": ["Fax", "SMS", "VoiceMail", "Pager"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "Fax",
+                "SMS",
+                "VoiceMail",
+                "Pager"
+              ]
+            },
             "description": "Message types to filter"
           },
           "availability": {
             "type": "array",
-            "items": {"type": "string", "enum": ["Alive", "Deleted", "Purged"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "Alive",
+                "Deleted",
+                "Purged"
+              ]
+            },
             "description": "Message availability"
           },
           "conversationId": {
@@ -95,7 +133,13 @@
           },
           "direction": {
             "type": "array",
-            "items": {"type": "string", "enum": ["Inbound", "Outbound"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "Inbound",
+                "Outbound"
+              ]
+            },
             "description": "Message direction"
           },
           "distinctConversations": {
@@ -104,12 +148,28 @@
           },
           "messageStatus": {
             "type": "array",
-            "items": {"type": "string", "enum": ["Queued", "Sent", "Received", "DeliveryFailed", "SendingFailed", "Delivered"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "Queued",
+                "Sent",
+                "Received",
+                "DeliveryFailed",
+                "SendingFailed",
+                "Delivered"
+              ]
+            },
             "description": "Message status"
           },
           "readStatus": {
             "type": "array",
-            "items": {"type": "string", "enum": ["Read", "Unread"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "Read",
+                "Unread"
+              ]
+            },
             "description": "Read status"
           },
           "page": {
@@ -147,17 +207,32 @@
           },
           "direction": {
             "type": "array",
-            "items": {"type": "string", "enum": ["Inbound", "Outbound"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "Inbound",
+                "Outbound"
+              ]
+            },
             "description": "Call direction"
           },
           "type": {
             "type": "array",
-            "items": {"type": "string", "enum": ["Voice", "Fax"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "Voice",
+                "Fax"
+              ]
+            },
             "description": "Call type"
           },
           "view": {
             "type": "string",
-            "enum": ["Simple", "Detailed"],
+            "enum": [
+              "Simple",
+              "Detailed"
+            ],
             "default": "Simple",
             "description": "View type"
           },
@@ -167,7 +242,10 @@
           },
           "recordingType": {
             "type": "string",
-            "enum": ["Automatic", "OnDemand"],
+            "enum": [
+              "Automatic",
+              "OnDemand"
+            ],
             "description": "Recording type"
           },
           "dateFrom": {
@@ -206,23 +284,33 @@
           "from": {
             "type": "object",
             "properties": {
-              "phoneNumber": {"type": "string"},
-              "forwardingNumberId": {"type": "string"}
+              "phoneNumber": {
+                "type": "string"
+              },
+              "forwardingNumberId": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           },
           "to": {
             "type": "object",
             "properties": {
-              "phoneNumber": {"type": "string"}
+              "phoneNumber": {
+                "type": "string"
+              }
             },
-            "required": ["phoneNumber"],
+            "required": [
+              "phoneNumber"
+            ],
             "additionalProperties": false
           },
           "callerId": {
             "type": "object",
             "properties": {
-              "phoneNumber": {"type": "string"}
+              "phoneNumber": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           },
@@ -233,12 +321,17 @@
           "country": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"}
+              "id": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           }
         },
-        "required": ["from", "to"],
+        "required": [
+          "from",
+          "to"
+        ],
         "additionalProperties": false
       }
     },
@@ -255,16 +348,29 @@
           },
           "meetingType": {
             "type": "string",
-            "enum": ["Instant", "Scheduled", "ScheduledRecurring", "InstantRecurring"],
+            "enum": [
+              "Instant",
+              "Scheduled",
+              "ScheduledRecurring",
+              "InstantRecurring"
+            ],
             "default": "Scheduled",
             "description": "Meeting type"
           },
           "schedule": {
             "type": "object",
             "properties": {
-              "startTime": {"type": "string", "format": "date-time"},
-              "durationInMinutes": {"type": "number", "minimum": 1},
-              "timeZone": {"type": "object"}
+              "startTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "durationInMinutes": {
+                "type": "number",
+                "minimum": 1
+              },
+              "timeZone": {
+                "type": "object"
+              }
             },
             "additionalProperties": false
           },
@@ -275,7 +381,9 @@
           "host": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"}
+              "id": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           },
@@ -293,19 +401,28 @@
           },
           "audioOptions": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Audio options"
           },
           "recurrence": {
             "type": "object",
             "properties": {
-              "schedule": {"type": "object"},
-              "until": {"type": "string", "format": "date-time"}
+              "schedule": {
+                "type": "object"
+              },
+              "until": {
+                "type": "string",
+                "format": "date-time"
+              }
             },
             "additionalProperties": false
           }
         },
-        "required": ["topic"],
+        "required": [
+          "topic"
+        ],
         "additionalProperties": false
       }
     },
@@ -332,7 +449,9 @@
             "description": "Extension ID"
           }
         },
-        "required": ["extensionId"],
+        "required": [
+          "extensionId"
+        ],
         "additionalProperties": false
       }
     }
@@ -348,7 +467,11 @@
         "properties": {
           "messageType": {
             "type": "string",
-            "enum": ["SMS", "Fax", "VoiceMail"],
+            "enum": [
+              "SMS",
+              "Fax",
+              "VoiceMail"
+            ],
             "description": "Filter by message type"
           }
         },
@@ -358,17 +481,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "uuid": {"type": "string"},
-          "event": {"type": "string"},
-          "timestamp": {"type": "string"},
-          "subscriptionId": {"type": "string"},
-          "ownerId": {"type": "string"},
+          "uuid": {
+            "type": "string"
+          },
+          "event": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "subscriptionId": {
+            "type": "string"
+          },
+          "ownerId": {
+            "type": "string"
+          },
           "body": {
             "type": "object",
             "properties": {
-              "extensionId": {"type": "number"},
-              "lastUpdated": {"type": "string"},
-              "changes": {"type": "array"}
+              "extensionId": {
+                "type": "number"
+              },
+              "lastUpdated": {
+                "type": "string"
+              },
+              "changes": {
+                "type": "array"
+              }
             }
           }
         }
@@ -393,10 +532,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "uuid": {"type": "string"},
-          "event": {"type": "string"},
-          "timestamp": {"type": "string"},
-          "body": {"type": "object"}
+          "uuid": {
+            "type": "string"
+          },
+          "event": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "body": {
+            "type": "object"
+          }
         }
       }
     }
@@ -404,5 +551,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/account/~/extension/~"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/sageintacct/definition.json
+++ b/connectors/sageintacct/definition.json
@@ -73,42 +73,78 @@
           "displaycontact": {
             "type": "object",
             "properties": {
-              "contactname": {"type": "string"},
-              "companyname": {"type": "string"},
+              "contactname": {
+                "type": "string"
+              },
+              "companyname": {
+                "type": "string"
+              },
               "mailaddress": {
                 "type": "object",
                 "properties": {
-                  "address1": {"type": "string"},
-                  "address2": {"type": "string"},
-                  "city": {"type": "string"},
-                  "state": {"type": "string"},
-                  "zip": {"type": "string"},
-                  "country": {"type": "string"}
+                  "address1": {
+                    "type": "string"
+                  },
+                  "address2": {
+                    "type": "string"
+                  },
+                  "city": {
+                    "type": "string"
+                  },
+                  "state": {
+                    "type": "string"
+                  },
+                  "zip": {
+                    "type": "string"
+                  },
+                  "country": {
+                    "type": "string"
+                  }
                 }
               },
-              "phone1": {"type": "string"},
-              "email1": {"type": "string", "format": "email"}
+              "phone1": {
+                "type": "string"
+              },
+              "email1": {
+                "type": "string",
+                "format": "email"
+              }
             },
             "description": "Display contact information"
           },
           "status": {
             "type": "string",
-            "enum": ["active", "inactive"],
+            "enum": [
+              "active",
+              "inactive"
+            ],
             "default": "active",
             "description": "Customer status"
           },
           "billto": {
             "type": "object",
             "properties": {
-              "contactname": {"type": "string"},
-              "companyname": {"type": "string"},
+              "contactname": {
+                "type": "string"
+              },
+              "companyname": {
+                "type": "string"
+              },
               "mailaddress": {
                 "type": "object",
                 "properties": {
-                  "address1": {"type": "string"},
-                  "city": {"type": "string"},
-                  "state": {"type": "string"},
-                  "zip": {"type": "string"}
+                  "address1": {
+                    "type": "string"
+                  },
+                  "city": {
+                    "type": "string"
+                  },
+                  "state": {
+                    "type": "string"
+                  },
+                  "zip": {
+                    "type": "string"
+                  }
                 }
               }
             },
@@ -117,22 +153,37 @@
           "shipto": {
             "type": "object",
             "properties": {
-              "contactname": {"type": "string"},
-              "companyname": {"type": "string"},
+              "contactname": {
+                "type": "string"
+              },
+              "companyname": {
+                "type": "string"
+              },
               "mailaddress": {
                 "type": "object",
                 "properties": {
-                  "address1": {"type": "string"},
-                  "city": {"type": "string"},
-                  "state": {"type": "string"},
-                  "zip": {"type": "string"}
+                  "address1": {
+                    "type": "string"
+                  },
+                  "city": {
+                    "type": "string"
+                  },
+                  "state": {
+                    "type": "string"
+                  },
+                  "zip": {
+                    "type": "string"
+                  }
                 }
               }
             },
             "description": "Ship to contact information"
           }
         },
-        "required": ["customerid", "name"],
+        "required": [
+          "customerid",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -186,13 +237,26 @@
             "items": {
               "type": "object",
               "properties": {
-                "glaccountno": {"type": "string"},
-                "amount": {"type": "number"},
-                "memo": {"type": "string"},
-                "locationid": {"type": "string"},
-                "departmentid": {"type": "string"}
+                "glaccountno": {
+                  "type": "string"
+                },
+                "amount": {
+                  "type": "number"
+                },
+                "memo": {
+                  "type": "string"
+                },
+                "locationid": {
+                  "type": "string"
+                },
+                "departmentid": {
+                  "type": "string"
+                }
               },
-              "required": ["glaccountno", "amount"]
+              "required": [
+                "glaccountno",
+                "amount"
+              ]
             },
             "description": "Invoice line items"
           },
@@ -205,7 +269,11 @@
             "description": "External ID"
           }
         },
-        "required": ["customerid", "datecreated", "invoiceitems"],
+        "required": [
+          "customerid",
+          "datecreated",
+          "invoiceitems"
+        ],
         "additionalProperties": false
       }
     },
@@ -263,13 +331,26 @@
             "items": {
               "type": "object",
               "properties": {
-                "glaccountno": {"type": "string"},
-                "amount": {"type": "number"},
-                "memo": {"type": "string"},
-                "locationid": {"type": "string"},
-                "departmentid": {"type": "string"}
+                "glaccountno": {
+                  "type": "string"
+                },
+                "amount": {
+                  "type": "number"
+                },
+                "memo": {
+                  "type": "string"
+                },
+                "locationid": {
+                  "type": "string"
+                },
+                "departmentid": {
+                  "type": "string"
+                }
               },
-              "required": ["glaccountno", "amount"]
+              "required": [
+                "glaccountno",
+                "amount"
+              ]
             },
             "description": "Bill line items"
           },
@@ -278,7 +359,11 @@
             "description": "Bill description"
           }
         },
-        "required": ["vendorid", "datecreated", "billitems"],
+        "required": [
+          "vendorid",
+          "datecreated",
+          "billitems"
+        ],
         "additionalProperties": false
       }
     },
@@ -328,11 +413,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "recordno": {"type": "string"},
-          "customerid": {"type": "string"},
-          "customername": {"type": "string"},
-          "totalentered": {"type": "number"},
-          "datecreated": {"type": "string"}
+          "recordno": {
+            "type": "string"
+          },
+          "customerid": {
+            "type": "string"
+          },
+          "customername": {
+            "type": "string"
+          },
+          "totalentered": {
+            "type": "number"
+          },
+          "datecreated": {
+            "type": "string"
+          }
         }
       }
     }
@@ -344,5 +439,19 @@
       "function": "get_list",
       "object": "customer"
     }
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/salesforce-enhanced/definition.json
+++ b/connectors/salesforce-enhanced/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://login.salesforce.com/services/oauth2/authorize",
       "tokenUrl": "https://login.salesforce.com/services/oauth2/token",
-      "scopes": ["full", "refresh_token"]
+      "scopes": [
+        "full",
+        "refresh_token"
+      ]
     }
   },
   "baseUrl": "https://your-instance.salesforce.com/services/data/v58.0",
@@ -39,7 +42,9 @@
             "description": "SOQL query string"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -59,7 +64,10 @@
             "description": "Record fields"
           }
         },
-        "required": ["sobjectType", "fields"],
+        "required": [
+          "sobjectType",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -83,7 +91,11 @@
             "description": "Fields to update"
           }
         },
-        "required": ["sobjectType", "recordId", "fields"],
+        "required": [
+          "sobjectType",
+          "recordId",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -103,7 +115,10 @@
             "description": "Record ID"
           }
         },
-        "required": ["sobjectType", "recordId"],
+        "required": [
+          "sobjectType",
+          "recordId"
+        ],
         "additionalProperties": false
       }
     },
@@ -124,11 +139,16 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to retrieve"
           }
         },
-        "required": ["sobjectType", "recordId"],
+        "required": [
+          "sobjectType",
+          "recordId"
+        ],
         "additionalProperties": false
       }
     },
@@ -156,7 +176,12 @@
             "description": "Record fields"
           }
         },
-        "required": ["sobjectType", "externalIdField", "externalId", "fields"],
+        "required": [
+          "sobjectType",
+          "externalIdField",
+          "externalId",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -173,7 +198,12 @@
           },
           "method": {
             "type": "string",
-            "enum": ["GET", "POST", "PUT", "DELETE"],
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "DELETE"
+            ],
             "default": "POST",
             "description": "HTTP method"
           },
@@ -182,7 +212,9 @@
             "description": "Parameters to pass"
           }
         },
-        "required": ["apexClass"],
+        "required": [
+          "apexClass"
+        ],
         "additionalProperties": false
       }
     }
@@ -207,9 +239,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "Id": {"type": "string"},
-          "sobjectType": {"type": "string"},
-          "fields": {"type": "object"}
+          "Id": {
+            "type": "string"
+          },
+          "sobjectType": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "object"
+          }
         }
       }
     },
@@ -232,9 +270,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "Id": {"type": "string"},
-          "sobjectType": {"type": "string"},
-          "fields": {"type": "object"}
+          "Id": {
+            "type": "string"
+          },
+          "sobjectType": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "object"
+          }
         }
       }
     }
@@ -242,5 +286,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/limits"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/salesforce/definition.json
+++ b/connectors/salesforce/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://login.salesforce.com/services/oauth2/authorize",
       "tokenUrl": "https://login.salesforce.com/services/oauth2/token",
-      "scopes": ["full", "refresh_token"]
+      "scopes": [
+        "full",
+        "refresh_token"
+      ]
     }
   },
   "baseUrl": "https://your-instance.salesforce.com/services/data/v58.0",
@@ -43,7 +46,10 @@
             "description": "Record fields"
           }
         },
-        "required": ["sobjectType", "fields"],
+        "required": [
+          "sobjectType",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -67,7 +73,11 @@
             "description": "Fields to update"
           }
         },
-        "required": ["sobjectType", "recordId", "fields"],
+        "required": [
+          "sobjectType",
+          "recordId",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -87,7 +97,10 @@
             "description": "Record ID"
           }
         },
-        "required": ["sobjectType", "recordId"],
+        "required": [
+          "sobjectType",
+          "recordId"
+        ],
         "additionalProperties": false
       }
     },
@@ -103,7 +116,9 @@
             "description": "SOQL query string"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     }
@@ -128,8 +143,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "Id": {"type": "string"},
-          "sobjectType": {"type": "string"}
+          "Id": {
+            "type": "string"
+          },
+          "sobjectType": {
+            "type": "string"
+          }
         }
       }
     }
@@ -137,5 +156,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/limits"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/sap-ariba/definition.json
+++ b/connectors/sap-ariba/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://api.ariba.com/v2/oauth/authorize",
       "tokenUrl": "https://api.ariba.com/v2/oauth/token",
-      "scopes": ["FullAccess"]
+      "scopes": [
+        "FullAccess"
+      ]
     }
   },
   "baseUrl": "https://openapi.ariba.com",
@@ -41,21 +43,35 @@
           "filters": {
             "type": "object",
             "properties": {
-              "updatedDateFrom": {"type": "string", "format": "date"},
-              "updatedDateTo": {"type": "string", "format": "date"},
-              "status": {"type": "string"},
-              "vendorId": {"type": "string"}
+              "updatedDateFrom": {
+                "type": "string",
+                "format": "date"
+              },
+              "updatedDateTo": {
+                "type": "string",
+                "format": "date"
+              },
+              "status": {
+                "type": "string"
+              },
+              "vendorId": {
+                "type": "string"
+              }
             },
             "description": "Filter criteria"
           },
           "orderBy": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Sort fields"
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           },
           "$top": {
@@ -72,7 +88,9 @@
             "description": "Number of records to skip"
           }
         },
-        "required": ["realm"],
+        "required": [
+          "realm"
+        ],
         "additionalProperties": false
       }
     },
@@ -93,11 +111,16 @@
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           }
         },
-        "required": ["realm", "supplierId"],
+        "required": [
+          "realm",
+          "supplierId"
+        ],
         "additionalProperties": false
       }
     },
@@ -115,23 +138,41 @@
           "filters": {
             "type": "object",
             "properties": {
-              "updatedDateFrom": {"type": "string", "format": "date"},
-              "updatedDateTo": {"type": "string", "format": "date"},
-              "status": {"type": "string"},
-              "poNumber": {"type": "string"},
-              "supplierId": {"type": "string"},
-              "buyerId": {"type": "string"}
+              "updatedDateFrom": {
+                "type": "string",
+                "format": "date"
+              },
+              "updatedDateTo": {
+                "type": "string",
+                "format": "date"
+              },
+              "status": {
+                "type": "string"
+              },
+              "poNumber": {
+                "type": "string"
+              },
+              "supplierId": {
+                "type": "string"
+              },
+              "buyerId": {
+                "type": "string"
+              }
             },
             "description": "Filter criteria"
           },
           "orderBy": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Sort fields"
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           },
           "$top": {
@@ -148,7 +189,9 @@
             "description": "Number of records to skip"
           }
         },
-        "required": ["realm"],
+        "required": [
+          "realm"
+        ],
         "additionalProperties": false
       }
     },
@@ -169,11 +212,16 @@
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           }
         },
-        "required": ["realm", "purchaseOrderId"],
+        "required": [
+          "realm",
+          "purchaseOrderId"
+        ],
         "additionalProperties": false
       }
     },
@@ -191,23 +239,41 @@
           "filters": {
             "type": "object",
             "properties": {
-              "updatedDateFrom": {"type": "string", "format": "date"},
-              "updatedDateTo": {"type": "string", "format": "date"},
-              "status": {"type": "string"},
-              "invoiceNumber": {"type": "string"},
-              "supplierId": {"type": "string"},
-              "poNumber": {"type": "string"}
+              "updatedDateFrom": {
+                "type": "string",
+                "format": "date"
+              },
+              "updatedDateTo": {
+                "type": "string",
+                "format": "date"
+              },
+              "status": {
+                "type": "string"
+              },
+              "invoiceNumber": {
+                "type": "string"
+              },
+              "supplierId": {
+                "type": "string"
+              },
+              "poNumber": {
+                "type": "string"
+              }
             },
             "description": "Filter criteria"
           },
           "orderBy": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Sort fields"
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           },
           "$top": {
@@ -224,7 +290,9 @@
             "description": "Number of records to skip"
           }
         },
-        "required": ["realm"],
+        "required": [
+          "realm"
+        ],
         "additionalProperties": false
       }
     },
@@ -245,11 +313,16 @@
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           }
         },
-        "required": ["realm", "invoiceId"],
+        "required": [
+          "realm",
+          "invoiceId"
+        ],
         "additionalProperties": false
       }
     },
@@ -267,23 +340,41 @@
           "filters": {
             "type": "object",
             "properties": {
-              "updatedDateFrom": {"type": "string", "format": "date"},
-              "updatedDateTo": {"type": "string", "format": "date"},
-              "status": {"type": "string"},
-              "contractId": {"type": "string"},
-              "supplierId": {"type": "string"},
-              "projectId": {"type": "string"}
+              "updatedDateFrom": {
+                "type": "string",
+                "format": "date"
+              },
+              "updatedDateTo": {
+                "type": "string",
+                "format": "date"
+              },
+              "status": {
+                "type": "string"
+              },
+              "contractId": {
+                "type": "string"
+              },
+              "supplierId": {
+                "type": "string"
+              },
+              "projectId": {
+                "type": "string"
+              }
             },
             "description": "Filter criteria"
           },
           "orderBy": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Sort fields"
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           },
           "$top": {
@@ -300,7 +391,9 @@
             "description": "Number of records to skip"
           }
         },
-        "required": ["realm"],
+        "required": [
+          "realm"
+        ],
         "additionalProperties": false
       }
     },
@@ -321,11 +414,16 @@
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           }
         },
-        "required": ["realm", "contractId"],
+        "required": [
+          "realm",
+          "contractId"
+        ],
         "additionalProperties": false
       }
     },
@@ -343,22 +441,38 @@
           "filters": {
             "type": "object",
             "properties": {
-              "updatedDateFrom": {"type": "string", "format": "date"},
-              "updatedDateTo": {"type": "string", "format": "date"},
-              "status": {"type": "string"},
-              "projectId": {"type": "string"},
-              "projectType": {"type": "string"}
+              "updatedDateFrom": {
+                "type": "string",
+                "format": "date"
+              },
+              "updatedDateTo": {
+                "type": "string",
+                "format": "date"
+              },
+              "status": {
+                "type": "string"
+              },
+              "projectId": {
+                "type": "string"
+              },
+              "projectType": {
+                "type": "string"
+              }
             },
             "description": "Filter criteria"
           },
           "orderBy": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Sort fields"
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           },
           "$top": {
@@ -375,7 +489,9 @@
             "description": "Number of records to skip"
           }
         },
-        "required": ["realm"],
+        "required": [
+          "realm"
+        ],
         "additionalProperties": false
       }
     },
@@ -396,11 +512,16 @@
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           }
         },
-        "required": ["realm", "projectId"],
+        "required": [
+          "realm",
+          "projectId"
+        ],
         "additionalProperties": false
       }
     },
@@ -418,22 +539,38 @@
           "filters": {
             "type": "object",
             "properties": {
-              "updatedDateFrom": {"type": "string", "format": "date"},
-              "updatedDateTo": {"type": "string", "format": "date"},
-              "status": {"type": "string"},
-              "requisitionId": {"type": "string"},
-              "requesterId": {"type": "string"}
+              "updatedDateFrom": {
+                "type": "string",
+                "format": "date"
+              },
+              "updatedDateTo": {
+                "type": "string",
+                "format": "date"
+              },
+              "status": {
+                "type": "string"
+              },
+              "requisitionId": {
+                "type": "string"
+              },
+              "requesterId": {
+                "type": "string"
+              }
             },
             "description": "Filter criteria"
           },
           "orderBy": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Sort fields"
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           },
           "$top": {
@@ -450,7 +587,9 @@
             "description": "Number of records to skip"
           }
         },
-        "required": ["realm"],
+        "required": [
+          "realm"
+        ],
         "additionalProperties": false
       }
     },
@@ -471,11 +610,16 @@
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           }
         },
-        "required": ["realm", "requisitionId"],
+        "required": [
+          "realm",
+          "requisitionId"
+        ],
         "additionalProperties": false
       }
     },
@@ -500,7 +644,9 @@
           },
           "select": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to select"
           },
           "$top": {
@@ -517,7 +663,10 @@
             "description": "Number of records to skip"
           }
         },
-        "required": ["realm", "viewTemplateName"],
+        "required": [
+          "realm",
+          "viewTemplateName"
+        ],
         "additionalProperties": false
       }
     }
@@ -546,14 +695,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "poNumber": {"type": "string"},
-          "supplierId": {"type": "string"},
-          "supplierName": {"type": "string"},
-          "totalAmount": {"type": "number"},
-          "currency": {"type": "string"},
-          "status": {"type": "string"},
-          "createdDate": {"type": "string"},
-          "buyerId": {"type": "string"}
+          "poNumber": {
+            "type": "string"
+          },
+          "supplierId": {
+            "type": "string"
+          },
+          "supplierName": {
+            "type": "string"
+          },
+          "totalAmount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "createdDate": {
+            "type": "string"
+          },
+          "buyerId": {
+            "type": "string"
+          }
         }
       }
     },
@@ -580,14 +745,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "invoiceNumber": {"type": "string"},
-          "supplierId": {"type": "string"},
-          "supplierName": {"type": "string"},
-          "invoiceAmount": {"type": "number"},
-          "currency": {"type": "string"},
-          "status": {"type": "string"},
-          "receivedDate": {"type": "string"},
-          "poNumber": {"type": "string"}
+          "invoiceNumber": {
+            "type": "string"
+          },
+          "supplierId": {
+            "type": "string"
+          },
+          "supplierName": {
+            "type": "string"
+          },
+          "invoiceAmount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "receivedDate": {
+            "type": "string"
+          },
+          "poNumber": {
+            "type": "string"
+          }
         }
       }
     },
@@ -614,15 +795,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "contractId": {"type": "string"},
-          "contractTitle": {"type": "string"},
-          "supplierId": {"type": "string"},
-          "supplierName": {"type": "string"},
-          "contractValue": {"type": "number"},
-          "currency": {"type": "string"},
-          "approvedDate": {"type": "string"},
-          "effectiveDate": {"type": "string"},
-          "expirationDate": {"type": "string"}
+          "contractId": {
+            "type": "string"
+          },
+          "contractTitle": {
+            "type": "string"
+          },
+          "supplierId": {
+            "type": "string"
+          },
+          "supplierName": {
+            "type": "string"
+          },
+          "contractValue": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "approvedDate": {
+            "type": "string"
+          },
+          "effectiveDate": {
+            "type": "string"
+          },
+          "expirationDate": {
+            "type": "string"
+          }
         }
       }
     }
@@ -630,5 +829,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/api/analytics/v2/reporting"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/sendgrid/definition.json
+++ b/connectors/sendgrid/definition.json
@@ -44,10 +44,17 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "email": {"type": "string", "format": "email"},
-                      "name": {"type": "string"}
+                      "email": {
+                        "type": "string",
+                        "format": "email"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
                     },
-                    "required": ["email"],
+                    "required": [
+                      "email"
+                    ],
                     "additionalProperties": false
                   }
                 },
@@ -56,8 +63,13 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "email": {"type": "string", "format": "email"},
-                      "name": {"type": "string"}
+                      "email": {
+                        "type": "string",
+                        "format": "email"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
                     },
                     "additionalProperties": false
                   }
@@ -67,37 +79,68 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "email": {"type": "string", "format": "email"},
-                      "name": {"type": "string"}
+                      "email": {
+                        "type": "string",
+                        "format": "email"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
                     },
                     "additionalProperties": false
                   }
                 },
-                "subject": {"type": "string"},
-                "headers": {"type": "object"},
-                "substitutions": {"type": "object"},
-                "dynamic_template_data": {"type": "object"},
-                "custom_args": {"type": "object"},
-                "send_at": {"type": "number"}
+                "subject": {
+                  "type": "string"
+                },
+                "headers": {
+                  "type": "object"
+                },
+                "substitutions": {
+                  "type": "object"
+                },
+                "dynamic_template_data": {
+                  "type": "object"
+                },
+                "custom_args": {
+                  "type": "object"
+                },
+                "send_at": {
+                  "type": "number"
+                }
               },
-              "required": ["to"],
+              "required": [
+                "to"
+              ],
               "additionalProperties": false
             }
           },
           "from": {
             "type": "object",
             "properties": {
-              "email": {"type": "string", "format": "email"},
-              "name": {"type": "string"}
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "name": {
+                "type": "string"
+              }
             },
-            "required": ["email"],
+            "required": [
+              "email"
+            ],
             "additionalProperties": false
           },
           "reply_to": {
             "type": "object",
             "properties": {
-              "email": {"type": "string", "format": "email"},
-              "name": {"type": "string"}
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "additionalProperties": false
           },
@@ -106,8 +149,13 @@
             "items": {
               "type": "object",
               "properties": {
-                "email": {"type": "string", "format": "email"},
-                "name": {"type": "string"}
+                "email": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "name": {
+                  "type": "string"
+                }
               },
               "additionalProperties": false
             }
@@ -121,10 +169,21 @@
             "items": {
               "type": "object",
               "properties": {
-                "type": {"type": "string", "enum": ["text/plain", "text/html"]},
-                "value": {"type": "string"}
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "text/plain",
+                    "text/html"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
               },
-              "required": ["type", "value"],
+              "required": [
+                "type",
+                "value"
+              ],
               "additionalProperties": false
             }
           },
@@ -133,13 +192,30 @@
             "items": {
               "type": "object",
               "properties": {
-                "content": {"type": "string"},
-                "filename": {"type": "string"},
-                "type": {"type": "string"},
-                "disposition": {"type": "string", "enum": ["inline", "attachment"]},
-                "content_id": {"type": "string"}
+                "content": {
+                  "type": "string"
+                },
+                "filename": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "disposition": {
+                  "type": "string",
+                  "enum": [
+                    "inline",
+                    "attachment"
+                  ]
+                },
+                "content_id": {
+                  "type": "string"
+                }
               },
-              "required": ["content", "filename"],
+              "required": [
+                "content",
+                "filename"
+              ],
               "additionalProperties": false
             }
           },
@@ -153,7 +229,9 @@
           },
           "categories": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Categories for analytics"
           },
           "custom_args": {
@@ -171,8 +249,15 @@
           "asm": {
             "type": "object",
             "properties": {
-              "group_id": {"type": "number"},
-              "groups_to_display": {"type": "array", "items": {"type": "number"}}
+              "group_id": {
+                "type": "number"
+              },
+              "groups_to_display": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
             },
             "additionalProperties": false
           },
@@ -186,23 +271,33 @@
               "bypass_list_management": {
                 "type": "object",
                 "properties": {
-                  "enable": {"type": "boolean"}
+                  "enable": {
+                    "type": "boolean"
+                  }
                 },
                 "additionalProperties": false
               },
               "footer": {
                 "type": "object",
                 "properties": {
-                  "enable": {"type": "boolean"},
-                  "text": {"type": "string"},
-                  "html": {"type": "string"}
+                  "enable": {
+                    "type": "boolean"
+                  },
+                  "text": {
+                    "type": "string"
+                  },
+                  "html": {
+                    "type": "string"
+                  }
                 },
                 "additionalProperties": false
               },
               "sandbox_mode": {
                 "type": "object",
                 "properties": {
-                  "enable": {"type": "boolean"}
+                  "enable": {
+                    "type": "boolean"
+                  }
                 },
                 "additionalProperties": false
               }
@@ -215,38 +310,66 @@
               "click_tracking": {
                 "type": "object",
                 "properties": {
-                  "enable": {"type": "boolean"},
-                  "enable_text": {"type": "boolean"}
+                  "enable": {
+                    "type": "boolean"
+                  },
+                  "enable_text": {
+                    "type": "boolean"
+                  }
                 },
                 "additionalProperties": false
               },
               "open_tracking": {
                 "type": "object",
                 "properties": {
-                  "enable": {"type": "boolean"},
-                  "substitution_tag": {"type": "string"}
+                  "enable": {
+                    "type": "boolean"
+                  },
+                  "substitution_tag": {
+                    "type": "string"
+                  }
                 },
                 "additionalProperties": false
               },
               "subscription_tracking": {
                 "type": "object",
                 "properties": {
-                  "enable": {"type": "boolean"},
-                  "text": {"type": "string"},
-                  "html": {"type": "string"},
-                  "substitution_tag": {"type": "string"}
+                  "enable": {
+                    "type": "boolean"
+                  },
+                  "text": {
+                    "type": "string"
+                  },
+                  "html": {
+                    "type": "string"
+                  },
+                  "substitution_tag": {
+                    "type": "string"
+                  }
                 },
                 "additionalProperties": false
               },
               "ganalytics": {
                 "type": "object",
                 "properties": {
-                  "enable": {"type": "boolean"},
-                  "utm_source": {"type": "string"},
-                  "utm_medium": {"type": "string"},
-                  "utm_term": {"type": "string"},
-                  "utm_content": {"type": "string"},
-                  "utm_campaign": {"type": "string"}
+                  "enable": {
+                    "type": "boolean"
+                  },
+                  "utm_source": {
+                    "type": "string"
+                  },
+                  "utm_medium": {
+                    "type": "string"
+                  },
+                  "utm_term": {
+                    "type": "string"
+                  },
+                  "utm_content": {
+                    "type": "string"
+                  },
+                  "utm_campaign": {
+                    "type": "string"
+                  }
                 },
                 "additionalProperties": false
               }
@@ -254,7 +377,10 @@
             "additionalProperties": false
           }
         },
-        "required": ["personalizations", "from"],
+        "required": [
+          "personalizations",
+          "from"
+        ],
         "additionalProperties": false
       }
     },
@@ -277,7 +403,11 @@
           },
           "aggregated_by": {
             "type": "string",
-            "enum": ["day", "week", "month"],
+            "enum": [
+              "day",
+              "week",
+              "month"
+            ],
             "description": "Aggregation period"
           },
           "limit": {
@@ -292,7 +422,9 @@
             "description": "Number of results to skip"
           }
         },
-        "required": ["start_date"],
+        "required": [
+          "start_date"
+        ],
         "additionalProperties": false
       }
     },
@@ -305,7 +437,9 @@
         "properties": {
           "list_ids": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List IDs to add contact to"
           },
           "contacts": {
@@ -313,24 +447,51 @@
             "items": {
               "type": "object",
               "properties": {
-                "email": {"type": "string", "format": "email"},
-                "first_name": {"type": "string"},
-                "last_name": {"type": "string"},
-                "phone_number": {"type": "string"},
-                "address_line_1": {"type": "string"},
-                "address_line_2": {"type": "string"},
-                "city": {"type": "string"},
-                "state_province_region": {"type": "string"},
-                "postal_code": {"type": "string"},
-                "country": {"type": "string"},
-                "custom_fields": {"type": "object"}
+                "email": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "first_name": {
+                  "type": "string"
+                },
+                "last_name": {
+                  "type": "string"
+                },
+                "phone_number": {
+                  "type": "string"
+                },
+                "address_line_1": {
+                  "type": "string"
+                },
+                "address_line_2": {
+                  "type": "string"
+                },
+                "city": {
+                  "type": "string"
+                },
+                "state_province_region": {
+                  "type": "string"
+                },
+                "postal_code": {
+                  "type": "string"
+                },
+                "country": {
+                  "type": "string"
+                },
+                "custom_fields": {
+                  "type": "object"
+                }
               },
-              "required": ["email"],
+              "required": [
+                "email"
+              ],
               "additionalProperties": false
             }
           }
         },
-        "required": ["contacts"],
+        "required": [
+          "contacts"
+        ],
         "additionalProperties": false
       }
     },
@@ -368,7 +529,9 @@
             "description": "List name"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -389,7 +552,10 @@
           },
           "emails": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "Email addresses to send test to"
           },
           "sender_id": {
@@ -397,7 +563,10 @@
             "description": "Sender ID"
           }
         },
-        "required": ["template_id", "emails"],
+        "required": [
+          "template_id",
+          "emails"
+        ],
         "additionalProperties": false
       }
     }
@@ -422,19 +591,45 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "email": {"type": "string"},
-          "timestamp": {"type": "number"},
-          "smtp-id": {"type": "string"},
-          "event": {"type": "string"},
-          "category": {"type": "array"},
-          "sg_event_id": {"type": "string"},
-          "sg_message_id": {"type": "string"},
-          "response": {"type": "string"},
-          "attempt": {"type": "string"},
-          "useragent": {"type": "string"},
-          "ip": {"type": "string"},
-          "url": {"type": "string"},
-          "asm_group_id": {"type": "number"}
+          "email": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "smtp-id": {
+            "type": "string"
+          },
+          "event": {
+            "type": "string"
+          },
+          "category": {
+            "type": "array"
+          },
+          "sg_event_id": {
+            "type": "string"
+          },
+          "sg_message_id": {
+            "type": "string"
+          },
+          "response": {
+            "type": "string"
+          },
+          "attempt": {
+            "type": "string"
+          },
+          "useragent": {
+            "type": "string"
+          },
+          "ip": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "asm_group_id": {
+            "type": "number"
+          }
         }
       }
     },
@@ -457,14 +652,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "email": {"type": "string"},
-          "timestamp": {"type": "number"},
-          "event": {"type": "string"},
-          "category": {"type": "array"},
-          "sg_event_id": {"type": "string"},
-          "sg_message_id": {"type": "string"},
-          "useragent": {"type": "string"},
-          "ip": {"type": "string"}
+          "email": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "event": {
+            "type": "string"
+          },
+          "category": {
+            "type": "array"
+          },
+          "sg_event_id": {
+            "type": "string"
+          },
+          "sg_message_id": {
+            "type": "string"
+          },
+          "useragent": {
+            "type": "string"
+          },
+          "ip": {
+            "type": "string"
+          }
         }
       }
     },
@@ -487,15 +698,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "email": {"type": "string"},
-          "timestamp": {"type": "number"},
-          "event": {"type": "string"},
-          "category": {"type": "array"},
-          "sg_event_id": {"type": "string"},
-          "sg_message_id": {"type": "string"},
-          "useragent": {"type": "string"},
-          "ip": {"type": "string"},
-          "url": {"type": "string"}
+          "email": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "event": {
+            "type": "string"
+          },
+          "category": {
+            "type": "array"
+          },
+          "sg_event_id": {
+            "type": "string"
+          },
+          "sg_message_id": {
+            "type": "string"
+          },
+          "useragent": {
+            "type": "string"
+          },
+          "ip": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
         }
       }
     }
@@ -503,5 +732,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user/account"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/sentry/definition.json
+++ b/connectors/sentry/definition.json
@@ -59,7 +59,9 @@
             "description": "Organization slug"
           }
         },
-        "required": ["organizationSlug"],
+        "required": [
+          "organizationSlug"
+        ],
         "additionalProperties": false
       }
     },
@@ -79,7 +81,9 @@
             "description": "Pagination cursor"
           }
         },
-        "required": ["organizationSlug"],
+        "required": [
+          "organizationSlug"
+        ],
         "additionalProperties": false
       }
     },
@@ -99,7 +103,10 @@
             "description": "Project slug"
           }
         },
-        "required": ["organizationSlug", "projectSlug"],
+        "required": [
+          "organizationSlug",
+          "projectSlug"
+        ],
         "additionalProperties": false
       }
     },
@@ -132,7 +139,10 @@
             "description": "Create default alert rules"
           }
         },
-        "required": ["organizationSlug", "name"],
+        "required": [
+          "organizationSlug",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -176,7 +186,10 @@
             "description": "Maximum delay for digest notifications"
           }
         },
-        "required": ["organizationSlug", "projectSlug"],
+        "required": [
+          "organizationSlug",
+          "projectSlug"
+        ],
         "additionalProperties": false
       }
     },
@@ -197,7 +210,10 @@
           },
           "statsPeriod": {
             "type": "string",
-            "enum": ["14d", "24h"],
+            "enum": [
+              "14d",
+              "24h"
+            ],
             "description": "Statistics period"
           },
           "shortIdLookup": {
@@ -210,7 +226,13 @@
           },
           "sort": {
             "type": "string",
-            "enum": ["date", "new", "priority", "freq", "user"],
+            "enum": [
+              "date",
+              "new",
+              "priority",
+              "freq",
+              "user"
+            ],
             "description": "Sort order"
           },
           "cursor": {
@@ -218,7 +240,10 @@
             "description": "Pagination cursor"
           }
         },
-        "required": ["organizationSlug", "projectSlug"],
+        "required": [
+          "organizationSlug",
+          "projectSlug"
+        ],
         "additionalProperties": false
       }
     },
@@ -234,7 +259,9 @@
             "description": "Issue ID"
           }
         },
-        "required": ["issueId"],
+        "required": [
+          "issueId"
+        ],
         "additionalProperties": false
       }
     },
@@ -251,15 +278,25 @@
           },
           "status": {
             "type": "string",
-            "enum": ["resolved", "unresolved", "ignored"],
+            "enum": [
+              "resolved",
+              "unresolved",
+              "ignored"
+            ],
             "description": "Issue status"
           },
           "statusDetails": {
             "type": "object",
             "properties": {
-              "inRelease": {"type": "string"},
-              "inNextRelease": {"type": "boolean"},
-              "inCommit": {"type": "string"}
+              "inRelease": {
+                "type": "string"
+              },
+              "inNextRelease": {
+                "type": "boolean"
+              },
+              "inCommit": {
+                "type": "string"
+              }
             },
             "description": "Status details"
           },
@@ -284,7 +321,9 @@
             "description": "Whether issue is public"
           }
         },
-        "required": ["issueId"],
+        "required": [
+          "issueId"
+        ],
         "additionalProperties": false
       }
     },
@@ -300,7 +339,9 @@
             "description": "Issue ID"
           }
         },
-        "required": ["issueId"],
+        "required": [
+          "issueId"
+        ],
         "additionalProperties": false
       }
     },
@@ -325,7 +366,9 @@
             "description": "Pagination cursor"
           }
         },
-        "required": ["issueId"],
+        "required": [
+          "issueId"
+        ],
         "additionalProperties": false
       }
     },
@@ -349,7 +392,11 @@
             "description": "Event ID"
           }
         },
-        "required": ["organizationSlug", "projectSlug", "eventId"],
+        "required": [
+          "organizationSlug",
+          "projectSlug",
+          "eventId"
+        ],
         "additionalProperties": false
       }
     },
@@ -378,7 +425,9 @@
           },
           "projects": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Project slugs"
           },
           "dateReleased": {
@@ -391,12 +440,24 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"},
-                "repository": {"type": "string"},
-                "author_name": {"type": "string"},
-                "author_email": {"type": "string"},
-                "message": {"type": "string"},
-                "timestamp": {"type": "string"}
+                "id": {
+                  "type": "string"
+                },
+                "repository": {
+                  "type": "string"
+                },
+                "author_name": {
+                  "type": "string"
+                },
+                "author_email": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "string"
+                }
               }
             },
             "description": "Release commits"
@@ -406,15 +467,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "repository": {"type": "string"},
-                "commit": {"type": "string"},
-                "previousCommit": {"type": "string"}
+                "repository": {
+                  "type": "string"
+                },
+                "commit": {
+                  "type": "string"
+                },
+                "previousCommit": {
+                  "type": "string"
+                }
               }
             },
             "description": "Repository references"
           }
         },
-        "required": ["organizationSlug", "version", "projects"],
+        "required": [
+          "organizationSlug",
+          "version",
+          "projects"
+        ],
         "additionalProperties": false
       }
     },
@@ -435,7 +506,11 @@
           },
           "sort": {
             "type": "string",
-            "enum": ["date", "date_added", "sessions"],
+            "enum": [
+              "date",
+              "date_added",
+              "sessions"
+            ],
             "description": "Sort order"
           },
           "cursor": {
@@ -443,7 +518,9 @@
             "description": "Pagination cursor"
           }
         },
-        "required": ["organizationSlug"],
+        "required": [
+          "organizationSlug"
+        ],
         "additionalProperties": false
       }
     },
@@ -468,7 +545,10 @@
             "description": "Release date"
           }
         },
-        "required": ["organizationSlug", "version"],
+        "required": [
+          "organizationSlug",
+          "version"
+        ],
         "additionalProperties": false
       }
     },
@@ -488,7 +568,9 @@
             "description": "Pagination cursor"
           }
         },
-        "required": ["organizationSlug"],
+        "required": [
+          "organizationSlug"
+        ],
         "additionalProperties": false
       }
     }
@@ -512,7 +594,12 @@
           },
           "level": {
             "type": "string",
-            "enum": ["error", "warning", "info", "debug"],
+            "enum": [
+              "error",
+              "warning",
+              "info",
+              "debug"
+            ],
             "description": "Filter by issue level"
           }
         },
@@ -522,19 +609,45 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "culprit": {"type": "string"},
-          "level": {"type": "string"},
-          "status": {"type": "string"},
-          "statusDetails": {"type": "object"},
-          "isPublic": {"type": "boolean"},
-          "platform": {"type": "string"},
-          "project": {"type": "object"},
-          "count": {"type": "string"},
-          "userCount": {"type": "number"},
-          "firstSeen": {"type": "string"},
-          "lastSeen": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "culprit": {
+            "type": "string"
+          },
+          "level": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusDetails": {
+            "type": "object"
+          },
+          "isPublic": {
+            "type": "boolean"
+          },
+          "platform": {
+            "type": "string"
+          },
+          "project": {
+            "type": "object"
+          },
+          "count": {
+            "type": "string"
+          },
+          "userCount": {
+            "type": "number"
+          },
+          "firstSeen": {
+            "type": "string"
+          },
+          "lastSeen": {
+            "type": "string"
+          }
         }
       }
     },
@@ -561,13 +674,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "status": {"type": "string"},
-          "statusDetails": {"type": "object"},
-          "resolution": {"type": "string"},
-          "resolvedAt": {"type": "string"},
-          "project": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusDetails": {
+            "type": "object"
+          },
+          "resolution": {
+            "type": "string"
+          },
+          "resolvedAt": {
+            "type": "string"
+          },
+          "project": {
+            "type": "object"
+          }
         }
       }
     },
@@ -589,7 +716,12 @@
           },
           "level": {
             "type": "string",
-            "enum": ["error", "warning", "info", "debug"],
+            "enum": [
+              "error",
+              "warning",
+              "info",
+              "debug"
+            ],
             "description": "Filter by event level"
           }
         },
@@ -599,15 +731,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "eventID": {"type": "string"},
-          "issue": {"type": "object"},
-          "level": {"type": "string"},
-          "message": {"type": "string"},
-          "platform": {"type": "string"},
-          "project": {"type": "object"},
-          "timestamp": {"type": "string"},
-          "user": {"type": "object"},
-          "exception": {"type": "object"}
+          "eventID": {
+            "type": "string"
+          },
+          "issue": {
+            "type": "object"
+          },
+          "level": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "platform": {
+            "type": "string"
+          },
+          "project": {
+            "type": "object"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "user": {
+            "type": "object"
+          },
+          "exception": {
+            "type": "object"
+          }
         }
       }
     },
@@ -634,14 +784,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "version": {"type": "string"},
-          "ref": {"type": "string"},
-          "url": {"type": "string"},
-          "dateCreated": {"type": "string"},
-          "dateReleased": {"type": "string"},
-          "projects": {"type": "array"},
-          "commitCount": {"type": "number"},
-          "deployCount": {"type": "number"}
+          "version": {
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "dateCreated": {
+            "type": "string"
+          },
+          "dateReleased": {
+            "type": "string"
+          },
+          "projects": {
+            "type": "array"
+          },
+          "commitCount": {
+            "type": "number"
+          },
+          "deployCount": {
+            "type": "number"
+          }
         }
       }
     }
@@ -649,5 +815,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/organizations/"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/servicenow/definition.json
+++ b/connectors/servicenow/definition.json
@@ -55,17 +55,31 @@
           },
           "urgency": {
             "type": "string",
-            "enum": ["1", "2", "3"],
+            "enum": [
+              "1",
+              "2",
+              "3"
+            ],
             "description": "Urgency level (1=High, 2=Medium, 3=Low)"
           },
           "impact": {
             "type": "string",
-            "enum": ["1", "2", "3"],
+            "enum": [
+              "1",
+              "2",
+              "3"
+            ],
             "description": "Impact level (1=High, 2=Medium, 3=Low)"
           },
           "priority": {
             "type": "string",
-            "enum": ["1", "2", "3", "4", "5"],
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ],
             "description": "Priority level"
           },
           "assignment_group": {
@@ -85,7 +99,9 @@
             "description": "Configuration item"
           }
         },
-        "required": ["short_description"],
+        "required": [
+          "short_description"
+        ],
         "additionalProperties": false
       }
     },
@@ -119,7 +135,11 @@
           },
           "sysparm_display_value": {
             "type": "string",
-            "enum": ["true", "false", "all"],
+            "enum": [
+              "true",
+              "false",
+              "all"
+            ],
             "default": "false",
             "description": "Return display values"
           }
@@ -149,12 +169,25 @@
           },
           "state": {
             "type": "string",
-            "enum": ["1", "2", "3", "6", "7", "8"],
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "6",
+              "7",
+              "8"
+            ],
             "description": "Incident state"
           },
           "priority": {
             "type": "string",
-            "enum": ["1", "2", "3", "4", "5"],
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ],
             "description": "Priority level"
           },
           "assignment_group": {
@@ -178,7 +211,9 @@
             "description": "Close notes"
           }
         },
-        "required": ["sys_id"],
+        "required": [
+          "sys_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -199,22 +234,40 @@
           },
           "type": {
             "type": "string",
-            "enum": ["standard", "normal", "emergency"],
+            "enum": [
+              "standard",
+              "normal",
+              "emergency"
+            ],
             "description": "Change type"
           },
           "priority": {
             "type": "string",
-            "enum": ["1", "2", "3", "4"],
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "4"
+            ],
             "description": "Priority level"
           },
           "risk": {
             "type": "string",
-            "enum": ["1", "2", "3", "4"],
+            "enum": [
+              "1",
+              "2",
+              "3",
+              "4"
+            ],
             "description": "Risk level"
           },
           "impact": {
             "type": "string",
-            "enum": ["1", "2", "3"],
+            "enum": [
+              "1",
+              "2",
+              "3"
+            ],
             "description": "Impact level"
           },
           "requested_by": {
@@ -252,7 +305,9 @@
             "description": "Test plan"
           }
         },
-        "required": ["short_description"],
+        "required": [
+          "short_description"
+        ],
         "additionalProperties": false
       }
     },
@@ -308,17 +363,39 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "sys_id": {"type": "string"},
-          "number": {"type": "string"},
-          "short_description": {"type": "string"},
-          "state": {"type": "string"},
-          "priority": {"type": "string"},
-          "urgency": {"type": "string"},
-          "impact": {"type": "string"},
-          "caller_id": {"type": "string"},
-          "assignment_group": {"type": "string"},
-          "assigned_to": {"type": "string"},
-          "opened_at": {"type": "string"}
+          "sys_id": {
+            "type": "string"
+          },
+          "number": {
+            "type": "string"
+          },
+          "short_description": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "urgency": {
+            "type": "string"
+          },
+          "impact": {
+            "type": "string"
+          },
+          "caller_id": {
+            "type": "string"
+          },
+          "assignment_group": {
+            "type": "string"
+          },
+          "assigned_to": {
+            "type": "string"
+          },
+          "opened_at": {
+            "type": "string"
+          }
         }
       }
     },
@@ -341,14 +418,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "sys_id": {"type": "string"},
-          "number": {"type": "string"},
-          "short_description": {"type": "string"},
-          "state": {"type": "string"},
-          "priority": {"type": "string"},
-          "assignment_group": {"type": "string"},
-          "assigned_to": {"type": "string"},
-          "updated_on": {"type": "string"}
+          "sys_id": {
+            "type": "string"
+          },
+          "number": {
+            "type": "string"
+          },
+          "short_description": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "assignment_group": {
+            "type": "string"
+          },
+          "assigned_to": {
+            "type": "string"
+          },
+          "updated_on": {
+            "type": "string"
+          }
         }
       }
     }
@@ -356,5 +449,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/table/incident?sysparm_limit=1"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/sharepoint/definition.json
+++ b/connectors/sharepoint/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-      "scopes": ["Sites.ReadWrite.All", "Files.ReadWrite.All"]
+      "scopes": [
+        "Sites.ReadWrite.All",
+        "Files.ReadWrite.All"
+      ]
     }
   },
   "baseUrl": "https://graph.microsoft.com/v1.0",
@@ -56,12 +59,20 @@
           },
           "conflictBehavior": {
             "type": "string",
-            "enum": ["fail", "replace", "rename"],
+            "enum": [
+              "fail",
+              "replace",
+              "rename"
+            ],
             "default": "fail",
             "description": "What to do if file already exists"
           }
         },
-        "required": ["siteId", "fileName", "content"],
+        "required": [
+          "siteId",
+          "fileName",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -94,7 +105,9 @@
             "description": "Include file content in response"
           }
         },
-        "required": ["siteId"],
+        "required": [
+          "siteId"
+        ],
         "additionalProperties": false
       }
     },
@@ -122,7 +135,11 @@
             "description": "New file content"
           }
         },
-        "required": ["siteId", "fileId", "content"],
+        "required": [
+          "siteId",
+          "fileId",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -146,7 +163,10 @@
             "description": "File ID to delete"
           }
         },
-        "required": ["siteId", "fileId"],
+        "required": [
+          "siteId",
+          "fileId"
+        ],
         "additionalProperties": false
       }
     },
@@ -188,7 +208,9 @@
             "description": "Number of items to return"
           }
         },
-        "required": ["siteId"],
+        "required": [
+          "siteId"
+        ],
         "additionalProperties": false
       }
     },
@@ -217,12 +239,19 @@
           },
           "conflictBehavior": {
             "type": "string",
-            "enum": ["fail", "replace", "rename"],
+            "enum": [
+              "fail",
+              "replace",
+              "rename"
+            ],
             "default": "fail",
             "description": "What to do if folder already exists"
           }
         },
-        "required": ["siteId", "folderName"],
+        "required": [
+          "siteId",
+          "folderName"
+        ],
         "additionalProperties": false
       }
     },
@@ -246,7 +275,11 @@
             "description": "Field values for the new item"
           }
         },
-        "required": ["siteId", "listId", "fields"],
+        "required": [
+          "siteId",
+          "listId",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -274,7 +307,12 @@
             "description": "Field values to update"
           }
         },
-        "required": ["siteId", "listId", "itemId", "fields"],
+        "required": [
+          "siteId",
+          "listId",
+          "itemId",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -316,7 +354,10 @@
             "description": "Number of items to return"
           }
         },
-        "required": ["siteId", "listId"],
+        "required": [
+          "siteId",
+          "listId"
+        ],
         "additionalProperties": false
       }
     },
@@ -341,13 +382,21 @@
           },
           "type": {
             "type": "string",
-            "enum": ["view", "edit", "embed"],
+            "enum": [
+              "view",
+              "edit",
+              "embed"
+            ],
             "default": "view",
             "description": "Type of sharing link"
           },
           "scope": {
             "type": "string",
-            "enum": ["anonymous", "organization", "users"],
+            "enum": [
+              "anonymous",
+              "organization",
+              "users"
+            ],
             "default": "anonymous",
             "description": "Who can access the link"
           },
@@ -361,7 +410,10 @@
             "description": "Link expiration date"
           }
         },
-        "required": ["siteId", "itemId"],
+        "required": [
+          "siteId",
+          "itemId"
+        ],
         "additionalProperties": false
       }
     },
@@ -411,7 +463,9 @@
             "description": "Fields to select"
           }
         },
-        "required": ["siteId"],
+        "required": [
+          "siteId"
+        ],
         "additionalProperties": false
       }
     },
@@ -432,7 +486,15 @@
           },
           "entityTypes": {
             "type": "array",
-            "items": {"type": "string", "enum": ["driveItem", "list", "listItem", "site"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "driveItem",
+                "list",
+                "listItem",
+                "site"
+              ]
+            },
             "description": "Types of entities to search"
           },
           "top": {
@@ -442,7 +504,9 @@
             "description": "Number of results to return"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     }
@@ -475,14 +539,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "webUrl": {"type": "string"},
-          "createdDateTime": {"type": "string"},
-          "lastModifiedDateTime": {"type": "string"},
-          "size": {"type": "number"},
-          "createdBy": {"type": "object"},
-          "lastModifiedBy": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "webUrl": {
+            "type": "string"
+          },
+          "createdDateTime": {
+            "type": "string"
+          },
+          "lastModifiedDateTime": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "object"
+          },
+          "lastModifiedBy": {
+            "type": "object"
+          }
         }
       }
     },
@@ -513,12 +593,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "webUrl": {"type": "string"},
-          "lastModifiedDateTime": {"type": "string"},
-          "size": {"type": "number"},
-          "lastModifiedBy": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "webUrl": {
+            "type": "string"
+          },
+          "lastModifiedDateTime": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "lastModifiedBy": {
+            "type": "object"
+          }
         }
       }
     },
@@ -545,13 +637,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "webUrl": {"type": "string"},
-          "createdDateTime": {"type": "string"},
-          "lastModifiedDateTime": {"type": "string"},
-          "createdBy": {"type": "object"},
-          "lastModifiedBy": {"type": "object"},
-          "fields": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "webUrl": {
+            "type": "string"
+          },
+          "createdDateTime": {
+            "type": "string"
+          },
+          "lastModifiedDateTime": {
+            "type": "string"
+          },
+          "createdBy": {
+            "type": "object"
+          },
+          "lastModifiedBy": {
+            "type": "object"
+          },
+          "fields": {
+            "type": "object"
+          }
         }
       }
     },
@@ -578,11 +684,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "webUrl": {"type": "string"},
-          "lastModifiedDateTime": {"type": "string"},
-          "lastModifiedBy": {"type": "object"},
-          "fields": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "webUrl": {
+            "type": "string"
+          },
+          "lastModifiedDateTime": {
+            "type": "string"
+          },
+          "lastModifiedBy": {
+            "type": "object"
+          },
+          "fields": {
+            "type": "object"
+          }
         }
       }
     }
@@ -590,5 +706,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/shopify-enhanced/definition.json
+++ b/connectors/shopify-enhanced/definition.json
@@ -76,7 +76,11 @@
           },
           "published_status": {
             "type": "string",
-            "enum": ["published", "unpublished", "any"],
+            "enum": [
+              "published",
+              "unpublished",
+              "any"
+            ],
             "description": "Filter by published status"
           },
           "vendor": {
@@ -93,7 +97,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "archived", "draft"],
+            "enum": [
+              "active",
+              "archived",
+              "draft"
+            ],
             "description": "Filter by status"
           },
           "presentment_currencies": {
@@ -119,36 +127,105 @@
           "product": {
             "type": "object",
             "properties": {
-              "title": {"type": "string"},
-              "body_html": {"type": "string"},
-              "vendor": {"type": "string"},
-              "product_type": {"type": "string"},
-              "tags": {"type": "string"},
-              "status": {"type": "string", "enum": ["active", "archived", "draft"]},
-              "published": {"type": "boolean"},
-              "published_scope": {"type": "string", "enum": ["web", "global"]},
-              "template_suffix": {"type": "string"},
-              "handle": {"type": "string"},
+              "title": {
+                "type": "string"
+              },
+              "body_html": {
+                "type": "string"
+              },
+              "vendor": {
+                "type": "string"
+              },
+              "product_type": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "active",
+                  "archived",
+                  "draft"
+                ]
+              },
+              "published": {
+                "type": "boolean"
+              },
+              "published_scope": {
+                "type": "string",
+                "enum": [
+                  "web",
+                  "global"
+                ]
+              },
+              "template_suffix": {
+                "type": "string"
+              },
+              "handle": {
+                "type": "string"
+              },
               "variants": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "option1": {"type": "string"},
-                    "option2": {"type": "string"},
-                    "option3": {"type": "string"},
-                    "price": {"type": "string"},
-                    "compare_at_price": {"type": "string"},
-                    "sku": {"type": "string"},
-                    "barcode": {"type": "string"},
-                    "grams": {"type": "number"},
-                    "inventory_management": {"type": "string"},
-                    "inventory_policy": {"type": "string", "enum": ["deny", "continue"]},
-                    "inventory_quantity": {"type": "number"},
-                    "weight": {"type": "number"},
-                    "weight_unit": {"type": "string", "enum": ["g", "kg", "oz", "lb"]},
-                    "requires_shipping": {"type": "boolean"},
-                    "taxable": {"type": "boolean"}
+                    "option1": {
+                      "type": "string"
+                    },
+                    "option2": {
+                      "type": "string"
+                    },
+                    "option3": {
+                      "type": "string"
+                    },
+                    "price": {
+                      "type": "string"
+                    },
+                    "compare_at_price": {
+                      "type": "string"
+                    },
+                    "sku": {
+                      "type": "string"
+                    },
+                    "barcode": {
+                      "type": "string"
+                    },
+                    "grams": {
+                      "type": "number"
+                    },
+                    "inventory_management": {
+                      "type": "string"
+                    },
+                    "inventory_policy": {
+                      "type": "string",
+                      "enum": [
+                        "deny",
+                        "continue"
+                      ]
+                    },
+                    "inventory_quantity": {
+                      "type": "number"
+                    },
+                    "weight": {
+                      "type": "number"
+                    },
+                    "weight_unit": {
+                      "type": "string",
+                      "enum": [
+                        "g",
+                        "kg",
+                        "oz",
+                        "lb"
+                      ]
+                    },
+                    "requires_shipping": {
+                      "type": "boolean"
+                    },
+                    "taxable": {
+                      "type": "boolean"
+                    }
                   }
                 }
               },
@@ -157,8 +234,15 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "name": {"type": "string"},
-                    "values": {"type": "array", "items": {"type": "string"}}
+                    "name": {
+                      "type": "string"
+                    },
+                    "values": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               },
@@ -167,21 +251,35 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "src": {"type": "string"},
-                    "alt": {"type": "string"},
-                    "position": {"type": "number"}
+                    "src": {
+                      "type": "string"
+                    },
+                    "alt": {
+                      "type": "string"
+                    },
+                    "position": {
+                      "type": "number"
+                    }
                   }
                 }
               },
-              "seo_title": {"type": "string"},
-              "seo_description": {"type": "string"}
+              "seo_title": {
+                "type": "string"
+              },
+              "seo_description": {
+                "type": "string"
+              }
             },
-            "required": ["title"],
+            "required": [
+              "title"
+            ],
             "additionalProperties": false,
             "description": "Product data"
           }
         },
-        "required": ["product"],
+        "required": [
+          "product"
+        ],
         "additionalProperties": false
       }
     },
@@ -199,18 +297,40 @@
           "product": {
             "type": "object",
             "properties": {
-              "title": {"type": "string"},
-              "body_html": {"type": "string"},
-              "vendor": {"type": "string"},
-              "product_type": {"type": "string"},
-              "tags": {"type": "string"},
-              "status": {"type": "string", "enum": ["active", "archived", "draft"]},
-              "published": {"type": "boolean"}
+              "title": {
+                "type": "string"
+              },
+              "body_html": {
+                "type": "string"
+              },
+              "vendor": {
+                "type": "string"
+              },
+              "product_type": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "active",
+                  "archived",
+                  "draft"
+                ]
+              },
+              "published": {
+                "type": "boolean"
+              }
             },
             "description": "Product data to update"
           }
         },
-        "required": ["id", "product"],
+        "required": [
+          "id",
+          "product"
+        ],
         "additionalProperties": false
       }
     },
@@ -268,18 +388,38 @@
           },
           "status": {
             "type": "string",
-            "enum": ["open", "closed", "cancelled", "any"],
+            "enum": [
+              "open",
+              "closed",
+              "cancelled",
+              "any"
+            ],
             "default": "open",
             "description": "Filter by order status"
           },
           "financial_status": {
             "type": "string",
-            "enum": ["authorized", "pending", "paid", "partially_paid", "refunded", "voided", "partially_refunded", "any"],
+            "enum": [
+              "authorized",
+              "pending",
+              "paid",
+              "partially_paid",
+              "refunded",
+              "voided",
+              "partially_refunded",
+              "any"
+            ],
             "description": "Filter by financial status"
           },
           "fulfillment_status": {
             "type": "string",
-            "enum": ["shipped", "partial", "unshipped", "any", "unfulfilled"],
+            "enum": [
+              "shipped",
+              "partial",
+              "unshipped",
+              "any",
+              "unfulfilled"
+            ],
             "description": "Filter by fulfillment status"
           },
           "fields": {
@@ -301,72 +441,178 @@
           "order": {
             "type": "object",
             "properties": {
-              "email": {"type": "string", "format": "email"},
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
               "line_items": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "variant_id": {"type": "number"},
-                    "quantity": {"type": "number", "minimum": 1},
-                    "price": {"type": "string"},
-                    "title": {"type": "string"},
-                    "sku": {"type": "string"},
-                    "grams": {"type": "number"},
-                    "vendor": {"type": "string"},
-                    "product_id": {"type": "number"},
-                    "requires_shipping": {"type": "boolean"},
-                    "taxable": {"type": "boolean"}
+                    "variant_id": {
+                      "type": "number"
+                    },
+                    "quantity": {
+                      "type": "number",
+                      "minimum": 1
+                    },
+                    "price": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "sku": {
+                      "type": "string"
+                    },
+                    "grams": {
+                      "type": "number"
+                    },
+                    "vendor": {
+                      "type": "string"
+                    },
+                    "product_id": {
+                      "type": "number"
+                    },
+                    "requires_shipping": {
+                      "type": "boolean"
+                    },
+                    "taxable": {
+                      "type": "boolean"
+                    }
                   },
-                  "required": ["quantity"]
+                  "required": [
+                    "quantity"
+                  ]
                 }
               },
               "billing_address": {
                 "type": "object",
                 "properties": {
-                  "first_name": {"type": "string"},
-                  "last_name": {"type": "string"},
-                  "address1": {"type": "string"},
-                  "address2": {"type": "string"},
-                  "city": {"type": "string"},
-                  "province": {"type": "string"},
-                  "country": {"type": "string"},
-                  "zip": {"type": "string"},
-                  "phone": {"type": "string"},
-                  "company": {"type": "string"}
+                  "first_name": {
+                    "type": "string"
+                  },
+                  "last_name": {
+                    "type": "string"
+                  },
+                  "address1": {
+                    "type": "string"
+                  },
+                  "address2": {
+                    "type": "string"
+                  },
+                  "city": {
+                    "type": "string"
+                  },
+                  "province": {
+                    "type": "string"
+                  },
+                  "country": {
+                    "type": "string"
+                  },
+                  "zip": {
+                    "type": "string"
+                  },
+                  "phone": {
+                    "type": "string"
+                  },
+                  "company": {
+                    "type": "string"
+                  }
                 }
               },
               "shipping_address": {
                 "type": "object",
                 "properties": {
-                  "first_name": {"type": "string"},
-                  "last_name": {"type": "string"},
-                  "address1": {"type": "string"},
-                  "address2": {"type": "string"},
-                  "city": {"type": "string"},
-                  "province": {"type": "string"},
-                  "country": {"type": "string"},
-                  "zip": {"type": "string"},
-                  "phone": {"type": "string"},
-                  "company": {"type": "string"}
+                  "first_name": {
+                    "type": "string"
+                  },
+                  "last_name": {
+                    "type": "string"
+                  },
+                  "address1": {
+                    "type": "string"
+                  },
+                  "address2": {
+                    "type": "string"
+                  },
+                  "city": {
+                    "type": "string"
+                  },
+                  "province": {
+                    "type": "string"
+                  },
+                  "country": {
+                    "type": "string"
+                  },
+                  "zip": {
+                    "type": "string"
+                  },
+                  "phone": {
+                    "type": "string"
+                  },
+                  "company": {
+                    "type": "string"
+                  }
                 }
               },
-              "financial_status": {"type": "string", "enum": ["pending", "authorized", "paid", "partially_paid", "refunded", "voided", "partially_refunded", "unpaid"]},
-              "send_receipt": {"type": "boolean", "default": false},
-              "send_fulfillment_receipt": {"type": "boolean", "default": false},
-              "inventory_behaviour": {"type": "string", "enum": ["bypass", "decrement_ignoring_policy", "decrement_obeying_policy"]},
-              "note": {"type": "string"},
-              "tags": {"type": "string"},
-              "test": {"type": "boolean", "default": false},
-              "total_tax": {"type": "string"},
-              "currency": {"type": "string"}
+              "financial_status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "authorized",
+                  "paid",
+                  "partially_paid",
+                  "refunded",
+                  "voided",
+                  "partially_refunded",
+                  "unpaid"
+                ]
+              },
+              "send_receipt": {
+                "type": "boolean",
+                "default": false
+              },
+              "send_fulfillment_receipt": {
+                "type": "boolean",
+                "default": false
+              },
+              "inventory_behaviour": {
+                "type": "string",
+                "enum": [
+                  "bypass",
+                  "decrement_ignoring_policy",
+                  "decrement_obeying_policy"
+                ]
+              },
+              "note": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "string"
+              },
+              "test": {
+                "type": "boolean",
+                "default": false
+              },
+              "total_tax": {
+                "type": "string"
+              },
+              "currency": {
+                "type": "string"
+              }
             },
-            "required": ["line_items"],
+            "required": [
+              "line_items"
+            ],
             "additionalProperties": false,
             "description": "Order data"
           }
         },
-        "required": ["order"],
+        "required": [
+          "order"
+        ],
         "additionalProperties": false
       }
     },
@@ -427,52 +673,138 @@
           "customer": {
             "type": "object",
             "properties": {
-              "first_name": {"type": "string"},
-              "last_name": {"type": "string"},
-              "email": {"type": "string", "format": "email"},
-              "phone": {"type": "string"},
-              "verified_email": {"type": "boolean"},
+              "first_name": {
+                "type": "string"
+              },
+              "last_name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "verified_email": {
+                "type": "boolean"
+              },
               "addresses": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "address1": {"type": "string"},
-                    "address2": {"type": "string"},
-                    "city": {"type": "string"},
-                    "company": {"type": "string"},
-                    "country": {"type": "string"},
-                    "first_name": {"type": "string"},
-                    "last_name": {"type": "string"},
-                    "phone": {"type": "string"},
-                    "province": {"type": "string"},
-                    "zip": {"type": "string"},
-                    "name": {"type": "string"},
-                    "province_code": {"type": "string"},
-                    "country_code": {"type": "string"},
-                    "country_name": {"type": "string"},
-                    "default": {"type": "boolean"}
+                    "address1": {
+                      "type": "string"
+                    },
+                    "address2": {
+                      "type": "string"
+                    },
+                    "city": {
+                      "type": "string"
+                    },
+                    "company": {
+                      "type": "string"
+                    },
+                    "country": {
+                      "type": "string"
+                    },
+                    "first_name": {
+                      "type": "string"
+                    },
+                    "last_name": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "string"
+                    },
+                    "province": {
+                      "type": "string"
+                    },
+                    "zip": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "province_code": {
+                      "type": "string"
+                    },
+                    "country_code": {
+                      "type": "string"
+                    },
+                    "country_name": {
+                      "type": "string"
+                    },
+                    "default": {
+                      "type": "boolean"
+                    }
                   }
                 }
               },
-              "password": {"type": "string"},
-              "password_confirmation": {"type": "string"},
-              "send_email_welcome": {"type": "boolean", "default": false},
-              "send_email_invite": {"type": "boolean", "default": false},
-              "multipass_identifier": {"type": "string"},
-              "tax_exempt": {"type": "boolean"},
-              "tax_exemptions": {"type": "array", "items": {"type": "string"}},
-              "tags": {"type": "string"},
-              "note": {"type": "string"},
-              "state": {"type": "string", "enum": ["disabled", "invited", "enabled", "declined"]},
-              "accepts_marketing": {"type": "boolean"},
-              "accepts_marketing_updated_at": {"type": "string", "format": "date-time"},
-              "marketing_opt_in_level": {"type": "string", "enum": ["single_opt_in", "confirmed_opt_in", "unknown"]}
+              "password": {
+                "type": "string"
+              },
+              "password_confirmation": {
+                "type": "string"
+              },
+              "send_email_welcome": {
+                "type": "boolean",
+                "default": false
+              },
+              "send_email_invite": {
+                "type": "boolean",
+                "default": false
+              },
+              "multipass_identifier": {
+                "type": "string"
+              },
+              "tax_exempt": {
+                "type": "boolean"
+              },
+              "tax_exemptions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "tags": {
+                "type": "string"
+              },
+              "note": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "disabled",
+                  "invited",
+                  "enabled",
+                  "declined"
+                ]
+              },
+              "accepts_marketing": {
+                "type": "boolean"
+              },
+              "accepts_marketing_updated_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "marketing_opt_in_level": {
+                "type": "string",
+                "enum": [
+                  "single_opt_in",
+                  "confirmed_opt_in",
+                  "unknown"
+                ]
+              }
             },
             "description": "Customer data"
           }
         },
-        "required": ["customer"],
+        "required": [
+          "customer"
+        ],
         "additionalProperties": false
       }
     },
@@ -528,7 +860,11 @@
             "description": "Amount to adjust inventory by"
           }
         },
-        "required": ["location_id", "inventory_item_id", "available_adjustment"],
+        "required": [
+          "location_id",
+          "inventory_item_id",
+          "available_adjustment"
+        ],
         "additionalProperties": false
       }
     },
@@ -542,16 +878,99 @@
           "webhook": {
             "type": "object",
             "properties": {
-              "topic": {"type": "string", "enum": ["orders/create", "orders/delete", "orders/updated", "orders/paid", "orders/cancelled", "orders/fulfilled", "orders/partially_fulfilled", "order_transactions/create", "carts/create", "carts/update", "checkouts/create", "checkouts/delete", "checkouts/update", "refunds/create", "products/create", "products/update", "products/delete", "collections/create", "collections/update", "collections/delete", "customer_groups/create", "customer_groups/update", "customer_groups/delete", "customers/create", "customers/delete", "customers/disable", "customers/enable", "customers/update", "fulfillments/create", "fulfillments/update", "shop/update", "disputes/create", "disputes/update", "app/uninstalled", "channels/delete", "product_publications/create", "product_publications/delete", "product_publications/update", "collection_publications/create", "collection_publications/delete", "collection_publications/update", "variants/in_stock", "variants/out_of_stock", "inventory_levels/connect", "inventory_levels/update", "inventory_levels/disconnect", "inventory_items/create", "inventory_items/update", "inventory_items/delete", "locations/create", "locations/update", "locations/delete", "tender_transactions/create", "customers_marketing_consent/update", "customers_email_marketing_consent/update", "subscription_billing_attempts/success", "subscription_billing_attempts/failure", "subscription_billing_attempts/challenged", "subscription_contracts/create", "subscription_contracts/update", "bulk_operations/finish", "domains/create", "domains/update", "domains/destroy"]},
-              "address": {"type": "string", "format": "uri"},
-              "format": {"type": "string", "enum": ["json", "xml"], "default": "json"}
+              "topic": {
+                "type": "string",
+                "enum": [
+                  "orders/create",
+                  "orders/delete",
+                  "orders/updated",
+                  "orders/paid",
+                  "orders/cancelled",
+                  "orders/fulfilled",
+                  "orders/partially_fulfilled",
+                  "order_transactions/create",
+                  "carts/create",
+                  "carts/update",
+                  "checkouts/create",
+                  "checkouts/delete",
+                  "checkouts/update",
+                  "refunds/create",
+                  "products/create",
+                  "products/update",
+                  "products/delete",
+                  "collections/create",
+                  "collections/update",
+                  "collections/delete",
+                  "customer_groups/create",
+                  "customer_groups/update",
+                  "customer_groups/delete",
+                  "customers/create",
+                  "customers/delete",
+                  "customers/disable",
+                  "customers/enable",
+                  "customers/update",
+                  "fulfillments/create",
+                  "fulfillments/update",
+                  "shop/update",
+                  "disputes/create",
+                  "disputes/update",
+                  "app/uninstalled",
+                  "channels/delete",
+                  "product_publications/create",
+                  "product_publications/delete",
+                  "product_publications/update",
+                  "collection_publications/create",
+                  "collection_publications/delete",
+                  "collection_publications/update",
+                  "variants/in_stock",
+                  "variants/out_of_stock",
+                  "inventory_levels/connect",
+                  "inventory_levels/update",
+                  "inventory_levels/disconnect",
+                  "inventory_items/create",
+                  "inventory_items/update",
+                  "inventory_items/delete",
+                  "locations/create",
+                  "locations/update",
+                  "locations/delete",
+                  "tender_transactions/create",
+                  "customers_marketing_consent/update",
+                  "customers_email_marketing_consent/update",
+                  "subscription_billing_attempts/success",
+                  "subscription_billing_attempts/failure",
+                  "subscription_billing_attempts/challenged",
+                  "subscription_contracts/create",
+                  "subscription_contracts/update",
+                  "bulk_operations/finish",
+                  "domains/create",
+                  "domains/update",
+                  "domains/destroy"
+                ]
+              },
+              "address": {
+                "type": "string",
+                "format": "uri"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json",
+                  "xml"
+                ],
+                "default": "json"
+              }
             },
-            "required": ["topic", "address"],
+            "required": [
+              "topic",
+              "address"
+            ],
             "additionalProperties": false,
             "description": "Webhook data"
           }
         },
-        "required": ["webhook"],
+        "required": [
+          "webhook"
+        ],
         "additionalProperties": false
       }
     }
@@ -576,78 +995,222 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "email": {"type": "string"},
-          "closed_at": {"type": "string"},
-          "created_at": {"type": "string"},
-          "updated_at": {"type": "string"},
-          "number": {"type": "number"},
-          "note": {"type": "string"},
-          "token": {"type": "string"},
-          "gateway": {"type": "string"},
-          "test": {"type": "boolean"},
-          "total_price": {"type": "string"},
-          "subtotal_price": {"type": "string"},
-          "total_weight": {"type": "number"},
-          "total_tax": {"type": "string"},
-          "taxes_included": {"type": "boolean"},
-          "currency": {"type": "string"},
-          "financial_status": {"type": "string"},
-          "confirmed": {"type": "boolean"},
-          "total_discounts": {"type": "string"},
-          "total_line_items_price": {"type": "string"},
-          "cart_token": {"type": "string"},
-          "buyer_accepts_marketing": {"type": "boolean"},
-          "name": {"type": "string"},
-          "referring_site": {"type": "string"},
-          "landing_site": {"type": "string"},
-          "cancelled_at": {"type": "string"},
-          "cancel_reason": {"type": "string"},
-          "total_price_usd": {"type": "string"},
-          "checkout_token": {"type": "string"},
-          "reference": {"type": "string"},
-          "user_id": {"type": "number"},
-          "location_id": {"type": "number"},
-          "source_identifier": {"type": "string"},
-          "source_url": {"type": "string"},
-          "processed_at": {"type": "string"},
-          "device_id": {"type": "number"},
-          "phone": {"type": "string"},
-          "customer_locale": {"type": "string"},
-          "app_id": {"type": "number"},
-          "browser_ip": {"type": "string"},
-          "landing_site_ref": {"type": "string"},
-          "order_number": {"type": "number"},
-          "discount_applications": {"type": "array"},
-          "discount_codes": {"type": "array"},
-          "note_attributes": {"type": "array"},
-          "payment_gateway_names": {"type": "array"},
-          "processing_method": {"type": "string"},
-          "checkout_id": {"type": "number"},
-          "source_name": {"type": "string"},
-          "fulfillment_status": {"type": "string"},
-          "tax_lines": {"type": "array"},
-          "tags": {"type": "string"},
-          "contact_email": {"type": "string"},
-          "order_status_url": {"type": "string"},
-          "presentment_currency": {"type": "string"},
-          "total_line_items_price_set": {"type": "object"},
-          "total_discounts_set": {"type": "object"},
-          "total_shipping_price_set": {"type": "object"},
-          "subtotal_price_set": {"type": "object"},
-          "total_price_set": {"type": "object"},
-          "total_tax_set": {"type": "object"},
-          "line_items": {"type": "array"},
-          "fulfillments": {"type": "array"},
-          "refunds": {"type": "array"},
-          "total_tip_received": {"type": "string"},
-          "original_total_duties_set": {"type": "string"},
-          "current_total_duties_set": {"type": "string"},
-          "admin_graphql_api_id": {"type": "string"},
-          "shipping_lines": {"type": "array"},
-          "billing_address": {"type": "object"},
-          "shipping_address": {"type": "object"},
-          "customer": {"type": "object"}
+          "id": {
+            "type": "number"
+          },
+          "email": {
+            "type": "string"
+          },
+          "closed_at": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "number": {
+            "type": "number"
+          },
+          "note": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "gateway": {
+            "type": "string"
+          },
+          "test": {
+            "type": "boolean"
+          },
+          "total_price": {
+            "type": "string"
+          },
+          "subtotal_price": {
+            "type": "string"
+          },
+          "total_weight": {
+            "type": "number"
+          },
+          "total_tax": {
+            "type": "string"
+          },
+          "taxes_included": {
+            "type": "boolean"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "financial_status": {
+            "type": "string"
+          },
+          "confirmed": {
+            "type": "boolean"
+          },
+          "total_discounts": {
+            "type": "string"
+          },
+          "total_line_items_price": {
+            "type": "string"
+          },
+          "cart_token": {
+            "type": "string"
+          },
+          "buyer_accepts_marketing": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "referring_site": {
+            "type": "string"
+          },
+          "landing_site": {
+            "type": "string"
+          },
+          "cancelled_at": {
+            "type": "string"
+          },
+          "cancel_reason": {
+            "type": "string"
+          },
+          "total_price_usd": {
+            "type": "string"
+          },
+          "checkout_token": {
+            "type": "string"
+          },
+          "reference": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "number"
+          },
+          "location_id": {
+            "type": "number"
+          },
+          "source_identifier": {
+            "type": "string"
+          },
+          "source_url": {
+            "type": "string"
+          },
+          "processed_at": {
+            "type": "string"
+          },
+          "device_id": {
+            "type": "number"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "customer_locale": {
+            "type": "string"
+          },
+          "app_id": {
+            "type": "number"
+          },
+          "browser_ip": {
+            "type": "string"
+          },
+          "landing_site_ref": {
+            "type": "string"
+          },
+          "order_number": {
+            "type": "number"
+          },
+          "discount_applications": {
+            "type": "array"
+          },
+          "discount_codes": {
+            "type": "array"
+          },
+          "note_attributes": {
+            "type": "array"
+          },
+          "payment_gateway_names": {
+            "type": "array"
+          },
+          "processing_method": {
+            "type": "string"
+          },
+          "checkout_id": {
+            "type": "number"
+          },
+          "source_name": {
+            "type": "string"
+          },
+          "fulfillment_status": {
+            "type": "string"
+          },
+          "tax_lines": {
+            "type": "array"
+          },
+          "tags": {
+            "type": "string"
+          },
+          "contact_email": {
+            "type": "string"
+          },
+          "order_status_url": {
+            "type": "string"
+          },
+          "presentment_currency": {
+            "type": "string"
+          },
+          "total_line_items_price_set": {
+            "type": "object"
+          },
+          "total_discounts_set": {
+            "type": "object"
+          },
+          "total_shipping_price_set": {
+            "type": "object"
+          },
+          "subtotal_price_set": {
+            "type": "object"
+          },
+          "total_price_set": {
+            "type": "object"
+          },
+          "total_tax_set": {
+            "type": "object"
+          },
+          "line_items": {
+            "type": "array"
+          },
+          "fulfillments": {
+            "type": "array"
+          },
+          "refunds": {
+            "type": "array"
+          },
+          "total_tip_received": {
+            "type": "string"
+          },
+          "original_total_duties_set": {
+            "type": "string"
+          },
+          "current_total_duties_set": {
+            "type": "string"
+          },
+          "admin_graphql_api_id": {
+            "type": "string"
+          },
+          "shipping_lines": {
+            "type": "array"
+          },
+          "billing_address": {
+            "type": "object"
+          },
+          "shipping_address": {
+            "type": "object"
+          },
+          "customer": {
+            "type": "object"
+          }
         }
       }
     },
@@ -670,24 +1233,60 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "title": {"type": "string"},
-          "body_html": {"type": "string"},
-          "vendor": {"type": "string"},
-          "product_type": {"type": "string"},
-          "created_at": {"type": "string"},
-          "handle": {"type": "string"},
-          "updated_at": {"type": "string"},
-          "published_at": {"type": "string"},
-          "template_suffix": {"type": "string"},
-          "status": {"type": "string"},
-          "published_scope": {"type": "string"},
-          "tags": {"type": "string"},
-          "admin_graphql_api_id": {"type": "string"},
-          "variants": {"type": "array"},
-          "options": {"type": "array"},
-          "images": {"type": "array"},
-          "image": {"type": "object"}
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body_html": {
+            "type": "string"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "product_type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "handle": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string"
+          },
+          "template_suffix": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "published_scope": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "string"
+          },
+          "admin_graphql_api_id": {
+            "type": "string"
+          },
+          "variants": {
+            "type": "array"
+          },
+          "options": {
+            "type": "array"
+          },
+          "images": {
+            "type": "array"
+          },
+          "image": {
+            "type": "object"
+          }
         }
       }
     },
@@ -705,31 +1304,81 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "email": {"type": "string"},
-          "accepts_marketing": {"type": "boolean"},
-          "created_at": {"type": "string"},
-          "updated_at": {"type": "string"},
-          "first_name": {"type": "string"},
-          "last_name": {"type": "string"},
-          "orders_count": {"type": "number"},
-          "state": {"type": "string"},
-          "total_spent": {"type": "string"},
-          "last_order_id": {"type": "number"},
-          "note": {"type": "string"},
-          "verified_email": {"type": "boolean"},
-          "multipass_identifier": {"type": "string"},
-          "tax_exempt": {"type": "boolean"},
-          "phone": {"type": "string"},
-          "tags": {"type": "string"},
-          "last_order_name": {"type": "string"},
-          "currency": {"type": "string"},
-          "addresses": {"type": "array"},
-          "accepts_marketing_updated_at": {"type": "string"},
-          "marketing_opt_in_level": {"type": "string"},
-          "tax_exemptions": {"type": "array"},
-          "admin_graphql_api_id": {"type": "string"},
-          "default_address": {"type": "object"}
+          "id": {
+            "type": "number"
+          },
+          "email": {
+            "type": "string"
+          },
+          "accepts_marketing": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "orders_count": {
+            "type": "number"
+          },
+          "state": {
+            "type": "string"
+          },
+          "total_spent": {
+            "type": "string"
+          },
+          "last_order_id": {
+            "type": "number"
+          },
+          "note": {
+            "type": "string"
+          },
+          "verified_email": {
+            "type": "boolean"
+          },
+          "multipass_identifier": {
+            "type": "string"
+          },
+          "tax_exempt": {
+            "type": "boolean"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "string"
+          },
+          "last_order_name": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "addresses": {
+            "type": "array"
+          },
+          "accepts_marketing_updated_at": {
+            "type": "string"
+          },
+          "marketing_opt_in_level": {
+            "type": "string"
+          },
+          "tax_exemptions": {
+            "type": "array"
+          },
+          "admin_graphql_api_id": {
+            "type": "string"
+          },
+          "default_address": {
+            "type": "object"
+          }
         }
       }
     }
@@ -737,5 +1386,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/shop.json"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/shopify/definition.json
+++ b/connectors/shopify/definition.json
@@ -73,13 +73,37 @@
             "items": {
               "type": "object",
               "properties": {
-                "title": {"type": "string"},
-                "price": {"type": "string"},
-                "sku": {"type": "string"},
-                "inventory_quantity": {"type": "number"},
-                "weight": {"type": "number"},
-                "weight_unit": {"type": "string", "enum": ["g", "kg", "oz", "lb"]},
-                "inventory_policy": {"type": "string", "enum": ["deny", "continue"]}
+                "title": {
+                  "type": "string"
+                },
+                "price": {
+                  "type": "string"
+                },
+                "sku": {
+                  "type": "string"
+                },
+                "inventory_quantity": {
+                  "type": "number"
+                },
+                "weight": {
+                  "type": "number"
+                },
+                "weight_unit": {
+                  "type": "string",
+                  "enum": [
+                    "g",
+                    "kg",
+                    "oz",
+                    "lb"
+                  ]
+                },
+                "inventory_policy": {
+                  "type": "string",
+                  "enum": [
+                    "deny",
+                    "continue"
+                  ]
+                }
               }
             },
             "description": "Product variants"
@@ -89,14 +113,20 @@
             "items": {
               "type": "object",
               "properties": {
-                "src": {"type": "string"},
-                "alt": {"type": "string"}
+                "src": {
+                  "type": "string"
+                },
+                "alt": {
+                  "type": "string"
+                }
               }
             },
             "description": "Product images"
           }
         },
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -136,7 +166,9 @@
             "description": "Whether the product is published"
           }
         },
-        "required": ["product_id"],
+        "required": [
+          "product_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -156,7 +188,9 @@
             "description": "Comma-separated list of fields to retrieve"
           }
         },
-        "required": ["product_id"],
+        "required": [
+          "product_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -175,7 +209,11 @@
           },
           "published_status": {
             "type": "string",
-            "enum": ["published", "unpublished", "any"],
+            "enum": [
+              "published",
+              "unpublished",
+              "any"
+            ],
             "default": "any",
             "description": "Filter by published status"
           },
@@ -244,22 +282,44 @@
             "items": {
               "type": "object",
               "properties": {
-                "first_name": {"type": "string"},
-                "last_name": {"type": "string"},
-                "address1": {"type": "string"},
-                "address2": {"type": "string"},
-                "city": {"type": "string"},
-                "province": {"type": "string"},
-                "country": {"type": "string"},
-                "zip": {"type": "string"},
-                "phone": {"type": "string"},
-                "default": {"type": "boolean"}
+                "first_name": {
+                  "type": "string"
+                },
+                "last_name": {
+                  "type": "string"
+                },
+                "address1": {
+                  "type": "string"
+                },
+                "address2": {
+                  "type": "string"
+                },
+                "city": {
+                  "type": "string"
+                },
+                "province": {
+                  "type": "string"
+                },
+                "country": {
+                  "type": "string"
+                },
+                "zip": {
+                  "type": "string"
+                },
+                "phone": {
+                  "type": "string"
+                },
+                "default": {
+                  "type": "boolean"
+                }
               }
             },
             "description": "Customer addresses"
           }
         },
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "additionalProperties": false
       }
     },
@@ -300,7 +360,9 @@
             "description": "Whether customer accepts marketing"
           }
         },
-        "required": ["customer_id"],
+        "required": [
+          "customer_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -320,7 +382,9 @@
             "description": "Comma-separated list of fields to retrieve"
           }
         },
-        "required": ["order_id"],
+        "required": [
+          "order_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -339,19 +403,38 @@
           },
           "status": {
             "type": "string",
-            "enum": ["open", "closed", "cancelled", "any"],
+            "enum": [
+              "open",
+              "closed",
+              "cancelled",
+              "any"
+            ],
             "default": "any",
             "description": "Filter by order status"
           },
           "financial_status": {
             "type": "string",
-            "enum": ["authorized", "pending", "paid", "partially_paid", "refunded", "voided", "partially_refunded", "any"],
+            "enum": [
+              "authorized",
+              "pending",
+              "paid",
+              "partially_paid",
+              "refunded",
+              "voided",
+              "partially_refunded",
+              "any"
+            ],
             "default": "any",
             "description": "Filter by financial status"
           },
           "fulfillment_status": {
             "type": "string",
-            "enum": ["shipped", "partial", "unshipped", "any"],
+            "enum": [
+              "shipped",
+              "partial",
+              "unshipped",
+              "any"
+            ],
             "default": "any",
             "description": "Filter by fulfillment status"
           },
@@ -382,11 +465,21 @@
             "items": {
               "type": "object",
               "properties": {
-                "variant_id": {"type": "string"},
-                "product_id": {"type": "string"},
-                "title": {"type": "string"},
-                "quantity": {"type": "number"},
-                "price": {"type": "string"}
+                "variant_id": {
+                  "type": "string"
+                },
+                "product_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "number"
+                },
+                "price": {
+                  "type": "string"
+                }
               }
             },
             "description": "Order line items"
@@ -394,44 +487,89 @@
           "customer": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"},
-              "email": {"type": "string", "format": "email"},
-              "first_name": {"type": "string"},
-              "last_name": {"type": "string"}
+              "id": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "first_name": {
+                "type": "string"
+              },
+              "last_name": {
+                "type": "string"
+              }
             },
             "description": "Customer information"
           },
           "billing_address": {
             "type": "object",
             "properties": {
-              "first_name": {"type": "string"},
-              "last_name": {"type": "string"},
-              "address1": {"type": "string"},
-              "city": {"type": "string"},
-              "province": {"type": "string"},
-              "country": {"type": "string"},
-              "zip": {"type": "string"},
-              "phone": {"type": "string"}
+              "first_name": {
+                "type": "string"
+              },
+              "last_name": {
+                "type": "string"
+              },
+              "address1": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "province": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              },
+              "zip": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              }
             },
             "description": "Billing address"
           },
           "shipping_address": {
             "type": "object",
             "properties": {
-              "first_name": {"type": "string"},
-              "last_name": {"type": "string"},
-              "address1": {"type": "string"},
-              "city": {"type": "string"},
-              "province": {"type": "string"},
-              "country": {"type": "string"},
-              "zip": {"type": "string"},
-              "phone": {"type": "string"}
+              "first_name": {
+                "type": "string"
+              },
+              "last_name": {
+                "type": "string"
+              },
+              "address1": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "province": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              },
+              "zip": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              }
             },
             "description": "Shipping address"
           },
           "financial_status": {
             "type": "string",
-            "enum": ["pending", "authorized", "paid"],
+            "enum": [
+              "pending",
+              "authorized",
+              "paid"
+            ],
             "default": "pending",
             "description": "Financial status of the order"
           },
@@ -446,7 +584,9 @@
             "description": "Send fulfillment notification email"
           }
         },
-        "required": ["line_items"],
+        "required": [
+          "line_items"
+        ],
         "additionalProperties": false
       }
     },
@@ -475,7 +615,9 @@
             "description": "Customer email"
           }
         },
-        "required": ["order_id"],
+        "required": [
+          "order_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -516,14 +658,20 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"},
-                "quantity": {"type": "number"}
+                "id": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "number"
+                }
               }
             },
             "description": "Line items to fulfill"
           }
         },
-        "required": ["order_id"],
+        "required": [
+          "order_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -547,7 +695,11 @@
             "description": "Inventory adjustment amount"
           }
         },
-        "required": ["inventory_item_id", "location_id", "available_adjustment"],
+        "required": [
+          "inventory_item_id",
+          "location_id",
+          "available_adjustment"
+        ],
         "additionalProperties": false
       }
     }
@@ -570,12 +722,22 @@
         "properties": {
           "financial_status": {
             "type": "string",
-            "enum": ["any", "authorized", "pending", "paid"],
+            "enum": [
+              "any",
+              "authorized",
+              "pending",
+              "paid"
+            ],
             "description": "Filter by financial status"
           },
           "fulfillment_status": {
-            "type": "string", 
-            "enum": ["any", "shipped", "partial", "unshipped"],
+            "type": "string",
+            "enum": [
+              "any",
+              "shipped",
+              "partial",
+              "unshipped"
+            ],
             "description": "Filter by fulfillment status"
           }
         },
@@ -585,16 +747,36 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "order_number": {"type": "number"},
-          "email": {"type": "string"},
-          "total_price": {"type": "string"},
-          "currency": {"type": "string"},
-          "financial_status": {"type": "string"},
-          "fulfillment_status": {"type": "string"},
-          "created_at": {"type": "string"},
-          "customer": {"type": "object"},
-          "line_items": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "order_number": {
+            "type": "number"
+          },
+          "email": {
+            "type": "string"
+          },
+          "total_price": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "financial_status": {
+            "type": "string"
+          },
+          "fulfillment_status": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "customer": {
+            "type": "object"
+          },
+          "line_items": {
+            "type": "array"
+          }
         }
       }
     },
@@ -615,7 +797,9 @@
         "properties": {
           "watch_properties": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Specific properties to watch for changes"
           }
         },
@@ -625,11 +809,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "order_number": {"type": "number"},
-          "updated_at": {"type": "string"},
-          "financial_status": {"type": "string"},
-          "fulfillment_status": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "order_number": {
+            "type": "number"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "financial_status": {
+            "type": "string"
+          },
+          "fulfillment_status": {
+            "type": "string"
+          }
         }
       }
     },
@@ -654,11 +848,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "order_number": {"type": "number"},
-          "total_price": {"type": "string"},
-          "customer": {"type": "object"},
-          "created_at": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "order_number": {
+            "type": "number"
+          },
+          "total_price": {
+            "type": "string"
+          },
+          "customer": {
+            "type": "object"
+          },
+          "created_at": {
+            "type": "string"
+          }
         }
       }
     },
@@ -692,12 +896,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "vendor": {"type": "string"},
-          "product_type": {"type": "string"},
-          "created_at": {"type": "string"},
-          "variants": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "vendor": {
+            "type": "string"
+          },
+          "product_type": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "variants": {
+            "type": "array"
+          }
         }
       }
     },
@@ -722,12 +938,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "email": {"type": "string"},
-          "first_name": {"type": "string"},
-          "last_name": {"type": "string"},
-          "created_at": {"type": "string"},
-          "tags": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "string"
+          }
         }
       }
     }
@@ -735,5 +963,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/admin/api/2023-10/shop.json"
+  },
+  "semanticVersion": "1.3.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/slab/definition.json
+++ b/connectors/slab/definition.json
@@ -52,12 +52,20 @@
           },
           "visibility": {
             "type": "string",
-            "enum": ["team", "organization", "public"],
+            "enum": [
+              "team",
+              "organization",
+              "public"
+            ],
             "default": "team",
             "description": "Post visibility"
           }
         },
-        "required": ["title", "content", "topic_id"],
+        "required": [
+          "title",
+          "content",
+          "topic_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -73,7 +81,9 @@
             "description": "Post ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -98,11 +108,17 @@
           },
           "visibility": {
             "type": "string",
-            "enum": ["team", "organization", "public"],
+            "enum": [
+              "team",
+              "organization",
+              "public"
+            ],
             "description": "Post visibility"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -118,7 +134,9 @@
             "description": "Post ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -151,7 +169,9 @@
             "description": "Number of results to skip"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -192,7 +212,9 @@
             "description": "Topic ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     }
@@ -217,13 +239,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "content": {"type": "string"},
-          "topic_id": {"type": "string"},
-          "author": {"type": "object"},
-          "created_at": {"type": "string"},
-          "updated_at": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "topic_id": {
+            "type": "string"
+          },
+          "author": {
+            "type": "object"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
         }
       }
     },
@@ -246,12 +282,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "content": {"type": "string"},
-          "topic_id": {"type": "string"},
-          "author": {"type": "object"},
-          "updated_at": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "topic_id": {
+            "type": "string"
+          },
+          "author": {
+            "type": "object"
+          },
+          "updated_at": {
+            "type": "string"
+          }
         }
       }
     }
@@ -259,5 +307,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/slack-enhanced/definition.json
+++ b/connectors/slack-enhanced/definition.json
@@ -94,7 +94,10 @@
           },
           "parse": {
             "type": "string",
-            "enum": ["full", "none"],
+            "enum": [
+              "full",
+              "none"
+            ],
             "description": "Change how messages are treated"
           },
           "reply_broadcast": {
@@ -125,7 +128,10 @@
             }
           }
         },
-        "required": ["channel", "text"],
+        "required": [
+          "channel",
+          "text"
+        ],
         "additionalProperties": false
       }
     },
@@ -170,7 +176,10 @@
           },
           "parse": {
             "type": "string",
-            "enum": ["full", "none"],
+            "enum": [
+              "full",
+              "none"
+            ],
             "description": "Change how messages are treated"
           },
           "mrkdwn": {
@@ -193,7 +202,10 @@
             }
           }
         },
-        "required": ["user", "text"],
+        "required": [
+          "user",
+          "text"
+        ],
         "additionalProperties": false
       }
     },
@@ -218,7 +230,9 @@
             "description": "Encoded team id to create the channel in"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -256,7 +270,10 @@
             }
           }
         },
-        "required": ["channel", "user"],
+        "required": [
+          "channel",
+          "user"
+        ],
         "additionalProperties": false
       }
     },
@@ -304,7 +321,9 @@
             "description": "Start of time range of messages to include in results"
           }
         },
-        "required": ["channel"],
+        "required": [
+          "channel"
+        ],
         "additionalProperties": false
       }
     },
@@ -381,7 +400,11 @@
             "description": "Timestamp of the message to add reaction to"
           }
         },
-        "required": ["channel", "name", "timestamp"],
+        "required": [
+          "channel",
+          "name",
+          "timestamp"
+        ],
         "additionalProperties": false
       }
     },
@@ -401,7 +424,9 @@
             "description": "Set this to true to receive the locale for this user"
           }
         },
-        "required": ["user"],
+        "required": [
+          "user"
+        ],
         "additionalProperties": false
       }
     },
@@ -466,7 +491,10 @@
             "description": "The new topic"
           }
         },
-        "required": ["channel", "topic"],
+        "required": [
+          "channel",
+          "topic"
+        ],
         "additionalProperties": false
       }
     },
@@ -491,7 +519,9 @@
             }
           }
         },
-        "required": ["channel"],
+        "required": [
+          "channel"
+        ],
         "additionalProperties": false
       }
     },
@@ -520,7 +550,10 @@
             "description": "Timestamp of the message to pin"
           }
         },
-        "required": ["channel", "timestamp"],
+        "required": [
+          "channel",
+          "timestamp"
+        ],
         "additionalProperties": false
       }
     },
@@ -578,7 +611,10 @@
           },
           "parse": {
             "type": "string",
-            "enum": ["full", "none"],
+            "enum": [
+              "full",
+              "none"
+            ],
             "description": "Change how messages are treated"
           },
           "thread_ts": {
@@ -604,7 +640,11 @@
             }
           }
         },
-        "required": ["channel", "text", "post_at"],
+        "required": [
+          "channel",
+          "text",
+          "post_at"
+        ],
         "additionalProperties": false
       }
     }
@@ -641,32 +681,74 @@
             "description": "Exclude messages from bots"
           }
         },
-        "required": ["channel"],
+        "required": [
+          "channel"
+        ],
         "additionalProperties": false
       },
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "subtype": {"type": "string"},
-          "channel": {"type": "string"},
-          "user": {"type": "string"},
-          "text": {"type": "string"},
-          "ts": {"type": "string"},
-          "team": {"type": "string"},
-          "thread_ts": {"type": "string"},
-          "parent_user_id": {"type": "string"},
-          "blocks": {"type": "array"},
-          "attachments": {"type": "array"},
-          "files": {"type": "array"},
-          "upload": {"type": "boolean"},
-          "display_as_bot": {"type": "boolean"},
-          "username": {"type": "string"},
-          "bot_id": {"type": "string"},
-          "app_id": {"type": "string"},
-          "edited": {"type": "object"},
-          "client_msg_id": {"type": "string"},
-          "reactions": {"type": "array"}
+          "type": {
+            "type": "string"
+          },
+          "subtype": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "ts": {
+            "type": "string"
+          },
+          "team": {
+            "type": "string"
+          },
+          "thread_ts": {
+            "type": "string"
+          },
+          "parent_user_id": {
+            "type": "string"
+          },
+          "blocks": {
+            "type": "array"
+          },
+          "attachments": {
+            "type": "array"
+          },
+          "files": {
+            "type": "array"
+          },
+          "upload": {
+            "type": "boolean"
+          },
+          "display_as_bot": {
+            "type": "boolean"
+          },
+          "username": {
+            "type": "string"
+          },
+          "bot_id": {
+            "type": "string"
+          },
+          "app_id": {
+            "type": "string"
+          },
+          "edited": {
+            "type": "object"
+          },
+          "client_msg_id": {
+            "type": "string"
+          },
+          "reactions": {
+            "type": "array"
+          }
         }
       }
     },
@@ -690,39 +772,99 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
+          "type": {
+            "type": "string"
+          },
           "channel": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"},
-              "name": {"type": "string"},
-              "is_channel": {"type": "boolean"},
-              "is_group": {"type": "boolean"},
-              "is_im": {"type": "boolean"},
-              "is_mpim": {"type": "boolean"},
-              "is_private": {"type": "boolean"},
-              "created": {"type": "number"},
-              "is_archived": {"type": "boolean"},
-              "is_general": {"type": "boolean"},
-              "unlinked": {"type": "number"},
-              "name_normalized": {"type": "string"},
-              "is_shared": {"type": "boolean"},
-              "is_org_shared": {"type": "boolean"},
-              "is_member": {"type": "boolean"},
-              "is_pending_ext_shared": {"type": "boolean"},
-              "pending_shared": {"type": "array"},
-              "context_team_id": {"type": "string"},
-              "updated": {"type": "number"},
-              "parent_conversation": {"type": "string"},
-              "creator": {"type": "string"},
-              "is_ext_shared": {"type": "boolean"},
-              "shared_team_ids": {"type": "array"},
-              "pending_connected_team_ids": {"type": "array"},
-              "is_pending_ext_shared_private": {"type": "boolean"},
-              "topic": {"type": "object"},
-              "purpose": {"type": "object"},
-              "previous_names": {"type": "array"},
-              "num_members": {"type": "number"}
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "is_channel": {
+                "type": "boolean"
+              },
+              "is_group": {
+                "type": "boolean"
+              },
+              "is_im": {
+                "type": "boolean"
+              },
+              "is_mpim": {
+                "type": "boolean"
+              },
+              "is_private": {
+                "type": "boolean"
+              },
+              "created": {
+                "type": "number"
+              },
+              "is_archived": {
+                "type": "boolean"
+              },
+              "is_general": {
+                "type": "boolean"
+              },
+              "unlinked": {
+                "type": "number"
+              },
+              "name_normalized": {
+                "type": "string"
+              },
+              "is_shared": {
+                "type": "boolean"
+              },
+              "is_org_shared": {
+                "type": "boolean"
+              },
+              "is_member": {
+                "type": "boolean"
+              },
+              "is_pending_ext_shared": {
+                "type": "boolean"
+              },
+              "pending_shared": {
+                "type": "array"
+              },
+              "context_team_id": {
+                "type": "string"
+              },
+              "updated": {
+                "type": "number"
+              },
+              "parent_conversation": {
+                "type": "string"
+              },
+              "creator": {
+                "type": "string"
+              },
+              "is_ext_shared": {
+                "type": "boolean"
+              },
+              "shared_team_ids": {
+                "type": "array"
+              },
+              "pending_connected_team_ids": {
+                "type": "array"
+              },
+              "is_pending_ext_shared_private": {
+                "type": "boolean"
+              },
+              "topic": {
+                "type": "object"
+              },
+              "purpose": {
+                "type": "object"
+              },
+              "previous_names": {
+                "type": "array"
+              },
+              "num_members": {
+                "type": "number"
+              }
             }
           }
         }
@@ -760,44 +902,114 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "file_id": {"type": "string"},
-          "user_id": {"type": "string"},
+          "type": {
+            "type": "string"
+          },
+          "file_id": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "string"
+          },
           "file": {
             "type": "object",
             "properties": {
-              "id": {"type": "string"},
-              "created": {"type": "number"},
-              "timestamp": {"type": "number"},
-              "name": {"type": "string"},
-              "title": {"type": "string"},
-              "mimetype": {"type": "string"},
-              "filetype": {"type": "string"},
-              "pretty_type": {"type": "string"},
-              "user": {"type": "string"},
-              "editable": {"type": "boolean"},
-              "size": {"type": "number"},
-              "mode": {"type": "string"},
-              "is_external": {"type": "boolean"},
-              "external_type": {"type": "string"},
-              "is_public": {"type": "boolean"},
-              "public_url_shared": {"type": "boolean"},
-              "display_as_bot": {"type": "boolean"},
-              "username": {"type": "string"},
-              "url_private": {"type": "string"},
-              "url_private_download": {"type": "string"},
-              "permalink": {"type": "string"},
-              "permalink_public": {"type": "string"},
-              "edit_link": {"type": "string"},
-              "preview": {"type": "string"},
-              "preview_highlight": {"type": "string"},
-              "lines": {"type": "number"},
-              "lines_more": {"type": "number"},
-              "preview_is_truncated": {"type": "boolean"},
-              "channels": {"type": "array"},
-              "groups": {"type": "array"},
-              "ims": {"type": "array"},
-              "has_rich_preview": {"type": "boolean"}
+              "id": {
+                "type": "string"
+              },
+              "created": {
+                "type": "number"
+              },
+              "timestamp": {
+                "type": "number"
+              },
+              "name": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "mimetype": {
+                "type": "string"
+              },
+              "filetype": {
+                "type": "string"
+              },
+              "pretty_type": {
+                "type": "string"
+              },
+              "user": {
+                "type": "string"
+              },
+              "editable": {
+                "type": "boolean"
+              },
+              "size": {
+                "type": "number"
+              },
+              "mode": {
+                "type": "string"
+              },
+              "is_external": {
+                "type": "boolean"
+              },
+              "external_type": {
+                "type": "string"
+              },
+              "is_public": {
+                "type": "boolean"
+              },
+              "public_url_shared": {
+                "type": "boolean"
+              },
+              "display_as_bot": {
+                "type": "boolean"
+              },
+              "username": {
+                "type": "string"
+              },
+              "url_private": {
+                "type": "string"
+              },
+              "url_private_download": {
+                "type": "string"
+              },
+              "permalink": {
+                "type": "string"
+              },
+              "permalink_public": {
+                "type": "string"
+              },
+              "edit_link": {
+                "type": "string"
+              },
+              "preview": {
+                "type": "string"
+              },
+              "preview_highlight": {
+                "type": "string"
+              },
+              "lines": {
+                "type": "number"
+              },
+              "lines_more": {
+                "type": "number"
+              },
+              "preview_is_truncated": {
+                "type": "boolean"
+              },
+              "channels": {
+                "type": "array"
+              },
+              "groups": {
+                "type": "array"
+              },
+              "ims": {
+                "type": "array"
+              },
+              "has_rich_preview": {
+                "type": "boolean"
+              }
             }
           }
         }
@@ -835,19 +1047,35 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
-          "user": {"type": "string"},
-          "reaction": {"type": "string"},
+          "type": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          },
+          "reaction": {
+            "type": "string"
+          },
           "item": {
             "type": "object",
             "properties": {
-              "type": {"type": "string"},
-              "channel": {"type": "string"},
-              "ts": {"type": "string"}
+              "type": {
+                "type": "string"
+              },
+              "channel": {
+                "type": "string"
+              },
+              "ts": {
+                "type": "string"
+              }
             }
           },
-          "item_user": {"type": "string"},
-          "event_ts": {"type": "string"}
+          "item_user": {
+            "type": "string"
+          },
+          "event_ts": {
+            "type": "string"
+          }
         }
       }
     }
@@ -855,5 +1083,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/auth.test"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/slack/definition.json
+++ b/connectors/slack/definition.json
@@ -39,7 +39,9 @@
         "required": [],
         "additionalProperties": false
       },
-      "requiredScopes": ["users:read"],
+      "requiredScopes": [
+        "users:read"
+      ],
       "rateLimits": {
         "requests": 10,
         "period": "1m",
@@ -86,14 +88,23 @@
           },
           "blocks": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Rich message blocks for formatting"
           }
         },
-        "required": ["channel", "text"],
+        "required": [
+          "channel",
+          "text"
+        ],
         "additionalProperties": false
       },
-      "responseFields": ["ts", "channel", "message"],
+      "responseFields": [
+        "ts",
+        "channel",
+        "message"
+      ],
       "errorCodes": {
         "channel_not_found": "The specified channel does not exist",
         "not_in_channel": "Bot is not a member of the channel",
@@ -119,7 +130,9 @@
             "description": "Create a private channel"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -159,7 +172,10 @@
             }
           }
         },
-        "required": ["channel", "users"],
+        "required": [
+          "channel",
+          "users"
+        ],
         "additionalProperties": false
       }
     },
@@ -197,7 +213,10 @@
             "description": "Title of the file"
           }
         },
-        "required": ["content", "filename"],
+        "required": [
+          "content",
+          "filename"
+        ],
         "additionalProperties": false
       }
     },
@@ -224,7 +243,9 @@
             }
           }
         },
-        "required": ["channel"],
+        "required": [
+          "channel"
+        ],
         "additionalProperties": false
       }
     },
@@ -266,7 +287,9 @@
             "description": "User ID to get info for"
           }
         },
-        "required": ["user"],
+        "required": [
+          "user"
+        ],
         "additionalProperties": false
       }
     },
@@ -320,7 +343,11 @@
             "description": "Emoji name (without colons)"
           }
         },
-        "required": ["channel", "timestamp", "name"],
+        "required": [
+          "channel",
+          "timestamp",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -355,11 +382,14 @@
             "description": "Unix timestamp for when to send the message"
           }
         },
-        "required": ["channel", "text", "post_at"],
+        "required": [
+          "channel",
+          "text",
+          "post_at"
+        ],
         "additionalProperties": false
       }
-    }
-    ,
+    },
     {
       "id": "list_files",
       "name": "List Files",
@@ -369,17 +399,27 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "user": {"type":"string"},
-          "channel": {"type":"string"},
-          "ts_from": {"type":"number"},
-          "ts_to": {"type":"number"},
-          "count": {"type":"number","default":100}
+          "user": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "ts_from": {
+            "type": "number"
+          },
+          "ts_to": {
+            "type": "number"
+          },
+          "count": {
+            "type": "number",
+            "default": 100
+          }
         },
         "required": [],
         "additionalProperties": false
       }
-    }
-    ,
+    },
     {
       "id": "conversations_history",
       "name": "Conversations History",
@@ -389,13 +429,26 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "channel": {"type":"string"},
-          "latest": {"type":"string"},
-          "oldest": {"type":"string"},
-          "inclusive": {"type":"boolean"},
-          "limit": {"type":"number","default":100}
+          "channel": {
+            "type": "string"
+          },
+          "latest": {
+            "type": "string"
+          },
+          "oldest": {
+            "type": "string"
+          },
+          "inclusive": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "number",
+            "default": 100
+          }
         },
-        "required": ["channel"],
+        "required": [
+          "channel"
+        ],
         "additionalProperties": false
       }
     }
@@ -445,11 +498,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "channel": {"type": "string"},
-          "user": {"type": "string"},
-          "text": {"type": "string"},
-          "timestamp": {"type": "string"},
-          "thread_ts": {"type": "string"}
+          "channel": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "thread_ts": {
+            "type": "string"
+          }
         }
       }
     },
@@ -493,10 +556,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "channel": {"type": "string"},
-          "user": {"type": "string"},
-          "reaction": {"type": "string"},
-          "timestamp": {"type": "string"}
+          "channel": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          },
+          "reaction": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          }
         }
       }
     },
@@ -530,15 +601,23 @@
             }
           }
         },
-        "required": ["channel"],
+        "required": [
+          "channel"
+        ],
         "additionalProperties": false
       },
       "outputSchema": {
         "type": "object",
         "properties": {
-          "channel": {"type": "string"},
-          "user": {"type": "string"},
-          "timestamp": {"type": "string"}
+          "channel": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          }
         }
       }
     }
@@ -551,5 +630,20 @@
     }
   },
   "documentation": "https://api.slack.com/web",
-  "supportContact": "https://slack.com/help/contact"
+  "supportContact": "https://slack.com/help/contact",
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/smartsheet/definition.json
+++ b/connectors/smartsheet/definition.json
@@ -64,7 +64,14 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["attachments", "discussions", "filters", "format", "objectValue", "source"]
+              "enum": [
+                "attachments",
+                "discussions",
+                "filters",
+                "format",
+                "objectValue",
+                "source"
+              ]
             },
             "description": "Additional elements to include"
           },
@@ -75,21 +82,29 @@
           },
           "rowIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Specific row IDs to retrieve"
           },
           "rowNumbers": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Specific row numbers to retrieve"
           },
           "columnIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Specific column IDs to retrieve"
           }
         },
-        "required": ["sheetId"],
+        "required": [
+          "sheetId"
+        ],
         "additionalProperties": false
       }
     },
@@ -109,13 +124,40 @@
             "items": {
               "type": "object",
               "properties": {
-                "title": {"type": "string"},
-                "type": {"type": "string", "enum": ["TEXT_NUMBER", "DATE", "DATETIME", "CONTACT_LIST", "CHECKBOX", "PICKLIST", "DURATION", "PREDECESSOR", "ABSTRACT_DATETIME"]},
-                "primary": {"type": "boolean"},
-                "width": {"type": "number"},
-                "options": {"type": "array", "items": {"type": "string"}}
+                "title": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "TEXT_NUMBER",
+                    "DATE",
+                    "DATETIME",
+                    "CONTACT_LIST",
+                    "CHECKBOX",
+                    "PICKLIST",
+                    "DURATION",
+                    "PREDECESSOR",
+                    "ABSTRACT_DATETIME"
+                  ]
+                },
+                "primary": {
+                  "type": "boolean"
+                },
+                "width": {
+                  "type": "number"
+                },
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
-              "required": ["title", "type"]
+              "required": [
+                "title",
+                "type"
+              ]
             },
             "description": "Sheet columns"
           },
@@ -128,7 +170,10 @@
             "description": "Workspace ID to create sheet in"
           }
         },
-        "required": ["name", "columns"],
+        "required": [
+          "name",
+          "columns"
+        ],
         "additionalProperties": false
       }
     },
@@ -150,22 +195,40 @@
           "userSettings": {
             "type": "object",
             "properties": {
-              "criticalPathEnabled": {"type": "boolean"},
-              "displaySummaryTasks": {"type": "boolean"}
+              "criticalPathEnabled": {
+                "type": "boolean"
+              },
+              "displaySummaryTasks": {
+                "type": "boolean"
+              }
             },
             "description": "User settings"
           },
           "projectSettings": {
             "type": "object",
             "properties": {
-              "workingDays": {"type": "array", "items": {"type": "string"}},
-              "nonWorkingDays": {"type": "array", "items": {"type": "string"}},
-              "lengthOfDay": {"type": "number"}
+              "workingDays": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "nonWorkingDays": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "lengthOfDay": {
+                "type": "number"
+              }
             },
             "description": "Project settings"
           }
         },
-        "required": ["sheetId"],
+        "required": [
+          "sheetId"
+        ],
         "additionalProperties": false
       }
     },
@@ -185,32 +248,63 @@
             "items": {
               "type": "object",
               "properties": {
-                "toTop": {"type": "boolean"},
-                "toBottom": {"type": "boolean"},
-                "parentId": {"type": "string"},
-                "siblingId": {"type": "string"},
-                "above": {"type": "boolean"},
+                "toTop": {
+                  "type": "boolean"
+                },
+                "toBottom": {
+                  "type": "boolean"
+                },
+                "parentId": {
+                  "type": "string"
+                },
+                "siblingId": {
+                  "type": "string"
+                },
+                "above": {
+                  "type": "boolean"
+                },
                 "cells": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "properties": {
-                      "columnId": {"type": "string"},
-                      "value": {"type": ["string", "number", "boolean"]},
-                      "displayValue": {"type": "string"},
-                      "formula": {"type": "string"},
-                      "strict": {"type": "boolean"}
+                      "columnId": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": [
+                          "string",
+                          "number",
+                          "boolean"
+                        ]
+                      },
+                      "displayValue": {
+                        "type": "string"
+                      },
+                      "formula": {
+                        "type": "string"
+                      },
+                      "strict": {
+                        "type": "boolean"
+                      }
                     },
-                    "required": ["columnId"]
+                    "required": [
+                      "columnId"
+                    ]
                   }
                 }
               },
-              "required": ["cells"]
+              "required": [
+                "cells"
+              ]
             },
             "description": "Rows to add"
           }
         },
-        "required": ["sheetId", "rows"],
+        "required": [
+          "sheetId",
+          "rows"
+        ],
         "additionalProperties": false
       }
     },
@@ -230,27 +324,49 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "string"},
+                "id": {
+                  "type": "string"
+                },
                 "cells": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "properties": {
-                      "columnId": {"type": "string"},
-                      "value": {"type": ["string", "number", "boolean"]},
-                      "displayValue": {"type": "string"},
-                      "formula": {"type": "string"}
+                      "columnId": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": [
+                          "string",
+                          "number",
+                          "boolean"
+                        ]
+                      },
+                      "displayValue": {
+                        "type": "string"
+                      },
+                      "formula": {
+                        "type": "string"
+                      }
                     },
-                    "required": ["columnId"]
+                    "required": [
+                      "columnId"
+                    ]
                   }
                 }
               },
-              "required": ["id", "cells"]
+              "required": [
+                "id",
+                "cells"
+              ]
             },
             "description": "Rows to update"
           }
         },
-        "required": ["sheetId", "rows"],
+        "required": [
+          "sheetId",
+          "rows"
+        ],
         "additionalProperties": false
       }
     },
@@ -267,7 +383,9 @@
           },
           "rowIds": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Row IDs to delete"
           },
           "ignoreRowsNotFound": {
@@ -276,7 +394,10 @@
             "description": "Ignore if rows are not found"
           }
         },
-        "required": ["sheetId", "rowIds"],
+        "required": [
+          "sheetId",
+          "rowIds"
+        ],
         "additionalProperties": false
       }
     },
@@ -296,29 +417,71 @@
             "items": {
               "type": "object",
               "properties": {
-                "title": {"type": "string"},
-                "type": {"type": "string", "enum": ["TEXT_NUMBER", "DATE", "DATETIME", "CONTACT_LIST", "CHECKBOX", "PICKLIST", "DURATION", "PREDECESSOR", "ABSTRACT_DATETIME"]},
-                "index": {"type": "number"},
-                "width": {"type": "number"},
-                "options": {"type": "array", "items": {"type": "string"}},
-                "symbol": {"type": "string"},
-                "systemColumnType": {"type": "string"},
+                "title": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "TEXT_NUMBER",
+                    "DATE",
+                    "DATETIME",
+                    "CONTACT_LIST",
+                    "CHECKBOX",
+                    "PICKLIST",
+                    "DURATION",
+                    "PREDECESSOR",
+                    "ABSTRACT_DATETIME"
+                  ]
+                },
+                "index": {
+                  "type": "number"
+                },
+                "width": {
+                  "type": "number"
+                },
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "symbol": {
+                  "type": "string"
+                },
+                "systemColumnType": {
+                  "type": "string"
+                },
                 "autoNumberFormat": {
                   "type": "object",
                   "properties": {
-                    "prefix": {"type": "string"},
-                    "suffix": {"type": "string"},
-                    "startingNumber": {"type": "number"},
-                    "fill": {"type": "string"}
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "suffix": {
+                      "type": "string"
+                    },
+                    "startingNumber": {
+                      "type": "number"
+                    },
+                    "fill": {
+                      "type": "string"
+                    }
                   }
                 }
               },
-              "required": ["title", "type"]
+              "required": [
+                "title",
+                "type"
+              ]
             },
             "description": "Columns to add"
           }
         },
-        "required": ["sheetId", "columns"],
+        "required": [
+          "sheetId",
+          "columns"
+        ],
         "additionalProperties": false
       }
     },
@@ -351,7 +514,9 @@
             "description": "Workspace name"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -387,7 +552,14 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["attachments", "discussions", "filters", "format", "objectValue", "source"]
+              "enum": [
+                "attachments",
+                "discussions",
+                "filters",
+                "format",
+                "objectValue",
+                "source"
+              ]
             },
             "description": "Additional elements to include"
           },
@@ -403,7 +575,9 @@
             "description": "Page number"
           }
         },
-        "required": ["reportId"],
+        "required": [
+          "reportId"
+        ],
         "additionalProperties": false
       }
     },
@@ -423,9 +597,14 @@
             "items": {
               "type": "object",
               "properties": {
-                "email": {"type": "string", "format": "email"}
+                "email": {
+                  "type": "string",
+                  "format": "email"
+                }
               },
-              "required": ["email"]
+              "required": [
+                "email"
+              ]
             },
             "description": "Recipients"
           },
@@ -444,19 +623,45 @@
           },
           "format": {
             "type": "string",
-            "enum": ["PDF", "EXCEL", "PDF_GANTT"],
+            "enum": [
+              "PDF",
+              "EXCEL",
+              "PDF_GANTT"
+            ],
             "description": "Attachment format"
           },
           "formatDetails": {
             "type": "object",
             "properties": {
-              "paperSize": {"type": "string", "enum": ["LETTER", "LEGAL", "A4", "A3", "A2", "A1", "A0"]},
-              "orientation": {"type": "string", "enum": ["PORTRAIT", "LANDSCAPE"]}
+              "paperSize": {
+                "type": "string",
+                "enum": [
+                  "LETTER",
+                  "LEGAL",
+                  "A4",
+                  "A3",
+                  "A2",
+                  "A1",
+                  "A0"
+                ]
+              },
+              "orientation": {
+                "type": "string",
+                "enum": [
+                  "PORTRAIT",
+                  "LANDSCAPE"
+                ]
+              }
             },
             "description": "Format details"
           }
         },
-        "required": ["sheetId", "sendTo", "subject", "format"],
+        "required": [
+          "sheetId",
+          "sendTo",
+          "subject",
+          "format"
+        ],
         "additionalProperties": false
       }
     }
@@ -485,13 +690,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "sheetId": {"type": "string"},
-          "sheetName": {"type": "string"},
-          "rowId": {"type": "string"},
-          "rowNumber": {"type": "number"},
-          "userId": {"type": "string"},
-          "timestamp": {"type": "string"},
-          "cells": {"type": "array"}
+          "sheetId": {
+            "type": "string"
+          },
+          "sheetName": {
+            "type": "string"
+          },
+          "rowId": {
+            "type": "string"
+          },
+          "rowNumber": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "cells": {
+            "type": "array"
+          }
         }
       }
     },
@@ -518,14 +737,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "sheetId": {"type": "string"},
-          "sheetName": {"type": "string"},
-          "rowId": {"type": "string"},
-          "rowNumber": {"type": "number"},
-          "userId": {"type": "string"},
-          "timestamp": {"type": "string"},
-          "cells": {"type": "array"},
-          "changedCells": {"type": "array"}
+          "sheetId": {
+            "type": "string"
+          },
+          "sheetName": {
+            "type": "string"
+          },
+          "rowId": {
+            "type": "string"
+          },
+          "rowNumber": {
+            "type": "number"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "cells": {
+            "type": "array"
+          },
+          "changedCells": {
+            "type": "array"
+          }
         }
       }
     },
@@ -552,12 +787,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "sheetId": {"type": "string"},
-          "sheetName": {"type": "string"},
-          "userId": {"type": "string"},
-          "timestamp": {"type": "string"},
-          "workspaceId": {"type": "string"},
-          "folderId": {"type": "string"}
+          "sheetId": {
+            "type": "string"
+          },
+          "sheetName": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "workspaceId": {
+            "type": "string"
+          },
+          "folderId": {
+            "type": "string"
+          }
         }
       }
     }
@@ -565,5 +812,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/snowflake/definition.json
+++ b/connectors/snowflake/definition.json
@@ -66,7 +66,9 @@
             "description": "Query parameters for parameterized queries"
           }
         },
-        "required": ["sql"],
+        "required": [
+          "sql"
+        ],
         "additionalProperties": false
       }
     },
@@ -94,19 +96,35 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {"type": "string"},
-                "type": {"type": "string"},
-                "nullable": {"type": "boolean", "default": true},
-                "default": {"type": "string"},
-                "comment": {"type": "string"}
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "nullable": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "default": {
+                  "type": "string"
+                },
+                "comment": {
+                  "type": "string"
+                }
               },
-              "required": ["name", "type"]
+              "required": [
+                "name",
+                "type"
+              ]
             },
             "description": "Table columns definition"
           },
           "cluster_by": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Clustering keys"
           },
           "comment": {
@@ -114,7 +132,10 @@
             "description": "Table comment"
           }
         },
-        "required": ["table_name", "columns"],
+        "required": [
+          "table_name",
+          "columns"
+        ],
         "additionalProperties": false
       }
     },
@@ -139,7 +160,9 @@
           },
           "data": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Array of objects representing rows to insert"
           },
           "overwrite": {
@@ -148,7 +171,10 @@
             "description": "Whether to overwrite existing data"
           }
         },
-        "required": ["table_name", "data"],
+        "required": [
+          "table_name",
+          "data"
+        ],
         "additionalProperties": false
       }
     },
@@ -188,7 +214,10 @@
             "description": "COPY command options"
           }
         },
-        "required": ["table_name", "stage_name"],
+        "required": [
+          "table_name",
+          "stage_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -213,7 +242,10 @@
           },
           "stage_type": {
             "type": "string",
-            "enum": ["internal", "external"],
+            "enum": [
+              "internal",
+              "external"
+            ],
             "default": "internal",
             "description": "Stage type"
           },
@@ -234,7 +266,9 @@
             "description": "Stage comment"
           }
         },
-        "required": ["stage_name"],
+        "required": [
+          "stage_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -270,7 +304,9 @@
             "description": "Pattern to filter schema names"
           }
         },
-        "required": ["database"],
+        "required": [
+          "database"
+        ],
         "additionalProperties": false
       }
     },
@@ -294,7 +330,10 @@
             "description": "Pattern to filter table names"
           }
         },
-        "required": ["database", "schema"],
+        "required": [
+          "database",
+          "schema"
+        ],
         "additionalProperties": false
       }
     },
@@ -318,7 +357,9 @@
             "description": "Table name"
           }
         },
-        "required": ["table_name"],
+        "required": [
+          "table_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -335,7 +376,16 @@
           },
           "warehouse_size": {
             "type": "string",
-            "enum": ["X-SMALL", "SMALL", "MEDIUM", "LARGE", "X-LARGE", "2X-LARGE", "3X-LARGE", "4X-LARGE"],
+            "enum": [
+              "X-SMALL",
+              "SMALL",
+              "MEDIUM",
+              "LARGE",
+              "X-LARGE",
+              "2X-LARGE",
+              "3X-LARGE",
+              "4X-LARGE"
+            ],
             "default": "X-SMALL",
             "description": "Warehouse size"
           },
@@ -360,7 +410,9 @@
             "description": "Warehouse comment"
           }
         },
-        "required": ["warehouse_name"],
+        "required": [
+          "warehouse_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -439,7 +491,9 @@
             "description": "User comment"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -463,7 +517,9 @@
             "description": "Role to grant role to"
           }
         },
-        "required": ["role"],
+        "required": [
+          "role"
+        ],
         "additionalProperties": false
       }
     }
@@ -496,16 +552,36 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "database": {"type": "string"},
-          "schema": {"type": "string"},
-          "table_name": {"type": "string"},
-          "rows_loaded": {"type": "number"},
-          "rows_parsed": {"type": "number"},
-          "load_time": {"type": "string"},
-          "status": {"type": "string"},
-          "error_count": {"type": "number"},
-          "first_error": {"type": "string"},
-          "file_name": {"type": "string"}
+          "database": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "table_name": {
+            "type": "string"
+          },
+          "rows_loaded": {
+            "type": "number"
+          },
+          "rows_parsed": {
+            "type": "number"
+          },
+          "load_time": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "error_count": {
+            "type": "number"
+          },
+          "first_error": {
+            "type": "string"
+          },
+          "file_name": {
+            "type": "string"
+          }
         }
       }
     },
@@ -536,44 +612,120 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "query_id": {"type": "string"},
-          "query_text": {"type": "string"},
-          "user_name": {"type": "string"},
-          "role_name": {"type": "string"},
-          "warehouse_name": {"type": "string"},
-          "database_name": {"type": "string"},
-          "schema_name": {"type": "string"},
-          "query_type": {"type": "string"},
-          "session_id": {"type": "string"},
-          "start_time": {"type": "string"},
-          "end_time": {"type": "string"},
-          "total_elapsed_time": {"type": "number"},
-          "bytes_scanned": {"type": "number"},
-          "rows_produced": {"type": "number"},
-          "compilation_time": {"type": "number"},
-          "execution_time": {"type": "number"},
-          "queued_provisioning_time": {"type": "number"},
-          "queued_repair_time": {"type": "number"},
-          "queued_overload_time": {"type": "number"},
-          "transaction_blocked_time": {"type": "number"},
-          "outbound_data_transfer_cloud": {"type": "string"},
-          "outbound_data_transfer_region": {"type": "string"},
-          "outbound_data_transfer_bytes": {"type": "number"},
-          "inbound_data_transfer_cloud": {"type": "string"},
-          "inbound_data_transfer_region": {"type": "string"},
-          "inbound_data_transfer_bytes": {"type": "number"},
-          "credits_used_cloud_services": {"type": "number"},
-          "release_version": {"type": "string"},
-          "external_function_total_invocations": {"type": "number"},
-          "external_function_total_sent_rows": {"type": "number"},
-          "external_function_total_received_rows": {"type": "number"},
-          "external_function_total_sent_bytes": {"type": "number"},
-          "external_function_total_received_bytes": {"type": "number"},
-          "query_load_percent": {"type": "number"},
-          "is_client_generated_statement": {"type": "boolean"},
-          "query_acceleration_bytes_scanned": {"type": "number"},
-          "query_acceleration_partitions_scanned": {"type": "number"},
-          "query_acceleration_upper_limit_scale_factor": {"type": "number"}
+          "query_id": {
+            "type": "string"
+          },
+          "query_text": {
+            "type": "string"
+          },
+          "user_name": {
+            "type": "string"
+          },
+          "role_name": {
+            "type": "string"
+          },
+          "warehouse_name": {
+            "type": "string"
+          },
+          "database_name": {
+            "type": "string"
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "query_type": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "start_time": {
+            "type": "string"
+          },
+          "end_time": {
+            "type": "string"
+          },
+          "total_elapsed_time": {
+            "type": "number"
+          },
+          "bytes_scanned": {
+            "type": "number"
+          },
+          "rows_produced": {
+            "type": "number"
+          },
+          "compilation_time": {
+            "type": "number"
+          },
+          "execution_time": {
+            "type": "number"
+          },
+          "queued_provisioning_time": {
+            "type": "number"
+          },
+          "queued_repair_time": {
+            "type": "number"
+          },
+          "queued_overload_time": {
+            "type": "number"
+          },
+          "transaction_blocked_time": {
+            "type": "number"
+          },
+          "outbound_data_transfer_cloud": {
+            "type": "string"
+          },
+          "outbound_data_transfer_region": {
+            "type": "string"
+          },
+          "outbound_data_transfer_bytes": {
+            "type": "number"
+          },
+          "inbound_data_transfer_cloud": {
+            "type": "string"
+          },
+          "inbound_data_transfer_region": {
+            "type": "string"
+          },
+          "inbound_data_transfer_bytes": {
+            "type": "number"
+          },
+          "credits_used_cloud_services": {
+            "type": "number"
+          },
+          "release_version": {
+            "type": "string"
+          },
+          "external_function_total_invocations": {
+            "type": "number"
+          },
+          "external_function_total_sent_rows": {
+            "type": "number"
+          },
+          "external_function_total_received_rows": {
+            "type": "number"
+          },
+          "external_function_total_sent_bytes": {
+            "type": "number"
+          },
+          "external_function_total_received_bytes": {
+            "type": "number"
+          },
+          "query_load_percent": {
+            "type": "number"
+          },
+          "is_client_generated_statement": {
+            "type": "boolean"
+          },
+          "query_acceleration_bytes_scanned": {
+            "type": "number"
+          },
+          "query_acceleration_partitions_scanned": {
+            "type": "number"
+          },
+          "query_acceleration_upper_limit_scale_factor": {
+            "type": "number"
+          }
         }
       }
     }
@@ -581,5 +733,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/accounts/current"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/sonarqube/definition.json
+++ b/connectors/sonarqube/definition.json
@@ -47,12 +47,18 @@
           },
           "visibility": {
             "type": "string",
-            "enum": ["private", "public"],
+            "enum": [
+              "private",
+              "public"
+            ],
             "default": "private",
             "description": "Project visibility"
           }
         },
-        "required": ["project_key", "name"],
+        "required": [
+          "project_key",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -69,7 +75,9 @@
             "description": "Project key"
           }
         },
-        "required": ["project_key"],
+        "required": [
+          "project_key"
+        ],
         "additionalProperties": false
       }
     },
@@ -89,7 +97,13 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO"]
+              "enum": [
+                "BLOCKER",
+                "CRITICAL",
+                "MAJOR",
+                "MINOR",
+                "INFO"
+              ]
             },
             "description": "Filter by issue severities"
           },
@@ -97,7 +111,12 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["BUG", "VULNERABILITY", "CODE_SMELL", "SECURITY_HOTSPOT"]
+              "enum": [
+                "BUG",
+                "VULNERABILITY",
+                "CODE_SMELL",
+                "SECURITY_HOTSPOT"
+              ]
             },
             "description": "Filter by issue types"
           },
@@ -105,12 +124,20 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["OPEN", "CONFIRMED", "REOPENED", "RESOLVED", "CLOSED"]
+              "enum": [
+                "OPEN",
+                "CONFIRMED",
+                "REOPENED",
+                "RESOLVED",
+                "CLOSED"
+              ]
             },
             "description": "Filter by issue statuses"
           }
         },
-        "required": ["project_key"],
+        "required": [
+          "project_key"
+        ],
         "additionalProperties": false
       }
     },
@@ -128,11 +155,15 @@
           },
           "metric_keys": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Metric keys to retrieve"
           }
         },
-        "required": ["project_key"],
+        "required": [
+          "project_key"
+        ],
         "additionalProperties": false
       }
     },
@@ -164,7 +195,11 @@
           },
           "quality_gate_status": {
             "type": "string",
-            "enum": ["OK", "WARN", "ERROR"],
+            "enum": [
+              "OK",
+              "WARN",
+              "ERROR"
+            ],
             "description": "Filter by quality gate status"
           }
         },
@@ -189,5 +224,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/square/definition.json
+++ b/connectors/square/definition.json
@@ -45,10 +45,19 @@
           "amount_money": {
             "type": "object",
             "properties": {
-              "amount": {"type": "number", "description": "Amount in smallest currency unit"},
-              "currency": {"type": "string", "description": "Currency code (e.g., USD)"}
+              "amount": {
+                "type": "number",
+                "description": "Amount in smallest currency unit"
+              },
+              "currency": {
+                "type": "string",
+                "description": "Currency code (e.g., USD)"
+              }
             },
-            "required": ["amount", "currency"],
+            "required": [
+              "amount",
+              "currency"
+            ],
             "additionalProperties": false,
             "description": "Payment amount"
           },
@@ -70,7 +79,11 @@
             "description": "Whether to complete the payment automatically"
           }
         },
-        "required": ["source_id", "idempotency_key", "amount_money"],
+        "required": [
+          "source_id",
+          "idempotency_key",
+          "amount_money"
+        ],
         "additionalProperties": false
       }
     },
@@ -86,7 +99,9 @@
             "description": "Payment ID"
           }
         },
-        "required": ["payment_id"],
+        "required": [
+          "payment_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -109,7 +124,10 @@
           },
           "sort_order": {
             "type": "string",
-            "enum": ["ASC", "DESC"],
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
             "description": "Sort order"
           },
           "cursor": {
@@ -139,10 +157,17 @@
           "amount_money": {
             "type": "object",
             "properties": {
-              "amount": {"type": "number"},
-              "currency": {"type": "string"}
+              "amount": {
+                "type": "number"
+              },
+              "currency": {
+                "type": "string"
+              }
             },
-            "required": ["amount", "currency"],
+            "required": [
+              "amount",
+              "currency"
+            ],
             "additionalProperties": false,
             "description": "Refund amount"
           },
@@ -155,7 +180,11 @@
             "description": "Reason for refund"
           }
         },
-        "required": ["idempotency_key", "amount_money", "payment_id"],
+        "required": [
+          "idempotency_key",
+          "amount_money",
+          "payment_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -212,7 +241,9 @@
             "description": "Customer ID"
           }
         },
-        "required": ["customer_id"],
+        "required": [
+          "customer_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -230,32 +261,49 @@
           "order": {
             "type": "object",
             "properties": {
-              "location_id": {"type": "string"},
-              "reference_id": {"type": "string"},
+              "location_id": {
+                "type": "string"
+              },
+              "reference_id": {
+                "type": "string"
+              },
               "line_items": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "name": {"type": "string"},
-                    "quantity": {"type": "string"},
+                    "name": {
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "type": "string"
+                    },
                     "base_price_money": {
                       "type": "object",
                       "properties": {
-                        "amount": {"type": "number"},
-                        "currency": {"type": "string"}
+                        "amount": {
+                          "type": "number"
+                        },
+                        "currency": {
+                          "type": "string"
+                        }
                       }
                     }
                   }
                 }
               }
             },
-            "required": ["location_id"],
+            "required": [
+              "location_id"
+            ],
             "additionalProperties": false,
             "description": "Order details"
           }
         },
-        "required": ["idempotency_key", "order"],
+        "required": [
+          "idempotency_key",
+          "order"
+        ],
         "additionalProperties": false
       }
     }
@@ -280,12 +328,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "merchant_id": {"type": "string"},
-          "location_id": {"type": "string"},
-          "type": {"type": "string"},
-          "event_id": {"type": "string"},
-          "created_at": {"type": "string"},
-          "data": {"type": "object"}
+          "merchant_id": {
+            "type": "string"
+          },
+          "location_id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "event_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
+          }
         }
       }
     },
@@ -308,12 +368,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "merchant_id": {"type": "string"},
-          "location_id": {"type": "string"},
-          "type": {"type": "string"},
-          "event_id": {"type": "string"},
-          "created_at": {"type": "string"},
-          "data": {"type": "object"}
+          "merchant_id": {
+            "type": "string"
+          },
+          "location_id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "event_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
+          }
         }
       }
     }
@@ -321,5 +393,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/locations"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/stripe-enhanced/definition.json
+++ b/connectors/stripe-enhanced/definition.json
@@ -85,7 +85,10 @@
             "description": "Set of key-value pairs for storing additional information"
           }
         },
-        "required": ["amount", "currency"],
+        "required": [
+          "amount",
+          "currency"
+        ],
         "additionalProperties": false
       }
     },
@@ -105,10 +108,17 @@
             "items": {
               "type": "object",
               "properties": {
-                "price": {"type": "string"},
-                "quantity": {"type": "number", "minimum": 1}
+                "price": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "number",
+                  "minimum": 1
+                }
               },
-              "required": ["price"],
+              "required": [
+                "price"
+              ],
               "additionalProperties": false
             },
             "description": "Subscription items"
@@ -118,7 +128,10 @@
             "description": "Set of key-value pairs for storing additional information"
           }
         },
-        "required": ["customer", "items"],
+        "required": [
+          "customer",
+          "items"
+        ],
         "additionalProperties": false
       }
     },
@@ -142,7 +155,9 @@
             "description": "Set of key-value pairs for storing additional information"
           }
         },
-        "required": ["customer"],
+        "required": [
+          "customer"
+        ],
         "additionalProperties": false
       }
     }
@@ -162,11 +177,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "email": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "created": {"type": "number"}
+          "id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          }
         }
       }
     },
@@ -189,11 +214,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "amount": {"type": "number"},
-          "currency": {"type": "string"},
-          "customer": {"type": "string"},
-          "status": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "customer": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
         }
       }
     }
@@ -201,5 +236,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/account"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/stripe/definition.json
+++ b/connectors/stripe/definition.json
@@ -60,20 +60,36 @@
           "address": {
             "type": "object",
             "properties": {
-              "line1": {"type": "string"},
-              "line2": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "postal_code": {"type": "string"},
-              "country": {"type": "string"}
+              "line1": {
+                "type": "string"
+              },
+              "line2": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "postal_code": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              }
             },
             "description": "Customer address"
           },
           "shipping": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "address": {"type": "object"}
+              "name": {
+                "type": "string"
+              },
+              "address": {
+                "type": "object"
+              }
             },
             "description": "Customer shipping information"
           },
@@ -91,7 +107,11 @@
           },
           "tax_exempt": {
             "type": "string",
-            "enum": ["none", "exempt", "reverse"],
+            "enum": [
+              "none",
+              "exempt",
+              "reverse"
+            ],
             "description": "Customer tax exemption status"
           }
         },
@@ -131,8 +151,12 @@
           },
           "payment_method_types": {
             "type": "array",
-            "items": {"type": "string"},
-            "default": ["card"],
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "card"
+            ],
             "description": "Allowed payment method types"
           },
           "confirm": {
@@ -147,7 +171,10 @@
           },
           "setup_future_usage": {
             "type": "string",
-            "enum": ["on_session", "off_session"],
+            "enum": [
+              "on_session",
+              "off_session"
+            ],
             "description": "Setup for future usage"
           },
           "shipping": {
@@ -163,7 +190,10 @@
             "description": "Custom metadata"
           }
         },
-        "required": ["amount", "currency"],
+        "required": [
+          "amount",
+          "currency"
+        ],
         "additionalProperties": false
       }
     },
@@ -176,11 +206,25 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "subscription": { "type": "string", "description": "Subscription ID" },
-          "cancel_at_period_end": { "type": "boolean" },
-          "proration_behavior": { "type": "string", "enum": ["create_prorations","none","always_invoice"] }
+          "subscription": {
+            "type": "string",
+            "description": "Subscription ID"
+          },
+          "cancel_at_period_end": {
+            "type": "boolean"
+          },
+          "proration_behavior": {
+            "type": "string",
+            "enum": [
+              "create_prorations",
+              "none",
+              "always_invoice"
+            ]
+          }
         },
-        "required": ["subscription"],
+        "required": [
+          "subscription"
+        ],
         "additionalProperties": false
       }
     },
@@ -193,9 +237,15 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "charge": { "type": "string" },
-          "payment_intent": { "type": "string" },
-          "amount": { "type": "number" }
+          "charge": {
+            "type": "string"
+          },
+          "payment_intent": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          }
         },
         "required": [],
         "additionalProperties": false
@@ -217,8 +267,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "price": {"type": "string"},
-                "quantity": {"type": "number"}
+                "price": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "number"
+                }
               }
             },
             "description": "Subscription items with prices and quantities"
@@ -233,7 +287,10 @@
           },
           "collection_method": {
             "type": "string",
-            "enum": ["charge_automatically", "send_invoice"],
+            "enum": [
+              "charge_automatically",
+              "send_invoice"
+            ],
             "default": "charge_automatically",
             "description": "Collection method"
           },
@@ -247,7 +304,11 @@
           },
           "proration_behavior": {
             "type": "string",
-            "enum": ["create_prorations", "none", "always_invoice"],
+            "enum": [
+              "create_prorations",
+              "none",
+              "always_invoice"
+            ],
             "description": "Proration behavior"
           },
           "coupon": {
@@ -255,7 +316,10 @@
             "description": "Coupon ID to apply"
           }
         },
-        "required": ["customer", "items"],
+        "required": [
+          "customer",
+          "items"
+        ],
         "additionalProperties": false
       }
     },
@@ -280,7 +344,11 @@
           },
           "reason": {
             "type": "string",
-            "enum": ["duplicate", "fraudulent", "requested_by_customer"],
+            "enum": [
+              "duplicate",
+              "fraudulent",
+              "requested_by_customer"
+            ],
             "description": "Reason for the refund"
           },
           "refund_application_fee": {
@@ -312,7 +380,9 @@
             "description": "Customer ID"
           }
         },
-        "required": ["customer_id"],
+        "required": [
+          "customer_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -364,7 +434,9 @@
           },
           "items": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Updated subscription items"
           },
           "default_payment_method": {
@@ -377,11 +449,17 @@
           },
           "proration_behavior": {
             "type": "string",
-            "enum": ["create_prorations", "none", "always_invoice"],
+            "enum": [
+              "create_prorations",
+              "none",
+              "always_invoice"
+            ],
             "description": "Proration behavior"
           }
         },
-        "required": ["subscription_id"],
+        "required": [
+          "subscription_id"
+        ],
         "additionalProperties": false
       }
     }
@@ -418,13 +496,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "amount": {"type": "number"},
-          "currency": {"type": "string"},
-          "customer": {"type": "string"},
-          "description": {"type": "string"},
-          "status": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "customer": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
         }
       }
     },
@@ -455,12 +547,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "amount": {"type": "number"},
-          "currency": {"type": "string"},
-          "customer": {"type": "string"},
-          "last_payment_error": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "customer": {
+            "type": "string"
+          },
+          "last_payment_error": {
+            "type": "object"
+          }
         }
       }
     },
@@ -491,13 +595,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "customer": {"type": "string"},
-          "status": {"type": "string"},
-          "items": {"type": "object"},
-          "current_period_start": {"type": "number"},
-          "current_period_end": {"type": "number"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "customer": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "items": {
+            "type": "object"
+          },
+          "current_period_start": {
+            "type": "number"
+          },
+          "current_period_end": {
+            "type": "number"
+          }
         }
       }
     },
@@ -532,12 +650,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "customer": {"type": "string"},
-          "subscription": {"type": "string"},
-          "amount_paid": {"type": "number"},
-          "currency": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "customer": {
+            "type": "string"
+          },
+          "subscription": {
+            "type": "string"
+          },
+          "amount_paid": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          }
         }
       }
     }
@@ -545,6 +675,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/account"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }
-

--- a/connectors/successfactors/definition.json
+++ b/connectors/successfactors/definition.json
@@ -11,7 +11,10 @@
     "config": {
       "authUrl": "https://{datacenter}.successfactors.com/oauth/authorize",
       "tokenUrl": "https://{datacenter}.successfactors.com/oauth/token",
-      "scopes": ["read", "write"]
+      "scopes": [
+        "read",
+        "write"
+      ]
     }
   },
   "baseUrl": "https://{datacenter}.successfactors.com/odata/v2",
@@ -39,7 +42,9 @@
             "description": "Employee user ID"
           }
         },
-        "required": ["user_id"],
+        "required": [
+          "user_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -85,7 +90,11 @@
             "description": "Manager user ID"
           }
         },
-        "required": ["user_id", "first_name", "last_name"],
+        "required": [
+          "user_id",
+          "first_name",
+          "last_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -126,7 +135,9 @@
             "description": "Manager user ID"
           }
         },
-        "required": ["user_id"],
+        "required": [
+          "user_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -184,14 +195,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "user_id": {"type": "string"},
-          "first_name": {"type": "string"},
-          "last_name": {"type": "string"},
-          "email": {"type": "string"},
-          "hire_date": {"type": "string"},
-          "job_title": {"type": "string"},
-          "department": {"type": "string"},
-          "manager_id": {"type": "string"}
+          "user_id": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "hire_date": {
+            "type": "string"
+          },
+          "job_title": {
+            "type": "string"
+          },
+          "department": {
+            "type": "string"
+          },
+          "manager_id": {
+            "type": "string"
+          }
         }
       }
     },
@@ -214,9 +241,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "user_id": {"type": "string"},
-          "updated_fields": {"type": "array"},
-          "updated_at": {"type": "string"}
+          "user_id": {
+            "type": "string"
+          },
+          "updated_fields": {
+            "type": "array"
+          },
+          "updated_at": {
+            "type": "string"
+          }
         }
       }
     }
@@ -224,5 +257,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/User"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/surveymonkey/definition.json
+++ b/connectors/surveymonkey/definition.json
@@ -78,7 +78,9 @@
             "description": "Survey ID to copy from"
           }
         },
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -94,7 +96,9 @@
             "description": "Survey ID"
           }
         },
-        "required": ["survey_id"],
+        "required": [
+          "survey_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -130,7 +134,9 @@
             "description": "Folder ID to move survey to"
           }
         },
-        "required": ["survey_id"],
+        "required": [
+          "survey_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -146,7 +152,9 @@
             "description": "Survey ID"
           }
         },
-        "required": ["survey_id"],
+        "required": [
+          "survey_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -172,12 +180,19 @@
           },
           "sort_by": {
             "type": "string",
-            "enum": ["title", "date_modified", "num_responses"],
+            "enum": [
+              "title",
+              "date_modified",
+              "num_responses"
+            ],
             "description": "Sort criteria"
           },
           "sort_order": {
             "type": "string",
-            "enum": ["ASC", "DESC"],
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
             "default": "DESC",
             "description": "Sort order"
           },
@@ -199,7 +214,15 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["response_count", "date_created", "date_modified", "language", "question_count", "analyze_url", "preview"]
+              "enum": [
+                "response_count",
+                "date_created",
+                "date_modified",
+                "language",
+                "question_count",
+                "analyze_url",
+                "preview"
+              ]
             },
             "description": "Additional fields to include"
           },
@@ -258,7 +281,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["completed", "partial", "overquota", "disqualified"],
+            "enum": [
+              "completed",
+              "partial",
+              "overquota",
+              "disqualified"
+            ],
             "description": "Filter by response status"
           },
           "email": {
@@ -291,22 +319,33 @@
           },
           "total_time_units": {
             "type": "string",
-            "enum": ["seconds", "minutes", "hours"],
+            "enum": [
+              "seconds",
+              "minutes",
+              "hours"
+            ],
             "description": "Time units for total_time filters"
           },
           "sort_order": {
             "type": "string",
-            "enum": ["ASC", "DESC"],
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
             "default": "DESC",
             "description": "Sort order"
           },
           "sort_by": {
             "type": "string",
-            "enum": ["date_modified"],
+            "enum": [
+              "date_modified"
+            ],
             "description": "Sort criteria"
           }
         },
-        "required": ["survey_id"],
+        "required": [
+          "survey_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -326,7 +365,10 @@
             "description": "Response ID"
           }
         },
-        "required": ["survey_id", "response_id"],
+        "required": [
+          "survey_id",
+          "response_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -343,7 +385,10 @@
           },
           "type": {
             "type": "string",
-            "enum": ["weblink", "email"],
+            "enum": [
+              "weblink",
+              "email"
+            ],
             "description": "Collector type"
           },
           "name": {
@@ -377,12 +422,20 @@
           },
           "edit_response_type": {
             "type": "string",
-            "enum": ["until_complete", "never", "always"],
+            "enum": [
+              "until_complete",
+              "never",
+              "always"
+            ],
             "description": "When respondents can edit their responses"
           },
           "anonymous_type": {
             "type": "string",
-            "enum": ["not_anonymous", "partially_anonymous", "fully_anonymous"],
+            "enum": [
+              "not_anonymous",
+              "partially_anonymous",
+              "fully_anonymous"
+            ],
             "description": "Level of anonymity"
           },
           "allow_multiple_responses": {
@@ -394,7 +447,10 @@
             "description": "Whether to include survey URL in email invitations"
           }
         },
-        "required": ["survey_id", "type"],
+        "required": [
+          "survey_id",
+          "type"
+        ],
         "additionalProperties": false
       }
     },
@@ -410,7 +466,9 @@
             "description": "Collector ID"
           }
         },
-        "required": ["collector_id"],
+        "required": [
+          "collector_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -440,12 +498,18 @@
           },
           "sort_by": {
             "type": "string",
-            "enum": ["date_modified", "date_created"],
+            "enum": [
+              "date_modified",
+              "date_created"
+            ],
             "description": "Sort criteria"
           },
           "sort_order": {
             "type": "string",
-            "enum": ["ASC", "DESC"],
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
             "default": "DESC",
             "description": "Sort order"
           },
@@ -467,12 +531,20 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["type", "status", "date_created", "date_modified", "url"]
+              "enum": [
+                "type",
+                "status",
+                "date_created",
+                "date_modified",
+                "url"
+              ]
             },
             "description": "Additional fields to include"
           }
         },
-        "required": ["survey_id"],
+        "required": [
+          "survey_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -509,7 +581,9 @@
             "description": "Custom field 3 value"
           }
         },
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "additionalProperties": false
       }
     },
@@ -525,7 +599,9 @@
             "description": "Contact ID"
           }
         },
-        "required": ["contact_id"],
+        "required": [
+          "contact_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -551,12 +627,21 @@
           },
           "sort_by": {
             "type": "string",
-            "enum": ["date_modified", "date_created", "email", "first_name", "last_name"],
+            "enum": [
+              "date_modified",
+              "date_created",
+              "email",
+              "first_name",
+              "last_name"
+            ],
             "description": "Sort criteria"
           },
           "sort_order": {
             "type": "string",
-            "enum": ["ASC", "DESC"],
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
             "default": "ASC",
             "description": "Sort order"
           },
@@ -602,24 +687,60 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "survey_id": {"type": "string"},
-          "collector_id": {"type": "string"},
-          "response_id": {"type": "string"},
-          "status": {"type": "string"},
-          "date_created": {"type": "string"},
-          "date_modified": {"type": "string"},
-          "logic_path": {"type": "object"},
-          "metadata": {"type": "object"},
-          "page_path": {"type": "array"},
-          "recipient_id": {"type": "string"},
-          "collection_mode": {"type": "string"},
-          "custom_value": {"type": "string"},
-          "edit_url": {"type": "string"},
-          "analyze_url": {"type": "string"},
-          "total_time": {"type": "number"},
-          "custom_variables": {"type": "object"},
-          "ip_address": {"type": "string"},
-          "pages": {"type": "array"}
+          "survey_id": {
+            "type": "string"
+          },
+          "collector_id": {
+            "type": "string"
+          },
+          "response_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "date_created": {
+            "type": "string"
+          },
+          "date_modified": {
+            "type": "string"
+          },
+          "logic_path": {
+            "type": "object"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "page_path": {
+            "type": "array"
+          },
+          "recipient_id": {
+            "type": "string"
+          },
+          "collection_mode": {
+            "type": "string"
+          },
+          "custom_value": {
+            "type": "string"
+          },
+          "edit_url": {
+            "type": "string"
+          },
+          "analyze_url": {
+            "type": "string"
+          },
+          "total_time": {
+            "type": "number"
+          },
+          "custom_variables": {
+            "type": "object"
+          },
+          "ip_address": {
+            "type": "string"
+          },
+          "pages": {
+            "type": "array"
+          }
         }
       }
     },
@@ -637,25 +758,63 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "nickname": {"type": "string"},
-          "language": {"type": "string"},
-          "question_count": {"type": "number"},
-          "page_count": {"type": "number"},
-          "date_created": {"type": "string"},
-          "date_modified": {"type": "string"},
-          "summary": {"type": "string"},
-          "analyze_url": {"type": "string"},
-          "edit_url": {"type": "string"},
-          "collect_url": {"type": "string"},
-          "preview": {"type": "string"},
-          "category": {"type": "string"},
-          "folder_id": {"type": "string"},
-          "buttons_text": {"type": "object"},
-          "is_owner": {"type": "boolean"},
-          "footer": {"type": "boolean"},
-          "theme": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "nickname": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "question_count": {
+            "type": "number"
+          },
+          "page_count": {
+            "type": "number"
+          },
+          "date_created": {
+            "type": "string"
+          },
+          "date_modified": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "analyze_url": {
+            "type": "string"
+          },
+          "edit_url": {
+            "type": "string"
+          },
+          "collect_url": {
+            "type": "string"
+          },
+          "preview": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "folder_id": {
+            "type": "string"
+          },
+          "buttons_text": {
+            "type": "object"
+          },
+          "is_owner": {
+            "type": "boolean"
+          },
+          "footer": {
+            "type": "boolean"
+          },
+          "theme": {
+            "type": "object"
+          }
         }
       }
     },
@@ -678,26 +837,66 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "date_created": {"type": "string"},
-          "date_modified": {"type": "string"},
-          "url": {"type": "string"},
-          "open": {"type": "boolean"},
-          "type": {"type": "string"},
-          "display_survey_results": {"type": "boolean"},
-          "edit_response_type": {"type": "string"},
-          "anonymous_type": {"type": "string"},
-          "allow_multiple_responses": {"type": "boolean"},
-          "redirect_type": {"type": "string"},
-          "redirect_url": {"type": "string"},
-          "thank_you_message": {"type": "string"},
-          "disqualification_message": {"type": "string"},
-          "closed_page_message": {"type": "string"},
-          "close_date": {"type": "string"},
-          "password_enabled": {"type": "boolean"},
-          "sender_email": {"type": "string"},
-          "include_survey_url": {"type": "boolean"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "date_created": {
+            "type": "string"
+          },
+          "date_modified": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "open": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          },
+          "display_survey_results": {
+            "type": "boolean"
+          },
+          "edit_response_type": {
+            "type": "string"
+          },
+          "anonymous_type": {
+            "type": "string"
+          },
+          "allow_multiple_responses": {
+            "type": "boolean"
+          },
+          "redirect_type": {
+            "type": "string"
+          },
+          "redirect_url": {
+            "type": "string"
+          },
+          "thank_you_message": {
+            "type": "string"
+          },
+          "disqualification_message": {
+            "type": "string"
+          },
+          "closed_page_message": {
+            "type": "string"
+          },
+          "close_date": {
+            "type": "string"
+          },
+          "password_enabled": {
+            "type": "boolean"
+          },
+          "sender_email": {
+            "type": "string"
+          },
+          "include_survey_url": {
+            "type": "boolean"
+          }
         }
       }
     }
@@ -705,5 +904,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/tableau/definition.json
+++ b/connectors/tableau/definition.json
@@ -46,7 +46,10 @@
             "description": "Site name (optional)"
           }
         },
-        "required": ["username", "password"],
+        "required": [
+          "username",
+          "password"
+        ],
         "additionalProperties": false
       }
     },
@@ -112,7 +115,9 @@
             "description": "Fields to include"
           }
         },
-        "required": ["siteId"],
+        "required": [
+          "siteId"
+        ],
         "additionalProperties": false
       }
     },
@@ -132,7 +137,10 @@
             "description": "Workbook ID"
           }
         },
-        "required": ["siteId", "workbookId"],
+        "required": [
+          "siteId",
+          "workbookId"
+        ],
         "additionalProperties": false
       }
     },
@@ -172,7 +180,10 @@
             "description": "Owner ID"
           }
         },
-        "required": ["siteId", "workbookId"],
+        "required": [
+          "siteId",
+          "workbookId"
+        ],
         "additionalProperties": false
       }
     },
@@ -209,7 +220,10 @@
             "description": "Filter expression"
           }
         },
-        "required": ["siteId", "workbookId"],
+        "required": [
+          "siteId",
+          "workbookId"
+        ],
         "additionalProperties": false
       }
     },
@@ -229,7 +243,10 @@
             "description": "View ID"
           }
         },
-        "required": ["siteId", "viewId"],
+        "required": [
+          "siteId",
+          "viewId"
+        ],
         "additionalProperties": false
       }
     },
@@ -258,7 +275,10 @@
             "description": "View parameters"
           }
         },
-        "required": ["siteId", "viewId"],
+        "required": [
+          "siteId",
+          "viewId"
+        ],
         "additionalProperties": false
       }
     },
@@ -291,7 +311,9 @@
             "description": "Filter expression"
           }
         },
-        "required": ["siteId"],
+        "required": [
+          "siteId"
+        ],
         "additionalProperties": false
       }
     },
@@ -311,7 +333,10 @@
             "description": "Data source ID"
           }
         },
-        "required": ["siteId", "datasourceId"],
+        "required": [
+          "siteId",
+          "datasourceId"
+        ],
         "additionalProperties": false
       }
     },
@@ -331,7 +356,10 @@
             "description": "Data source ID"
           }
         },
-        "required": ["siteId", "datasourceId"],
+        "required": [
+          "siteId",
+          "datasourceId"
+        ],
         "additionalProperties": false
       }
     },
@@ -364,7 +392,9 @@
             "description": "Filter expression"
           }
         },
-        "required": ["siteId"],
+        "required": [
+          "siteId"
+        ],
         "additionalProperties": false
       }
     },
@@ -393,7 +423,9 @@
             "description": "Page number"
           }
         },
-        "required": ["siteId"],
+        "required": [
+          "siteId"
+        ],
         "additionalProperties": false
       }
     },
@@ -418,7 +450,10 @@
           },
           "contentPermissions": {
             "type": "string",
-            "enum": ["LockedToProject", "ManagedByOwner"],
+            "enum": [
+              "LockedToProject",
+              "ManagedByOwner"
+            ],
             "description": "Content permissions mode"
           },
           "parentProjectId": {
@@ -426,7 +461,10 @@
             "description": "Parent project ID"
           }
         },
-        "required": ["siteId", "name"],
+        "required": [
+          "siteId",
+          "name"
+        ],
         "additionalProperties": false
       }
     }
@@ -455,12 +493,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "datasourceId": {"type": "string"},
-          "datasourceName": {"type": "string"},
-          "siteId": {"type": "string"},
-          "refreshStatus": {"type": "string"},
-          "refreshTime": {"type": "string"},
-          "jobId": {"type": "string"}
+          "datasourceId": {
+            "type": "string"
+          },
+          "datasourceName": {
+            "type": "string"
+          },
+          "siteId": {
+            "type": "string"
+          },
+          "refreshStatus": {
+            "type": "string"
+          },
+          "refreshTime": {
+            "type": "string"
+          },
+          "jobId": {
+            "type": "string"
+          }
         }
       }
     },
@@ -487,12 +537,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "workbookId": {"type": "string"},
-          "workbookName": {"type": "string"},
-          "siteId": {"type": "string"},
-          "projectId": {"type": "string"},
-          "ownerId": {"type": "string"},
-          "publishTime": {"type": "string"}
+          "workbookId": {
+            "type": "string"
+          },
+          "workbookName": {
+            "type": "string"
+          },
+          "siteId": {
+            "type": "string"
+          },
+          "projectId": {
+            "type": "string"
+          },
+          "ownerId": {
+            "type": "string"
+          },
+          "publishTime": {
+            "type": "string"
+          }
         }
       }
     }
@@ -500,5 +562,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/sites"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/talkdesk/definition.json
+++ b/connectors/talkdesk/definition.json
@@ -53,7 +53,9 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Contact tags"
           },
           "custom_fields": {
@@ -61,7 +63,9 @@
             "description": "Custom field values"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -95,7 +99,9 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Contact tags"
           },
           "custom_fields": {
@@ -103,7 +109,9 @@
             "description": "Custom field values"
           }
         },
-        "required": ["contact_id"],
+        "required": [
+          "contact_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -119,7 +127,9 @@
             "description": "Contact ID"
           }
         },
-        "required": ["contact_id"],
+        "required": [
+          "contact_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -184,7 +194,10 @@
             "description": "Custom field values for the call"
           }
         },
-        "required": ["to", "agent_id"],
+        "required": [
+          "to",
+          "agent_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -200,7 +213,9 @@
             "description": "Call ID"
           }
         },
-        "required": ["call_id"],
+        "required": [
+          "call_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -244,12 +259,20 @@
           },
           "direction": {
             "type": "string",
-            "enum": ["inbound", "outbound"],
+            "enum": [
+              "inbound",
+              "outbound"
+            ],
             "description": "Call direction filter"
           },
           "status": {
             "type": "string",
-            "enum": ["completed", "missed", "abandoned", "failed"],
+            "enum": [
+              "completed",
+              "missed",
+              "abandoned",
+              "failed"
+            ],
             "description": "Call status filter"
           }
         },
@@ -274,13 +297,23 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["low", "medium", "high", "urgent"],
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "urgent"
+            ],
             "default": "medium",
             "description": "Ticket priority"
           },
           "status": {
             "type": "string",
-            "enum": ["open", "pending", "resolved", "closed"],
+            "enum": [
+              "open",
+              "pending",
+              "resolved",
+              "closed"
+            ],
             "default": "open",
             "description": "Ticket status"
           },
@@ -294,7 +327,9 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Ticket tags"
           },
           "custom_fields": {
@@ -302,7 +337,10 @@
             "description": "Custom field values"
           }
         },
-        "required": ["subject", "description"],
+        "required": [
+          "subject",
+          "description"
+        ],
         "additionalProperties": false
       }
     },
@@ -327,12 +365,22 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["low", "medium", "high", "urgent"],
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "urgent"
+            ],
             "description": "Ticket priority"
           },
           "status": {
             "type": "string",
-            "enum": ["open", "pending", "resolved", "closed"],
+            "enum": [
+              "open",
+              "pending",
+              "resolved",
+              "closed"
+            ],
             "description": "Ticket status"
           },
           "assignee_id": {
@@ -341,7 +389,9 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Ticket tags"
           },
           "custom_fields": {
@@ -349,7 +399,9 @@
             "description": "Custom field values"
           }
         },
-        "required": ["ticket_id"],
+        "required": [
+          "ticket_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -365,7 +417,9 @@
             "description": "Ticket ID"
           }
         },
-        "required": ["ticket_id"],
+        "required": [
+          "ticket_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -391,12 +445,22 @@
           },
           "status": {
             "type": "string",
-            "enum": ["open", "pending", "resolved", "closed"],
+            "enum": [
+              "open",
+              "pending",
+              "resolved",
+              "closed"
+            ],
             "description": "Filter by status"
           },
           "priority": {
             "type": "string",
-            "enum": ["low", "medium", "high", "urgent"],
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "urgent"
+            ],
             "description": "Filter by priority"
           },
           "assignee_id": {
@@ -438,7 +502,9 @@
             "description": "Agent ID"
           }
         },
-        "required": ["agent_id"],
+        "required": [
+          "agent_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -464,7 +530,10 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "inactive"],
+            "enum": [
+              "active",
+              "inactive"
+            ],
             "description": "Filter by agent status"
           },
           "role": {
@@ -492,7 +561,10 @@
           },
           "direction": {
             "type": "string",
-            "enum": ["inbound", "outbound"],
+            "enum": [
+              "inbound",
+              "outbound"
+            ],
             "description": "Filter by call direction"
           }
         },
@@ -502,19 +574,45 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "call_id": {"type": "string"},
-          "direction": {"type": "string"},
-          "from": {"type": "string"},
-          "to": {"type": "string"},
-          "agent_id": {"type": "string"},
-          "contact_id": {"type": "string"},
-          "duration": {"type": "number"},
-          "status": {"type": "string"},
-          "start_time": {"type": "string"},
-          "end_time": {"type": "string"},
-          "disposition": {"type": "string"},
-          "recording_url": {"type": "string"},
-          "custom_fields": {"type": "object"}
+          "call_id": {
+            "type": "string"
+          },
+          "direction": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          },
+          "agent_id": {
+            "type": "string"
+          },
+          "contact_id": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          },
+          "start_time": {
+            "type": "string"
+          },
+          "end_time": {
+            "type": "string"
+          },
+          "disposition": {
+            "type": "string"
+          },
+          "recording_url": {
+            "type": "string"
+          },
+          "custom_fields": {
+            "type": "object"
+          }
         }
       }
     },
@@ -532,7 +630,12 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["low", "medium", "high", "urgent"],
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "urgent"
+            ],
             "description": "Filter by priority"
           }
         },
@@ -542,17 +645,39 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "ticket_id": {"type": "string"},
-          "subject": {"type": "string"},
-          "description": {"type": "string"},
-          "priority": {"type": "string"},
-          "status": {"type": "string"},
-          "assignee_id": {"type": "string"},
-          "contact_id": {"type": "string"},
-          "created_at": {"type": "string"},
-          "updated_at": {"type": "string"},
-          "tags": {"type": "array"},
-          "custom_fields": {"type": "object"}
+          "ticket_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "assignee_id": {
+            "type": "string"
+          },
+          "contact_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array"
+          },
+          "custom_fields": {
+            "type": "object"
+          }
         }
       }
     },
@@ -566,12 +691,22 @@
         "properties": {
           "from_status": {
             "type": "string",
-            "enum": ["open", "pending", "resolved", "closed"],
+            "enum": [
+              "open",
+              "pending",
+              "resolved",
+              "closed"
+            ],
             "description": "Filter by previous status"
           },
           "to_status": {
             "type": "string",
-            "enum": ["open", "pending", "resolved", "closed"],
+            "enum": [
+              "open",
+              "pending",
+              "resolved",
+              "closed"
+            ],
             "description": "Filter by new status"
           },
           "assignee_id": {
@@ -585,15 +720,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "ticket_id": {"type": "string"},
-          "subject": {"type": "string"},
-          "previous_status": {"type": "string"},
-          "new_status": {"type": "string"},
-          "priority": {"type": "string"},
-          "assignee_id": {"type": "string"},
-          "contact_id": {"type": "string"},
-          "updated_at": {"type": "string"},
-          "updated_by": {"type": "string"}
+          "ticket_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "previous_status": {
+            "type": "string"
+          },
+          "new_status": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "assignee_id": {
+            "type": "string"
+          },
+          "contact_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "updated_by": {
+            "type": "string"
+          }
         }
       }
     }
@@ -601,5 +754,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/api/v1/agents/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/teamwork/definition.json
+++ b/connectors/teamwork/definition.json
@@ -66,13 +66,20 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "archived", "template"],
+            "enum": [
+              "active",
+              "archived",
+              "template"
+            ],
             "default": "active",
             "description": "Project status"
           },
           "privacy": {
             "type": "string",
-            "enum": ["open", "private"],
+            "enum": [
+              "open",
+              "private"
+            ],
             "default": "open",
             "description": "Project privacy setting"
           },
@@ -81,7 +88,9 @@
             "description": "Comma-separated list of tags"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -128,12 +137,19 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "archived", "template"],
+            "enum": [
+              "active",
+              "archived",
+              "template"
+            ],
             "description": "Project status"
           },
           "privacy": {
             "type": "string",
-            "enum": ["open", "private"],
+            "enum": [
+              "open",
+              "private"
+            ],
             "description": "Project privacy setting"
           },
           "tags": {
@@ -141,7 +157,9 @@
             "description": "Comma-separated list of tags"
           }
         },
-        "required": ["project_id"],
+        "required": [
+          "project_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -157,7 +175,9 @@
             "description": "Project ID"
           }
         },
-        "required": ["project_id"],
+        "required": [
+          "project_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -170,7 +190,12 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["active", "archived", "template", "all"],
+            "enum": [
+              "active",
+              "archived",
+              "template",
+              "all"
+            ],
             "default": "active",
             "description": "Filter by project status"
           },
@@ -244,7 +269,11 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["low", "medium", "high"],
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
             "default": "medium",
             "description": "Task priority"
           },
@@ -272,7 +301,10 @@
             "description": "Whether the task is private"
           }
         },
-        "required": ["project_id", "content"],
+        "required": [
+          "project_id",
+          "content"
+        ],
         "additionalProperties": false
       }
     },
@@ -301,7 +333,11 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["low", "medium", "high"],
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
             "description": "Task priority"
           },
           "due_date": {
@@ -331,7 +367,9 @@
             "description": "Whether the task is completed"
           }
         },
-        "required": ["task_id"],
+        "required": [
+          "task_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -347,7 +385,9 @@
             "description": "Task ID"
           }
         },
-        "required": ["task_id"],
+        "required": [
+          "task_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -376,7 +416,11 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["low", "medium", "high"],
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
             "description": "Filter by priority"
           },
           "due_date_from": {
@@ -467,7 +511,13 @@
             "description": "Comma-separated list of tags"
           }
         },
-        "required": ["project_id", "person_id", "description", "hours", "date"],
+        "required": [
+          "project_id",
+          "person_id",
+          "description",
+          "hours",
+          "date"
+        ],
         "additionalProperties": false
       }
     },
@@ -483,7 +533,9 @@
             "description": "Time entry ID"
           }
         },
-        "required": ["time_entry_id"],
+        "required": [
+          "time_entry_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -581,7 +633,10 @@
             "description": "Comma-separated list of tags"
           }
         },
-        "required": ["project_id", "title"],
+        "required": [
+          "project_id",
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -615,7 +670,9 @@
             "description": "Filter milestones with deadline to (YYYY-MM-DD)"
           }
         },
-        "required": ["project_id"],
+        "required": [
+          "project_id"
+        ],
         "additionalProperties": false
       }
     }
@@ -644,19 +701,45 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "project_id": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "company_id": {"type": "string"},
-          "category_id": {"type": "string"},
-          "start_date": {"type": "string"},
-          "end_date": {"type": "string"},
-          "status": {"type": "string"},
-          "privacy": {"type": "string"},
-          "created_at": {"type": "string"},
-          "created_by": {"type": "string"},
-          "budget": {"type": "number"},
-          "tags": {"type": "string"}
+          "project_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "company_id": {
+            "type": "string"
+          },
+          "category_id": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string"
+          },
+          "end_date": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "privacy": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "budget": {
+            "type": "number"
+          },
+          "tags": {
+            "type": "string"
+          }
         }
       }
     },
@@ -678,7 +761,11 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["low", "medium", "high"],
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
             "description": "Filter by priority"
           }
         },
@@ -688,19 +775,45 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "task_id": {"type": "string"},
-          "project_id": {"type": "string"},
-          "content": {"type": "string"},
-          "description": {"type": "string"},
-          "responsible_party_id": {"type": "string"},
-          "task_list_id": {"type": "string"},
-          "priority": {"type": "string"},
-          "due_date": {"type": "string"},
-          "start_date": {"type": "string"},
-          "estimated_minutes": {"type": "number"},
-          "created_at": {"type": "string"},
-          "created_by": {"type": "string"},
-          "tags": {"type": "string"}
+          "task_id": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "responsible_party_id": {
+            "type": "string"
+          },
+          "task_list_id": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "due_date": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string"
+          },
+          "estimated_minutes": {
+            "type": "number"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "string"
+          }
         }
       }
     },
@@ -722,7 +835,11 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["low", "medium", "high"],
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
             "description": "Filter by priority"
           }
         },
@@ -732,14 +849,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "task_id": {"type": "string"},
-          "project_id": {"type": "string"},
-          "content": {"type": "string"},
-          "responsible_party_id": {"type": "string"},
-          "priority": {"type": "string"},
-          "due_date": {"type": "string"},
-          "completed_at": {"type": "string"},
-          "completed_by": {"type": "string"}
+          "task_id": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "responsible_party_id": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "due_date": {
+            "type": "string"
+          },
+          "completed_at": {
+            "type": "string"
+          },
+          "completed_by": {
+            "type": "string"
+          }
         }
       }
     },
@@ -770,18 +903,42 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "time_entry_id": {"type": "string"},
-          "project_id": {"type": "string"},
-          "task_id": {"type": "string"},
-          "person_id": {"type": "string"},
-          "description": {"type": "string"},
-          "hours": {"type": "number"},
-          "minutes": {"type": "number"},
-          "date": {"type": "string"},
-          "time": {"type": "string"},
-          "is_billable": {"type": "boolean"},
-          "created_at": {"type": "string"},
-          "tags": {"type": "string"}
+          "time_entry_id": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "task_id": {
+            "type": "string"
+          },
+          "person_id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "hours": {
+            "type": "number"
+          },
+          "minutes": {
+            "type": "number"
+          },
+          "date": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
+          },
+          "is_billable": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "string"
+          }
         }
       }
     }
@@ -789,5 +946,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/authenticate.json"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/terraform-cloud/definition.json
+++ b/connectors/terraform-cloud/definition.json
@@ -55,7 +55,9 @@
             "description": "Auto-apply successful plans"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -81,7 +83,9 @@
             "description": "Whether this is a destroy run"
           }
         },
-        "required": ["workspace_id"],
+        "required": [
+          "workspace_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -98,7 +102,9 @@
             "description": "Run ID"
           }
         },
-        "required": ["run_id"],
+        "required": [
+          "run_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -119,16 +125,32 @@
             "items": {
               "type": "object",
               "properties": {
-                "key": {"type": "string"},
-                "value": {"type": "string"},
-                "category": {"type": "string", "enum": ["terraform", "env"]},
-                "sensitive": {"type": "boolean", "default": false}
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                },
+                "category": {
+                  "type": "string",
+                  "enum": [
+                    "terraform",
+                    "env"
+                  ]
+                },
+                "sensitive": {
+                  "type": "boolean",
+                  "default": false
+                }
               }
             },
             "description": "Variables to set"
           }
         },
-        "required": ["workspace_id", "variables"],
+        "required": [
+          "workspace_id",
+          "variables"
+        ],
         "additionalProperties": false
       }
     },
@@ -160,7 +182,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["applied", "planned", "errored", "canceled"],
+            "enum": [
+              "applied",
+              "planned",
+              "errored",
+              "canceled"
+            ],
             "description": "Filter by run status"
           }
         },
@@ -180,5 +207,20 @@
         "additionalProperties": false
       }
     }
-  ]
+  ],
+  "version": "1.0.0",
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
+  }
 }

--- a/connectors/toggl/definition.json
+++ b/connectors/toggl/definition.json
@@ -66,7 +66,9 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of tags"
           },
           "created_with": {
@@ -74,7 +76,9 @@
             "description": "Name of the client/application"
           }
         },
-        "required": ["workspace_id"],
+        "required": [
+          "workspace_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -90,7 +94,9 @@
             "description": "Workspace ID"
           }
         },
-        "required": ["workspace_id"],
+        "required": [
+          "workspace_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -138,7 +144,9 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of tags"
           },
           "created_with": {
@@ -146,7 +154,11 @@
             "description": "Name of the client/application"
           }
         },
-        "required": ["workspace_id", "start", "duration"],
+        "required": [
+          "workspace_id",
+          "start",
+          "duration"
+        ],
         "additionalProperties": false
       }
     },
@@ -197,11 +209,16 @@
           },
           "tags": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of tags"
           }
         },
-        "required": ["workspace_id", "time_entry_id"],
+        "required": [
+          "workspace_id",
+          "time_entry_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -221,7 +238,10 @@
             "description": "Time entry ID"
           }
         },
-        "required": ["workspace_id", "time_entry_id"],
+        "required": [
+          "workspace_id",
+          "time_entry_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -241,7 +261,10 @@
             "description": "Time entry ID"
           }
         },
-        "required": ["workspace_id", "time_entry_id"],
+        "required": [
+          "workspace_id",
+          "time_entry_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -293,7 +316,9 @@
             "description": "Get entries after this date (ISO 8601)"
           }
         },
-        "required": ["workspace_id"],
+        "required": [
+          "workspace_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -369,7 +394,10 @@
             "description": "Currency code (e.g., USD, EUR)"
           }
         },
-        "required": ["workspace_id", "name"],
+        "required": [
+          "workspace_id",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -433,7 +461,10 @@
             "description": "Currency code (e.g., USD, EUR)"
           }
         },
-        "required": ["workspace_id", "project_id"],
+        "required": [
+          "workspace_id",
+          "project_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -453,7 +484,10 @@
             "description": "Project ID"
           }
         },
-        "required": ["workspace_id", "project_id"],
+        "required": [
+          "workspace_id",
+          "project_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -482,16 +516,22 @@
           },
           "user_ids": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "List of user IDs to filter by project membership"
           },
           "client_ids": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "List of client IDs to filter by"
           }
         },
-        "required": ["workspace_id"],
+        "required": [
+          "workspace_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -515,7 +555,10 @@
             "description": "Client notes"
           }
         },
-        "required": ["workspace_id", "name"],
+        "required": [
+          "workspace_id",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -535,7 +578,9 @@
             "description": "Unix timestamp to get clients modified since"
           }
         },
-        "required": ["workspace_id"],
+        "required": [
+          "workspace_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -551,7 +596,9 @@
             "description": "Workspace ID"
           }
         },
-        "required": ["workspace_id"],
+        "required": [
+          "workspace_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -600,24 +647,60 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "workspace_id": {"type": "number"},
-          "project_id": {"type": "number"},
-          "task_id": {"type": "number"},
-          "billable": {"type": "boolean"},
-          "start": {"type": "string"},
-          "stop": {"type": "string"},
-          "duration": {"type": "number"},
-          "description": {"type": "string"},
-          "tags": {"type": "array"},
-          "tag_ids": {"type": "array"},
-          "duronly": {"type": "boolean"},
-          "at": {"type": "string"},
-          "server_deleted_at": {"type": "string"},
-          "user_id": {"type": "number"},
-          "uid": {"type": "number"},
-          "wid": {"type": "number"},
-          "pid": {"type": "number"}
+          "id": {
+            "type": "number"
+          },
+          "workspace_id": {
+            "type": "number"
+          },
+          "project_id": {
+            "type": "number"
+          },
+          "task_id": {
+            "type": "number"
+          },
+          "billable": {
+            "type": "boolean"
+          },
+          "start": {
+            "type": "string"
+          },
+          "stop": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array"
+          },
+          "tag_ids": {
+            "type": "array"
+          },
+          "duronly": {
+            "type": "boolean"
+          },
+          "at": {
+            "type": "string"
+          },
+          "server_deleted_at": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "number"
+          },
+          "uid": {
+            "type": "number"
+          },
+          "wid": {
+            "type": "number"
+          },
+          "pid": {
+            "type": "number"
+          }
         }
       }
     },
@@ -648,18 +731,42 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "workspace_id": {"type": "number"},
-          "project_id": {"type": "number"},
-          "task_id": {"type": "number"},
-          "billable": {"type": "boolean"},
-          "start": {"type": "string"},
-          "stop": {"type": "string"},
-          "duration": {"type": "number"},
-          "description": {"type": "string"},
-          "tags": {"type": "array"},
-          "at": {"type": "string"},
-          "user_id": {"type": "number"}
+          "id": {
+            "type": "number"
+          },
+          "workspace_id": {
+            "type": "number"
+          },
+          "project_id": {
+            "type": "number"
+          },
+          "task_id": {
+            "type": "number"
+          },
+          "billable": {
+            "type": "boolean"
+          },
+          "start": {
+            "type": "string"
+          },
+          "stop": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array"
+          },
+          "at": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "number"
+          }
         }
       }
     },
@@ -690,10 +797,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "workspace_id": {"type": "number"},
-          "user_id": {"type": "number"},
-          "deleted_at": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "workspace_id": {
+            "type": "number"
+          },
+          "user_id": {
+            "type": "number"
+          },
+          "deleted_at": {
+            "type": "string"
+          }
         }
       }
     },
@@ -720,22 +835,54 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "workspace_id": {"type": "number"},
-          "client_id": {"type": "number"},
-          "name": {"type": "string"},
-          "is_private": {"type": "boolean"},
-          "active": {"type": "boolean"},
-          "at": {"type": "string"},
-          "created_at": {"type": "string"},
-          "server_deleted_at": {"type": "string"},
-          "color": {"type": "string"},
-          "billable": {"type": "boolean"},
-          "template": {"type": "boolean"},
-          "auto_estimates": {"type": "boolean"},
-          "estimated_hours": {"type": "number"},
-          "rate": {"type": "number"},
-          "currency": {"type": "string"}
+          "id": {
+            "type": "number"
+          },
+          "workspace_id": {
+            "type": "number"
+          },
+          "client_id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "is_private": {
+            "type": "boolean"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "at": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "server_deleted_at": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "billable": {
+            "type": "boolean"
+          },
+          "template": {
+            "type": "boolean"
+          },
+          "auto_estimates": {
+            "type": "boolean"
+          },
+          "estimated_hours": {
+            "type": "number"
+          },
+          "rate": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          }
         }
       }
     }
@@ -743,5 +890,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/trello-enhanced/definition.json
+++ b/connectors/trello-enhanced/definition.json
@@ -20,7 +20,7 @@
   "actions": [
     {
       "id": "test_connection",
-      "name": "Test Connection", 
+      "name": "Test Connection",
       "description": "Test the connection to Trello",
       "parameters": {
         "type": "object",
@@ -50,19 +50,35 @@
           },
           "prefs_permissionLevel": {
             "type": "string",
-            "enum": ["private", "org", "public"],
+            "enum": [
+              "private",
+              "org",
+              "public"
+            ],
             "default": "private",
             "description": "Permission level"
           },
           "prefs_voting": {
             "type": "string",
-            "enum": ["disabled", "members", "observers", "org", "public"],
+            "enum": [
+              "disabled",
+              "members",
+              "observers",
+              "org",
+              "public"
+            ],
             "default": "disabled",
             "description": "Voting permission"
           },
           "prefs_comments": {
             "type": "string",
-            "enum": ["disabled", "members", "observers", "org", "public"],
+            "enum": [
+              "disabled",
+              "members",
+              "observers",
+              "org",
+              "public"
+            ],
             "default": "members",
             "description": "Comment permission"
           },
@@ -71,7 +87,9 @@
             "description": "Background color or image"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -109,17 +127,23 @@
           },
           "idMembers": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of member IDs"
           },
           "idLabels": {
             "type": "array",
-            "items": {"type": "string"}, 
+            "items": {
+              "type": "string"
+            },
             "description": "Array of label IDs"
           },
           "idChecklists": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of checklist IDs"
           },
           "address": {
@@ -135,7 +159,10 @@
             "description": "GPS coordinates"
           }
         },
-        "required": ["name", "idList"],
+        "required": [
+          "name",
+          "idList"
+        ],
         "additionalProperties": false
       }
     },
@@ -159,7 +186,10 @@
             "description": "Position of the checklist"
           }
         },
-        "required": ["idCard", "name"],
+        "required": [
+          "idCard",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -188,7 +218,10 @@
             "description": "Whether the item is checked"
           }
         },
-        "required": ["idChecklist", "name"],
+        "required": [
+          "idChecklist",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -225,7 +258,9 @@
             "description": "Whether to set as card cover"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -237,7 +272,7 @@
         "type": "object",
         "properties": {
           "idBoard": {
-            "type": "string", 
+            "type": "string",
             "description": "Board ID"
           },
           "name": {
@@ -246,11 +281,26 @@
           },
           "color": {
             "type": "string",
-            "enum": ["yellow", "purple", "blue", "red", "green", "orange", "black", "sky", "pink", "lime"],
+            "enum": [
+              "yellow",
+              "purple",
+              "blue",
+              "red",
+              "green",
+              "orange",
+              "black",
+              "sky",
+              "pink",
+              "lime"
+            ],
             "description": "Label color"
           }
         },
-        "required": ["idBoard", "name", "color"],
+        "required": [
+          "idBoard",
+          "name",
+          "color"
+        ],
         "additionalProperties": false
       }
     },
@@ -294,7 +344,7 @@
             "description": "Limit for boards"
           },
           "card_fields": {
-            "type": "string", 
+            "type": "string",
             "description": "Card fields to include"
           },
           "cards_limit": {
@@ -357,7 +407,9 @@
             "description": "Whether to allow partial matches"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -386,7 +438,10 @@
             "description": "Whether webhook is active"
           }
         },
-        "required": ["callbackURL", "idModel"],
+        "required": [
+          "callbackURL",
+          "idModel"
+        ],
         "additionalProperties": false
       }
     }
@@ -415,8 +470,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "action": {"type": "object"},
-          "model": {"type": "object"}
+          "action": {
+            "type": "object"
+          },
+          "model": {
+            "type": "object"
+          }
         }
       }
     },
@@ -439,8 +498,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "action": {"type": "object"},
-          "model": {"type": "object"}
+          "action": {
+            "type": "object"
+          },
+          "model": {
+            "type": "object"
+          }
         }
       }
     },
@@ -463,8 +526,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "action": {"type": "object"},
-          "model": {"type": "object"}
+          "action": {
+            "type": "object"
+          },
+          "model": {
+            "type": "object"
+          }
         }
       }
     }
@@ -472,5 +539,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/members/me"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/trello/definition.json
+++ b/connectors/trello/definition.json
@@ -62,25 +62,44 @@
           },
           "prefs_permissionLevel": {
             "type": "string",
-            "enum": ["private", "org", "public"],
+            "enum": [
+              "private",
+              "org",
+              "public"
+            ],
             "default": "private",
             "description": "Permission level"
           },
           "prefs_voting": {
             "type": "string",
-            "enum": ["disabled", "members", "observers", "org", "public"],
+            "enum": [
+              "disabled",
+              "members",
+              "observers",
+              "org",
+              "public"
+            ],
             "default": "disabled",
             "description": "Voting permission"
           },
           "prefs_comments": {
             "type": "string",
-            "enum": ["disabled", "members", "observers", "org", "public"],
+            "enum": [
+              "disabled",
+              "members",
+              "observers",
+              "org",
+              "public"
+            ],
             "default": "members",
             "description": "Comment permission"
           },
           "prefs_invitations": {
             "type": "string",
-            "enum": ["members", "admins"],
+            "enum": [
+              "members",
+              "admins"
+            ],
             "default": "members",
             "description": "Invitation permission"
           },
@@ -100,12 +119,17 @@
           },
           "prefs_cardAging": {
             "type": "string",
-            "enum": ["pirate", "regular"],
+            "enum": [
+              "pirate",
+              "regular"
+            ],
             "default": "regular",
             "description": "Card aging style"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -140,7 +164,11 @@
           },
           "actions_format": {
             "type": "string",
-            "enum": ["count", "list", "minimal"],
+            "enum": [
+              "count",
+              "list",
+              "minimal"
+            ],
             "description": "Format for actions"
           },
           "actions_since": {
@@ -176,7 +204,13 @@
           },
           "cards": {
             "type": "string",
-            "enum": ["none", "visible", "open", "closed", "all"],
+            "enum": [
+              "none",
+              "visible",
+              "open",
+              "closed",
+              "all"
+            ],
             "default": "none",
             "description": "Which cards to include"
           },
@@ -206,7 +240,10 @@
           },
           "labels": {
             "type": "string",
-            "enum": ["none", "all"],
+            "enum": [
+              "none",
+              "all"
+            ],
             "default": "none",
             "description": "Which labels to include"
           },
@@ -220,7 +257,12 @@
           },
           "lists": {
             "type": "string",
-            "enum": ["none", "open", "closed", "all"],
+            "enum": [
+              "none",
+              "open",
+              "closed",
+              "all"
+            ],
             "default": "none",
             "description": "Which lists to include"
           },
@@ -230,7 +272,14 @@
           },
           "memberships": {
             "type": "string",
-            "enum": ["none", "active", "admin", "deactivated", "me", "normal"],
+            "enum": [
+              "none",
+              "active",
+              "admin",
+              "deactivated",
+              "me",
+              "normal"
+            ],
             "default": "none",
             "description": "Which memberships to include"
           },
@@ -244,7 +293,14 @@
           },
           "members": {
             "type": "string",
-            "enum": ["none", "active", "admin", "deactivated", "me", "normal"],
+            "enum": [
+              "none",
+              "active",
+              "admin",
+              "deactivated",
+              "me",
+              "normal"
+            ],
             "default": "none",
             "description": "Which members to include"
           },
@@ -254,7 +310,14 @@
           },
           "membersInvited": {
             "type": "string",
-            "enum": ["none", "active", "admin", "deactivated", "me", "normal"],
+            "enum": [
+              "none",
+              "active",
+              "admin",
+              "deactivated",
+              "me",
+              "normal"
+            ],
             "default": "none",
             "description": "Which invited members to include"
           },
@@ -264,7 +327,10 @@
           },
           "checklists": {
             "type": "string",
-            "enum": ["none", "all"],
+            "enum": [
+              "none",
+              "all"
+            ],
             "default": "none",
             "description": "Which checklists to include"
           },
@@ -293,7 +359,9 @@
             "description": "Whether to include tags"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -330,7 +398,11 @@
           },
           "prefs/permissionLevel": {
             "type": "string",
-            "enum": ["private", "org", "public"],
+            "enum": [
+              "private",
+              "org",
+              "public"
+            ],
             "description": "Permission level"
           },
           "prefs/selfJoin": {
@@ -343,17 +415,32 @@
           },
           "prefs/invitations": {
             "type": "string",
-            "enum": ["members", "admins"],
+            "enum": [
+              "members",
+              "admins"
+            ],
             "description": "Invitation permission"
           },
           "prefs/voting": {
             "type": "string",
-            "enum": ["disabled", "members", "observers", "org", "public"],
+            "enum": [
+              "disabled",
+              "members",
+              "observers",
+              "org",
+              "public"
+            ],
             "description": "Voting permission"
           },
           "prefs/comments": {
             "type": "string",
-            "enum": ["disabled", "members", "observers", "org", "public"],
+            "enum": [
+              "disabled",
+              "members",
+              "observers",
+              "org",
+              "public"
+            ],
             "description": "Comment permission"
           },
           "prefs/background": {
@@ -362,7 +449,10 @@
           },
           "prefs/cardAging": {
             "type": "string",
-            "enum": ["pirate", "regular"],
+            "enum": [
+              "pirate",
+              "regular"
+            ],
             "description": "Card aging style"
           },
           "prefs/calendarFeedEnabled": {
@@ -394,7 +484,9 @@
             "description": "Blue label name"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -424,7 +516,10 @@
             "description": "Position of the list (top, bottom, or positive number)"
           }
         },
-        "required": ["name", "idBoard"],
+        "required": [
+          "name",
+          "idBoard"
+        ],
         "additionalProperties": false
       }
     },
@@ -436,8 +531,14 @@
       "method": "GET",
       "parameters": {
         "type": "object",
-        "properties": { "id": { "type": "string" } },
-        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -449,8 +550,17 @@
       "method": "PUT",
       "parameters": {
         "type": "object",
-        "properties": { "id": { "type": "string" }, "name": { "type": "string" } },
-        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -462,8 +572,21 @@
       "method": "POST",
       "parameters": {
         "type": "object",
-        "properties": { "name": {"type":"string"}, "idList": {"type":"string"}, "desc": {"type":"string"} },
-        "required": ["name","idList"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "idList": {
+            "type": "string"
+          },
+          "desc": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "idList"
+        ],
         "additionalProperties": false
       }
     },
@@ -475,8 +598,14 @@
       "method": "GET",
       "parameters": {
         "type": "object",
-        "properties": { "id": { "type": "string" } },
-        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -488,12 +617,23 @@
       "method": "PUT",
       "parameters": {
         "type": "object",
-        "properties": { "id": {"type":"string"}, "name": {"type":"string"}, "desc": {"type":"string"} },
-        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "desc": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
-    }
-    ,
+    },
     {
       "id": "add_comment_to_card",
       "name": "Add Comment To Card",
@@ -502,8 +642,18 @@
       "method": "POST",
       "parameters": {
         "type": "object",
-        "properties": { "id": {"type":"string"}, "text": {"type":"string"} },
-        "required": ["id","text"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "text"
+        ],
         "additionalProperties": false
       }
     },
@@ -516,11 +666,20 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "callbackURL": {"type":"string"},
-          "idModel": {"type":"string"},
-          "description": {"type":"string"}
+          "callbackURL": {
+            "type": "string"
+          },
+          "idModel": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
         },
-        "required": ["callbackURL","idModel"],
+        "required": [
+          "callbackURL",
+          "idModel"
+        ],
         "additionalProperties": false
       }
     },
@@ -541,7 +700,12 @@
           },
           "cards": {
             "type": "string",
-            "enum": ["none", "open", "closed", "all"],
+            "enum": [
+              "none",
+              "open",
+              "closed",
+              "all"
+            ],
             "default": "none",
             "description": "Which cards to include"
           },
@@ -558,7 +722,9 @@
             "description": "Fields to include for board"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -594,7 +760,9 @@
             "description": "Whether the user is subscribed to the list"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -632,12 +800,16 @@
           },
           "idMembers": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of member IDs"
           },
           "idLabels": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of label IDs"
           },
           "urlSource": {
@@ -669,7 +841,10 @@
             "description": "GPS coordinates"
           }
         },
-        "required": ["name", "idList"],
+        "required": [
+          "name",
+          "idList"
+        ],
         "additionalProperties": false
       }
     },
@@ -745,7 +920,10 @@
           },
           "checklists": {
             "type": "string",
-            "enum": ["none", "all"],
+            "enum": [
+              "none",
+              "all"
+            ],
             "default": "none",
             "description": "Which checklists to include"
           },
@@ -782,7 +960,9 @@
             "description": "Whether to include custom field items"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -811,7 +991,9 @@
           },
           "idMembers": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of member IDs"
           },
           "idAttachmentCover": {
@@ -824,7 +1006,9 @@
           },
           "idLabels": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Array of label IDs"
           },
           "idBoard": {
@@ -865,7 +1049,9 @@
             "description": "Cover settings"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -885,7 +1071,10 @@
             "description": "Comment text"
           }
         },
-        "required": ["id", "text"],
+        "required": [
+          "id",
+          "text"
+        ],
         "additionalProperties": false
       }
     },
@@ -913,7 +1102,10 @@
             "description": "Position of the checklist"
           }
         },
-        "required": ["idCard", "name"],
+        "required": [
+          "idCard",
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -951,7 +1143,10 @@
             "description": "Member ID to assign to the item"
           }
         },
-        "required": ["idChecklist", "name"],
+        "required": [
+          "idChecklist",
+          "name"
+        ],
         "additionalProperties": false
       }
     }
@@ -980,37 +1175,99 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "badges": {"type": "object"},
-          "checkItemStates": {"type": "array"},
-          "closed": {"type": "boolean"},
-          "dueComplete": {"type": "boolean"},
-          "dateLastActivity": {"type": "string"},
-          "desc": {"type": "string"},
-          "descData": {"type": "object"},
-          "due": {"type": "string"},
-          "email": {"type": "string"},
-          "idBoard": {"type": "string"},
-          "idChecklists": {"type": "array"},
-          "idLabels": {"type": "array"},
-          "idList": {"type": "string"},
-          "idMembers": {"type": "array"},
-          "idMembersVoted": {"type": "array"},
-          "idShort": {"type": "number"},
-          "idAttachmentCover": {"type": "string"},
-          "labels": {"type": "array"},
-          "limits": {"type": "object"},
-          "locationName": {"type": "string"},
-          "manualCoverAttachment": {"type": "boolean"},
-          "name": {"type": "string"},
-          "pos": {"type": "number"},
-          "shortLink": {"type": "string"},
-          "shortUrl": {"type": "string"},
-          "subscribed": {"type": "boolean"},
-          "url": {"type": "string"},
-          "address": {"type": "string"},
-          "coordinates": {"type": "object"},
-          "cover": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "badges": {
+            "type": "object"
+          },
+          "checkItemStates": {
+            "type": "array"
+          },
+          "closed": {
+            "type": "boolean"
+          },
+          "dueComplete": {
+            "type": "boolean"
+          },
+          "dateLastActivity": {
+            "type": "string"
+          },
+          "desc": {
+            "type": "string"
+          },
+          "descData": {
+            "type": "object"
+          },
+          "due": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "idBoard": {
+            "type": "string"
+          },
+          "idChecklists": {
+            "type": "array"
+          },
+          "idLabels": {
+            "type": "array"
+          },
+          "idList": {
+            "type": "string"
+          },
+          "idMembers": {
+            "type": "array"
+          },
+          "idMembersVoted": {
+            "type": "array"
+          },
+          "idShort": {
+            "type": "number"
+          },
+          "idAttachmentCover": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "array"
+          },
+          "limits": {
+            "type": "object"
+          },
+          "locationName": {
+            "type": "string"
+          },
+          "manualCoverAttachment": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pos": {
+            "type": "number"
+          },
+          "shortLink": {
+            "type": "string"
+          },
+          "shortUrl": {
+            "type": "string"
+          },
+          "subscribed": {
+            "type": "boolean"
+          },
+          "url": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "coordinates": {
+            "type": "object"
+          },
+          "cover": {
+            "type": "object"
+          }
         }
       }
     },
@@ -1037,18 +1294,42 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "desc": {"type": "string"},
-          "closed": {"type": "boolean"},
-          "idBoard": {"type": "string"},
-          "idList": {"type": "string"},
-          "idMembers": {"type": "array"},
-          "idLabels": {"type": "array"},
-          "due": {"type": "string"},
-          "dueComplete": {"type": "boolean"},
-          "pos": {"type": "number"},
-          "dateLastActivity": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "desc": {
+            "type": "string"
+          },
+          "closed": {
+            "type": "boolean"
+          },
+          "idBoard": {
+            "type": "string"
+          },
+          "idList": {
+            "type": "string"
+          },
+          "idMembers": {
+            "type": "array"
+          },
+          "idLabels": {
+            "type": "array"
+          },
+          "due": {
+            "type": "string"
+          },
+          "dueComplete": {
+            "type": "boolean"
+          },
+          "pos": {
+            "type": "number"
+          },
+          "dateLastActivity": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1079,10 +1360,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "card": {"type": "object"},
-          "listBefore": {"type": "object"},
-          "listAfter": {"type": "object"},
-          "board": {"type": "object"}
+          "card": {
+            "type": "object"
+          },
+          "listBefore": {
+            "type": "object"
+          },
+          "listAfter": {
+            "type": "object"
+          },
+          "board": {
+            "type": "object"
+          }
         }
       }
     },
@@ -1105,12 +1394,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "closed": {"type": "boolean"},
-          "idBoard": {"type": "string"},
-          "pos": {"type": "number"},
-          "subscribed": {"type": "boolean"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "closed": {
+            "type": "boolean"
+          },
+          "idBoard": {
+            "type": "string"
+          },
+          "pos": {
+            "type": "number"
+          },
+          "subscribed": {
+            "type": "boolean"
+          }
         }
       }
     }
@@ -1118,6 +1419,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/members/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }
-

--- a/connectors/twilio/definition.json
+++ b/connectors/twilio/definition.json
@@ -56,7 +56,10 @@
           },
           "status_callback_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for status callback"
           },
@@ -90,12 +93,18 @@
           },
           "content_retention": {
             "type": "string",
-            "enum": ["retain", "discard"],
+            "enum": [
+              "retain",
+              "discard"
+            ],
             "description": "Content retention policy"
           },
           "address_retention": {
             "type": "string",
-            "enum": ["retain", "discard"],
+            "enum": [
+              "retain",
+              "discard"
+            ],
             "description": "Address retention policy"
           },
           "smart_encoded": {
@@ -104,7 +113,9 @@
           },
           "persistent_action": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Persistent action buttons"
           },
           "shorten_urls": {
@@ -113,7 +124,9 @@
           },
           "schedule_type": {
             "type": "string",
-            "enum": ["fixed"],
+            "enum": [
+              "fixed"
+            ],
             "description": "Schedule type for delayed sending"
           },
           "send_at": {
@@ -130,7 +143,10 @@
             "description": "Template variable values"
           }
         },
-        "required": ["to", "body"],
+        "required": [
+          "to",
+          "body"
+        ],
         "additionalProperties": false
       }
     },
@@ -155,7 +171,9 @@
           },
           "media_url": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "URLs of media to include (up to 10)"
           },
           "messaging_service_sid": {
@@ -168,7 +186,10 @@
           },
           "status_callback_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for status callback"
           },
@@ -188,16 +209,25 @@
           },
           "content_retention": {
             "type": "string",
-            "enum": ["retain", "discard"],
+            "enum": [
+              "retain",
+              "discard"
+            ],
             "description": "Content retention policy"
           },
           "address_retention": {
             "type": "string",
-            "enum": ["retain", "discard"],
+            "enum": [
+              "retain",
+              "discard"
+            ],
             "description": "Address retention policy"
           }
         },
-        "required": ["to", "media_url"],
+        "required": [
+          "to",
+          "media_url"
+        ],
         "additionalProperties": false
       }
     },
@@ -230,7 +260,10 @@
           },
           "method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for URL"
           },
@@ -240,7 +273,10 @@
           },
           "fallback_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for fallback URL"
           },
@@ -252,13 +288,21 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["initiated", "ringing", "answered", "completed"]
+              "enum": [
+                "initiated",
+                "ringing",
+                "answered",
+                "completed"
+              ]
             },
             "description": "Events to callback for"
           },
           "status_callback_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for status callback"
           },
@@ -279,7 +323,10 @@
           },
           "recording_channels": {
             "type": "string",
-            "enum": ["mono", "dual"],
+            "enum": [
+              "mono",
+              "dual"
+            ],
             "description": "Recording channels"
           },
           "recording_status_callback": {
@@ -288,7 +335,10 @@
           },
           "recording_status_callback_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for recording callback"
           },
@@ -302,7 +352,10 @@
           },
           "machine_detection": {
             "type": "string",
-            "enum": ["Enable", "DetectMessageEnd"],
+            "enum": [
+              "Enable",
+              "DetectMessageEnd"
+            ],
             "description": "Answering machine detection"
           },
           "machine_detection_timeout": {
@@ -313,12 +366,19 @@
           },
           "recording_track": {
             "type": "string",
-            "enum": ["inbound", "outbound", "both"],
+            "enum": [
+              "inbound",
+              "outbound",
+              "both"
+            ],
             "description": "Which track to record"
           },
           "trim": {
             "type": "string",
-            "enum": ["trim-silence", "do-not-trim"],
+            "enum": [
+              "trim-silence",
+              "do-not-trim"
+            ],
             "description": "Whether to trim silence from recordings"
           },
           "caller_id": {
@@ -344,7 +404,10 @@
             "description": "Silence timeout for machine detection (ms)"
           }
         },
-        "required": ["to", "from"],
+        "required": [
+          "to",
+          "from"
+        ],
         "additionalProperties": false
       }
     },
@@ -364,7 +427,9 @@
             "description": "Message SID"
           }
         },
-        "required": ["sid"],
+        "required": [
+          "sid"
+        ],
         "additionalProperties": false
       }
     },
@@ -439,7 +504,9 @@
             "description": "Call SID"
           }
         },
-        "required": ["sid"],
+        "required": [
+          "sid"
+        ],
         "additionalProperties": false
       }
     },
@@ -464,7 +531,16 @@
           },
           "status": {
             "type": "string",
-            "enum": ["queued", "ringing", "in-progress", "completed", "busy", "failed", "no-answer", "canceled"],
+            "enum": [
+              "queued",
+              "ringing",
+              "in-progress",
+              "completed",
+              "busy",
+              "failed",
+              "no-answer",
+              "canceled"
+            ],
             "description": "Filter by call status"
           },
           "start_time": {
@@ -539,13 +615,19 @@
           },
           "method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for URL"
           },
           "status": {
             "type": "string",
-            "enum": ["canceled", "completed"],
+            "enum": [
+              "canceled",
+              "completed"
+            ],
             "description": "New call status"
           },
           "fallback_url": {
@@ -554,7 +636,10 @@
           },
           "fallback_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for fallback URL"
           },
@@ -564,7 +649,10 @@
           },
           "status_callback_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for status callback"
           },
@@ -573,7 +661,9 @@
             "description": "TwiML instructions to execute"
           }
         },
-        "required": ["sid"],
+        "required": [
+          "sid"
+        ],
         "additionalProperties": false
       }
     },
@@ -606,7 +696,10 @@
           },
           "voice_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for voice URL"
           },
@@ -616,7 +709,10 @@
           },
           "voice_fallback_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for voice fallback URL"
           },
@@ -626,7 +722,10 @@
           },
           "status_callback_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for status callback"
           },
@@ -644,7 +743,10 @@
           },
           "sms_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for SMS URL"
           },
@@ -654,7 +756,10 @@
           },
           "sms_fallback_method": {
             "type": "string",
-            "enum": ["GET", "POST"],
+            "enum": [
+              "GET",
+              "POST"
+            ],
             "default": "POST",
             "description": "HTTP method for SMS fallback URL"
           },
@@ -668,7 +773,10 @@
           },
           "emergency_status": {
             "type": "string",
-            "enum": ["Active", "Inactive"],
+            "enum": [
+              "Active",
+              "Inactive"
+            ],
             "description": "Emergency calling status"
           },
           "emergency_address_sid": {
@@ -688,7 +796,9 @@
             "description": "Bundle SID for regulatory compliance"
           }
         },
-        "required": ["phone_number"],
+        "required": [
+          "phone_number"
+        ],
         "additionalProperties": false
       }
     },
@@ -765,29 +875,75 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "MessageSid": {"type": "string"},
-          "AccountSid": {"type": "string"},
-          "MessagingServiceSid": {"type": "string"},
-          "From": {"type": "string"},
-          "To": {"type": "string"},
-          "Body": {"type": "string"},
-          "NumMedia": {"type": "string"},
-          "MediaContentType0": {"type": "string"},
-          "MediaUrl0": {"type": "string"},
-          "FromCity": {"type": "string"},
-          "FromState": {"type": "string"},
-          "FromZip": {"type": "string"},
-          "FromCountry": {"type": "string"},
-          "ToCity": {"type": "string"},
-          "ToState": {"type": "string"},
-          "ToZip": {"type": "string"},
-          "ToCountry": {"type": "string"},
-          "AddOns": {"type": "string"},
-          "SmsMessageSid": {"type": "string"},
-          "NumSegments": {"type": "string"},
-          "ReferralNumMedia": {"type": "string"},
-          "SmsStatus": {"type": "string"},
-          "SmsSid": {"type": "string"}
+          "MessageSid": {
+            "type": "string"
+          },
+          "AccountSid": {
+            "type": "string"
+          },
+          "MessagingServiceSid": {
+            "type": "string"
+          },
+          "From": {
+            "type": "string"
+          },
+          "To": {
+            "type": "string"
+          },
+          "Body": {
+            "type": "string"
+          },
+          "NumMedia": {
+            "type": "string"
+          },
+          "MediaContentType0": {
+            "type": "string"
+          },
+          "MediaUrl0": {
+            "type": "string"
+          },
+          "FromCity": {
+            "type": "string"
+          },
+          "FromState": {
+            "type": "string"
+          },
+          "FromZip": {
+            "type": "string"
+          },
+          "FromCountry": {
+            "type": "string"
+          },
+          "ToCity": {
+            "type": "string"
+          },
+          "ToState": {
+            "type": "string"
+          },
+          "ToZip": {
+            "type": "string"
+          },
+          "ToCountry": {
+            "type": "string"
+          },
+          "AddOns": {
+            "type": "string"
+          },
+          "SmsMessageSid": {
+            "type": "string"
+          },
+          "NumSegments": {
+            "type": "string"
+          },
+          "ReferralNumMedia": {
+            "type": "string"
+          },
+          "SmsStatus": {
+            "type": "string"
+          },
+          "SmsSid": {
+            "type": "string"
+          }
         }
       }
     },
@@ -814,28 +970,72 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "CallSid": {"type": "string"},
-          "AccountSid": {"type": "string"},
-          "From": {"type": "string"},
-          "To": {"type": "string"},
-          "CallStatus": {"type": "string"},
-          "ApiVersion": {"type": "string"},
-          "Direction": {"type": "string"},
-          "ForwardedFrom": {"type": "string"},
-          "CallerName": {"type": "string"},
-          "FromCity": {"type": "string"},
-          "FromState": {"type": "string"},
-          "FromZip": {"type": "string"},
-          "FromCountry": {"type": "string"},
-          "ToCity": {"type": "string"},
-          "ToState": {"type": "string"},
-          "ToZip": {"type": "string"},
-          "ToCountry": {"type": "string"},
-          "ApplicationSid": {"type": "string"},
-          "Digits": {"type": "string"},
-          "FinishedOnKey": {"type": "string"},
-          "SpeechResult": {"type": "string"},
-          "Confidence": {"type": "string"}
+          "CallSid": {
+            "type": "string"
+          },
+          "AccountSid": {
+            "type": "string"
+          },
+          "From": {
+            "type": "string"
+          },
+          "To": {
+            "type": "string"
+          },
+          "CallStatus": {
+            "type": "string"
+          },
+          "ApiVersion": {
+            "type": "string"
+          },
+          "Direction": {
+            "type": "string"
+          },
+          "ForwardedFrom": {
+            "type": "string"
+          },
+          "CallerName": {
+            "type": "string"
+          },
+          "FromCity": {
+            "type": "string"
+          },
+          "FromState": {
+            "type": "string"
+          },
+          "FromZip": {
+            "type": "string"
+          },
+          "FromCountry": {
+            "type": "string"
+          },
+          "ToCity": {
+            "type": "string"
+          },
+          "ToState": {
+            "type": "string"
+          },
+          "ToZip": {
+            "type": "string"
+          },
+          "ToCountry": {
+            "type": "string"
+          },
+          "ApplicationSid": {
+            "type": "string"
+          },
+          "Digits": {
+            "type": "string"
+          },
+          "FinishedOnKey": {
+            "type": "string"
+          },
+          "SpeechResult": {
+            "type": "string"
+          },
+          "Confidence": {
+            "type": "string"
+          }
         }
       }
     },
@@ -849,7 +1049,16 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["queued", "ringing", "in-progress", "completed", "busy", "failed", "no-answer", "canceled"],
+            "enum": [
+              "queued",
+              "ringing",
+              "in-progress",
+              "completed",
+              "busy",
+              "failed",
+              "no-answer",
+              "canceled"
+            ],
             "description": "Filter by call status"
           },
           "from": {
@@ -867,25 +1076,63 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "CallSid": {"type": "string"},
-          "AccountSid": {"type": "string"},
-          "From": {"type": "string"},
-          "To": {"type": "string"},
-          "CallStatus": {"type": "string"},
-          "Duration": {"type": "string"},
-          "StartTime": {"type": "string"},
-          "EndTime": {"type": "string"},
-          "Price": {"type": "string"},
-          "PriceUnit": {"type": "string"},
-          "Direction": {"type": "string"},
-          "AnsweredBy": {"type": "string"},
-          "MachineDetectionDuration": {"type": "string"},
-          "RecordingUrl": {"type": "string"},
-          "RecordingSid": {"type": "string"},
-          "RecordingDuration": {"type": "string"},
-          "Timestamp": {"type": "string"},
-          "CallbackSource": {"type": "string"},
-          "SequenceNumber": {"type": "string"}
+          "CallSid": {
+            "type": "string"
+          },
+          "AccountSid": {
+            "type": "string"
+          },
+          "From": {
+            "type": "string"
+          },
+          "To": {
+            "type": "string"
+          },
+          "CallStatus": {
+            "type": "string"
+          },
+          "Duration": {
+            "type": "string"
+          },
+          "StartTime": {
+            "type": "string"
+          },
+          "EndTime": {
+            "type": "string"
+          },
+          "Price": {
+            "type": "string"
+          },
+          "PriceUnit": {
+            "type": "string"
+          },
+          "Direction": {
+            "type": "string"
+          },
+          "AnsweredBy": {
+            "type": "string"
+          },
+          "MachineDetectionDuration": {
+            "type": "string"
+          },
+          "RecordingUrl": {
+            "type": "string"
+          },
+          "RecordingSid": {
+            "type": "string"
+          },
+          "RecordingDuration": {
+            "type": "string"
+          },
+          "Timestamp": {
+            "type": "string"
+          },
+          "CallbackSource": {
+            "type": "string"
+          },
+          "SequenceNumber": {
+            "type": "string"
+          }
         }
       }
     },
@@ -899,7 +1146,18 @@
         "properties": {
           "message_status": {
             "type": "string",
-            "enum": ["accepted", "queued", "sending", "sent", "receiving", "received", "delivered", "undelivered", "failed", "read"],
+            "enum": [
+              "accepted",
+              "queued",
+              "sending",
+              "sent",
+              "receiving",
+              "received",
+              "delivered",
+              "undelivered",
+              "failed",
+              "read"
+            ],
             "description": "Filter by message status"
           },
           "from": {
@@ -917,25 +1175,63 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "MessageSid": {"type": "string"},
-          "AccountSid": {"type": "string"},
-          "MessagingServiceSid": {"type": "string"},
-          "From": {"type": "string"},
-          "To": {"type": "string"},
-          "MessageStatus": {"type": "string"},
-          "Body": {"type": "string"},
-          "NumSegments": {"type": "string"},
-          "NumMedia": {"type": "string"},
-          "DateCreated": {"type": "string"},
-          "DateSent": {"type": "string"},
-          "DateUpdated": {"type": "string"},
-          "Direction": {"type": "string"},
-          "Price": {"type": "string"},
-          "PriceUnit": {"type": "string"},
-          "ApiVersion": {"type": "string"},
-          "Uri": {"type": "string"},
-          "ErrorCode": {"type": "string"},
-          "ErrorMessage": {"type": "string"}
+          "MessageSid": {
+            "type": "string"
+          },
+          "AccountSid": {
+            "type": "string"
+          },
+          "MessagingServiceSid": {
+            "type": "string"
+          },
+          "From": {
+            "type": "string"
+          },
+          "To": {
+            "type": "string"
+          },
+          "MessageStatus": {
+            "type": "string"
+          },
+          "Body": {
+            "type": "string"
+          },
+          "NumSegments": {
+            "type": "string"
+          },
+          "NumMedia": {
+            "type": "string"
+          },
+          "DateCreated": {
+            "type": "string"
+          },
+          "DateSent": {
+            "type": "string"
+          },
+          "DateUpdated": {
+            "type": "string"
+          },
+          "Direction": {
+            "type": "string"
+          },
+          "Price": {
+            "type": "string"
+          },
+          "PriceUnit": {
+            "type": "string"
+          },
+          "ApiVersion": {
+            "type": "string"
+          },
+          "Uri": {
+            "type": "string"
+          },
+          "ErrorCode": {
+            "type": "string"
+          },
+          "ErrorMessage": {
+            "type": "string"
+          }
         }
       }
     }
@@ -943,5 +1239,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/Accounts.json"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/typeform/definition.json
+++ b/connectors/typeform/definition.json
@@ -15,158 +15,7 @@
     }
   },
   "baseUrl": "https://api.typeform.com",
-  "actions": [
-    {
-      "id": "test_connection",
-      "name": "Test Connection",
-      "description": "Test the connection to Typeform",
-      "parameters": {
-        "type": "object",
-        "properties": {},
-        "required": [],
-        "additionalProperties": false
-      }
-    },
-    {
-      "id": "create_form",
-      "name": "Create Form",
-      "description": "Create a new form",
-      "endpoint": "/forms",
-      "method": "POST",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "Form title"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["form", "quiz"],
-            "default": "form",
-            "description": "Form type"
-          }
-        },
-        "required": ["title"],
-        "additionalProperties": false
-      }
-    },
-    {
-      "id": "get_form",
-      "name": "Get Form",
-      "description": "Get form details",
-      "endpoint": "/forms/{uid}",
-      "method": "GET",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "uid": {
-            "type": "string",
-            "description": "Form UID"
-          }
-        },
-        "required": ["uid"],
-        "additionalProperties": false
-      }
-    },
-    {
-      "id": "list_forms",
-      "name": "List Forms",
-      "description": "List all forms",
-      "endpoint": "/forms",
-      "method": "GET",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "number",
-            "minimum": 1,
-            "default": 1,
-            "description": "Page number"
-          },
-          "page_size": {
-            "type": "number",
-            "minimum": 1,
-            "maximum": 200,
-            "default": 10,
-            "description": "Number of forms per page"
-          },
-          "search": {
-            "type": "string",
-            "description": "Search query"
-          }
-        },
-        "required": [],
-        "additionalProperties": false
-      }
-    },
-    {
-      "id": "get_responses",
-      "name": "Get Responses",
-      "description": "Get responses for a form",
-      "endpoint": "/forms/{uid}/responses",
-      "method": "GET",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "uid": {
-            "type": "string",
-            "description": "Form UID"
-          },
-          "page_size": {
-            "type": "number",
-            "minimum": 1,
-            "maximum": 1000,
-            "default": 25,
-            "description": "Number of responses per page"
-          },
-          "since": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Return responses since this date (ISO 8601)"
-          },
-          "until": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Return responses until this date (ISO 8601)"
-          },
-          "completed": {
-            "type": "boolean",
-            "description": "Filter by completion status"
-          }
-        },
-        "required": ["uid"],
-        "additionalProperties": false
-      }
-    },
-    {
-      "id": "create_webhook",
-      "name": "Create Webhook",
-      "description": "Create a webhook for a form",
-      "endpoint": "/forms/{uid}/webhooks/default",
-      "method": "PUT",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "uid": {
-            "type": "string",
-            "description": "Form UID"
-          },
-          "url": {
-            "type": "string",
-            "description": "Webhook URL"
-          },
-          "enabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Whether the webhook is enabled"
-          }
-        },
-        "required": ["uid", "url"],
-        "additionalProperties": false
-      }
-    }
-  ],
+  "actions": [],
   "triggers": [
     {
       "id": "form_response",
@@ -191,9 +40,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event_id": {"type": "string"},
-          "event_type": {"type": "string"},
-          "form_response": {"type": "object"}
+          "event_id": {
+            "type": "string"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "form_response": {
+            "type": "object"
+          }
         }
       }
     },
@@ -211,14 +66,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "last_updated_at": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "last_updated_at": {
+            "type": "string"
+          }
         }
       }
     }
-  ],
-  "actions": [
   ],
   "actions_append": [
     {
@@ -229,8 +88,18 @@
       "method": "DELETE",
       "parameters": {
         "type": "object",
-        "properties": { "uid": {"type":"string"}, "tag": {"type":"string", "default":"default"} },
-        "required": ["uid"],
+        "properties": {
+          "uid": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string",
+            "default": "default"
+          }
+        },
+        "required": [
+          "uid"
+        ],
         "additionalProperties": false
       }
     }
@@ -238,5 +107,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/victorops/definition.json
+++ b/connectors/victorops/definition.json
@@ -38,7 +38,12 @@
         "properties": {
           "messageType": {
             "type": "string",
-            "enum": ["CRITICAL", "WARNING", "INFO", "RECOVERY"],
+            "enum": [
+              "CRITICAL",
+              "WARNING",
+              "INFO",
+              "RECOVERY"
+            ],
             "description": "Message type"
           },
           "entityId": {
@@ -66,7 +71,10 @@
             "description": "Routing key"
           }
         },
-        "required": ["messageType", "entityId"],
+        "required": [
+          "messageType",
+          "entityId"
+        ],
         "additionalProperties": false
       }
     },
@@ -125,7 +133,9 @@
             "description": "Incident number"
           }
         },
-        "required": ["incidentNumber"],
+        "required": [
+          "incidentNumber"
+        ],
         "additionalProperties": false
       }
     },
@@ -149,7 +159,10 @@
             "description": "Acknowledgment message"
           }
         },
-        "required": ["incidentNumber", "userName"],
+        "required": [
+          "incidentNumber",
+          "userName"
+        ],
         "additionalProperties": false
       }
     },
@@ -173,7 +186,10 @@
             "description": "Resolution message"
           }
         },
-        "required": ["incidentNumber", "userName"],
+        "required": [
+          "incidentNumber",
+          "userName"
+        ],
         "additionalProperties": false
       }
     },
@@ -200,7 +216,9 @@
             "description": "Team slug"
           }
         },
-        "required": ["team"],
+        "required": [
+          "team"
+        ],
         "additionalProperties": false
       }
     },
@@ -225,7 +243,9 @@
             "description": "Time to check on-call status"
           }
         },
-        "required": ["team"],
+        "required": [
+          "team"
+        ],
         "additionalProperties": false
       }
     },
@@ -252,11 +272,17 @@
           },
           "routingKeys": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Routing keys to include"
           }
         },
-        "required": ["name", "startTime", "endTime"],
+        "required": [
+          "name",
+          "startTime",
+          "endTime"
+        ],
         "additionalProperties": false
       }
     },
@@ -283,7 +309,9 @@
             "description": "Username"
           }
         },
-        "required": ["user"],
+        "required": [
+          "user"
+        ],
         "additionalProperties": false
       }
     }
@@ -312,13 +340,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "incidentNumber": {"type": "string"},
-          "entityId": {"type": "string"},
-          "entityDisplayName": {"type": "string"},
-          "messageType": {"type": "string"},
-          "stateMessage": {"type": "string"},
-          "startTime": {"type": "string"},
-          "currentPhase": {"type": "string"}
+          "incidentNumber": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "entityDisplayName": {
+            "type": "string"
+          },
+          "messageType": {
+            "type": "string"
+          },
+          "stateMessage": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "currentPhase": {
+            "type": "string"
+          }
         }
       }
     },
@@ -341,11 +383,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "incidentNumber": {"type": "string"},
-          "entityId": {"type": "string"},
-          "ackUserId": {"type": "string"},
-          "ackTime": {"type": "string"},
-          "message": {"type": "string"}
+          "incidentNumber": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "ackUserId": {
+            "type": "string"
+          },
+          "ackTime": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     },
@@ -368,11 +420,21 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "incidentNumber": {"type": "string"},
-          "entityId": {"type": "string"},
-          "resolveUserId": {"type": "string"},
-          "resolveTime": {"type": "string"},
-          "message": {"type": "string"}
+          "incidentNumber": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "resolveUserId": {
+            "type": "string"
+          },
+          "resolveTime": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     }
@@ -380,5 +442,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/webex/definition.json
+++ b/connectors/webex/definition.json
@@ -13,7 +13,7 @@
       "tokenUrl": "https://webexapis.com/v1/access_token",
       "scopes": [
         "spark:people_read",
-        "spark:rooms_read", 
+        "spark:rooms_read",
         "spark:rooms_write",
         "spark:memberships_read",
         "spark:memberships_write",
@@ -54,7 +54,10 @@
           },
           "type": {
             "type": "string",
-            "enum": ["group", "direct"],
+            "enum": [
+              "group",
+              "direct"
+            ],
             "default": "group",
             "description": "Room type"
           },
@@ -74,7 +77,9 @@
             "description": "Whether room is announcement only"
           }
         },
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "additionalProperties": false
       }
     },
@@ -90,7 +95,9 @@
             "description": "Room ID"
           }
         },
-        "required": ["roomId"],
+        "required": [
+          "roomId"
+        ],
         "additionalProperties": false
       }
     },
@@ -107,12 +114,19 @@
           },
           "type": {
             "type": "string",
-            "enum": ["group", "direct"],
+            "enum": [
+              "group",
+              "direct"
+            ],
             "description": "Filter by room type"
           },
           "sortBy": {
             "type": "string",
-            "enum": ["id", "lastactivity", "created"],
+            "enum": [
+              "id",
+              "lastactivity",
+              "created"
+            ],
             "default": "lastactivity",
             "description": "Sort criteria"
           },
@@ -157,7 +171,9 @@
           },
           "files": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "File URLs to attach"
           },
           "toPersonId": {
@@ -186,7 +202,9 @@
             "description": "Message ID"
           }
         },
-        "required": ["messageId"],
+        "required": [
+          "messageId"
+        ],
         "additionalProperties": false
       }
     },
@@ -226,7 +244,9 @@
             "description": "Maximum number of messages"
           }
         },
-        "required": ["roomId"],
+        "required": [
+          "roomId"
+        ],
         "additionalProperties": false
       }
     },
@@ -309,7 +329,11 @@
           },
           "unlockedMeetingJoinSecurity": {
             "type": "string",
-            "enum": ["allowJoin", "allowJoinWithLobby", "blockFromJoin"],
+            "enum": [
+              "allowJoin",
+              "allowJoinWithLobby",
+              "blockFromJoin"
+            ],
             "description": "Join security for unlocked meetings"
           },
           "sessionTypeId": {
@@ -326,8 +350,13 @@
             "items": {
               "type": "object",
               "properties": {
-                "email": {"type": "string", "format": "email"},
-                "displayName": {"type": "string"}
+                "email": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "displayName": {
+                  "type": "string"
+                }
               }
             },
             "description": "Meeting panelists"
@@ -337,15 +366,26 @@
             "items": {
               "type": "object",
               "properties": {
-                "email": {"type": "string", "format": "email"},
-                "displayName": {"type": "string"},
-                "coHost": {"type": "boolean"}
+                "email": {
+                  "type": "string",
+                  "format": "email"
+                },
+                "displayName": {
+                  "type": "string"
+                },
+                "coHost": {
+                  "type": "boolean"
+                }
               }
             },
             "description": "Meeting invitees"
           }
         },
-        "required": ["title", "start", "end"],
+        "required": [
+          "title",
+          "start",
+          "end"
+        ],
         "additionalProperties": false
       }
     },
@@ -370,7 +410,9 @@
             "description": "Host email filter"
           }
         },
-        "required": ["meetingId"],
+        "required": [
+          "meetingId"
+        ],
         "additionalProperties": false
       }
     },
@@ -395,17 +437,33 @@
           },
           "meetingType": {
             "type": "string",
-            "enum": ["meeting", "webinar", "personalRoomMeeting"],
+            "enum": [
+              "meeting",
+              "webinar",
+              "personalRoomMeeting"
+            ],
             "description": "Meeting type filter"
           },
           "state": {
             "type": "string",
-            "enum": ["active", "scheduled", "ready", "lobby", "inProgress", "ended", "missed"],
+            "enum": [
+              "active",
+              "scheduled",
+              "ready",
+              "lobby",
+              "inProgress",
+              "ended",
+              "missed"
+            ],
             "description": "Meeting state filter"
           },
           "scheduledType": {
             "type": "string",
-            "enum": ["meeting", "webinar", "personalRoomMeeting"],
+            "enum": [
+              "meeting",
+              "webinar",
+              "personalRoomMeeting"
+            ],
             "description": "Scheduled type filter"
           },
           "current": {
@@ -464,15 +522,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "roomId": {"type": "string"},
-          "roomType": {"type": "string"},
-          "text": {"type": "string"},
-          "personId": {"type": "string"},
-          "personEmail": {"type": "string"},
-          "created": {"type": "string"},
-          "mentionedPeople": {"type": "array"},
-          "mentionedGroups": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "roomId": {
+            "type": "string"
+          },
+          "roomType": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "personId": {
+            "type": "string"
+          },
+          "personEmail": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string"
+          },
+          "mentionedPeople": {
+            "type": "array"
+          },
+          "mentionedGroups": {
+            "type": "array"
+          }
         }
       }
     },
@@ -490,13 +566,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "title": {"type": "string"},
-          "type": {"type": "string"},
-          "isLocked": {"type": "boolean"},
-          "teamId": {"type": "string"},
-          "creatorId": {"type": "string"},
-          "created": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "isLocked": {
+            "type": "boolean"
+          },
+          "teamId": {
+            "type": "string"
+          },
+          "creatorId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string"
+          }
         }
       }
     },
@@ -520,13 +610,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "meetingNumber": {"type": "string"},
-          "title": {"type": "string"},
-          "hostUserId": {"type": "string"},
-          "hostEmail": {"type": "string"},
-          "start": {"type": "string"},
-          "end": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "meetingNumber": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "hostUserId": {
+            "type": "string"
+          },
+          "hostEmail": {
+            "type": "string"
+          },
+          "start": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string"
+          }
         }
       }
     }
@@ -534,5 +638,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/people/me"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/webflow/definition.json
+++ b/connectors/webflow/definition.json
@@ -50,7 +50,9 @@
             "description": "Site ID"
           }
         },
-        "required": ["site_id"],
+        "required": [
+          "site_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -66,7 +68,9 @@
             "description": "Site ID"
           }
         },
-        "required": ["site_id"],
+        "required": [
+          "site_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -82,7 +86,9 @@
             "description": "Collection ID"
           }
         },
-        "required": ["collection_id"],
+        "required": [
+          "collection_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -111,7 +117,9 @@
             "description": "Number of items to return"
           }
         },
-        "required": ["collection_id"],
+        "required": [
+          "collection_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -131,7 +139,10 @@
             "description": "Item ID"
           }
         },
-        "required": ["collection_id", "item_id"],
+        "required": [
+          "collection_id",
+          "item_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -156,7 +167,10 @@
             "description": "Whether to publish the item live"
           }
         },
-        "required": ["collection_id", "fields"],
+        "required": [
+          "collection_id",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -185,7 +199,11 @@
             "description": "Whether to publish the changes live"
           }
         },
-        "required": ["collection_id", "item_id", "fields"],
+        "required": [
+          "collection_id",
+          "item_id",
+          "fields"
+        ],
         "additionalProperties": false
       }
     },
@@ -210,7 +228,10 @@
             "description": "Whether to delete from live site"
           }
         },
-        "required": ["collection_id", "item_id"],
+        "required": [
+          "collection_id",
+          "item_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -227,11 +248,15 @@
           },
           "domains": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Domains to publish to"
           }
         },
-        "required": ["site_id"],
+        "required": [
+          "site_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -247,7 +272,9 @@
             "description": "Site ID"
           }
         },
-        "required": ["site_id"],
+        "required": [
+          "site_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -264,7 +291,18 @@
           },
           "triggerType": {
             "type": "string",
-            "enum": ["form_submission", "site_publish", "ecomm_new_order", "ecomm_order_changed", "ecomm_inventory_changed", "membership_user_account_added", "membership_user_account_updated", "collection_item_created", "collection_item_changed", "collection_item_deleted"],
+            "enum": [
+              "form_submission",
+              "site_publish",
+              "ecomm_new_order",
+              "ecomm_order_changed",
+              "ecomm_inventory_changed",
+              "membership_user_account_added",
+              "membership_user_account_updated",
+              "collection_item_created",
+              "collection_item_changed",
+              "collection_item_deleted"
+            ],
             "description": "Webhook trigger type"
           },
           "url": {
@@ -276,7 +314,11 @@
             "description": "Optional filter criteria"
           }
         },
-        "required": ["site_id", "triggerType", "url"],
+        "required": [
+          "site_id",
+          "triggerType",
+          "url"
+        ],
         "additionalProperties": false
       }
     },
@@ -296,7 +338,10 @@
             "description": "Webhook ID"
           }
         },
-        "required": ["site_id", "webhook_id"],
+        "required": [
+          "site_id",
+          "webhook_id"
+        ],
         "additionalProperties": false
       }
     }
@@ -325,12 +370,24 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "_id": {"type": "string"},
-          "name": {"type": "string"},
-          "email": {"type": "string"},
-          "data": {"type": "object"},
-          "d": {"type": "string"},
-          "site": {"type": "string"}
+          "_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
+          },
+          "d": {
+            "type": "string"
+          },
+          "site": {
+            "type": "string"
+          }
         }
       }
     },
@@ -357,15 +414,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "_cid": {"type": "string"},
-          "_id": {"type": "string"},
-          "name": {"type": "string"},
-          "slug": {"type": "string"},
-          "_archived": {"type": "boolean"},
-          "_draft": {"type": "boolean"},
-          "created-on": {"type": "string"},
-          "updated-on": {"type": "string"},
-          "published-on": {"type": "string"}
+          "_cid": {
+            "type": "string"
+          },
+          "_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "_archived": {
+            "type": "boolean"
+          },
+          "_draft": {
+            "type": "boolean"
+          },
+          "created-on": {
+            "type": "string"
+          },
+          "updated-on": {
+            "type": "string"
+          },
+          "published-on": {
+            "type": "string"
+          }
         }
       }
     },
@@ -392,15 +467,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "_cid": {"type": "string"},
-          "_id": {"type": "string"},
-          "name": {"type": "string"},
-          "slug": {"type": "string"},
-          "_archived": {"type": "boolean"},
-          "_draft": {"type": "boolean"},
-          "created-on": {"type": "string"},
-          "updated-on": {"type": "string"},
-          "published-on": {"type": "string"}
+          "_cid": {
+            "type": "string"
+          },
+          "_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "_archived": {
+            "type": "boolean"
+          },
+          "_draft": {
+            "type": "boolean"
+          },
+          "created-on": {
+            "type": "string"
+          },
+          "updated-on": {
+            "type": "string"
+          },
+          "published-on": {
+            "type": "string"
+          }
         }
       }
     },
@@ -423,9 +516,15 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "site": {"type": "string"},
-          "publishTime": {"type": "string"},
-          "domains": {"type": "array"}
+          "site": {
+            "type": "string"
+          },
+          "publishTime": {
+            "type": "string"
+          },
+          "domains": {
+            "type": "array"
+          }
         }
       }
     }
@@ -433,5 +532,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/sites"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/woocommerce/definition.json
+++ b/connectors/woocommerce/definition.json
@@ -40,13 +40,23 @@
           },
           "type": {
             "type": "string",
-            "enum": ["simple", "grouped", "external", "variable"],
+            "enum": [
+              "simple",
+              "grouped",
+              "external",
+              "variable"
+            ],
             "default": "simple",
             "description": "Product type"
           },
           "status": {
             "type": "string",
-            "enum": ["draft", "pending", "private", "publish"],
+            "enum": [
+              "draft",
+              "pending",
+              "private",
+              "publish"
+            ],
             "default": "publish",
             "description": "Product status"
           },
@@ -57,7 +67,12 @@
           },
           "catalog_visibility": {
             "type": "string",
-            "enum": ["visible", "catalog", "search", "hidden"],
+            "enum": [
+              "visible",
+              "catalog",
+              "search",
+              "hidden"
+            ],
             "default": "visible",
             "description": "Catalog visibility"
           },
@@ -96,7 +111,11 @@
           },
           "stock_status": {
             "type": "string",
-            "enum": ["instock", "outofstock", "onbackorder"],
+            "enum": [
+              "instock",
+              "outofstock",
+              "onbackorder"
+            ],
             "default": "instock",
             "description": "Stock status"
           },
@@ -107,9 +126,15 @@
           "dimensions": {
             "type": "object",
             "properties": {
-              "length": {"type": "string"},
-              "width": {"type": "string"},
-              "height": {"type": "string"}
+              "length": {
+                "type": "string"
+              },
+              "width": {
+                "type": "string"
+              },
+              "height": {
+                "type": "string"
+              }
             },
             "description": "Product dimensions"
           },
@@ -118,7 +143,9 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "number"}
+                "id": {
+                  "type": "number"
+                }
               }
             },
             "description": "Product categories"
@@ -128,7 +155,9 @@
             "items": {
               "type": "object",
               "properties": {
-                "id": {"type": "number"}
+                "id": {
+                  "type": "number"
+                }
               }
             },
             "description": "Product tags"
@@ -138,14 +167,20 @@
             "items": {
               "type": "object",
               "properties": {
-                "src": {"type": "string"},
-                "alt": {"type": "string"}
+                "src": {
+                  "type": "string"
+                },
+                "alt": {
+                  "type": "string"
+                }
               }
             },
             "description": "Product images"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -161,7 +196,9 @@
             "description": "Product ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -182,7 +219,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["draft", "pending", "private", "publish"],
+            "enum": [
+              "draft",
+              "pending",
+              "private",
+              "publish"
+            ],
             "description": "Product status"
           },
           "price": {
@@ -194,7 +236,9 @@
             "description": "Stock quantity"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -207,7 +251,10 @@
         "properties": {
           "context": {
             "type": "string",
-            "enum": ["view", "edit"],
+            "enum": [
+              "view",
+              "edit"
+            ],
             "default": "view",
             "description": "Request context"
           },
@@ -240,22 +287,30 @@
           },
           "include": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Product IDs to include"
           },
           "exclude": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Product IDs to exclude"
           },
           "parent": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Parent product IDs"
           },
           "parent_exclude": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+              "type": "number"
+            },
             "description": "Parent product IDs to exclude"
           },
           "slug": {
@@ -264,13 +319,24 @@
           },
           "status": {
             "type": "string",
-            "enum": ["any", "draft", "pending", "private", "publish"],
+            "enum": [
+              "any",
+              "draft",
+              "pending",
+              "private",
+              "publish"
+            ],
             "default": "any",
             "description": "Product status"
           },
           "type": {
             "type": "string",
-            "enum": ["simple", "grouped", "external", "variable"],
+            "enum": [
+              "simple",
+              "grouped",
+              "external",
+              "variable"
+            ],
             "description": "Product type"
           },
           "sku": {
@@ -315,18 +381,35 @@
           },
           "stock_status": {
             "type": "string",
-            "enum": ["instock", "outofstock", "onbackorder"],
+            "enum": [
+              "instock",
+              "outofstock",
+              "onbackorder"
+            ],
             "description": "Stock status"
           },
           "orderby": {
             "type": "string",
-            "enum": ["date", "id", "include", "title", "slug", "price", "popularity", "rating", "menu_order"],
+            "enum": [
+              "date",
+              "id",
+              "include",
+              "title",
+              "slug",
+              "price",
+              "popularity",
+              "rating",
+              "menu_order"
+            ],
             "default": "date",
             "description": "Sort field"
           },
           "order": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "default": "desc",
             "description": "Sort order"
           }
@@ -358,32 +441,73 @@
           "billing": {
             "type": "object",
             "properties": {
-              "first_name": {"type": "string"},
-              "last_name": {"type": "string"},
-              "company": {"type": "string"},
-              "address_1": {"type": "string"},
-              "address_2": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "postcode": {"type": "string"},
-              "country": {"type": "string"},
-              "email": {"type": "string", "format": "email"},
-              "phone": {"type": "string"}
+              "first_name": {
+                "type": "string"
+              },
+              "last_name": {
+                "type": "string"
+              },
+              "company": {
+                "type": "string"
+              },
+              "address_1": {
+                "type": "string"
+              },
+              "address_2": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "postcode": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "phone": {
+                "type": "string"
+              }
             },
             "description": "Billing address"
           },
           "shipping": {
             "type": "object",
             "properties": {
-              "first_name": {"type": "string"},
-              "last_name": {"type": "string"},
-              "company": {"type": "string"},
-              "address_1": {"type": "string"},
-              "address_2": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "postcode": {"type": "string"},
-              "country": {"type": "string"}
+              "first_name": {
+                "type": "string"
+              },
+              "last_name": {
+                "type": "string"
+              },
+              "company": {
+                "type": "string"
+              },
+              "address_1": {
+                "type": "string"
+              },
+              "address_2": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "postcode": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              }
             },
             "description": "Shipping address"
           },
@@ -392,14 +516,30 @@
             "items": {
               "type": "object",
               "properties": {
-                "product_id": {"type": "number"},
-                "variation_id": {"type": "number"},
-                "quantity": {"type": "number", "minimum": 1},
-                "name": {"type": "string"},
-                "sku": {"type": "string"},
-                "price": {"type": "string"}
+                "product_id": {
+                  "type": "number"
+                },
+                "variation_id": {
+                  "type": "number"
+                },
+                "quantity": {
+                  "type": "number",
+                  "minimum": 1
+                },
+                "name": {
+                  "type": "string"
+                },
+                "sku": {
+                  "type": "string"
+                },
+                "price": {
+                  "type": "string"
+                }
               },
-              "required": ["product_id", "quantity"]
+              "required": [
+                "product_id",
+                "quantity"
+              ]
             },
             "description": "Order line items"
           },
@@ -408,9 +548,15 @@
             "items": {
               "type": "object",
               "properties": {
-                "method_id": {"type": "string"},
-                "method_title": {"type": "string"},
-                "total": {"type": "string"}
+                "method_id": {
+                  "type": "string"
+                },
+                "method_title": {
+                  "type": "string"
+                },
+                "total": {
+                  "type": "string"
+                }
               }
             },
             "description": "Shipping lines"
@@ -420,8 +566,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": {"type": "string"},
-                "total": {"type": "string"}
+                "name": {
+                  "type": "string"
+                },
+                "total": {
+                  "type": "string"
+                }
               }
             },
             "description": "Fee lines"
@@ -431,14 +581,25 @@
             "items": {
               "type": "object",
               "properties": {
-                "code": {"type": "string"}
+                "code": {
+                  "type": "string"
+                }
               }
             },
             "description": "Coupon lines"
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "processing", "on-hold", "completed", "cancelled", "refunded", "failed", "trash"],
+            "enum": [
+              "pending",
+              "processing",
+              "on-hold",
+              "completed",
+              "cancelled",
+              "refunded",
+              "failed",
+              "trash"
+            ],
             "default": "pending",
             "description": "Order status"
           },
@@ -459,8 +620,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "key": {"type": "string"},
-                "value": {"type": "string"}
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
               }
             },
             "description": "Meta data"
@@ -482,7 +647,9 @@
             "description": "Order ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -499,7 +666,16 @@
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "processing", "on-hold", "completed", "cancelled", "refunded", "failed", "trash"],
+            "enum": [
+              "pending",
+              "processing",
+              "on-hold",
+              "completed",
+              "cancelled",
+              "refunded",
+              "failed",
+              "trash"
+            ],
             "description": "Order status"
           },
           "customer_note": {
@@ -507,7 +683,9 @@
             "description": "Customer note"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     }
@@ -523,7 +701,15 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["pending", "processing", "on-hold", "completed", "cancelled", "refunded", "failed"],
+            "enum": [
+              "pending",
+              "processing",
+              "on-hold",
+              "completed",
+              "cancelled",
+              "refunded",
+              "failed"
+            ],
             "description": "Filter by order status"
           }
         },
@@ -533,40 +719,108 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "parent_id": {"type": "number"},
-          "status": {"type": "string"},
-          "currency": {"type": "string"},
-          "date_created": {"type": "string"},
-          "date_modified": {"type": "string"},
-          "discount_total": {"type": "string"},
-          "discount_tax": {"type": "string"},
-          "shipping_total": {"type": "string"},
-          "shipping_tax": {"type": "string"},
-          "cart_tax": {"type": "string"},
-          "total": {"type": "string"},
-          "total_tax": {"type": "string"},
-          "prices_include_tax": {"type": "boolean"},
-          "customer_id": {"type": "number"},
-          "customer_ip_address": {"type": "string"},
-          "customer_user_agent": {"type": "string"},
-          "customer_note": {"type": "string"},
-          "billing": {"type": "object"},
-          "shipping": {"type": "object"},
-          "payment_method": {"type": "string"},
-          "payment_method_title": {"type": "string"},
-          "transaction_id": {"type": "string"},
-          "date_paid": {"type": "string"},
-          "date_completed": {"type": "string"},
-          "cart_hash": {"type": "string"},
-          "number": {"type": "string"},
-          "meta_data": {"type": "array"},
-          "line_items": {"type": "array"},
-          "tax_lines": {"type": "array"},
-          "shipping_lines": {"type": "array"},
-          "fee_lines": {"type": "array"},
-          "coupon_lines": {"type": "array"},
-          "refunds": {"type": "array"}
+          "id": {
+            "type": "number"
+          },
+          "parent_id": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "date_created": {
+            "type": "string"
+          },
+          "date_modified": {
+            "type": "string"
+          },
+          "discount_total": {
+            "type": "string"
+          },
+          "discount_tax": {
+            "type": "string"
+          },
+          "shipping_total": {
+            "type": "string"
+          },
+          "shipping_tax": {
+            "type": "string"
+          },
+          "cart_tax": {
+            "type": "string"
+          },
+          "total": {
+            "type": "string"
+          },
+          "total_tax": {
+            "type": "string"
+          },
+          "prices_include_tax": {
+            "type": "boolean"
+          },
+          "customer_id": {
+            "type": "number"
+          },
+          "customer_ip_address": {
+            "type": "string"
+          },
+          "customer_user_agent": {
+            "type": "string"
+          },
+          "customer_note": {
+            "type": "string"
+          },
+          "billing": {
+            "type": "object"
+          },
+          "shipping": {
+            "type": "object"
+          },
+          "payment_method": {
+            "type": "string"
+          },
+          "payment_method_title": {
+            "type": "string"
+          },
+          "transaction_id": {
+            "type": "string"
+          },
+          "date_paid": {
+            "type": "string"
+          },
+          "date_completed": {
+            "type": "string"
+          },
+          "cart_hash": {
+            "type": "string"
+          },
+          "number": {
+            "type": "string"
+          },
+          "meta_data": {
+            "type": "array"
+          },
+          "line_items": {
+            "type": "array"
+          },
+          "tax_lines": {
+            "type": "array"
+          },
+          "shipping_lines": {
+            "type": "array"
+          },
+          "fee_lines": {
+            "type": "array"
+          },
+          "coupon_lines": {
+            "type": "array"
+          },
+          "refunds": {
+            "type": "array"
+          }
         }
       }
     },
@@ -580,7 +834,12 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["simple", "grouped", "external", "variable"],
+            "enum": [
+              "simple",
+              "grouped",
+              "external",
+              "variable"
+            ],
             "description": "Filter by product type"
           }
         },
@@ -590,66 +849,186 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "number"},
-          "name": {"type": "string"},
-          "slug": {"type": "string"},
-          "permalink": {"type": "string"},
-          "date_created": {"type": "string"},
-          "date_modified": {"type": "string"},
-          "type": {"type": "string"},
-          "status": {"type": "string"},
-          "featured": {"type": "boolean"},
-          "catalog_visibility": {"type": "string"},
-          "description": {"type": "string"},
-          "short_description": {"type": "string"},
-          "sku": {"type": "string"},
-          "price": {"type": "string"},
-          "regular_price": {"type": "string"},
-          "sale_price": {"type": "string"},
-          "date_on_sale_from": {"type": "string"},
-          "date_on_sale_to": {"type": "string"},
-          "price_html": {"type": "string"},
-          "on_sale": {"type": "boolean"},
-          "purchasable": {"type": "boolean"},
-          "total_sales": {"type": "number"},
-          "virtual": {"type": "boolean"},
-          "downloadable": {"type": "boolean"},
-          "download_limit": {"type": "number"},
-          "download_expiry": {"type": "number"},
-          "external_url": {"type": "string"},
-          "button_text": {"type": "string"},
-          "tax_status": {"type": "string"},
-          "tax_class": {"type": "string"},
-          "manage_stock": {"type": "boolean"},
-          "stock_quantity": {"type": "number"},
-          "stock_status": {"type": "string"},
-          "backorders": {"type": "string"},
-          "backorders_allowed": {"type": "boolean"},
-          "backordered": {"type": "boolean"},
-          "sold_individually": {"type": "boolean"},
-          "weight": {"type": "string"},
-          "dimensions": {"type": "object"},
-          "shipping_required": {"type": "boolean"},
-          "shipping_taxable": {"type": "boolean"},
-          "shipping_class": {"type": "string"},
-          "shipping_class_id": {"type": "number"},
-          "reviews_allowed": {"type": "boolean"},
-          "average_rating": {"type": "string"},
-          "rating_count": {"type": "number"},
-          "related_ids": {"type": "array"},
-          "upsell_ids": {"type": "array"},
-          "cross_sell_ids": {"type": "array"},
-          "parent_id": {"type": "number"},
-          "purchase_note": {"type": "string"},
-          "categories": {"type": "array"},
-          "tags": {"type": "array"},
-          "images": {"type": "array"},
-          "attributes": {"type": "array"},
-          "default_attributes": {"type": "array"},
-          "variations": {"type": "array"},
-          "grouped_products": {"type": "array"},
-          "menu_order": {"type": "number"},
-          "meta_data": {"type": "array"}
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "permalink": {
+            "type": "string"
+          },
+          "date_created": {
+            "type": "string"
+          },
+          "date_modified": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "featured": {
+            "type": "boolean"
+          },
+          "catalog_visibility": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "short_description": {
+            "type": "string"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "price": {
+            "type": "string"
+          },
+          "regular_price": {
+            "type": "string"
+          },
+          "sale_price": {
+            "type": "string"
+          },
+          "date_on_sale_from": {
+            "type": "string"
+          },
+          "date_on_sale_to": {
+            "type": "string"
+          },
+          "price_html": {
+            "type": "string"
+          },
+          "on_sale": {
+            "type": "boolean"
+          },
+          "purchasable": {
+            "type": "boolean"
+          },
+          "total_sales": {
+            "type": "number"
+          },
+          "virtual": {
+            "type": "boolean"
+          },
+          "downloadable": {
+            "type": "boolean"
+          },
+          "download_limit": {
+            "type": "number"
+          },
+          "download_expiry": {
+            "type": "number"
+          },
+          "external_url": {
+            "type": "string"
+          },
+          "button_text": {
+            "type": "string"
+          },
+          "tax_status": {
+            "type": "string"
+          },
+          "tax_class": {
+            "type": "string"
+          },
+          "manage_stock": {
+            "type": "boolean"
+          },
+          "stock_quantity": {
+            "type": "number"
+          },
+          "stock_status": {
+            "type": "string"
+          },
+          "backorders": {
+            "type": "string"
+          },
+          "backorders_allowed": {
+            "type": "boolean"
+          },
+          "backordered": {
+            "type": "boolean"
+          },
+          "sold_individually": {
+            "type": "boolean"
+          },
+          "weight": {
+            "type": "string"
+          },
+          "dimensions": {
+            "type": "object"
+          },
+          "shipping_required": {
+            "type": "boolean"
+          },
+          "shipping_taxable": {
+            "type": "boolean"
+          },
+          "shipping_class": {
+            "type": "string"
+          },
+          "shipping_class_id": {
+            "type": "number"
+          },
+          "reviews_allowed": {
+            "type": "boolean"
+          },
+          "average_rating": {
+            "type": "string"
+          },
+          "rating_count": {
+            "type": "number"
+          },
+          "related_ids": {
+            "type": "array"
+          },
+          "upsell_ids": {
+            "type": "array"
+          },
+          "cross_sell_ids": {
+            "type": "array"
+          },
+          "parent_id": {
+            "type": "number"
+          },
+          "purchase_note": {
+            "type": "string"
+          },
+          "categories": {
+            "type": "array"
+          },
+          "tags": {
+            "type": "array"
+          },
+          "images": {
+            "type": "array"
+          },
+          "attributes": {
+            "type": "array"
+          },
+          "default_attributes": {
+            "type": "array"
+          },
+          "variations": {
+            "type": "array"
+          },
+          "grouped_products": {
+            "type": "array"
+          },
+          "menu_order": {
+            "type": "number"
+          },
+          "meta_data": {
+            "type": "array"
+          }
         }
       }
     }
@@ -657,5 +1036,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/system_status"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/workday/definition.json
+++ b/connectors/workday/definition.json
@@ -11,7 +11,12 @@
     "config": {
       "authUrl": "https://wd5-impl-services1.workday.com/ccx/oauth2/authorize",
       "tokenUrl": "https://wd5-impl-services1.workday.com/ccx/oauth2/token",
-      "scopes": ["staffing", "compensation", "time_tracking", "benefits"]
+      "scopes": [
+        "staffing",
+        "compensation",
+        "time_tracking",
+        "benefits"
+      ]
     }
   },
   "baseUrl": "https://wd5-impl-services1.workday.com/ccx/api/v1",
@@ -39,7 +44,9 @@
             "description": "Worker ID"
           }
         },
-        "required": ["workerId"],
+        "required": [
+          "workerId"
+        ],
         "additionalProperties": false
       }
     },
@@ -102,38 +109,108 @@
           "personalData": {
             "type": "object",
             "properties": {
-              "firstName": {"type": "string"},
-              "lastName": {"type": "string"},
-              "middleName": {"type": "string"},
-              "preferredName": {"type": "string"},
-              "email": {"type": "string", "format": "email"},
-              "phone": {"type": "string"},
-              "dateOfBirth": {"type": "string", "format": "date"},
-              "gender": {"type": "string", "enum": ["Male", "Female", "Other", "Prefer not to say"]},
-              "maritalStatus": {"type": "string", "enum": ["Single", "Married", "Divorced", "Widowed", "Other"]}
+              "firstName": {
+                "type": "string"
+              },
+              "lastName": {
+                "type": "string"
+              },
+              "middleName": {
+                "type": "string"
+              },
+              "preferredName": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "dateOfBirth": {
+                "type": "string",
+                "format": "date"
+              },
+              "gender": {
+                "type": "string",
+                "enum": [
+                  "Male",
+                  "Female",
+                  "Other",
+                  "Prefer not to say"
+                ]
+              },
+              "maritalStatus": {
+                "type": "string",
+                "enum": [
+                  "Single",
+                  "Married",
+                  "Divorced",
+                  "Widowed",
+                  "Other"
+                ]
+              }
             },
             "description": "Personal information"
           },
           "jobData": {
             "type": "object",
             "properties": {
-              "jobTitle": {"type": "string"},
-              "department": {"type": "string"},
-              "location": {"type": "string"},
-              "managerId": {"type": "string"},
-              "startDate": {"type": "string", "format": "date"},
-              "employmentType": {"type": "string", "enum": ["Full-time", "Part-time", "Contract", "Temporary"]},
-              "jobLevel": {"type": "string"}
+              "jobTitle": {
+                "type": "string"
+              },
+              "department": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              },
+              "managerId": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string",
+                "format": "date"
+              },
+              "employmentType": {
+                "type": "string",
+                "enum": [
+                  "Full-time",
+                  "Part-time",
+                  "Contract",
+                  "Temporary"
+                ]
+              },
+              "jobLevel": {
+                "type": "string"
+              }
             },
             "description": "Job-related information"
           },
           "compensationData": {
             "type": "object",
             "properties": {
-              "baseSalary": {"type": "number", "minimum": 0},
-              "currency": {"type": "string", "default": "USD"},
-              "payFrequency": {"type": "string", "enum": ["Weekly", "Bi-weekly", "Monthly", "Annual"]},
-              "payGroup": {"type": "string"}
+              "baseSalary": {
+                "type": "number",
+                "minimum": 0
+              },
+              "currency": {
+                "type": "string",
+                "default": "USD"
+              },
+              "payFrequency": {
+                "type": "string",
+                "enum": [
+                  "Weekly",
+                  "Bi-weekly",
+                  "Monthly",
+                  "Annual"
+                ]
+              },
+              "payGroup": {
+                "type": "string"
+              }
             },
             "description": "Compensation information"
           },
@@ -142,7 +219,10 @@
             "description": "Optional worker ID (if not provided, will be auto-generated)"
           }
         },
-        "required": ["personalData", "jobData"],
+        "required": [
+          "personalData",
+          "jobData"
+        ],
         "additionalProperties": false
       }
     },
@@ -160,37 +240,103 @@
           "personalData": {
             "type": "object",
             "properties": {
-              "firstName": {"type": "string"},
-              "lastName": {"type": "string"},
-              "middleName": {"type": "string"},
-              "preferredName": {"type": "string"},
-              "email": {"type": "string", "format": "email"},
-              "phone": {"type": "string"},
-              "dateOfBirth": {"type": "string", "format": "date"},
-              "gender": {"type": "string", "enum": ["Male", "Female", "Other", "Prefer not to say"]},
-              "maritalStatus": {"type": "string", "enum": ["Single", "Married", "Divorced", "Widowed", "Other"]}
+              "firstName": {
+                "type": "string"
+              },
+              "lastName": {
+                "type": "string"
+              },
+              "middleName": {
+                "type": "string"
+              },
+              "preferredName": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "dateOfBirth": {
+                "type": "string",
+                "format": "date"
+              },
+              "gender": {
+                "type": "string",
+                "enum": [
+                  "Male",
+                  "Female",
+                  "Other",
+                  "Prefer not to say"
+                ]
+              },
+              "maritalStatus": {
+                "type": "string",
+                "enum": [
+                  "Single",
+                  "Married",
+                  "Divorced",
+                  "Widowed",
+                  "Other"
+                ]
+              }
             },
             "description": "Personal information to update"
           },
           "jobData": {
             "type": "object",
             "properties": {
-              "jobTitle": {"type": "string"},
-              "department": {"type": "string"},
-              "location": {"type": "string"},
-              "managerId": {"type": "string"},
-              "employmentType": {"type": "string", "enum": ["Full-time", "Part-time", "Contract", "Temporary"]},
-              "jobLevel": {"type": "string"}
+              "jobTitle": {
+                "type": "string"
+              },
+              "department": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              },
+              "managerId": {
+                "type": "string"
+              },
+              "employmentType": {
+                "type": "string",
+                "enum": [
+                  "Full-time",
+                  "Part-time",
+                  "Contract",
+                  "Temporary"
+                ]
+              },
+              "jobLevel": {
+                "type": "string"
+              }
             },
             "description": "Job-related information to update"
           },
           "compensationData": {
             "type": "object",
             "properties": {
-              "baseSalary": {"type": "number", "minimum": 0},
-              "currency": {"type": "string"},
-              "payFrequency": {"type": "string", "enum": ["Weekly", "Bi-weekly", "Monthly", "Annual"]},
-              "payGroup": {"type": "string"}
+              "baseSalary": {
+                "type": "number",
+                "minimum": 0
+              },
+              "currency": {
+                "type": "string"
+              },
+              "payFrequency": {
+                "type": "string",
+                "enum": [
+                  "Weekly",
+                  "Bi-weekly",
+                  "Monthly",
+                  "Annual"
+                ]
+              },
+              "payGroup": {
+                "type": "string"
+              }
             },
             "description": "Compensation information to update"
           },
@@ -200,7 +346,9 @@
             "description": "Effective date for the changes"
           }
         },
-        "required": ["workerId"],
+        "required": [
+          "workerId"
+        ],
         "additionalProperties": false
       }
     },
@@ -222,7 +370,13 @@
           },
           "terminationReason": {
             "type": "string",
-            "enum": ["Voluntary", "Involuntary", "Retirement", "End of Contract", "Other"],
+            "enum": [
+              "Voluntary",
+              "Involuntary",
+              "Retirement",
+              "End of Contract",
+              "Other"
+            ],
             "description": "Reason for termination"
           },
           "lastDayWorked": {
@@ -240,7 +394,11 @@
             "description": "Additional notes"
           }
         },
-        "required": ["workerId", "terminationDate", "terminationReason"],
+        "required": [
+          "workerId",
+          "terminationDate",
+          "terminationReason"
+        ],
         "additionalProperties": false
       }
     },
@@ -256,7 +414,9 @@
             "description": "Time off request ID"
           }
         },
-        "required": ["requestId"],
+        "required": [
+          "requestId"
+        ],
         "additionalProperties": false
       }
     },
@@ -273,7 +433,15 @@
           },
           "timeOffType": {
             "type": "string",
-            "enum": ["Vacation", "Sick", "Personal", "Bereavement", "Jury Duty", "Military", "Other"],
+            "enum": [
+              "Vacation",
+              "Sick",
+              "Personal",
+              "Bereavement",
+              "Jury Duty",
+              "Military",
+              "Other"
+            ],
             "description": "Type of time off"
           },
           "startDate": {
@@ -306,7 +474,12 @@
             "description": "Additional comments"
           }
         },
-        "required": ["workerId", "timeOffType", "startDate", "endDate"],
+        "required": [
+          "workerId",
+          "timeOffType",
+          "startDate",
+          "endDate"
+        ],
         "additionalProperties": false
       }
     },
@@ -330,7 +503,10 @@
             "description": "Approval comments"
           }
         },
-        "required": ["requestId", "approverId"],
+        "required": [
+          "requestId",
+          "approverId"
+        ],
         "additionalProperties": false
       }
     },
@@ -354,7 +530,11 @@
             "description": "Reason for denial"
           }
         },
-        "required": ["requestId", "approverId", "reason"],
+        "required": [
+          "requestId",
+          "approverId",
+          "reason"
+        ],
         "additionalProperties": false
       }
     },
@@ -401,7 +581,9 @@
             "description": "As of date for historical data"
           }
         },
-        "required": ["workerId"],
+        "required": [
+          "workerId"
+        ],
         "additionalProperties": false
       }
     },
@@ -432,7 +614,13 @@
           },
           "reason": {
             "type": "string",
-            "enum": ["Merit Increase", "Promotion", "Market Adjustment", "Cost of Living", "Other"],
+            "enum": [
+              "Merit Increase",
+              "Promotion",
+              "Market Adjustment",
+              "Cost of Living",
+              "Other"
+            ],
             "description": "Reason for compensation change"
           },
           "notes": {
@@ -440,7 +628,12 @@
             "description": "Additional notes"
           }
         },
-        "required": ["workerId", "baseSalary", "effectiveDate", "reason"],
+        "required": [
+          "workerId",
+          "baseSalary",
+          "effectiveDate",
+          "reason"
+        ],
         "additionalProperties": false
       }
     }
@@ -469,14 +662,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "workerId": {"type": "string"},
-          "firstName": {"type": "string"},
-          "lastName": {"type": "string"},
-          "email": {"type": "string"},
-          "jobTitle": {"type": "string"},
-          "department": {"type": "string"},
-          "startDate": {"type": "string"},
-          "managerId": {"type": "string"}
+          "workerId": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "jobTitle": {
+            "type": "string"
+          },
+          "department": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "managerId": {
+            "type": "string"
+          }
         }
       }
     },
@@ -503,13 +712,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "workerId": {"type": "string"},
-          "firstName": {"type": "string"},
-          "lastName": {"type": "string"},
-          "email": {"type": "string"},
-          "terminationDate": {"type": "string"},
-          "terminationReason": {"type": "string"},
-          "lastDayWorked": {"type": "string"}
+          "workerId": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "terminationDate": {
+            "type": "string"
+          },
+          "terminationReason": {
+            "type": "string"
+          },
+          "lastDayWorked": {
+            "type": "string"
+          }
         }
       }
     },
@@ -536,14 +759,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "requestId": {"type": "string"},
-          "workerId": {"type": "string"},
-          "workerName": {"type": "string"},
-          "timeOffType": {"type": "string"},
-          "startDate": {"type": "string"},
-          "endDate": {"type": "string"},
-          "status": {"type": "string"},
-          "requestDate": {"type": "string"}
+          "requestId": {
+            "type": "string"
+          },
+          "workerId": {
+            "type": "string"
+          },
+          "workerName": {
+            "type": "string"
+          },
+          "timeOffType": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string"
+          },
+          "endDate": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "requestDate": {
+            "type": "string"
+          }
         }
       }
     },
@@ -570,13 +809,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "workerId": {"type": "string"},
-          "workerName": {"type": "string"},
-          "previousSalary": {"type": "number"},
-          "newSalary": {"type": "number"},
-          "effectiveDate": {"type": "string"},
-          "reason": {"type": "string"},
-          "department": {"type": "string"}
+          "workerId": {
+            "type": "string"
+          },
+          "workerName": {
+            "type": "string"
+          },
+          "previousSalary": {
+            "type": "number"
+          },
+          "newSalary": {
+            "type": "number"
+          },
+          "effectiveDate": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "department": {
+            "type": "string"
+          }
         }
       }
     }
@@ -584,5 +837,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/workers"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/workfront/definition.json
+++ b/connectors/workfront/definition.json
@@ -79,7 +79,14 @@
           },
           "status": {
             "type": "string",
-            "enum": ["PLN", "CUR", "CPL", "DAD", "REJ", "IDA"],
+            "enum": [
+              "PLN",
+              "CUR",
+              "CPL",
+              "DAD",
+              "REJ",
+              "IDA"
+            ],
             "description": "Project status"
           },
           "portfolioID": {
@@ -101,7 +108,9 @@
             "description": "Budgeted hours"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -118,11 +127,15 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to include in response"
           }
         },
-        "required": ["projectID"],
+        "required": [
+          "projectID"
+        ],
         "additionalProperties": false
       }
     },
@@ -151,7 +164,14 @@
           },
           "status": {
             "type": "string",
-            "enum": ["PLN", "CUR", "CPL", "DAD", "REJ", "IDA"],
+            "enum": [
+              "PLN",
+              "CUR",
+              "CPL",
+              "DAD",
+              "REJ",
+              "IDA"
+            ],
             "description": "Project status"
           },
           "priority": {
@@ -177,7 +197,9 @@
             "description": "Percent complete"
           }
         },
-        "required": ["projectID"],
+        "required": [
+          "projectID"
+        ],
         "additionalProperties": false
       }
     },
@@ -198,7 +220,9 @@
           },
           "status": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Filter by status"
           },
           "groupID": {
@@ -224,7 +248,9 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to include in response"
           }
         },
@@ -282,7 +308,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["NEW", "INP", "CPL"],
+            "enum": [
+              "NEW",
+              "INP",
+              "CPL"
+            ],
             "description": "Task status"
           },
           "percentComplete": {
@@ -293,11 +323,16 @@
           },
           "predecessors": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Predecessor task IDs"
           }
         },
-        "required": ["name", "projectID"],
+        "required": [
+          "name",
+          "projectID"
+        ],
         "additionalProperties": false
       }
     },
@@ -314,11 +349,15 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to include in response"
           }
         },
-        "required": ["taskID"],
+        "required": [
+          "taskID"
+        ],
         "additionalProperties": false
       }
     },
@@ -347,7 +386,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["NEW", "INP", "CPL"],
+            "enum": [
+              "NEW",
+              "INP",
+              "CPL"
+            ],
             "description": "Task status"
           },
           "priority": {
@@ -383,7 +426,9 @@
             "description": "Actual completion date"
           }
         },
-        "required": ["taskID"],
+        "required": [
+          "taskID"
+        ],
         "additionalProperties": false
       }
     },
@@ -428,12 +473,22 @@
           },
           "status": {
             "type": "string",
-            "enum": ["NEW", "INP", "CLS", "REO"],
+            "enum": [
+              "NEW",
+              "INP",
+              "CLS",
+              "REO"
+            ],
             "description": "Issue status"
           },
           "resolutionType": {
             "type": "string",
-            "enum": ["FIXED", "WONTFIX", "DUPLICATE", "CANNOT_REPRODUCE"],
+            "enum": [
+              "FIXED",
+              "WONTFIX",
+              "DUPLICATE",
+              "CANNOT_REPRODUCE"
+            ],
             "description": "Resolution type"
           },
           "plannedCompletionDate": {
@@ -442,7 +497,10 @@
             "description": "Planned completion date"
           }
         },
-        "required": ["name", "projectID"],
+        "required": [
+          "name",
+          "projectID"
+        ],
         "additionalProperties": false
       }
     },
@@ -476,7 +534,11 @@
             "description": "Timesheet profile ID"
           }
         },
-        "required": ["userID", "startDate", "endDate"],
+        "required": [
+          "userID",
+          "startDate",
+          "endDate"
+        ],
         "additionalProperties": false
       }
     },
@@ -518,7 +580,10 @@
             "description": "Hour type ID"
           }
         },
-        "required": ["hours", "entryDate"],
+        "required": [
+          "hours",
+          "entryDate"
+        ],
         "additionalProperties": false
       }
     },
@@ -550,7 +615,9 @@
           },
           "fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to include in response"
           }
         },
@@ -575,7 +642,13 @@
           },
           "docObjCode": {
             "type": "string",
-            "enum": ["PROJ", "TASK", "OPTASK", "USER", "COMP"],
+            "enum": [
+              "PROJ",
+              "TASK",
+              "OPTASK",
+              "USER",
+              "COMP"
+            ],
             "description": "Object type to attach document to"
           },
           "objID": {
@@ -585,14 +658,24 @@
           "currentVersion": {
             "type": "object",
             "properties": {
-              "fileName": {"type": "string"},
-              "handle": {"type": "string"},
-              "version": {"type": "string"}
+              "fileName": {
+                "type": "string"
+              },
+              "handle": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
             },
             "description": "Current version details"
           }
         },
-        "required": ["name", "docObjCode", "objID"],
+        "required": [
+          "name",
+          "docObjCode",
+          "objID"
+        ],
         "additionalProperties": false
       }
     }
@@ -621,14 +704,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "ID": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "ownerID": {"type": "string"},
-          "status": {"type": "string"},
-          "plannedStartDate": {"type": "string"},
-          "plannedCompletionDate": {"type": "string"},
-          "entryDate": {"type": "string"}
+          "ID": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "ownerID": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "plannedStartDate": {
+            "type": "string"
+          },
+          "plannedCompletionDate": {
+            "type": "string"
+          },
+          "entryDate": {
+            "type": "string"
+          }
         }
       }
     },
@@ -655,14 +754,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "ID": {"type": "string"},
-          "name": {"type": "string"},
-          "projectID": {"type": "string"},
-          "assignedToID": {"type": "string"},
-          "status": {"type": "string"},
-          "plannedStartDate": {"type": "string"},
-          "plannedCompletionDate": {"type": "string"},
-          "entryDate": {"type": "string"}
+          "ID": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "projectID": {
+            "type": "string"
+          },
+          "assignedToID": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "plannedStartDate": {
+            "type": "string"
+          },
+          "plannedCompletionDate": {
+            "type": "string"
+          },
+          "entryDate": {
+            "type": "string"
+          }
         }
       }
     },
@@ -689,13 +804,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "ID": {"type": "string"},
-          "name": {"type": "string"},
-          "projectID": {"type": "string"},
-          "assignedToID": {"type": "string"},
-          "status": {"type": "string"},
-          "actualCompletionDate": {"type": "string"},
-          "percentComplete": {"type": "number"}
+          "ID": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "projectID": {
+            "type": "string"
+          },
+          "assignedToID": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "actualCompletionDate": {
+            "type": "string"
+          },
+          "percentComplete": {
+            "type": "number"
+          }
         }
       }
     }
@@ -703,5 +832,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/user/search"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/xero/definition.json
+++ b/connectors/xero/definition.json
@@ -11,7 +11,11 @@
     "config": {
       "authUrl": "https://login.xero.com/identity/connect/authorize",
       "tokenUrl": "https://identity.xero.com/connect/token",
-      "scopes": ["accounting.transactions", "accounting.contacts", "accounting.settings"]
+      "scopes": [
+        "accounting.transactions",
+        "accounting.contacts",
+        "accounting.settings"
+      ]
     }
   },
   "baseUrl": "https://api.xero.com/api.xro/2.0",
@@ -59,7 +63,10 @@
           },
           "contactStatus": {
             "type": "string",
-            "enum": ["ACTIVE", "ARCHIVED"],
+            "enum": [
+              "ACTIVE",
+              "ARCHIVED"
+            ],
             "default": "ACTIVE",
             "description": "Contact status"
           },
@@ -81,15 +88,37 @@
             "items": {
               "type": "object",
               "properties": {
-                "addressType": {"type": "string", "enum": ["POBOX", "STREET"]},
-                "addressLine1": {"type": "string"},
-                "addressLine2": {"type": "string"},
-                "addressLine3": {"type": "string"},
-                "addressLine4": {"type": "string"},
-                "city": {"type": "string"},
-                "region": {"type": "string"},
-                "postalCode": {"type": "string"},
-                "country": {"type": "string"}
+                "addressType": {
+                  "type": "string",
+                  "enum": [
+                    "POBOX",
+                    "STREET"
+                  ]
+                },
+                "addressLine1": {
+                  "type": "string"
+                },
+                "addressLine2": {
+                  "type": "string"
+                },
+                "addressLine3": {
+                  "type": "string"
+                },
+                "addressLine4": {
+                  "type": "string"
+                },
+                "city": {
+                  "type": "string"
+                },
+                "region": {
+                  "type": "string"
+                },
+                "postalCode": {
+                  "type": "string"
+                },
+                "country": {
+                  "type": "string"
+                }
               }
             },
             "description": "Contact addresses"
@@ -99,10 +128,24 @@
             "items": {
               "type": "object",
               "properties": {
-                "phoneType": {"type": "string", "enum": ["DEFAULT", "DDI", "MOBILE", "FAX"]},
-                "phoneNumber": {"type": "string"},
-                "phoneAreaCode": {"type": "string"},
-                "phoneCountryCode": {"type": "string"}
+                "phoneType": {
+                  "type": "string",
+                  "enum": [
+                    "DEFAULT",
+                    "DDI",
+                    "MOBILE",
+                    "FAX"
+                  ]
+                },
+                "phoneNumber": {
+                  "type": "string"
+                },
+                "phoneAreaCode": {
+                  "type": "string"
+                },
+                "phoneCountryCode": {
+                  "type": "string"
+                }
               }
             },
             "description": "Contact phone numbers"
@@ -142,7 +185,9 @@
             "description": "Accounts payable tax type"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -158,7 +203,9 @@
             "description": "Contact ID"
           }
         },
-        "required": ["contactId"],
+        "required": [
+          "contactId"
+        ],
         "additionalProperties": false
       }
     },
@@ -184,7 +231,10 @@
           },
           "contactStatus": {
             "type": "string",
-            "enum": ["ACTIVE", "ARCHIVED"],
+            "enum": [
+              "ACTIVE",
+              "ARCHIVED"
+            ],
             "description": "Contact status"
           },
           "firstName": {
@@ -200,12 +250,28 @@
             "items": {
               "type": "object",
               "properties": {
-                "addressType": {"type": "string", "enum": ["POBOX", "STREET"]},
-                "addressLine1": {"type": "string"},
-                "city": {"type": "string"},
-                "region": {"type": "string"},
-                "postalCode": {"type": "string"},
-                "country": {"type": "string"}
+                "addressType": {
+                  "type": "string",
+                  "enum": [
+                    "POBOX",
+                    "STREET"
+                  ]
+                },
+                "addressLine1": {
+                  "type": "string"
+                },
+                "city": {
+                  "type": "string"
+                },
+                "region": {
+                  "type": "string"
+                },
+                "postalCode": {
+                  "type": "string"
+                },
+                "country": {
+                  "type": "string"
+                }
               }
             },
             "description": "Contact addresses"
@@ -215,14 +281,26 @@
             "items": {
               "type": "object",
               "properties": {
-                "phoneType": {"type": "string", "enum": ["DEFAULT", "DDI", "MOBILE", "FAX"]},
-                "phoneNumber": {"type": "string"}
+                "phoneType": {
+                  "type": "string",
+                  "enum": [
+                    "DEFAULT",
+                    "DDI",
+                    "MOBILE",
+                    "FAX"
+                  ]
+                },
+                "phoneNumber": {
+                  "type": "string"
+                }
               }
             },
             "description": "Contact phone numbers"
           }
         },
-        "required": ["contactId"],
+        "required": [
+          "contactId"
+        ],
         "additionalProperties": false
       }
     },
@@ -265,14 +343,21 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["ACCREC", "ACCPAY"],
+            "enum": [
+              "ACCREC",
+              "ACCPAY"
+            ],
             "description": "Invoice type (ACCREC=sales, ACCPAY=bill)"
           },
           "contact": {
             "type": "object",
             "properties": {
-              "contactID": {"type": "string"},
-              "name": {"type": "string"}
+              "contactID": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Contact information"
           },
@@ -288,7 +373,11 @@
           },
           "lineAmountTypes": {
             "type": "string",
-            "enum": ["Exclusive", "Inclusive", "NoTax"],
+            "enum": [
+              "Exclusive",
+              "Inclusive",
+              "NoTax"
+            ],
             "default": "Exclusive",
             "description": "Line amount types"
           },
@@ -297,17 +386,43 @@
             "items": {
               "type": "object",
               "properties": {
-                "description": {"type": "string"},
-                "quantity": {"type": "number", "minimum": 0},
-                "unitAmount": {"type": "number", "minimum": 0},
-                "itemCode": {"type": "string"},
-                "accountCode": {"type": "string"},
-                "taxType": {"type": "string"},
-                "taxAmount": {"type": "number"},
-                "lineAmount": {"type": "number"},
-                "discountRate": {"type": "number", "minimum": 0, "maximum": 100}
+                "description": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "unitAmount": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "itemCode": {
+                  "type": "string"
+                },
+                "accountCode": {
+                  "type": "string"
+                },
+                "taxType": {
+                  "type": "string"
+                },
+                "taxAmount": {
+                  "type": "number"
+                },
+                "lineAmount": {
+                  "type": "number"
+                },
+                "discountRate": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                }
               },
-              "required": ["description", "quantity", "unitAmount"]
+              "required": [
+                "description",
+                "quantity",
+                "unitAmount"
+              ]
             },
             "description": "Invoice line items"
           },
@@ -338,7 +453,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["DRAFT", "SUBMITTED", "AUTHORISED"],
+            "enum": [
+              "DRAFT",
+              "SUBMITTED",
+              "AUTHORISED"
+            ],
             "default": "DRAFT",
             "description": "Invoice status"
           },
@@ -358,7 +477,11 @@
             "description": "Planned payment date"
           }
         },
-        "required": ["type", "contact", "lineItems"],
+        "required": [
+          "type",
+          "contact",
+          "lineItems"
+        ],
         "additionalProperties": false
       }
     },
@@ -374,7 +497,9 @@
             "description": "Invoice ID"
           }
         },
-        "required": ["invoiceId"],
+        "required": [
+          "invoiceId"
+        ],
         "additionalProperties": false
       }
     },
@@ -391,7 +516,13 @@
           },
           "status": {
             "type": "string",
-            "enum": ["DRAFT", "SUBMITTED", "AUTHORISED", "DELETED", "VOIDED"],
+            "enum": [
+              "DRAFT",
+              "SUBMITTED",
+              "AUTHORISED",
+              "DELETED",
+              "VOIDED"
+            ],
             "description": "Invoice status"
           },
           "reference": {
@@ -408,16 +539,28 @@
             "items": {
               "type": "object",
               "properties": {
-                "lineItemID": {"type": "string"},
-                "description": {"type": "string"},
-                "quantity": {"type": "number", "minimum": 0},
-                "unitAmount": {"type": "number", "minimum": 0}
+                "lineItemID": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "unitAmount": {
+                  "type": "number",
+                  "minimum": 0
+                }
               }
             },
             "description": "Invoice line items to update"
           }
         },
-        "required": ["invoiceId"],
+        "required": [
+          "invoiceId"
+        ],
         "additionalProperties": false
       }
     },
@@ -431,15 +574,21 @@
           "invoice": {
             "type": "object",
             "properties": {
-              "invoiceID": {"type": "string"}
+              "invoiceID": {
+                "type": "string"
+              }
             },
             "description": "Invoice to apply payment to"
           },
           "account": {
             "type": "object",
             "properties": {
-              "accountID": {"type": "string"},
-              "code": {"type": "string"}
+              "accountID": {
+                "type": "string"
+              },
+              "code": {
+                "type": "string"
+              }
             },
             "description": "Account for payment"
           },
@@ -468,7 +617,12 @@
             "description": "Whether payment is reconciled"
           }
         },
-        "required": ["invoice", "account", "date", "amount"],
+        "required": [
+          "invoice",
+          "account",
+          "date",
+          "amount"
+        ],
         "additionalProperties": false
       }
     },
@@ -501,14 +655,21 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["RECEIVE", "SPEND"],
+            "enum": [
+              "RECEIVE",
+              "SPEND"
+            ],
             "description": "Transaction type"
           },
           "contact": {
             "type": "object",
             "properties": {
-              "contactID": {"type": "string"},
-              "name": {"type": "string"}
+              "contactID": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             },
             "description": "Contact information"
           },
@@ -517,21 +678,41 @@
             "items": {
               "type": "object",
               "properties": {
-                "description": {"type": "string"},
-                "unitAmount": {"type": "number"},
-                "accountCode": {"type": "string"},
-                "taxType": {"type": "string"},
-                "quantity": {"type": "number", "minimum": 0, "default": 1}
+                "description": {
+                  "type": "string"
+                },
+                "unitAmount": {
+                  "type": "number"
+                },
+                "accountCode": {
+                  "type": "string"
+                },
+                "taxType": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": "number",
+                  "minimum": 0,
+                  "default": 1
+                }
               },
-              "required": ["description", "unitAmount", "accountCode"]
+              "required": [
+                "description",
+                "unitAmount",
+                "accountCode"
+              ]
             },
             "description": "Transaction line items"
           },
           "bankAccount": {
             "type": "object",
             "properties": {
-              "accountID": {"type": "string"},
-              "code": {"type": "string"}
+              "accountID": {
+                "type": "string"
+              },
+              "code": {
+                "type": "string"
+              }
             },
             "description": "Bank account"
           },
@@ -550,7 +731,12 @@
             "description": "Whether transaction is reconciled"
           }
         },
-        "required": ["type", "lineItems", "bankAccount", "date"],
+        "required": [
+          "type",
+          "lineItems",
+          "bankAccount",
+          "date"
+        ],
         "additionalProperties": false
       }
     },
@@ -563,7 +749,16 @@
         "properties": {
           "reportId": {
             "type": "string",
-            "enum": ["BalanceSheet", "ProfitAndLoss", "TrialBalance", "CashSummary", "ExecutiveSummary", "BankSummary", "AgedReceivablesByContact", "AgedPayablesByContact"],
+            "enum": [
+              "BalanceSheet",
+              "ProfitAndLoss",
+              "TrialBalance",
+              "CashSummary",
+              "ExecutiveSummary",
+              "BankSummary",
+              "AgedReceivablesByContact",
+              "AgedPayablesByContact"
+            ],
             "description": "Report type"
           },
           "date": {
@@ -588,11 +783,17 @@
           },
           "timeframe": {
             "type": "string",
-            "enum": ["MONTH", "QUARTER", "YEAR"],
+            "enum": [
+              "MONTH",
+              "QUARTER",
+              "YEAR"
+            ],
             "description": "Timeframe for period reports"
           }
         },
-        "required": ["reportId"],
+        "required": [
+          "reportId"
+        ],
         "additionalProperties": false
       }
     }
@@ -612,7 +813,10 @@
           },
           "invoiceType": {
             "type": "string",
-            "enum": ["ACCREC", "ACCPAY"],
+            "enum": [
+              "ACCREC",
+              "ACCPAY"
+            ],
             "description": "Filter by invoice type"
           }
         },
@@ -622,15 +826,33 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "invoiceID": {"type": "string"},
-          "invoiceNumber": {"type": "string"},
-          "type": {"type": "string"},
-          "contactID": {"type": "string"},
-          "contactName": {"type": "string"},
-          "date": {"type": "string"},
-          "dueDate": {"type": "string"},
-          "total": {"type": "number"},
-          "status": {"type": "string"}
+          "invoiceID": {
+            "type": "string"
+          },
+          "invoiceNumber": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "contactID": {
+            "type": "string"
+          },
+          "contactName": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "total": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          }
         }
       }
     },
@@ -657,13 +879,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "paymentID": {"type": "string"},
-          "invoiceID": {"type": "string"},
-          "contactID": {"type": "string"},
-          "amount": {"type": "number"},
-          "date": {"type": "string"},
-          "reference": {"type": "string"},
-          "status": {"type": "string"}
+          "paymentID": {
+            "type": "string"
+          },
+          "invoiceID": {
+            "type": "string"
+          },
+          "contactID": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "date": {
+            "type": "string"
+          },
+          "reference": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
         }
       }
     },
@@ -677,7 +913,10 @@
         "properties": {
           "contactType": {
             "type": "string",
-            "enum": ["customer", "supplier"],
+            "enum": [
+              "customer",
+              "supplier"
+            ],
             "description": "Filter by contact type"
           }
         },
@@ -687,13 +926,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "contactID": {"type": "string"},
-          "name": {"type": "string"},
-          "emailAddress": {"type": "string"},
-          "contactStatus": {"type": "string"},
-          "isCustomer": {"type": "boolean"},
-          "isSupplier": {"type": "boolean"},
-          "defaultCurrency": {"type": "string"}
+          "contactID": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "emailAddress": {
+            "type": "string"
+          },
+          "contactStatus": {
+            "type": "string"
+          },
+          "isCustomer": {
+            "type": "boolean"
+          },
+          "isSupplier": {
+            "type": "boolean"
+          },
+          "defaultCurrency": {
+            "type": "string"
+          }
         }
       }
     }
@@ -701,5 +954,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/Organisation"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/zendesk/definition.json
+++ b/connectors/zendesk/definition.json
@@ -33,7 +33,18 @@
       "description": "List comments for a ticket",
       "endpoint": "/tickets/{id}/comments.json",
       "method": "GET",
-      "parameters": { "type":"object", "properties": { "id": {"type":"number"} }, "required": ["id"], "additionalProperties": false }
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false
+      }
     },
     {
       "id": "create_ticket",
@@ -47,53 +58,155 @@
           "ticket": {
             "type": "object",
             "properties": {
-              "subject": {"type": "string"},
+              "subject": {
+                "type": "string"
+              },
               "comment": {
                 "type": "object",
                 "properties": {
-                  "body": {"type": "string"},
-                  "html_body": {"type": "string"},
-                  "public": {"type": "boolean", "default": true}
+                  "body": {
+                    "type": "string"
+                  },
+                  "html_body": {
+                    "type": "string"
+                  },
+                  "public": {
+                    "type": "boolean",
+                    "default": true
+                  }
                 },
-                "required": ["body"],
+                "required": [
+                  "body"
+                ],
                 "additionalProperties": false
               },
               "requester": {
                 "type": "object",
                 "properties": {
-                  "name": {"type": "string"},
-                  "email": {"type": "string", "format": "email"}
+                  "name": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  }
                 },
                 "additionalProperties": false
               },
-              "submitter_id": {"type": "number"},
-              "assignee_id": {"type": "number"},
-              "group_id": {"type": "number"},
-              "collaborator_ids": {"type": "array", "items": {"type": "number"}},
-              "follower_ids": {"type": "array", "items": {"type": "number"}},
-              "email_cc_ids": {"type": "array", "items": {"type": "number"}},
-              "organization_id": {"type": "number"},
-              "external_id": {"type": "string"},
-              "type": {"type": "string", "enum": ["problem", "incident", "question", "task"]},
-              "priority": {"type": "string", "enum": ["urgent", "high", "normal", "low"]},
-              "status": {"type": "string", "enum": ["new", "open", "pending", "hold", "solved", "closed"]},
-              "recipient": {"type": "string"},
-              "requester_id": {"type": "number"},
-              "brand_id": {"type": "number"},
-              "due_at": {"type": "string", "format": "date-time"},
-              "ticket_form_id": {"type": "number"},
-              "is_public": {"type": "boolean", "default": true},
-              "tags": {"type": "array", "items": {"type": "string"}},
-              "custom_fields": {"type": "array", "items": {"type": "object"}},
-              "via": {"type": "object"},
-              "problem_id": {"type": "number"},
-              "forum_topic_id": {"type": "number"}
+              "submitter_id": {
+                "type": "number"
+              },
+              "assignee_id": {
+                "type": "number"
+              },
+              "group_id": {
+                "type": "number"
+              },
+              "collaborator_ids": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "follower_ids": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "email_cc_ids": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "organization_id": {
+                "type": "number"
+              },
+              "external_id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "problem",
+                  "incident",
+                  "question",
+                  "task"
+                ]
+              },
+              "priority": {
+                "type": "string",
+                "enum": [
+                  "urgent",
+                  "high",
+                  "normal",
+                  "low"
+                ]
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "new",
+                  "open",
+                  "pending",
+                  "hold",
+                  "solved",
+                  "closed"
+                ]
+              },
+              "recipient": {
+                "type": "string"
+              },
+              "requester_id": {
+                "type": "number"
+              },
+              "brand_id": {
+                "type": "number"
+              },
+              "due_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "ticket_form_id": {
+                "type": "number"
+              },
+              "is_public": {
+                "type": "boolean",
+                "default": true
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "custom_fields": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "via": {
+                "type": "object"
+              },
+              "problem_id": {
+                "type": "number"
+              },
+              "forum_topic_id": {
+                "type": "number"
+              }
             },
-            "required": ["subject", "comment"],
+            "required": [
+              "subject",
+              "comment"
+            ],
             "additionalProperties": false
           }
         },
-        "required": ["ticket"],
+        "required": [
+          "ticket"
+        ],
         "additionalProperties": false
       }
     },
@@ -115,7 +228,9 @@
             "description": "Related objects to include (e.g., users, groups, organizations)"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -135,36 +250,122 @@
           "ticket": {
             "type": "object",
             "properties": {
-              "subject": {"type": "string"},
+              "subject": {
+                "type": "string"
+              },
               "comment": {
                 "type": "object",
                 "properties": {
-                  "body": {"type": "string"},
-                  "html_body": {"type": "string"},
-                  "public": {"type": "boolean", "default": true},
-                  "author_id": {"type": "number"}
+                  "body": {
+                    "type": "string"
+                  },
+                  "html_body": {
+                    "type": "string"
+                  },
+                  "public": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "author_id": {
+                    "type": "number"
+                  }
                 }
               },
-              "assignee_id": {"type": "number"},
-              "group_id": {"type": "number"},
-              "collaborator_ids": {"type": "array", "items": {"type": "number"}},
-              "follower_ids": {"type": "array", "items": {"type": "number"}},
-              "email_cc_ids": {"type": "array", "items": {"type": "number"}},
-              "organization_id": {"type": "number"},
-              "external_id": {"type": "string"},
-              "type": {"type": "string", "enum": ["problem", "incident", "question", "task"]},
-              "priority": {"type": "string", "enum": ["urgent", "high", "normal", "low"]},
-              "status": {"type": "string", "enum": ["new", "open", "pending", "hold", "solved", "closed"]},
-              "due_at": {"type": "string", "format": "date-time"},
-              "tags": {"type": "array", "items": {"type": "string"}},
-              "custom_fields": {"type": "array", "items": {"type": "object"}},
-              "problem_id": {"type": "number"},
-              "additional_collaborators": {"type": "array", "items": {"type": "object"}},
-              "safe_update": {"type": "boolean", "default": false}
+              "assignee_id": {
+                "type": "number"
+              },
+              "group_id": {
+                "type": "number"
+              },
+              "collaborator_ids": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "follower_ids": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "email_cc_ids": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "organization_id": {
+                "type": "number"
+              },
+              "external_id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "problem",
+                  "incident",
+                  "question",
+                  "task"
+                ]
+              },
+              "priority": {
+                "type": "string",
+                "enum": [
+                  "urgent",
+                  "high",
+                  "normal",
+                  "low"
+                ]
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "new",
+                  "open",
+                  "pending",
+                  "hold",
+                  "solved",
+                  "closed"
+                ]
+              },
+              "due_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "custom_fields": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "problem_id": {
+                "type": "number"
+              },
+              "additional_collaborators": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "safe_update": {
+                "type": "boolean",
+                "default": false
+              }
             }
           }
         },
-        "required": ["id", "ticket"],
+        "required": [
+          "id",
+          "ticket"
+        ],
         "additionalProperties": false
       }
     },
@@ -182,7 +383,9 @@
             "description": "Ticket ID"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -197,12 +400,27 @@
         "properties": {
           "sort_by": {
             "type": "string",
-            "enum": ["assignee", "assignee.name", "created_at", "group", "id", "locale", "requester", "requester.name", "status", "subject", "updated_at"],
+            "enum": [
+              "assignee",
+              "assignee.name",
+              "created_at",
+              "group",
+              "id",
+              "locale",
+              "requester",
+              "requester.name",
+              "status",
+              "subject",
+              "updated_at"
+            ],
             "description": "Sort field"
           },
           "sort_order": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "default": "asc",
             "description": "Sort order"
           },
@@ -238,8 +456,14 @@
       "method": "GET",
       "parameters": {
         "type": "object",
-        "properties": { "query": {"type":"string"} },
-        "required": ["query"],
+        "properties": {
+          "query": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -255,14 +479,24 @@
           "user": {
             "type": "object",
             "properties": {
-              "name": {"type":"string"},
-              "email": {"type":"string","format":"email"}
+              "name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
             },
-            "required": ["name","email"],
+            "required": [
+              "name",
+              "email"
+            ],
             "additionalProperties": true
           }
         },
-        "required": ["user"],
+        "required": [
+          "user"
+        ],
         "additionalProperties": false
       }
     },
@@ -272,7 +506,18 @@
       "description": "Get a Zendesk user",
       "endpoint": "/users/{id}.json",
       "method": "GET",
-      "parameters": { "type": "object", "properties": { "id": {"type":"number"} }, "required": ["id"], "additionalProperties": false }
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false
+      }
     },
     {
       "id": "update_user",
@@ -280,7 +525,22 @@
       "description": "Update a Zendesk user",
       "endpoint": "/users/{id}.json",
       "method": "PUT",
-      "parameters": { "type": "object", "properties": { "id": {"type":"number"}, "user": {"type":"object"} }, "required": ["id","user"], "additionalProperties": false }
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "user": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "user"
+        ],
+        "additionalProperties": false
+      }
     },
     {
       "id": "list_users",
@@ -288,7 +548,12 @@
       "description": "List Zendesk users",
       "endpoint": "/users.json",
       "method": "GET",
-      "parameters": { "type": "object", "properties": {}, "required": [], "additionalProperties": false }
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": false
+      }
     },
     {
       "id": "create_webhook",
@@ -299,13 +564,37 @@
       "parameters": {
         "type": "object",
         "properties": {
-          "name": {"type":"string"},
-          "endpoint": {"type":"string"},
-          "http_method": {"type":"string","enum":["POST","PUT"]},
-          "request_format": {"type":"string","enum":["json","form_encoded"]},
-          "subscriptions": {"type":"array","items":{"type":"string"}}
+          "name": {
+            "type": "string"
+          },
+          "endpoint": {
+            "type": "string"
+          },
+          "http_method": {
+            "type": "string",
+            "enum": [
+              "POST",
+              "PUT"
+            ]
+          },
+          "request_format": {
+            "type": "string",
+            "enum": [
+              "json",
+              "form_encoded"
+            ]
+          },
+          "subscriptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         },
-        "required": ["name","endpoint"],
+        "required": [
+          "name",
+          "endpoint"
+        ],
         "additionalProperties": false
       }
     },
@@ -322,12 +611,21 @@
           },
           "sort_by": {
             "type": "string",
-            "enum": ["created_at", "updated_at", "priority", "status", "ticket_type"],
+            "enum": [
+              "created_at",
+              "updated_at",
+              "priority",
+              "status",
+              "ticket_type"
+            ],
             "description": "Sort field"
           },
           "sort_order": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "default": "desc",
             "description": "Sort order"
           },
@@ -344,7 +642,9 @@
             "description": "Page number"
           }
         },
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "additionalProperties": false
       }
     },
@@ -358,40 +658,124 @@
           "user": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "email": {"type": "string", "format": "email"},
-              "alias": {"type": "string"},
-              "active": {"type": "boolean", "default": true},
-              "verified": {"type": "boolean", "default": false},
-              "shared": {"type": "boolean", "default": false},
-              "shared_agent": {"type": "boolean", "default": false},
-              "locale": {"type": "string"},
-              "locale_id": {"type": "number"},
-              "time_zone": {"type": "string"},
-              "last_login_at": {"type": "string", "format": "date-time"},
-              "phone": {"type": "string"},
-              "shared_phone_number": {"type": "string"},
-              "photo": {"type": "object"},
-              "role_type": {"type": "number"},
-              "role": {"type": "string", "enum": ["end-user", "agent", "admin"]},
-              "custom_role_id": {"type": "number"},
-              "moderator": {"type": "boolean", "default": false},
-              "ticket_restriction": {"type": "string", "enum": ["assigned", "groups", "organization", "requested", "none"]},
-              "only_private_comments": {"type": "boolean", "default": false},
-              "tags": {"type": "array", "items": {"type": "string"}},
-              "details": {"type": "string"},
-              "notes": {"type": "string"},
-              "organization_id": {"type": "number"},
-              "default_group_id": {"type": "number"},
-              "signature": {"type": "string"},
-              "user_fields": {"type": "object"},
-              "external_id": {"type": "string"}
+              "name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "alias": {
+                "type": "string"
+              },
+              "active": {
+                "type": "boolean",
+                "default": true
+              },
+              "verified": {
+                "type": "boolean",
+                "default": false
+              },
+              "shared": {
+                "type": "boolean",
+                "default": false
+              },
+              "shared_agent": {
+                "type": "boolean",
+                "default": false
+              },
+              "locale": {
+                "type": "string"
+              },
+              "locale_id": {
+                "type": "number"
+              },
+              "time_zone": {
+                "type": "string"
+              },
+              "last_login_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "shared_phone_number": {
+                "type": "string"
+              },
+              "photo": {
+                "type": "object"
+              },
+              "role_type": {
+                "type": "number"
+              },
+              "role": {
+                "type": "string",
+                "enum": [
+                  "end-user",
+                  "agent",
+                  "admin"
+                ]
+              },
+              "custom_role_id": {
+                "type": "number"
+              },
+              "moderator": {
+                "type": "boolean",
+                "default": false
+              },
+              "ticket_restriction": {
+                "type": "string",
+                "enum": [
+                  "assigned",
+                  "groups",
+                  "organization",
+                  "requested",
+                  "none"
+                ]
+              },
+              "only_private_comments": {
+                "type": "boolean",
+                "default": false
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "details": {
+                "type": "string"
+              },
+              "notes": {
+                "type": "string"
+              },
+              "organization_id": {
+                "type": "number"
+              },
+              "default_group_id": {
+                "type": "number"
+              },
+              "signature": {
+                "type": "string"
+              },
+              "user_fields": {
+                "type": "object"
+              },
+              "external_id": {
+                "type": "string"
+              }
             },
-            "required": ["name", "email"],
+            "required": [
+              "name",
+              "email"
+            ],
             "additionalProperties": false
           }
         },
-        "required": ["user"],
+        "required": [
+          "user"
+        ],
         "additionalProperties": false
       }
     },
@@ -411,7 +795,9 @@
             "description": "Related objects to include"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "additionalProperties": false
       }
     },
@@ -429,34 +815,101 @@
           "user": {
             "type": "object",
             "properties": {
-              "name": {"type": "string"},
-              "email": {"type": "string", "format": "email"},
-              "alias": {"type": "string"},
-              "active": {"type": "boolean"},
-              "verified": {"type": "boolean"},
-              "shared": {"type": "boolean"},
-              "shared_agent": {"type": "boolean"},
-              "locale": {"type": "string"},
-              "locale_id": {"type": "number"},
-              "time_zone": {"type": "string"},
-              "phone": {"type": "string"},
-              "role": {"type": "string", "enum": ["end-user", "agent", "admin"]},
-              "custom_role_id": {"type": "number"},
-              "moderator": {"type": "boolean"},
-              "ticket_restriction": {"type": "string", "enum": ["assigned", "groups", "organization", "requested", "none"]},
-              "only_private_comments": {"type": "boolean"},
-              "tags": {"type": "array", "items": {"type": "string"}},
-              "details": {"type": "string"},
-              "notes": {"type": "string"},
-              "organization_id": {"type": "number"},
-              "default_group_id": {"type": "number"},
-              "signature": {"type": "string"},
-              "user_fields": {"type": "object"},
-              "external_id": {"type": "string"}
+              "name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              },
+              "alias": {
+                "type": "string"
+              },
+              "active": {
+                "type": "boolean"
+              },
+              "verified": {
+                "type": "boolean"
+              },
+              "shared": {
+                "type": "boolean"
+              },
+              "shared_agent": {
+                "type": "boolean"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "locale_id": {
+                "type": "number"
+              },
+              "time_zone": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string",
+                "enum": [
+                  "end-user",
+                  "agent",
+                  "admin"
+                ]
+              },
+              "custom_role_id": {
+                "type": "number"
+              },
+              "moderator": {
+                "type": "boolean"
+              },
+              "ticket_restriction": {
+                "type": "string",
+                "enum": [
+                  "assigned",
+                  "groups",
+                  "organization",
+                  "requested",
+                  "none"
+                ]
+              },
+              "only_private_comments": {
+                "type": "boolean"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "details": {
+                "type": "string"
+              },
+              "notes": {
+                "type": "string"
+              },
+              "organization_id": {
+                "type": "number"
+              },
+              "default_group_id": {
+                "type": "number"
+              },
+              "signature": {
+                "type": "string"
+              },
+              "user_fields": {
+                "type": "object"
+              },
+              "external_id": {
+                "type": "string"
+              }
             }
           }
         },
-        "required": ["id", "user"],
+        "required": [
+          "id",
+          "user"
+        ],
         "additionalProperties": false
       }
     },
@@ -469,12 +922,23 @@
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["end-user", "agent", "admin"],
+            "enum": [
+              "end-user",
+              "agent",
+              "admin"
+            ],
             "description": "Filter by user role"
           },
           "role[]": {
             "type": "array",
-            "items": {"type": "string", "enum": ["end-user", "agent", "admin"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "end-user",
+                "agent",
+                "admin"
+              ]
+            },
             "description": "Filter by multiple roles"
           },
           "permission_set": {
@@ -533,17 +997,34 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["urgent", "high", "normal", "low"],
+            "enum": [
+              "urgent",
+              "high",
+              "normal",
+              "low"
+            ],
             "description": "Filter by priority"
           },
           "status": {
             "type": "string",
-            "enum": ["new", "open", "pending", "hold", "solved", "closed"],
+            "enum": [
+              "new",
+              "open",
+              "pending",
+              "hold",
+              "solved",
+              "closed"
+            ],
             "description": "Filter by status"
           },
           "type": {
             "type": "string",
-            "enum": ["problem", "incident", "question", "task"],
+            "enum": [
+              "problem",
+              "incident",
+              "question",
+              "task"
+            ],
             "description": "Filter by ticket type"
           }
         },
@@ -556,41 +1037,111 @@
           "ticket": {
             "type": "object",
             "properties": {
-              "id": {"type": "number"},
-              "url": {"type": "string"},
-              "external_id": {"type": "string"},
-              "created_at": {"type": "string"},
-              "updated_at": {"type": "string"},
-              "type": {"type": "string"},
-              "subject": {"type": "string"},
-              "raw_subject": {"type": "string"},
-              "description": {"type": "string"},
-              "priority": {"type": "string"},
-              "status": {"type": "string"},
-              "recipient": {"type": "string"},
-              "requester_id": {"type": "number"},
-              "submitter_id": {"type": "number"},
-              "assignee_id": {"type": "number"},
-              "organization_id": {"type": "number"},
-              "group_id": {"type": "number"},
-              "collaborator_ids": {"type": "array"},
-              "follower_ids": {"type": "array"},
-              "email_cc_ids": {"type": "array"},
-              "forum_topic_id": {"type": "number"},
-              "problem_id": {"type": "number"},
-              "has_incidents": {"type": "boolean"},
-              "is_public": {"type": "boolean"},
-              "due_at": {"type": "string"},
-              "tags": {"type": "array"},
-              "custom_fields": {"type": "array"},
-              "satisfaction_rating": {"type": "object"},
-              "sharing_agreement_ids": {"type": "array"},
-              "fields": {"type": "array"},
-              "followup_ids": {"type": "array"},
-              "ticket_form_id": {"type": "number"},
-              "brand_id": {"type": "number"},
-              "allow_channelback": {"type": "boolean"},
-              "allow_attachments": {"type": "boolean"}
+              "id": {
+                "type": "number"
+              },
+              "url": {
+                "type": "string"
+              },
+              "external_id": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "subject": {
+                "type": "string"
+              },
+              "raw_subject": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "recipient": {
+                "type": "string"
+              },
+              "requester_id": {
+                "type": "number"
+              },
+              "submitter_id": {
+                "type": "number"
+              },
+              "assignee_id": {
+                "type": "number"
+              },
+              "organization_id": {
+                "type": "number"
+              },
+              "group_id": {
+                "type": "number"
+              },
+              "collaborator_ids": {
+                "type": "array"
+              },
+              "follower_ids": {
+                "type": "array"
+              },
+              "email_cc_ids": {
+                "type": "array"
+              },
+              "forum_topic_id": {
+                "type": "number"
+              },
+              "problem_id": {
+                "type": "number"
+              },
+              "has_incidents": {
+                "type": "boolean"
+              },
+              "is_public": {
+                "type": "boolean"
+              },
+              "due_at": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array"
+              },
+              "custom_fields": {
+                "type": "array"
+              },
+              "satisfaction_rating": {
+                "type": "object"
+              },
+              "sharing_agreement_ids": {
+                "type": "array"
+              },
+              "fields": {
+                "type": "array"
+              },
+              "followup_ids": {
+                "type": "array"
+              },
+              "ticket_form_id": {
+                "type": "number"
+              },
+              "brand_id": {
+                "type": "number"
+              },
+              "allow_channelback": {
+                "type": "boolean"
+              },
+              "allow_attachments": {
+                "type": "boolean"
+              }
             }
           }
         }
@@ -614,12 +1165,24 @@
           },
           "priority": {
             "type": "string",
-            "enum": ["urgent", "high", "normal", "low"],
+            "enum": [
+              "urgent",
+              "high",
+              "normal",
+              "low"
+            ],
             "description": "Filter by priority"
           },
           "status": {
             "type": "string",
-            "enum": ["new", "open", "pending", "hold", "solved", "closed"],
+            "enum": [
+              "new",
+              "open",
+              "pending",
+              "hold",
+              "solved",
+              "closed"
+            ],
             "description": "Filter by status"
           }
         },
@@ -629,8 +1192,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "ticket": {"type": "object"},
-          "audit": {"type": "object"}
+          "ticket": {
+            "type": "object"
+          },
+          "audit": {
+            "type": "object"
+          }
         }
       }
     },
@@ -644,7 +1211,11 @@
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["end-user", "agent", "admin"],
+            "enum": [
+              "end-user",
+              "agent",
+              "admin"
+            ],
             "description": "Filter by user role"
           },
           "organization_id": {
@@ -658,7 +1229,9 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "user": {"type": "object"}
+          "user": {
+            "type": "object"
+          }
         }
       }
     }
@@ -666,5 +1239,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/account/settings.json"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/zoho-books/definition.json
+++ b/connectors/zoho-books/definition.json
@@ -11,7 +11,9 @@
     "config": {
       "authUrl": "https://accounts.zoho.com/oauth/v2/auth",
       "tokenUrl": "https://accounts.zoho.com/oauth/v2/token",
-      "scopes": ["ZohoBooks.fullaccess.all"]
+      "scopes": [
+        "ZohoBooks.fullaccess.all"
+      ]
     }
   },
   "baseUrl": "https://books.zoho.com/api/v3",
@@ -74,22 +76,42 @@
           "billingAddress": {
             "type": "object",
             "properties": {
-              "address": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "zip": {"type": "string"},
-              "country": {"type": "string"}
+              "address": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "zip": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              }
             },
             "description": "Billing address"
           },
           "shippingAddress": {
             "type": "object",
             "properties": {
-              "address": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "zip": {"type": "string"},
-              "country": {"type": "string"}
+              "address": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "zip": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              }
             },
             "description": "Shipping address"
           },
@@ -106,7 +128,9 @@
             "description": "Notes"
           }
         },
-        "required": ["contactName"],
+        "required": [
+          "contactName"
+        ],
         "additionalProperties": false
       }
     },
@@ -122,7 +146,9 @@
             "description": "Customer ID"
           }
         },
-        "required": ["customerId"],
+        "required": [
+          "customerId"
+        ],
         "additionalProperties": false
       }
     },
@@ -161,11 +187,21 @@
           "billingAddress": {
             "type": "object",
             "properties": {
-              "address": {"type": "string"},
-              "city": {"type": "string"},
-              "state": {"type": "string"},
-              "zip": {"type": "string"},
-              "country": {"type": "string"}
+              "address": {
+                "type": "string"
+              },
+              "city": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              },
+              "zip": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              }
             },
             "description": "Billing address"
           },
@@ -178,7 +214,9 @@
             "description": "Notes"
           }
         },
-        "required": ["customerId"],
+        "required": [
+          "customerId"
+        ],
         "additionalProperties": false
       }
     },
@@ -204,17 +242,30 @@
           },
           "sortColumn": {
             "type": "string",
-            "enum": ["contact_name", "company_name", "email", "outstanding_receivable_amount", "created_time"],
+            "enum": [
+              "contact_name",
+              "company_name",
+              "email",
+              "outstanding_receivable_amount",
+              "created_time"
+            ],
             "description": "Sort column"
           },
           "sortOrder": {
             "type": "string",
-            "enum": ["A", "D"],
+            "enum": [
+              "A",
+              "D"
+            ],
             "description": "Sort order (A=ascending, D=descending)"
           },
           "filterBy": {
             "type": "string",
-            "enum": ["Status.All", "Status.Active", "Status.Inactive"],
+            "enum": [
+              "Status.All",
+              "Status.Active",
+              "Status.Inactive"
+            ],
             "description": "Filter by status"
           }
         },
@@ -260,16 +311,26 @@
           },
           "productType": {
             "type": "string",
-            "enum": ["goods", "service"],
+            "enum": [
+              "goods",
+              "service"
+            ],
             "description": "Product type"
           },
           "itemType": {
             "type": "string",
-            "enum": ["sales", "purchases", "sales_and_purchases", "inventory"],
+            "enum": [
+              "sales",
+              "purchases",
+              "sales_and_purchases",
+              "inventory"
+            ],
             "description": "Item type"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     },
@@ -303,16 +364,39 @@
             "items": {
               "type": "object",
               "properties": {
-                "itemId": {"type": "string"},
-                "name": {"type": "string"},
-                "description": {"type": "string"},
-                "rate": {"type": "number", "minimum": 0},
-                "quantity": {"type": "number", "minimum": 0},
-                "unit": {"type": "string"},
-                "discount": {"type": "number", "minimum": 0, "maximum": 100},
-                "taxId": {"type": "string"}
+                "itemId": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "rate": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "quantity": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "unit": {
+                  "type": "string"
+                },
+                "discount": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "taxId": {
+                  "type": "string"
+                }
               },
-              "required": ["rate", "quantity"]
+              "required": [
+                "rate",
+                "quantity"
+              ]
             },
             "description": "Invoice line items"
           },
@@ -328,7 +412,10 @@
           },
           "discountType": {
             "type": "string",
-            "enum": ["entity_level", "item_level"],
+            "enum": [
+              "entity_level",
+              "item_level"
+            ],
             "description": "Discount type"
           },
           "exchangeRate": {
@@ -349,8 +436,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "customfieldId": {"type": "string"},
-                "value": {"type": "string"}
+                "customfieldId": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
               }
             },
             "description": "Custom fields"
@@ -364,7 +455,10 @@
             "description": "Terms and conditions"
           }
         },
-        "required": ["customerId", "lineItems"],
+        "required": [
+          "customerId",
+          "lineItems"
+        ],
         "additionalProperties": false
       }
     },
@@ -380,7 +474,9 @@
             "description": "Invoice ID"
           }
         },
-        "required": ["invoiceId"],
+        "required": [
+          "invoiceId"
+        ],
         "additionalProperties": false
       }
     },
@@ -402,12 +498,18 @@
           },
           "toMailIds": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "Recipient email addresses"
           },
           "ccMailIds": {
             "type": "array",
-            "items": {"type": "string", "format": "email"},
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
             "description": "CC email addresses"
           },
           "subject": {
@@ -419,7 +521,9 @@
             "description": "Email body"
           }
         },
-        "required": ["invoiceId"],
+        "required": [
+          "invoiceId"
+        ],
         "additionalProperties": false
       }
     },
@@ -461,10 +565,18 @@
             "items": {
               "type": "object",
               "properties": {
-                "invoiceId": {"type": "string"},
-                "amountApplied": {"type": "number", "minimum": 0}
+                "invoiceId": {
+                  "type": "string"
+                },
+                "amountApplied": {
+                  "type": "number",
+                  "minimum": 0
+                }
               },
-              "required": ["invoiceId", "amountApplied"]
+              "required": [
+                "invoiceId",
+                "amountApplied"
+              ]
             },
             "description": "Invoices to apply payment to"
           },
@@ -474,7 +586,13 @@
             "description": "Exchange rate"
           }
         },
-        "required": ["customerId", "paymentMode", "amount", "date", "invoices"],
+        "required": [
+          "customerId",
+          "paymentMode",
+          "amount",
+          "date",
+          "invoices"
+        ],
         "additionalProperties": false
       }
     },
@@ -534,7 +652,12 @@
             "description": "Reference number"
           }
         },
-        "required": ["accountId", "date", "amount", "description"],
+        "required": [
+          "accountId",
+          "date",
+          "amount",
+          "description"
+        ],
         "additionalProperties": false
       }
     },
@@ -547,7 +670,13 @@
         "properties": {
           "reportType": {
             "type": "string",
-            "enum": ["profit_and_loss", "balance_sheet", "cash_flow", "trial_balance", "general_ledger"],
+            "enum": [
+              "profit_and_loss",
+              "balance_sheet",
+              "cash_flow",
+              "trial_balance",
+              "general_ledger"
+            ],
             "description": "Type of report"
           },
           "fromDate": {
@@ -562,7 +691,10 @@
           },
           "accountingBasis": {
             "type": "string",
-            "enum": ["accrual", "cash"],
+            "enum": [
+              "accrual",
+              "cash"
+            ],
             "default": "accrual",
             "description": "Accounting basis"
           },
@@ -571,7 +703,9 @@
             "description": "Filter criteria"
           }
         },
-        "required": ["reportType"],
+        "required": [
+          "reportType"
+        ],
         "additionalProperties": false
       }
     }
@@ -596,14 +730,30 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "invoiceId": {"type": "string"},
-          "invoiceNumber": {"type": "string"},
-          "customerId": {"type": "string"},
-          "customerName": {"type": "string"},
-          "date": {"type": "string"},
-          "dueDate": {"type": "string"},
-          "total": {"type": "number"},
-          "status": {"type": "string"}
+          "invoiceId": {
+            "type": "string"
+          },
+          "invoiceNumber": {
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string"
+          },
+          "customerName": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "total": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          }
         }
       }
     },
@@ -630,13 +780,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "paymentId": {"type": "string"},
-          "customerId": {"type": "string"},
-          "customerName": {"type": "string"},
-          "amount": {"type": "number"},
-          "date": {"type": "string"},
-          "paymentMode": {"type": "string"},
-          "referenceNumber": {"type": "string"}
+          "paymentId": {
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string"
+          },
+          "customerName": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "date": {
+            "type": "string"
+          },
+          "paymentMode": {
+            "type": "string"
+          },
+          "referenceNumber": {
+            "type": "string"
+          }
         }
       }
     },
@@ -663,13 +827,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "expenseId": {"type": "string"},
-          "accountId": {"type": "string"},
-          "vendorId": {"type": "string"},
-          "vendorName": {"type": "string"},
-          "amount": {"type": "number"},
-          "date": {"type": "string"},
-          "description": {"type": "string"}
+          "expenseId": {
+            "type": "string"
+          },
+          "accountId": {
+            "type": "string"
+          },
+          "vendorId": {
+            "type": "string"
+          },
+          "vendorName": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "date": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
         }
       }
     }
@@ -677,5 +855,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/organizations"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/zoho-crm/definition.json
+++ b/connectors/zoho-crm/definition.json
@@ -11,7 +11,12 @@
     "config": {
       "authUrl": "https://accounts.zoho.com/oauth/v2/auth",
       "tokenUrl": "https://accounts.zoho.com/oauth/v2/token",
-      "scopes": ["ZohoCRM.modules.ALL", "ZohoCRM.settings.ALL", "ZohoCRM.bulk.ALL", "ZohoCRM.notifications.ALL"]
+      "scopes": [
+        "ZohoCRM.modules.ALL",
+        "ZohoCRM.settings.ALL",
+        "ZohoCRM.bulk.ALL",
+        "ZohoCRM.notifications.ALL"
+      ]
     }
   },
   "baseUrl": "https://www.zohoapis.com/crm/v3",
@@ -36,7 +41,23 @@
         "properties": {
           "module": {
             "type": "string",
-            "enum": ["Leads", "Contacts", "Accounts", "Deals", "Tasks", "Events", "Calls", "Solutions", "Products", "Quotes", "Sales_Orders", "Purchase_Orders", "Invoices", "Campaigns", "Vendors"],
+            "enum": [
+              "Leads",
+              "Contacts",
+              "Accounts",
+              "Deals",
+              "Tasks",
+              "Events",
+              "Calls",
+              "Solutions",
+              "Products",
+              "Quotes",
+              "Sales_Orders",
+              "Purchase_Orders",
+              "Invoices",
+              "Campaigns",
+              "Vendors"
+            ],
             "description": "Module name"
           },
           "data": {
@@ -45,21 +66,30 @@
           },
           "duplicate_check_fields": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Fields to check for duplicates"
           },
           "apply_feature_execution": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Features to apply"
           },
           "trigger": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Triggers to execute"
           }
         },
-        "required": ["module", "data"],
+        "required": [
+          "module",
+          "data"
+        ],
         "additionalProperties": false
       }
     },
@@ -72,7 +102,23 @@
         "properties": {
           "module": {
             "type": "string",
-            "enum": ["Leads", "Contacts", "Accounts", "Deals", "Tasks", "Events", "Calls", "Solutions", "Products", "Quotes", "Sales_Orders", "Purchase_Orders", "Invoices", "Campaigns", "Vendors"],
+            "enum": [
+              "Leads",
+              "Contacts",
+              "Accounts",
+              "Deals",
+              "Tasks",
+              "Events",
+              "Calls",
+              "Solutions",
+              "Products",
+              "Quotes",
+              "Sales_Orders",
+              "Purchase_Orders",
+              "Invoices",
+              "Campaigns",
+              "Vendors"
+            ],
             "description": "Module name"
           },
           "record_id": {
@@ -84,7 +130,10 @@
             "description": "Comma-separated list of fields to retrieve"
           }
         },
-        "required": ["module", "record_id"],
+        "required": [
+          "module",
+          "record_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -97,7 +146,23 @@
         "properties": {
           "module": {
             "type": "string",
-            "enum": ["Leads", "Contacts", "Accounts", "Deals", "Tasks", "Events", "Calls", "Solutions", "Products", "Quotes", "Sales_Orders", "Purchase_Orders", "Invoices", "Campaigns", "Vendors"],
+            "enum": [
+              "Leads",
+              "Contacts",
+              "Accounts",
+              "Deals",
+              "Tasks",
+              "Events",
+              "Calls",
+              "Solutions",
+              "Products",
+              "Quotes",
+              "Sales_Orders",
+              "Purchase_Orders",
+              "Invoices",
+              "Campaigns",
+              "Vendors"
+            ],
             "description": "Module name"
           },
           "record_id": {
@@ -110,16 +175,24 @@
           },
           "apply_feature_execution": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Features to apply"
           },
           "trigger": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Triggers to execute"
           }
         },
-        "required": ["module", "record_id", "data"],
+        "required": [
+          "module",
+          "record_id",
+          "data"
+        ],
         "additionalProperties": false
       }
     },
@@ -132,7 +205,23 @@
         "properties": {
           "module": {
             "type": "string",
-            "enum": ["Leads", "Contacts", "Accounts", "Deals", "Tasks", "Events", "Calls", "Solutions", "Products", "Quotes", "Sales_Orders", "Purchase_Orders", "Invoices", "Campaigns", "Vendors"],
+            "enum": [
+              "Leads",
+              "Contacts",
+              "Accounts",
+              "Deals",
+              "Tasks",
+              "Events",
+              "Calls",
+              "Solutions",
+              "Products",
+              "Quotes",
+              "Sales_Orders",
+              "Purchase_Orders",
+              "Invoices",
+              "Campaigns",
+              "Vendors"
+            ],
             "description": "Module name"
           },
           "record_id": {
@@ -144,7 +233,10 @@
             "description": "Whether to trigger workflow"
           }
         },
-        "required": ["module", "record_id"],
+        "required": [
+          "module",
+          "record_id"
+        ],
         "additionalProperties": false
       }
     },
@@ -157,7 +249,23 @@
         "properties": {
           "module": {
             "type": "string",
-            "enum": ["Leads", "Contacts", "Accounts", "Deals", "Tasks", "Events", "Calls", "Solutions", "Products", "Quotes", "Sales_Orders", "Purchase_Orders", "Invoices", "Campaigns", "Vendors"],
+            "enum": [
+              "Leads",
+              "Contacts",
+              "Accounts",
+              "Deals",
+              "Tasks",
+              "Events",
+              "Calls",
+              "Solutions",
+              "Products",
+              "Quotes",
+              "Sales_Orders",
+              "Purchase_Orders",
+              "Invoices",
+              "Campaigns",
+              "Vendors"
+            ],
             "description": "Module name"
           },
           "criteria": {
@@ -178,12 +286,20 @@
           },
           "converted": {
             "type": "string",
-            "enum": ["true", "false", "both"],
+            "enum": [
+              "true",
+              "false",
+              "both"
+            ],
             "description": "Filter by conversion status"
           },
           "approved": {
             "type": "string",
-            "enum": ["true", "false", "both"],
+            "enum": [
+              "true",
+              "false",
+              "both"
+            ],
             "description": "Filter by approval status"
           },
           "page": {
@@ -205,7 +321,10 @@
           },
           "sort_order": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "description": "Sort order"
           },
           "sort_by": {
@@ -213,7 +332,9 @@
             "description": "Field to sort by"
           }
         },
-        "required": ["module"],
+        "required": [
+          "module"
+        ],
         "additionalProperties": false
       }
     },
@@ -226,7 +347,23 @@
         "properties": {
           "module": {
             "type": "string",
-            "enum": ["Leads", "Contacts", "Accounts", "Deals", "Tasks", "Events", "Calls", "Solutions", "Products", "Quotes", "Sales_Orders", "Purchase_Orders", "Invoices", "Campaigns", "Vendors"],
+            "enum": [
+              "Leads",
+              "Contacts",
+              "Accounts",
+              "Deals",
+              "Tasks",
+              "Events",
+              "Calls",
+              "Solutions",
+              "Products",
+              "Quotes",
+              "Sales_Orders",
+              "Purchase_Orders",
+              "Invoices",
+              "Campaigns",
+              "Vendors"
+            ],
             "description": "Module name"
           },
           "fields": {
@@ -235,7 +372,10 @@
           },
           "sort_order": {
             "type": "string",
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "description": "Sort order"
           },
           "sort_by": {
@@ -244,12 +384,20 @@
           },
           "converted": {
             "type": "string",
-            "enum": ["true", "false", "both"],
+            "enum": [
+              "true",
+              "false",
+              "both"
+            ],
             "description": "Filter by conversion status"
           },
           "approved": {
             "type": "string",
-            "enum": ["true", "false", "both"],
+            "enum": [
+              "true",
+              "false",
+              "both"
+            ],
             "description": "Filter by approval status"
           },
           "page": {
@@ -278,7 +426,9 @@
             "description": "Whether to include child records"
           }
         },
-        "required": ["module"],
+        "required": [
+          "module"
+        ],
         "additionalProperties": false
       }
     },
@@ -296,12 +446,24 @@
           "data": {
             "type": "object",
             "properties": {
-              "overwrite": {"type": "boolean"},
-              "notify_lead_owner": {"type": "boolean"},
-              "notify_new_entity_owner": {"type": "boolean"},
-              "Accounts": {"type": "object"},
-              "Contacts": {"type": "object"},
-              "Deals": {"type": "object"}
+              "overwrite": {
+                "type": "boolean"
+              },
+              "notify_lead_owner": {
+                "type": "boolean"
+              },
+              "notify_new_entity_owner": {
+                "type": "boolean"
+              },
+              "Accounts": {
+                "type": "object"
+              },
+              "Contacts": {
+                "type": "object"
+              },
+              "Deals": {
+                "type": "object"
+              }
             },
             "description": "Conversion data"
           },
@@ -310,7 +472,10 @@
             "description": "User ID to assign converted records to"
           }
         },
-        "required": ["lead_id", "data"],
+        "required": [
+          "lead_id",
+          "data"
+        ],
         "additionalProperties": false
       }
     },
@@ -323,7 +488,23 @@
         "properties": {
           "module": {
             "type": "string",
-            "enum": ["Leads", "Contacts", "Accounts", "Deals", "Tasks", "Events", "Calls", "Solutions", "Products", "Quotes", "Sales_Orders", "Purchase_Orders", "Invoices", "Campaigns", "Vendors"],
+            "enum": [
+              "Leads",
+              "Contacts",
+              "Accounts",
+              "Deals",
+              "Tasks",
+              "Events",
+              "Calls",
+              "Solutions",
+              "Products",
+              "Quotes",
+              "Sales_Orders",
+              "Purchase_Orders",
+              "Invoices",
+              "Campaigns",
+              "Vendors"
+            ],
             "description": "Module name"
           },
           "record_id": {
@@ -339,7 +520,12 @@
             "description": "File name"
           }
         },
-        "required": ["module", "record_id", "file", "file_name"],
+        "required": [
+          "module",
+          "record_id",
+          "file",
+          "file_name"
+        ],
         "additionalProperties": false
       }
     },
@@ -352,7 +538,23 @@
         "properties": {
           "module": {
             "type": "string",
-            "enum": ["Leads", "Contacts", "Accounts", "Deals", "Tasks", "Events", "Calls", "Solutions", "Products", "Quotes", "Sales_Orders", "Purchase_Orders", "Invoices", "Campaigns", "Vendors"],
+            "enum": [
+              "Leads",
+              "Contacts",
+              "Accounts",
+              "Deals",
+              "Tasks",
+              "Events",
+              "Calls",
+              "Solutions",
+              "Products",
+              "Quotes",
+              "Sales_Orders",
+              "Purchase_Orders",
+              "Invoices",
+              "Campaigns",
+              "Vendors"
+            ],
             "description": "Module name"
           },
           "record_id": {
@@ -368,7 +570,12 @@
             "description": "Note content"
           }
         },
-        "required": ["module", "record_id", "note_title", "note_content"],
+        "required": [
+          "module",
+          "record_id",
+          "note_title",
+          "note_content"
+        ],
         "additionalProperties": false
       }
     }
@@ -384,7 +591,23 @@
         "properties": {
           "module": {
             "type": "string",
-            "enum": ["Leads", "Contacts", "Accounts", "Deals", "Tasks", "Events", "Calls", "Solutions", "Products", "Quotes", "Sales_Orders", "Purchase_Orders", "Invoices", "Campaigns", "Vendors"],
+            "enum": [
+              "Leads",
+              "Contacts",
+              "Accounts",
+              "Deals",
+              "Tasks",
+              "Events",
+              "Calls",
+              "Solutions",
+              "Products",
+              "Quotes",
+              "Sales_Orders",
+              "Purchase_Orders",
+              "Invoices",
+              "Campaigns",
+              "Vendors"
+            ],
             "description": "Module to monitor"
           }
         },
@@ -394,13 +617,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "module": {"type": "string"},
-          "operation": {"type": "string"},
-          "resource_uri": {"type": "string"},
-          "token": {"type": "string"},
-          "affected_fields": {"type": "array"},
-          "ids": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "module": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string"
+          },
+          "resource_uri": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "affected_fields": {
+            "type": "array"
+          },
+          "ids": {
+            "type": "array"
+          }
         }
       }
     },
@@ -414,7 +651,23 @@
         "properties": {
           "module": {
             "type": "string",
-            "enum": ["Leads", "Contacts", "Accounts", "Deals", "Tasks", "Events", "Calls", "Solutions", "Products", "Quotes", "Sales_Orders", "Purchase_Orders", "Invoices", "Campaigns", "Vendors"],
+            "enum": [
+              "Leads",
+              "Contacts",
+              "Accounts",
+              "Deals",
+              "Tasks",
+              "Events",
+              "Calls",
+              "Solutions",
+              "Products",
+              "Quotes",
+              "Sales_Orders",
+              "Purchase_Orders",
+              "Invoices",
+              "Campaigns",
+              "Vendors"
+            ],
             "description": "Module to monitor"
           }
         },
@@ -424,13 +677,27 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "module": {"type": "string"},
-          "operation": {"type": "string"},
-          "resource_uri": {"type": "string"},
-          "token": {"type": "string"},
-          "affected_fields": {"type": "array"},
-          "ids": {"type": "array"}
+          "id": {
+            "type": "string"
+          },
+          "module": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string"
+          },
+          "resource_uri": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "affected_fields": {
+            "type": "array"
+          },
+          "ids": {
+            "type": "array"
+          }
         }
       }
     },
@@ -448,10 +715,18 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "module": {"type": "string"},
-          "operation": {"type": "string"},
-          "converted_detail": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "module": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string"
+          },
+          "converted_detail": {
+            "type": "object"
+          }
         }
       }
     }
@@ -459,5 +734,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/org"
+  },
+  "semanticVersion": "1.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/connectors/zoom-enhanced/definition.json
+++ b/connectors/zoom-enhanced/definition.json
@@ -54,7 +54,12 @@
           },
           "type": {
             "type": "number",
-            "enum": [1, 2, 3, 8],
+            "enum": [
+              1,
+              2,
+              3,
+              8
+            ],
             "default": 2,
             "description": "Meeting type (1=instant, 2=scheduled, 3=recurring no fixed time, 8=recurring fixed time)"
           },
@@ -83,72 +88,235 @@
           "recurrence": {
             "type": "object",
             "properties": {
-              "type": {"type": "number", "enum": [1, 2, 3]},
-              "repeat_interval": {"type": "number"},
-              "weekly_days": {"type": "string"},
-              "monthly_day": {"type": "number"},
-              "monthly_week": {"type": "number"},
-              "monthly_week_day": {"type": "number"},
-              "end_times": {"type": "number"},
-              "end_date_time": {"type": "string", "format": "date-time"}
+              "type": {
+                "type": "number",
+                "enum": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "repeat_interval": {
+                "type": "number"
+              },
+              "weekly_days": {
+                "type": "string"
+              },
+              "monthly_day": {
+                "type": "number"
+              },
+              "monthly_week": {
+                "type": "number"
+              },
+              "monthly_week_day": {
+                "type": "number"
+              },
+              "end_times": {
+                "type": "number"
+              },
+              "end_date_time": {
+                "type": "string",
+                "format": "date-time"
+              }
             },
             "description": "Recurrence settings"
           },
           "settings": {
             "type": "object",
             "properties": {
-              "host_video": {"type": "boolean", "default": false},
-              "participant_video": {"type": "boolean", "default": false},
-              "cn_meeting": {"type": "boolean", "default": false},
-              "in_meeting": {"type": "boolean", "default": false},
-              "join_before_host": {"type": "boolean", "default": false},
-              "jbh_time": {"type": "number", "enum": [0, 5, 10]},
-              "mute_upon_entry": {"type": "boolean", "default": false},
-              "watermark": {"type": "boolean", "default": false},
-              "use_pmi": {"type": "boolean", "default": false},
-              "approval_type": {"type": "number", "enum": [0, 1, 2]},
-              "registration_type": {"type": "number", "enum": [1, 2, 3]},
-              "audio": {"type": "string", "enum": ["both", "telephony", "voip"]},
-              "auto_recording": {"type": "string", "enum": ["local", "cloud", "none"]},
-              "enforce_login": {"type": "boolean", "default": false},
-              "enforce_login_domains": {"type": "string"},
-              "alternative_hosts": {"type": "string"},
-              "close_registration": {"type": "boolean", "default": false},
-              "show_share_button": {"type": "boolean", "default": false},
-              "allow_multiple_devices": {"type": "boolean", "default": false},
-              "registrants_confirmation_email": {"type": "boolean", "default": true},
-              "waiting_room": {"type": "boolean", "default": false},
-              "request_permission_to_unmute_participants": {"type": "boolean", "default": false},
-              "global_dial_in_countries": {"type": "array", "items": {"type": "string"}},
-              "global_dial_in_numbers": {"type": "array"},
-              "contact_name": {"type": "string"},
-              "contact_email": {"type": "string", "format": "email"},
-              "registrants_email_notification": {"type": "boolean", "default": true},
-              "meeting_authentication": {"type": "boolean", "default": false},
-              "authentication_option": {"type": "string"},
-              "authentication_domains": {"type": "string"},
-              "authentication_name": {"type": "string"},
-              "additional_data_center_regions": {"type": "array", "items": {"type": "string"}},
+              "host_video": {
+                "type": "boolean",
+                "default": false
+              },
+              "participant_video": {
+                "type": "boolean",
+                "default": false
+              },
+              "cn_meeting": {
+                "type": "boolean",
+                "default": false
+              },
+              "in_meeting": {
+                "type": "boolean",
+                "default": false
+              },
+              "join_before_host": {
+                "type": "boolean",
+                "default": false
+              },
+              "jbh_time": {
+                "type": "number",
+                "enum": [
+                  0,
+                  5,
+                  10
+                ]
+              },
+              "mute_upon_entry": {
+                "type": "boolean",
+                "default": false
+              },
+              "watermark": {
+                "type": "boolean",
+                "default": false
+              },
+              "use_pmi": {
+                "type": "boolean",
+                "default": false
+              },
+              "approval_type": {
+                "type": "number",
+                "enum": [
+                  0,
+                  1,
+                  2
+                ]
+              },
+              "registration_type": {
+                "type": "number",
+                "enum": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "audio": {
+                "type": "string",
+                "enum": [
+                  "both",
+                  "telephony",
+                  "voip"
+                ]
+              },
+              "auto_recording": {
+                "type": "string",
+                "enum": [
+                  "local",
+                  "cloud",
+                  "none"
+                ]
+              },
+              "enforce_login": {
+                "type": "boolean",
+                "default": false
+              },
+              "enforce_login_domains": {
+                "type": "string"
+              },
+              "alternative_hosts": {
+                "type": "string"
+              },
+              "close_registration": {
+                "type": "boolean",
+                "default": false
+              },
+              "show_share_button": {
+                "type": "boolean",
+                "default": false
+              },
+              "allow_multiple_devices": {
+                "type": "boolean",
+                "default": false
+              },
+              "registrants_confirmation_email": {
+                "type": "boolean",
+                "default": true
+              },
+              "waiting_room": {
+                "type": "boolean",
+                "default": false
+              },
+              "request_permission_to_unmute_participants": {
+                "type": "boolean",
+                "default": false
+              },
+              "global_dial_in_countries": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "global_dial_in_numbers": {
+                "type": "array"
+              },
+              "contact_name": {
+                "type": "string"
+              },
+              "contact_email": {
+                "type": "string",
+                "format": "email"
+              },
+              "registrants_email_notification": {
+                "type": "boolean",
+                "default": true
+              },
+              "meeting_authentication": {
+                "type": "boolean",
+                "default": false
+              },
+              "authentication_option": {
+                "type": "string"
+              },
+              "authentication_domains": {
+                "type": "string"
+              },
+              "authentication_name": {
+                "type": "string"
+              },
+              "additional_data_center_regions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "breakout_room": {
                 "type": "object",
                 "properties": {
-                  "enable": {"type": "boolean", "default": false},
-                  "rooms": {"type": "array"}
+                  "enable": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "rooms": {
+                    "type": "array"
+                  }
                 }
               },
-              "internal_meeting": {"type": "boolean", "default": false},
+              "internal_meeting": {
+                "type": "boolean",
+                "default": false
+              },
               "continuous_meeting_chat": {
                 "type": "object",
                 "properties": {
-                  "enable": {"type": "boolean", "default": false},
-                  "auto_add_invited_external_users": {"type": "boolean", "default": false}
+                  "enable": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "auto_add_invited_external_users": {
+                    "type": "boolean",
+                    "default": false
+                  }
                 }
               },
-              "participant_focused_meeting": {"type": "boolean", "default": false},
-              "push_change_to_calendar": {"type": "boolean", "default": false},
-              "resources": {"type": "array"},
-              "auto_start_meeting_summary": {"type": "boolean", "default": false},
-              "auto_start_ai_companion_questions": {"type": "boolean", "default": false}
+              "participant_focused_meeting": {
+                "type": "boolean",
+                "default": false
+              },
+              "push_change_to_calendar": {
+                "type": "boolean",
+                "default": false
+              },
+              "resources": {
+                "type": "array"
+              },
+              "auto_start_meeting_summary": {
+                "type": "boolean",
+                "default": false
+              },
+              "auto_start_ai_companion_questions": {
+                "type": "boolean",
+                "default": false
+              }
             },
             "description": "Meeting settings"
           },
@@ -157,8 +325,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "field": {"type": "string"},
-                "value": {"type": "string"}
+                "field": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
               }
             },
             "description": "Tracking fields"
@@ -168,7 +340,10 @@
             "description": "Meeting template ID"
           }
         },
-        "required": ["userId", "topic"],
+        "required": [
+          "userId",
+          "topic"
+        ],
         "additionalProperties": false
       }
     },
@@ -192,7 +367,9 @@
             "description": "Whether to show previous occurrences"
           }
         },
-        "required": ["meetingId"],
+        "required": [
+          "meetingId"
+        ],
         "additionalProperties": false
       }
     },
@@ -217,7 +394,12 @@
           },
           "type": {
             "type": "number",
-            "enum": [1, 2, 3, 8],
+            "enum": [
+              1,
+              2,
+              3,
+              8
+            ],
             "description": "Meeting type"
           },
           "start_time": {
@@ -252,11 +434,15 @@
           },
           "tracking_fields": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Tracking fields"
           }
         },
-        "required": ["meetingId"],
+        "required": [
+          "meetingId"
+        ],
         "additionalProperties": false
       }
     },
@@ -284,7 +470,9 @@
             "description": "Whether to send cancellation email"
           }
         },
-        "required": ["meetingId"],
+        "required": [
+          "meetingId"
+        ],
         "additionalProperties": false
       }
     },
@@ -301,7 +489,11 @@
           },
           "type": {
             "type": "string",
-            "enum": ["scheduled", "live", "upcoming"],
+            "enum": [
+              "scheduled",
+              "live",
+              "upcoming"
+            ],
             "default": "scheduled",
             "description": "Meeting type to list"
           },
@@ -322,7 +514,9 @@
             "description": "Page number (deprecated, use next_page_token)"
           }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       }
     },
@@ -343,7 +537,11 @@
           },
           "type": {
             "type": "number",
-            "enum": [5, 6, 9],
+            "enum": [
+              5,
+              6,
+              9
+            ],
             "default": 5,
             "description": "Webinar type (5=webinar, 6=recurring webinar no fixed time, 9=recurring webinar fixed time)"
           },
@@ -376,47 +574,147 @@
           "settings": {
             "type": "object",
             "properties": {
-              "host_video": {"type": "boolean", "default": false},
-              "panelists_video": {"type": "boolean", "default": false},
-              "practice_session": {"type": "boolean", "default": false},
-              "hd_video": {"type": "boolean", "default": false},
-              "approval_type": {"type": "number", "enum": [0, 1, 2]},
-              "registration_type": {"type": "number", "enum": [1, 2, 3]},
-              "audio": {"type": "string", "enum": ["both", "telephony", "voip"]},
-              "auto_recording": {"type": "string", "enum": ["local", "cloud", "none"]},
-              "enforce_login": {"type": "boolean", "default": false},
-              "enforce_login_domains": {"type": "string"},
-              "alternative_hosts": {"type": "string"},
-              "close_registration": {"type": "boolean", "default": false},
-              "show_share_button": {"type": "boolean", "default": false},
-              "allow_multiple_devices": {"type": "boolean", "default": false},
-              "on_demand": {"type": "boolean", "default": false},
-              "global_dial_in_countries": {"type": "array", "items": {"type": "string"}},
-              "contact_name": {"type": "string"},
-              "contact_email": {"type": "string", "format": "email"},
-              "registrants_email_notification": {"type": "boolean", "default": true},
-              "post_webinar_survey": {"type": "boolean", "default": false},
-              "survey_url": {"type": "string"},
-              "registrants_restrict_number": {"type": "number"},
-              "notify_registrants": {"type": "boolean", "default": true},
+              "host_video": {
+                "type": "boolean",
+                "default": false
+              },
+              "panelists_video": {
+                "type": "boolean",
+                "default": false
+              },
+              "practice_session": {
+                "type": "boolean",
+                "default": false
+              },
+              "hd_video": {
+                "type": "boolean",
+                "default": false
+              },
+              "approval_type": {
+                "type": "number",
+                "enum": [
+                  0,
+                  1,
+                  2
+                ]
+              },
+              "registration_type": {
+                "type": "number",
+                "enum": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "audio": {
+                "type": "string",
+                "enum": [
+                  "both",
+                  "telephony",
+                  "voip"
+                ]
+              },
+              "auto_recording": {
+                "type": "string",
+                "enum": [
+                  "local",
+                  "cloud",
+                  "none"
+                ]
+              },
+              "enforce_login": {
+                "type": "boolean",
+                "default": false
+              },
+              "enforce_login_domains": {
+                "type": "string"
+              },
+              "alternative_hosts": {
+                "type": "string"
+              },
+              "close_registration": {
+                "type": "boolean",
+                "default": false
+              },
+              "show_share_button": {
+                "type": "boolean",
+                "default": false
+              },
+              "allow_multiple_devices": {
+                "type": "boolean",
+                "default": false
+              },
+              "on_demand": {
+                "type": "boolean",
+                "default": false
+              },
+              "global_dial_in_countries": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "contact_name": {
+                "type": "string"
+              },
+              "contact_email": {
+                "type": "string",
+                "format": "email"
+              },
+              "registrants_email_notification": {
+                "type": "boolean",
+                "default": true
+              },
+              "post_webinar_survey": {
+                "type": "boolean",
+                "default": false
+              },
+              "survey_url": {
+                "type": "string"
+              },
+              "registrants_restrict_number": {
+                "type": "number"
+              },
+              "notify_registrants": {
+                "type": "boolean",
+                "default": true
+              },
               "webinar_live_stream": {
                 "type": "object",
                 "properties": {
-                  "enable": {"type": "boolean", "default": false},
-                  "live_streaming_service": {"type": "string"},
-                  "page_url": {"type": "string"},
-                  "stream_key": {"type": "string"},
-                  "stream_url": {"type": "string"}
+                  "enable": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "live_streaming_service": {
+                    "type": "string"
+                  },
+                  "page_url": {
+                    "type": "string"
+                  },
+                  "stream_key": {
+                    "type": "string"
+                  },
+                  "stream_url": {
+                    "type": "string"
+                  }
                 }
               },
-              "email_language": {"type": "string"},
-              "panelists_invitation_email_notification": {"type": "boolean", "default": true}
+              "email_language": {
+                "type": "string"
+              },
+              "panelists_invitation_email_notification": {
+                "type": "boolean",
+                "default": true
+              }
             },
             "description": "Webinar settings"
           },
           "tracking_fields": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+              "type": "object"
+            },
             "description": "Tracking fields"
           },
           "template_id": {
@@ -424,7 +722,10 @@
             "description": "Webinar template ID"
           }
         },
-        "required": ["userId", "topic"],
+        "required": [
+          "userId",
+          "topic"
+        ],
         "additionalProperties": false
       }
     },
@@ -448,7 +749,9 @@
             "description": "Time to live for download URLs in seconds"
           }
         },
-        "required": ["meetingId"],
+        "required": [
+          "meetingId"
+        ],
         "additionalProperties": false
       }
     },
@@ -476,7 +779,10 @@
           },
           "mc": {
             "type": "string",
-            "enum": ["true", "false"],
+            "enum": [
+              "true",
+              "false"
+            ],
             "description": "Query multicloud recordings"
           },
           "trash": {
@@ -495,7 +801,10 @@
           },
           "trash_type": {
             "type": "string",
-            "enum": ["meeting_recordings", "recording_file"],
+            "enum": [
+              "meeting_recordings",
+              "recording_file"
+            ],
             "description": "Trash type filter"
           },
           "meeting_id": {
@@ -503,7 +812,9 @@
             "description": "Meeting ID filter"
           }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       }
     }
@@ -528,22 +839,42 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
+          "event": {
+            "type": "string"
+          },
           "payload": {
             "type": "object",
             "properties": {
-              "account_id": {"type": "string"},
+              "account_id": {
+                "type": "string"
+              },
               "object": {
                 "type": "object",
                 "properties": {
-                  "uuid": {"type": "string"},
-                  "id": {"type": "number"},
-                  "host_id": {"type": "string"},
-                  "topic": {"type": "string"},
-                  "type": {"type": "number"},
-                  "start_time": {"type": "string"},
-                  "duration": {"type": "number"},
-                  "timezone": {"type": "string"}
+                  "uuid": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "number"
+                  },
+                  "host_id": {
+                    "type": "string"
+                  },
+                  "topic": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "number"
+                  },
+                  "start_time": {
+                    "type": "string"
+                  },
+                  "duration": {
+                    "type": "number"
+                  },
+                  "timezone": {
+                    "type": "string"
+                  }
                 }
               }
             }
@@ -570,8 +901,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
-          "payload": {"type": "object"}
+          "event": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object"
+          }
         }
       }
     },
@@ -594,8 +929,12 @@
       "outputSchema": {
         "type": "object",
         "properties": {
-          "event": {"type": "string"},
-          "payload": {"type": "object"}
+          "event": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object"
+          }
         }
       }
     }
@@ -603,5 +942,19 @@
   "testConnection": {
     "method": "GET",
     "endpoint": "/users/me"
+  },
+  "semanticVersion": "2.0.0",
+  "lifecycle": {
+    "status": "ga",
+    "beta": {
+      "enabled": false,
+      "startDate": null,
+      "endDate": null
+    },
+    "deprecation": {
+      "startDate": null,
+      "endDate": null
+    },
+    "sunsetDate": null
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "audit:bronze": "node scripts/audit-bronze.js",
     "smoke:e2e": "node scripts/e2e-smoke.js",
     "smoke:connectors": "tsx scripts/connector-smoke.ts",
-    "ci:smoke": "tsx scripts/connector-smoke.ts --use-simulator"
+    "ci:smoke": "tsx scripts/connector-contracts.ts && tsx scripts/connector-smoke.ts --use-simulator"
   },
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.676.0",

--- a/scripts/connector-contracts.ts
+++ b/scripts/connector-contracts.ts
@@ -1,0 +1,137 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+import {
+  ConnectorSimulator,
+  type ConnectorContractDefinitionInput,
+  type ConnectorContractTestResult,
+} from '../server/testing/ConnectorSimulator';
+
+const CONNECTORS_DIR = path.resolve(process.cwd(), 'connectors');
+
+interface ContractTestSummary {
+  passed: number;
+  failed: number;
+}
+
+const indent = (value: string, spaces = 2) => value.split('\n').map((line) => `${' '.repeat(spaces)}${line}`).join('\n');
+
+async function loadConnectorDefinitions(): Promise<ConnectorContractDefinitionInput[]> {
+  const entries = await safeReadDir(CONNECTORS_DIR);
+  const definitions: ConnectorContractDefinitionInput[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const definitionPath = path.join(CONNECTORS_DIR, entry.name, 'definition.json');
+    const raw = await safeReadFile(definitionPath);
+    if (!raw) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      const actions = Array.isArray(parsed.actions) ? parsed.actions : [];
+      const triggers = Array.isArray(parsed.triggers) ? parsed.triggers : [];
+
+      definitions.push({
+        appId: (parsed.id || entry.name).toString().toLowerCase(),
+        actions: actions.map((action: any) => ({ id: action.id })),
+        triggers: triggers.map((trigger: any) => ({ id: trigger.id })),
+      });
+    } catch (error) {
+      console.warn(`[connector-contracts] Skipping ${definitionPath}: ${(error as Error).message}`);
+    }
+  }
+
+  return definitions.sort((a, b) => a.appId.localeCompare(b.appId));
+}
+
+async function safeReadDir(dir: string) {
+  try {
+    return await fs.readdir(dir, { withFileTypes: true });
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      console.warn(`[connector-contracts] Connectors directory not found at ${dir}`);
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function safeReadFile(filePath: string) {
+  try {
+    return await fs.readFile(filePath, 'utf-8');
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      console.warn(`[connector-contracts] Missing definition at ${filePath}`);
+      return null;
+    }
+    throw error;
+  }
+}
+
+function printResult(result: ConnectorContractTestResult): void {
+  const statusIcon = result.passed ? '✅' : '❌';
+  console.log(`${statusIcon} ${result.appId} (${result.scenarios.length} scenarios)`);
+
+  if (!result.passed) {
+    for (const scenario of result.scenarios) {
+      if (scenario.passed) {
+        continue;
+      }
+      const heading = `• ${scenario.type.toUpperCase()} ${scenario.id}`;
+      console.log(indent(heading));
+      if (!scenario.hasFixture) {
+        console.log(indent('Missing fixture', 4));
+      }
+      scenario.errors.forEach((error) => console.log(indent(`Error: ${error}`, 4)));
+      scenario.warnings.forEach((warning) => console.log(indent(`Warning: ${warning}`, 4)));
+    }
+  } else {
+    const warnings = result.scenarios.filter((scenario) => scenario.warnings.length > 0);
+    warnings.forEach((scenario) => {
+      console.log(indent(`⚠️ ${scenario.type} ${scenario.id}`));
+      scenario.warnings.forEach((warning) => console.log(indent(warning, 4)));
+    });
+  }
+}
+
+function summarize(results: ConnectorContractTestResult[]): ContractTestSummary {
+  return results.reduce<ContractTestSummary>((acc, result) => {
+    if (result.passed) {
+      acc.passed += 1;
+    } else {
+      acc.failed += 1;
+    }
+    return acc;
+  }, { passed: 0, failed: 0 });
+}
+
+async function main(): Promise<void> {
+  const definitions = await loadConnectorDefinitions();
+  if (definitions.length === 0) {
+    console.log('[connector-contracts] No connector definitions found. Skipping contract tests.');
+    return;
+  }
+
+  const simulator = new ConnectorSimulator({ enabled: true, strict: true });
+  const results = await simulator.runContractSuite(definitions, { requireFixtures: true });
+
+  const summary = summarize(results);
+  console.log(`\nContract test summary: ${summary.passed} passed, ${summary.failed} failed.`);
+
+  results.forEach(printResult);
+
+  if (summary.failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('[connector-contracts] Unexpected failure:', error);
+  process.exitCode = 1;
+});

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -900,6 +900,13 @@ export const connectorDefinitions = pgTable(
     
     // Metadata for ALL application connectors
     version: text('version').default('1.0.0').notNull(),
+    semanticVersion: text('semantic_version').default('1.0.0').notNull(),
+    lifecycleStatus: text('lifecycle_status').default('ga').notNull(),
+    isBeta: boolean('is_beta').default(false).notNull(),
+    betaStartAt: timestamp('beta_start_at'),
+    betaEndAt: timestamp('beta_end_at'),
+    deprecationStartAt: timestamp('deprecation_start_at'),
+    sunsetAt: timestamp('sunset_at'),
     isActive: boolean('is_active').default(true).notNull(),
     popularity: integer('popularity').default(0).notNull(),
     
@@ -917,6 +924,9 @@ export const connectorDefinitions = pgTable(
     categoryIdx: index('connectors_category_idx').on(table.category),
     activeIdx: index('connectors_active_idx').on(table.isActive),
     popularityIdx: index('connectors_popularity_idx').on(table.popularity),
+    lifecycleStatusIdx: index('connectors_lifecycle_status_idx').on(table.lifecycleStatus),
+    betaIdx: index('connectors_beta_idx').on(table.isBeta),
+    sunsetIdx: index('connectors_sunset_idx').on(table.sunsetAt),
     
     // Security and compliance indexes for ALL applications
     piiIdx: index('connectors_pii_idx').on(table.handlesPersonalData),


### PR DESCRIPTION
## Summary
- extend connector definitions schema to store semantic versioning, beta flags, and deprecation windows and surface the data through ConnectorFramework and ConnectorRegistry
- add lifecycle metadata to every connector definition and expose a contract test runner plus CI script to validate simulator fixtures
- build admin lifecycle management tooling and show connector version/status badges in the marketplace sidebar

## Testing
- npx tsx scripts/connector-contracts.ts *(fails: npm 403 fetching tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e08b06b04083319ec1040a046c3a42