### PR TITLE
Remove stray return from WebhookManager verification failure handler

### DIFF
--- a/server/webhooks/WebhookManager.ts
+++ b/server/webhooks/WebhookManager.ts
@@ -471,9 +471,6 @@ export class WebhookManager {
     await this.persistence.markWebhookEventProcessed(logId, { success: false, error: message });
   }
 
-    return null;
-  }
-
   private resolveEventTimestamp(headers: Record<string, string>, payload: any): Date | null {
     const lowerCaseHeaders: Record<string, string | undefined> = {};
     for (const [key, value] of Object.entries(headers)) {


### PR DESCRIPTION
## Summary
- remove the extraneous return after recordVerificationFailure so the class structure is valid again

## Testing
- npm run check *(fails: missing @types/node and vite/client definitions because npm install cannot complete due to 403 from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e0acb6f0a4833180466a618614e1df