### PR TITLE
Add corrective migration for execution logs foreign key

### DIFF
--- a/migrations/0014_correct_execution_logs_fk.ts
+++ b/migrations/0014_correct_execution_logs_fk.ts
@@ -1,0 +1,61 @@
+import { sql } from 'drizzle-orm';
+
+type MigrationClient = { execute: (query: any) => Promise<unknown> };
+
+export async function up(db: MigrationClient): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    DROP CONSTRAINT IF EXISTS "node_logs_execution_id_execution_logs_execution_id_fk" CASCADE
+  `);
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    DROP CONSTRAINT IF EXISTS "node_logs_execution_id_fkey" CASCADE
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    DROP CONSTRAINT IF EXISTS "execution_logs_execution_id_pk" CASCADE
+  `);
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    DROP CONSTRAINT IF EXISTS "execution_logs_pkey" CASCADE
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    ADD CONSTRAINT "execution_logs_execution_id_pk" PRIMARY KEY ("execution_id")
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    ADD CONSTRAINT "node_logs_execution_id_execution_logs_execution_id_fk"
+    FOREIGN KEY ("execution_id") REFERENCES "execution_logs"("execution_id") ON DELETE CASCADE
+  `);
+}
+
+export async function down(db: MigrationClient): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    DROP CONSTRAINT IF EXISTS "node_logs_execution_id_execution_logs_execution_id_fk" CASCADE
+  `);
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    DROP CONSTRAINT IF EXISTS "node_logs_execution_id_fkey" CASCADE
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    DROP CONSTRAINT IF EXISTS "execution_logs_execution_id_pk" CASCADE
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    ADD CONSTRAINT "execution_logs_pkey" PRIMARY KEY ("execution_id")
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    ADD CONSTRAINT "node_logs_execution_id_fkey"
+    FOREIGN KEY ("execution_id") REFERENCES "execution_logs"("execution_id") ON DELETE CASCADE
+  `);
+}


### PR DESCRIPTION
## Summary
- add a corrective migration that drops the node_logs foreign key before changing the execution_logs primary key
- recreate the node_logs foreign key after re-establishing the execution_logs primary key with cascade cleanup

## Testing
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres npx drizzle-kit push *(fails: unable to download drizzle-kit due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a81ae3708331affdaa171351c2ee