### PR TITLE
Fix missing brace in parseTimestampValue

### DIFF
--- a/server/webhooks/WebhookManager.ts
+++ b/server/webhooks/WebhookManager.ts
@@ -249,7 +249,10 @@ export class WebhookManager {
       }
 
       const parsed = new Date(trimmed);
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    return null;
   }
 
   private lookupSignatureEnforcement(appId: string, triggerId: string): SignatureEnforcementConfig | null {


### PR DESCRIPTION
## Summary
- add the missing closing brace in `parseTimestampValue` for the string branch
- return null when no parseable timestamp is found and align braces for readability

## Testing
- `npm run build` *(fails: missing optional workspace dependencies in check:deps stage)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a8160a70833186a6fbe3346bcb96