### PR TITLE
Add region-aware execution routing and compliance reporting

### DIFF
--- a/migrations/0011_organization_region.ts
+++ b/migrations/0011_organization_region.ts
@@ -1,0 +1,23 @@
+import { sql } from 'drizzle-orm';
+
+type MigrationClient = { execute: (query: any) => Promise<unknown> };
+
+const DEFAULT_REGION = process.env.DEFAULT_ORGANIZATION_REGION ?? 'us';
+
+export async function up(db: MigrationClient): Promise<void> {
+  await db.execute(
+    sql`ALTER TABLE "organizations" ADD COLUMN IF NOT EXISTS "region" text NOT NULL DEFAULT 'us'`
+  );
+
+  await db.execute(
+    sql`UPDATE "organizations" SET "region" = COALESCE(NULLIF(lower(("compliance"->>'dataResidency')), ''), ${DEFAULT_REGION})`
+  );
+
+  await db.execute(
+    sql`UPDATE "organizations" SET "compliance" = jsonb_set(COALESCE("compliance"::jsonb, '{}'::jsonb), '{dataResidency}', to_jsonb(lower("region")))`
+  );
+}
+
+export async function down(db: MigrationClient): Promise<void> {
+  await db.execute(sql`ALTER TABLE "organizations" DROP COLUMN IF EXISTS "region"`);
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1759132947664,
       "tag": "0009_fix_execution_logs_pk",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1759132948664,
+      "tag": "0011_organization_region",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -74,11 +74,13 @@ export interface OrganizationBranding {
   supportEmail: string;
 }
 
+export type OrganizationRegion = 'us' | 'eu' | 'asia' | 'global' | (string & {});
+
 export interface OrganizationComplianceSettings {
   gdprEnabled: boolean;
   hipaaCompliant: boolean;
   soc2Type2: boolean;
-  dataResidency: 'us' | 'eu' | 'asia' | 'global';
+  dataResidency: OrganizationRegion;
   retentionPolicyDays: number;
 }
 
@@ -138,6 +140,7 @@ export const organizations = pgTable(
     name: text('name').notNull(),
     domain: text('domain'),
     subdomain: text('subdomain').notNull(),
+    region: text('region').notNull().default('us'),
     plan: text('plan').notNull().default('starter'),
     status: text('status').notNull().default('trial'),
     createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -6,6 +6,7 @@ import {
   OrganizationStatus,
   OrganizationLimits,
   OrganizationUsageMetrics,
+  OrganizationRegion,
 } from '../database/schema';
 import { setRequestUser } from '../utils/ExecutionContext';
 
@@ -35,6 +36,7 @@ declare global {
         activeOrganization?: AuthOrganization;
         organizations?: AuthOrganization[];
         permissions?: Permission[];
+        organizationRegion?: OrganizationRegion;
       };
       organizationId?: string;
       organizationRole?: string;
@@ -42,6 +44,7 @@ declare global {
       organizationStatus?: OrganizationStatus;
       organizationLimits?: OrganizationLimits;
       organizationUsage?: OrganizationUsageMetrics;
+      organizationRegion?: OrganizationRegion;
       permissions?: Permission[];
     }
   }
@@ -83,10 +86,12 @@ const buildDevUser = () => {
       storageUsed: 0,
       usersActive: 1,
     },
+    organizationRegion: 'us',
     activeOrganization: {
       id: 'dev-org',
       name: 'Developer Workspace',
       domain: null,
+      region: 'us',
       plan: 'enterprise',
       status: 'active',
       role: 'owner',
@@ -133,11 +138,12 @@ export const authenticateToken = async (req: Request, res: Response, next: NextF
         req.user = { ...devUser, permissions };
         req.organizationId = devUser.organizationId;
         req.organizationRole = devUser.organizationRole;
-        req.organizationPlan = devUser.organizationPlan as OrganizationPlan;
-        req.organizationStatus = devUser.organizationStatus as OrganizationStatus;
-        req.organizationLimits = devUser.organizationLimits;
-        req.organizationUsage = devUser.organizationUsage;
-        req.permissions = permissions;
+    req.organizationPlan = devUser.organizationPlan as OrganizationPlan;
+    req.organizationStatus = devUser.organizationStatus as OrganizationStatus;
+    req.organizationLimits = devUser.organizationLimits;
+    req.organizationUsage = devUser.organizationUsage;
+    req.organizationRegion = devUser.organizationRegion as OrganizationRegion;
+    req.permissions = permissions;
         setRequestUser(devUser.id);
         return next();
       }
@@ -166,6 +172,7 @@ export const authenticateToken = async (req: Request, res: Response, next: NextF
     req.organizationStatus = user.organizationStatus;
     req.organizationLimits = user.organizationLimits;
     req.organizationUsage = user.organizationUsage;
+    req.organizationRegion = user.organizationRegion;
     req.permissions = permissions;
     setRequestUser(user.id);
     next();
@@ -204,6 +211,7 @@ export const optionalAuth = async (req: Request, res: Response, next: NextFuncti
         req.organizationStatus = user.organizationStatus;
         req.organizationLimits = user.organizationLimits;
         req.organizationUsage = user.organizationUsage;
+        req.organizationRegion = user.organizationRegion;
         req.permissions = permissions;
         setRequestUser(user.id);
       }
@@ -216,6 +224,7 @@ export const optionalAuth = async (req: Request, res: Response, next: NextFuncti
       req.organizationStatus = devUser.organizationStatus as OrganizationStatus;
       req.organizationLimits = devUser.organizationLimits;
       req.organizationUsage = devUser.organizationUsage;
+      req.organizationRegion = devUser.organizationRegion as OrganizationRegion;
       req.permissions = permissions;
       setRequestUser(devUser.id);
     }
@@ -231,6 +240,7 @@ export const optionalAuth = async (req: Request, res: Response, next: NextFuncti
       req.organizationStatus = devUser.organizationStatus as OrganizationStatus;
       req.organizationLimits = devUser.organizationLimits;
       req.organizationUsage = devUser.organizationUsage;
+      req.organizationRegion = devUser.organizationRegion as OrganizationRegion;
       req.permissions = permissions;
       setRequestUser(devUser.id);
       next();

--- a/server/queue/types.ts
+++ b/server/queue/types.ts
@@ -22,12 +22,20 @@ export type WorkflowExecuteJobPayload = {
   resumeState?: WorkflowResumeState | null;
   initialData?: any;
   timerId?: string | null;
+  region?: string;
 };
 
-export interface JobPayloads {
-  'workflow.execute': WorkflowExecuteJobPayload;
+export type WorkflowQueueName = 'workflow.execute' | `workflow.execute.${string}`;
+
+type WorkflowJobPayloads = {
+  [Name in WorkflowQueueName]: WorkflowExecuteJobPayload;
+};
+
+type BaseJobPayloads = {
   'encryption.rotate': { jobId: string };
-}
+};
+
+export type JobPayloads = WorkflowJobPayloads & BaseJobPayloads;
 
 export type QueueName = keyof JobPayloads;
 

--- a/server/services/AuthService.ts
+++ b/server/services/AuthService.ts
@@ -7,6 +7,7 @@ import {
   OrganizationStatus,
   OrganizationLimits,
   OrganizationUsageMetrics,
+  OrganizationRegion,
 } from '../database/schema';
 import { EncryptionService } from './EncryptionService';
 import { JWTPayload } from '../types/common';
@@ -57,6 +58,7 @@ export interface AuthUser {
   organizationStatus?: OrganizationStatus;
   organizationLimits?: OrganizationLimits;
   organizationUsage?: OrganizationUsageMetrics;
+  organizationRegion?: OrganizationRegion;
   activeOrganization?: AuthOrganization;
   organizations?: AuthOrganization[];
   permissions?: Permission[];
@@ -66,6 +68,7 @@ export interface AuthOrganization {
   id: string;
   name: string;
   domain: string | null;
+  region: OrganizationRegion;
   plan: OrganizationPlan;
   status: OrganizationStatus;
   role: string;
@@ -513,6 +516,7 @@ export class AuthService {
       id: context.id,
       name: context.name,
       domain: context.domain,
+      region: context.region,
       plan: context.plan,
       status: context.status,
       role: context.role,
@@ -572,6 +576,7 @@ export class AuthService {
       organizationStatus: activeOrganization?.status,
       organizationLimits: activeOrganization?.limits,
       organizationUsage: activeOrganization?.usage,
+      organizationRegion: activeOrganization?.region,
       activeOrganization,
       organizations: organizationSummaries,
       permissions: organizationPermissions,

--- a/server/services/ComplianceReportingService.ts
+++ b/server/services/ComplianceReportingService.ts
@@ -1,0 +1,99 @@
+import { resolveWorkflowQueueName } from '../utils/region.js';
+import { connectionService } from './ConnectionService';
+import { organizationService } from './OrganizationService';
+import { getAuditLogPath } from './ExecutionAuditService.js';
+
+export interface ResidencyAssetRecord {
+  type: 'workflowQueue' | 'scheduler' | 'connectionSecrets' | 'executionLogs';
+  region: string;
+  location: string;
+  description: string;
+  details?: Record<string, any>;
+}
+
+export interface OrganizationResidencyReport {
+  organizationId: string;
+  organizationName: string;
+  primaryRegion: string;
+  assets: ResidencyAssetRecord[];
+  metadata: Record<string, any>;
+}
+
+class ComplianceReportingService {
+  public async getOrganizationResidencyReport(organizationId: string): Promise<OrganizationResidencyReport> {
+    const profile = await organizationService.getOrganizationProfile(organizationId);
+    if (!profile) {
+      throw new Error(`Organization not found: ${organizationId}`);
+    }
+
+    const queueName = resolveWorkflowQueueName(profile.region);
+    const connectionStorage = await connectionService.describeStorageLocation(organizationId);
+    const auditLogPath = getAuditLogPath(profile.region);
+
+    const assets: ResidencyAssetRecord[] = [
+      {
+        type: 'workflowQueue',
+        region: profile.region,
+        location: queueName,
+        description: 'Primary workflow execution queue',
+      },
+      {
+        type: 'scheduler',
+        region: profile.region,
+        location: `scheduler:${profile.region}`,
+        description: 'Polling scheduler workers process triggers within this region',
+      },
+      {
+        type: 'connectionSecrets',
+        region: connectionStorage.region,
+        location: connectionStorage.location,
+        description:
+          connectionStorage.backend === 'file'
+            ? 'Encrypted connection secrets stored in regional filesystem enclave'
+            : 'Encrypted connection secrets stored in regional database partition',
+        details: {
+          backend: connectionStorage.backend,
+          metadata: connectionStorage.metadata ?? {},
+        },
+      },
+      {
+        type: 'executionLogs',
+        region: profile.region,
+        location: auditLogPath,
+        description: 'Workflow execution audit logs written to region-scoped storage',
+      },
+    ];
+
+    return {
+      organizationId: profile.id,
+      organizationName: profile.name,
+      primaryRegion: profile.region,
+      assets,
+      metadata: {
+        plan: profile.plan,
+        status: profile.status,
+        compliance: profile.compliance,
+        generatedAt: new Date().toISOString(),
+      },
+    };
+  }
+
+  public async listOrganizationResidencyReports(
+    organizationIds: string[]
+  ): Promise<OrganizationResidencyReport[]> {
+    const reports: OrganizationResidencyReport[] = [];
+    for (const id of organizationIds) {
+      try {
+        reports.push(await this.getOrganizationResidencyReport(id));
+      } catch (error) {
+        console.warn(
+          `⚠️ Unable to generate residency report for organization ${id}:`,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    }
+    return reports;
+  }
+}
+
+export const complianceReportingService = new ComplianceReportingService();

--- a/server/services/ExecutionAuditService.ts
+++ b/server/services/ExecutionAuditService.ts
@@ -1,7 +1,11 @@
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from 'fs';
 import { resolve, dirname } from 'path';
 
-const AUDIT_PATH = resolve(process.cwd(), 'production', 'reports', 'execution-log.jsonl');
+import { normalizeRegion as normalizeRegionValue, defaultRegion, isWildcardRegion } from '../utils/region.js';
+
+const AUDIT_BASE_PATH = resolve(process.cwd(), 'production', 'reports');
+const AUDIT_FILE_NAME = 'execution-log.jsonl';
+const LEGACY_AUDIT_PATH = resolve(AUDIT_BASE_PATH, AUDIT_FILE_NAME);
 
 type AuditEntry = {
   ts: string;
@@ -12,27 +16,105 @@ type AuditEntry = {
   success: boolean;
   error?: string;
   meta?: Record<string, any>;
+  organizationId?: string | null;
+  region: string;
 };
 
-export function recordExecution(entry: Omit<AuditEntry, 'ts'>): void {
-  try {
-    const dir = dirname(AUDIT_PATH);
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    const line: AuditEntry = { ts: new Date().toISOString(), ...entry };
-    appendFileSync(AUDIT_PATH, JSON.stringify(line) + '\n', { encoding: 'utf8' });
-  } catch (err) {
-    console.warn('⚠️ Failed to write execution audit log:', (err as any)?.message || err);
-  }
-}
+type RecordExecutionInput = Omit<AuditEntry, 'ts' | 'region'> & { region?: string | null };
 
-export function readExecutions(limit = 100): AuditEntry[] {
+function readLogFileEntries(filePath: string, fallbackRegion: string): AuditEntry[] {
+  if (!existsSync(filePath)) {
+    return [];
+  }
+
   try {
-    if (!existsSync(AUDIT_PATH)) return [];
-    const lines = readFileSync(AUDIT_PATH, 'utf8').trim().split('\n');
-    return lines.slice(-limit).map(line => JSON.parse(line));
+    const raw = readFileSync(filePath, 'utf8').trim();
+    if (raw.length === 0) {
+      return [];
+    }
+
+    return raw.split('\n').map((line) => {
+      const parsed = JSON.parse(line) as Partial<AuditEntry>;
+      const region = typeof parsed.region === 'string' && parsed.region.length > 0 ? parsed.region : fallbackRegion;
+      return {
+        ts: parsed.ts ?? new Date().toISOString(),
+        requestId: parsed.requestId ?? 'unknown',
+        appId: parsed.appId ?? 'unknown',
+        functionId: parsed.functionId ?? 'unknown',
+        durationMs: parsed.durationMs ?? 0,
+        success: parsed.success ?? false,
+        error: parsed.error,
+        meta: parsed.meta,
+        organizationId: parsed.organizationId ?? null,
+        region,
+      };
+    });
   } catch (err) {
     console.warn('⚠️ Failed to read execution audit log:', (err as any)?.message || err);
     return [];
   }
 }
 
+export function getAuditLogPath(region?: string | null): string {
+  const normalized = normalizeRegionValue(region, defaultRegion);
+  return resolve(AUDIT_BASE_PATH, normalized, AUDIT_FILE_NAME);
+}
+
+export function recordExecution(entry: RecordExecutionInput): void {
+  const { region, ...rest } = entry;
+  const normalizedRegion = normalizeRegionValue(region, defaultRegion);
+  const targetPath = getAuditLogPath(normalizedRegion);
+
+  try {
+    const dir = dirname(targetPath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const line: AuditEntry = {
+      ts: new Date().toISOString(),
+      region: normalizedRegion,
+      ...rest,
+    };
+    appendFileSync(targetPath, JSON.stringify(line) + '\n', { encoding: 'utf8' });
+  } catch (err) {
+    console.warn('⚠️ Failed to write execution audit log:', (err as any)?.message || err);
+  }
+}
+
+export function readExecutions(limit = 100, region?: string | null): AuditEntry[] {
+  try {
+    const normalizedRegion = region ? normalizeRegionValue(region, defaultRegion) : defaultRegion;
+    const wildcard = region ? isWildcardRegion(region) && normalizedRegion !== 'global' : false;
+
+    if (wildcard) {
+      if (!existsSync(AUDIT_BASE_PATH)) {
+        return readLogFileEntries(LEGACY_AUDIT_PATH, defaultRegion).slice(-limit);
+      }
+
+      const dirEntries = readdirSync(AUDIT_BASE_PATH, { withFileTypes: true });
+      const aggregated: AuditEntry[] = [];
+
+      for (const dirEntry of dirEntries) {
+        if (!dirEntry.isDirectory()) {
+          continue;
+        }
+        const filePath = resolve(AUDIT_BASE_PATH, dirEntry.name, AUDIT_FILE_NAME);
+        aggregated.push(...readLogFileEntries(filePath, dirEntry.name));
+      }
+
+      aggregated.push(...readLogFileEntries(LEGACY_AUDIT_PATH, defaultRegion));
+
+      return aggregated
+        .sort((a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime())
+        .slice(-limit);
+    }
+
+    const filePath = getAuditLogPath(normalizedRegion);
+    let entries = readLogFileEntries(filePath, normalizedRegion);
+    if (entries.length === 0 && normalizedRegion === defaultRegion) {
+      entries = readLogFileEntries(LEGACY_AUDIT_PATH, normalizedRegion);
+    }
+    return entries.slice(-limit);
+  } catch (err) {
+    console.warn('⚠️ Failed to read execution audit log:', (err as any)?.message || err);
+    return [];
+  }
+}

--- a/server/utils/region.ts
+++ b/server/utils/region.ts
@@ -1,0 +1,47 @@
+import type { OrganizationRegion } from '../database/schema.js';
+import type { WorkflowQueueName } from '../queue/types.js';
+
+const DEFAULT_REGION = normalizeInput(process.env.DEFAULT_ORGANIZATION_REGION) ?? 'us';
+
+function normalizeInput(value?: string | null): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  return trimmed.toLowerCase();
+}
+
+export function normalizeRegion(
+  region?: string | null,
+  fallback: OrganizationRegion = DEFAULT_REGION as OrganizationRegion
+): OrganizationRegion {
+  const normalized = normalizeInput(region);
+  if (normalized) {
+    return normalized as OrganizationRegion;
+  }
+  return fallback;
+}
+
+export function isWildcardRegion(region: string | null | undefined): boolean {
+  const normalized = normalizeInput(region);
+  if (!normalized) {
+    return false;
+  }
+  return normalized === 'global' || normalized === 'any' || normalized === 'all';
+}
+
+export function resolveWorkerRegion(): OrganizationRegion {
+  const configured =
+    normalizeInput(process.env.WORKER_REGION) ?? normalizeInput(process.env.EXECUTION_WORKER_REGION);
+  return normalizeRegion(configured);
+}
+
+export function resolveWorkflowQueueName(region: string | null | undefined): WorkflowQueueName {
+  const normalized = normalizeRegion(region);
+  return isWildcardRegion(normalized) ? 'workflow.execute' : (`workflow.execute.${normalized}` as WorkflowQueueName);
+}
+
+export const defaultRegion: OrganizationRegion = normalizeRegion(DEFAULT_REGION);

--- a/server/webhooks/types.ts
+++ b/server/webhooks/types.ts
@@ -44,4 +44,6 @@ export interface PollingTrigger {
   cursor?: Record<string, any> | null;
   backoffCount?: number;
   lastStatus?: string | null;
+  organizationId?: string;
+  region?: string;
 }

--- a/server/workers/scheduler.ts
+++ b/server/workers/scheduler.ts
@@ -2,15 +2,19 @@ import { env } from '../env';
 import { executionQueueService } from '../services/ExecutionQueueService.js';
 import { triggerPersistenceService } from '../services/TriggerPersistenceService.js';
 import { WebhookManager } from '../webhooks/WebhookManager.js';
+import { resolveWorkerRegion } from '../utils/region.js';
 
 const DEFAULT_INTERVAL_MS = 5000;
 const DEFAULT_BATCH_SIZE = 25;
+
+const workerRegion = resolveWorkerRegion();
 
 async function runSchedulerCycle(batchSize: number): Promise<void> {
   const now = new Date();
   const dueTriggers = await triggerPersistenceService.claimDuePollingTriggers({
     limit: batchSize,
     now,
+    region: workerRegion,
   });
 
   if (dueTriggers.length === 0) {
@@ -33,7 +37,7 @@ async function runSchedulerCycle(batchSize: number): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  console.log('🕒 Starting polling scheduler worker');
+  console.log(`🕒 Starting polling scheduler worker (region=${workerRegion})`);
   console.log('🌍 Worker environment:', env.NODE_ENV);
 
   WebhookManager.configureQueueService(executionQueueService);


### PR DESCRIPTION
## Summary
- add region utilities and propagate organization residency through execution queue payloads, scheduler selection, and trigger persistence
- scope connection storage, execution audit logs, and webhook polling to organization regions while enriching jobs/events with residency metadata
- introduce compliance reporting service and API endpoint plus database migration to persist explicit organization regions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0891fee3c83319a0020c2006a1953