### PR TITLE
Add migration to lock execution log constraints

### DIFF
--- a/migrations/0015_execution_logs_pk_lock.ts
+++ b/migrations/0015_execution_logs_pk_lock.ts
@@ -1,0 +1,63 @@
+import { sql } from 'drizzle-orm';
+
+type MigrationClient = { execute: (query: any) => Promise<unknown> };
+
+export async function up(db: MigrationClient): Promise<void> {
+  await db.execute(sql`LOCK TABLE "execution_logs" IN ACCESS EXCLUSIVE MODE`);
+  await db.execute(sql`LOCK TABLE "node_logs" IN ACCESS EXCLUSIVE MODE`);
+
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    DROP CONSTRAINT IF EXISTS "node_logs_execution_id_execution_logs_execution_id_fk"
+  `);
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    DROP CONSTRAINT IF EXISTS "node_logs_execution_id_fkey"
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    DROP CONSTRAINT IF EXISTS "execution_logs_execution_id_pk" CASCADE
+  `);
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    DROP CONSTRAINT IF EXISTS "execution_logs_pkey" CASCADE
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    ADD CONSTRAINT "execution_logs_execution_id_pk" PRIMARY KEY ("execution_id")
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    ADD CONSTRAINT "node_logs_execution_id_execution_logs_execution_id_fk"
+    FOREIGN KEY ("execution_id") REFERENCES "execution_logs"("execution_id") ON DELETE CASCADE
+  `);
+}
+
+export async function down(db: MigrationClient): Promise<void> {
+  await db.execute(sql`LOCK TABLE "execution_logs" IN ACCESS EXCLUSIVE MODE`);
+  await db.execute(sql`LOCK TABLE "node_logs" IN ACCESS EXCLUSIVE MODE`);
+
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    DROP CONSTRAINT IF EXISTS "node_logs_execution_id_execution_logs_execution_id_fk"
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    DROP CONSTRAINT IF EXISTS "execution_logs_execution_id_pk" CASCADE
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "execution_logs"
+    ADD CONSTRAINT "execution_logs_pkey" PRIMARY KEY ("execution_id")
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "node_logs"
+    ADD CONSTRAINT "node_logs_execution_id_fkey"
+    FOREIGN KEY ("execution_id") REFERENCES "execution_logs"("execution_id") ON DELETE CASCADE
+  `);
+}


### PR DESCRIPTION
## Summary
- add a migration that locks the execution_logs and node_logs tables before adjusting constraints
- recreate the execution_logs primary key and node_logs foreign key after dropping existing constraints

## Testing
- npx drizzle-kit push *(fails: 403 Forbidden fetching drizzle-kit from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e0accd180083319ab572b6ccf2f3e0