### PR TITLE
Enforce migrations for breaking workflow promotions

### DIFF
--- a/common/workflow-types.ts
+++ b/common/workflow-types.ts
@@ -75,6 +75,21 @@ export interface WorkflowDeploymentSummary {
   rollbackOf?: string | null;
 }
 
+export type WorkflowBreakingChangeType =
+  | 'node-removed'
+  | 'output-removed'
+  | 'schema-changed';
+
+export interface WorkflowBreakingChange {
+  type: WorkflowBreakingChangeType;
+  nodeId: string;
+  description: string;
+  removedOutputs?: string[];
+  field?: string;
+  previousSchema?: Record<string, any> | null;
+  currentSchema?: Record<string, any> | null;
+}
+
 export interface WorkflowDiffSummary {
   hasChanges: boolean;
   addedNodes: string[];
@@ -83,6 +98,18 @@ export interface WorkflowDiffSummary {
   addedEdges: string[];
   removedEdges: string[];
   metadataChanged: boolean;
+  breakingChanges: WorkflowBreakingChange[];
+  hasBreakingChanges: boolean;
+}
+
+export interface WorkflowMigrationMetadata {
+  required: boolean;
+  freezeActiveRuns: boolean;
+  scheduleRollForward: boolean;
+  scheduleBackfill: boolean;
+  notes?: string | null;
+  assessedAt?: string;
+  breakingChanges?: WorkflowBreakingChange[];
 }
 
 export interface WorkflowDiffResponse {


### PR DESCRIPTION
## Summary
- extend workflow diffing to flag breaking changes by inspecting removed nodes, outputs, and schema updates
- require and persist migration metadata when promoting versions with breaking changes and expose the details to the deployment record
- update the graph editor to warn on promotion, gather migration decisions, and add coverage to block publishing without a migration plan

## Testing
- ⚠️ `npx tsx server/workflow/__tests__/WorkflowRepository.test.ts` *(fails: npm registry access forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ae33014883319759506f52d3827c