### PR TITLE
Add platform network policy defaults and connector network requirements

### DIFF
--- a/server/ConnectorRegistry.ts
+++ b/server/ConnectorRegistry.ts
@@ -96,6 +96,12 @@ interface ConnectorDefinition {
     config: any;
   };
   baseUrl?: string;
+  network?: {
+    requiredOutbound?: {
+      domains?: string[];
+      ipRanges?: string[];
+    };
+  };
   rateLimits?: {
     requestsPerSecond?: number;
     requestsPerMinute?: number;

--- a/server/connectors/ConnectorFramework.ts
+++ b/server/connectors/ConnectorFramework.ts
@@ -84,7 +84,14 @@ export interface ConnectorDefinition {
     reset?: string[];
     retryAfter?: string[];
   };
-  
+
+  network?: {
+    requiredOutbound?: {
+      domains?: string[];
+      ipRanges?: string[];
+    };
+  };
+
   // Metadata
   isActive: boolean;
   isVerified: boolean;

--- a/server/workflow/WorkflowRuntimeService.ts
+++ b/server/workflow/WorkflowRuntimeService.ts
@@ -964,7 +964,13 @@ export class WorkflowRuntimeService {
 
       const credentials = { ...context.credentials };
 
-      if (context.networkAllowlist) {
+      if (context.networkPolicy) {
+        (credentials as APICredentials).__organizationNetworkPolicy = context.networkPolicy;
+        if (context.networkPolicy.allowlist) {
+          (credentials as APICredentials).__organizationNetworkAllowlist =
+            context.networkPolicy.allowlist;
+        }
+      } else if (context.networkAllowlist) {
         (credentials as APICredentials).__organizationNetworkAllowlist = context.networkAllowlist;
       }
 


### PR DESCRIPTION
## Summary
- add platform-level network policy parsing in `ConnectionService` and expose getters for sandbox use
- update sandbox/network enforcement to merge organization, platform, and connector requirements with enhanced telemetry
- allow connector definitions to define required outbound hosts and extend tests for default policy coverage

## Testing
- npx tsx server/runtime/__tests__/WorkflowRuntime.sandbox.test.ts *(fails: npm 403 fetching tsx in restricted environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b332a99883318ab0c1c5991268fd