### PR TITLE
feat: add run explorer search experience

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,6 +25,7 @@ import AdminUsage from "./pages/AdminUsage";
 import WorkflowBuilder from "./pages/WorkflowBuilder";
 import GraphEditor from "./pages/GraphEditor";
 import OAuthCallback from "./pages/OAuthCallback";
+import RunExplorer from "./pages/RunExplorer";
 
 const queryClient = new QueryClient();
 
@@ -44,6 +45,7 @@ const App = () => (
             <Route path="/graph-editor" element={<GraphEditor />} />
             <Route path="/admin/settings" element={<AdminSettings />} />
             <Route path="/admin/usage" element={<AdminUsage />} />
+            <Route path="/runs" element={<RunExplorer />} />
             <Route path="/pre-built-apps" element={<PreBuiltApps />} />
             <Route path="/schedule" element={<Schedule />} />
             <Route path="/contact" element={<Contact />} />

--- a/client/src/pages/RunExplorer.tsx
+++ b/client/src/pages/RunExplorer.tsx
@@ -1,0 +1,440 @@
+import { useEffect, useMemo, useState } from 'react';
+import { format } from 'date-fns';
+import { AlertTriangle, Clock, Link as LinkIcon, Logs, RefreshCw } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import { RunViewer } from '@/components/workflow/RunViewer';
+import { searchRuns, type RunFacetEntry, type RunSearchResult, type RunSummary } from '@/services/runExplorer';
+
+const STATUS_COLORS: Record<string, string> = {
+  succeeded: 'bg-green-100 text-green-800 border-green-200',
+  failed: 'bg-red-100 text-red-800 border-red-200',
+  running: 'bg-blue-100 text-blue-800 border-blue-200',
+  pending: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+  waiting: 'bg-amber-100 text-amber-800 border-amber-200',
+};
+
+const formatDuration = (ms?: number) => {
+  if (ms == null) return '—';
+  if (ms < 1000) return `${ms} ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)} s`;
+  if (ms < 3600000) return `${(ms / 60000).toFixed(1)} m`;
+  return `${(ms / 3600000).toFixed(1)} h`;
+};
+
+const formatTimestamp = (value?: string) => {
+  if (!value) return '—';
+  try {
+    return format(new Date(value), 'MMM d, yyyy HH:mm:ss');
+  } catch (error) {
+    console.error('Failed to format timestamp', error);
+    return value;
+  }
+};
+
+const useFacetToggle = () => {
+  const [values, setValues] = useState<string[]>([]);
+  const toggleValue = (value: string) => {
+    setValues((current) => {
+      if (current.includes(value)) {
+        return current.filter((entry) => entry !== value);
+      }
+      return [...current, value];
+    });
+  };
+  const clear = () => setValues([]);
+  return { values, toggleValue, clear };
+};
+
+const FacetGroup = ({
+  title,
+  facets,
+  selected,
+  onToggle,
+  onClear,
+}: {
+  title: string;
+  facets: RunFacetEntry[];
+  selected: string[];
+  onToggle: (value: string) => void;
+  onClear: () => void;
+}) => (
+  <Card className="border border-slate-200">
+    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+      <CardTitle className="text-sm font-semibold text-slate-700">{title}</CardTitle>
+      <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={onClear}>
+        Reset
+      </Button>
+    </CardHeader>
+    <CardContent className="space-y-2">
+      {facets.length === 0 ? (
+        <p className="text-xs text-slate-500">No facet data.</p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {facets.map((facet) => {
+            const isActive = selected.includes(facet.value);
+            return (
+              <Button
+                key={`${title}-${facet.value}`}
+                variant={isActive ? 'default' : 'secondary'}
+                size="sm"
+                className="h-8 rounded-full"
+                onClick={() => onToggle(facet.value)}
+              >
+                {facet.value}
+                <Badge variant="outline" className="ml-2 text-xs">
+                  {facet.count}
+                </Badge>
+              </Button>
+            );
+          })}
+        </div>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const RunRow = ({
+  run,
+  onSelect,
+}: {
+  run: RunSummary;
+  onSelect: (run: RunSummary) => void;
+}) => {
+  const statusStyle = STATUS_COLORS[run.status] ?? 'bg-slate-100 text-slate-800 border-slate-200';
+  const duplicateCount = run.duplicateEvents?.length ?? 0;
+
+  return (
+    <Card className="border border-slate-200 shadow-sm hover:shadow-md transition-shadow">
+      <CardContent className="space-y-4 p-4">
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className={`border ${statusStyle}`}>
+                {run.status}
+              </Badge>
+              <span className="text-sm text-slate-500">{run.triggerType ?? 'manual'}</span>
+            </div>
+            <h3 className="mt-2 text-lg font-semibold text-slate-900">{run.workflowName}</h3>
+            <p className="text-sm text-slate-500">Execution ID: {run.executionId}</p>
+            {run.organizationId && (
+              <p className="text-sm text-slate-500">Organization: {run.organizationId}</p>
+            )}
+          </div>
+          <div className="flex flex-col items-end gap-2">
+            <div className="flex items-center gap-3 text-sm text-slate-500">
+              <Clock className="h-4 w-4" />
+              <span>{formatTimestamp(run.startTime)}</span>
+            </div>
+            <div className="text-sm text-slate-500">Duration: {formatDuration(run.durationMs)}</div>
+            <Button variant="default" size="sm" onClick={() => onSelect(run)}>
+              Open in Run Viewer
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-slate-700">Connectors:</span>
+            {run.connectors.length === 0 ? (
+              <Badge variant="secondary">None</Badge>
+            ) : (
+              run.connectors.map((connector) => (
+                <Badge key={`${run.executionId}-${connector}`} variant="secondary" className="capitalize">
+                  {connector}
+                </Badge>
+              ))
+            )}
+          </div>
+          <Separator orientation="vertical" className="h-5" />
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-slate-700">Trace:</span>
+            {run.correlationId ? (
+              <a
+                href={`/observability/traces/${run.correlationId}`}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+              >
+                <LinkIcon className="h-4 w-4" />
+                {run.correlationId}
+              </a>
+            ) : (
+              <span className="text-slate-500">Not available</span>
+            )}
+          </div>
+          <Separator orientation="vertical" className="h-5" />
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-slate-700">Logs:</span>
+            <a
+              href={`/api/executions/${run.executionId}`}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+            >
+              <Logs className="h-4 w-4" />
+              Download JSON
+            </a>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          {duplicateCount > 0 ? (
+            <Badge variant="destructive" className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4" />
+              {duplicateCount} webhook duplicate{duplicateCount === 1 ? '' : 's'} detected
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="text-slate-600">
+              No webhook dedupe events detected
+            </Badge>
+          )}
+          {run.requestId && (
+            <Badge variant="outline" className="flex items-center gap-2 text-slate-600">
+              <RefreshCw className="h-4 w-4" />
+              Request {run.requestId}
+            </Badge>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+const RunExplorer = () => {
+  const [organizationId, setOrganizationId] = useState('');
+  const [workflowId, setWorkflowId] = useState('');
+  const statusFacet = useFacetToggle();
+  const connectorFacet = useFacetToggle();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
+  const [data, setData] = useState<RunSearchResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedRun, setSelectedRun] = useState<RunSummary | null>(null);
+
+  useEffect(() => {
+    setPage(1);
+  }, [organizationId, workflowId, statusFacet.values, connectorFacet.values]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const loadRuns = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await searchRuns({
+          organizationId: organizationId || undefined,
+          workflowId: workflowId || undefined,
+          statuses: statusFacet.values,
+          connectors: connectorFacet.values,
+          page,
+          pageSize,
+        });
+        if (!controller.signal.aborted) {
+          setData(response);
+          if (response.runs.length > 0) {
+            if (!selectedRun || !response.runs.some((run) => run.executionId === selectedRun.executionId)) {
+              setSelectedRun(response.runs[0]);
+            }
+          } else {
+            setSelectedRun(null);
+          }
+        }
+      } catch (fetchError) {
+        if (!controller.signal.aborted) {
+          setError(fetchError instanceof Error ? fetchError.message : 'Failed to load runs');
+          setData(null);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadRuns();
+    return () => controller.abort();
+  }, [organizationId, workflowId, statusFacet.values, connectorFacet.values, page, pageSize]);
+
+  const pagination = data?.pagination;
+  const canGoNext = Boolean(pagination?.hasMore);
+  const canGoPrev = page > 1;
+
+  const duplicateDetails = useMemo(() => {
+    if (!selectedRun) return [] as RunSummary['duplicateEvents'];
+    return selectedRun.duplicateEvents ?? [];
+  }, [selectedRun]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 py-10">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold text-slate-900">Run Explorer</h1>
+        <p className="text-sm text-slate-600">
+          Investigate workflow executions with rich filtering, connector facets, and deep links into detailed telemetry.
+        </p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[280px_1fr]">
+        <div className="flex flex-col gap-4">
+          <Card className="border border-slate-200">
+            <CardHeader>
+              <CardTitle className="text-base font-semibold text-slate-800">Filters</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-1">
+                <label className="text-sm font-medium text-slate-700" htmlFor="organizationId">
+                  Organization ID
+                </label>
+                <Input
+                  id="organizationId"
+                  placeholder="org_..."
+                  value={organizationId}
+                  onChange={(event) => setOrganizationId(event.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium text-slate-700" htmlFor="workflowId">
+                  Workflow ID
+                </label>
+                <Input
+                  id="workflowId"
+                  placeholder="wf_..."
+                  value={workflowId}
+                  onChange={(event) => setWorkflowId(event.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium text-slate-700" htmlFor="pageSize">
+                  Page size
+                </label>
+                <Input
+                  id="pageSize"
+                  type="number"
+                  min={5}
+                  max={100}
+                  value={pageSize}
+                  onChange={(event) => setPageSize(Number(event.target.value) || 25)}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <FacetGroup
+            title="Status"
+            facets={data?.facets.status ?? []}
+            selected={statusFacet.values}
+            onToggle={statusFacet.toggleValue}
+            onClear={statusFacet.clear}
+          />
+
+          <FacetGroup
+            title="Connectors"
+            facets={data?.facets.connector ?? []}
+            selected={connectorFacet.values}
+            onToggle={connectorFacet.toggleValue}
+            onClear={connectorFacet.clear}
+          />
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <Card className="border border-slate-200">
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle className="text-lg font-semibold text-slate-800">Recent Runs</CardTitle>
+              <div className="flex items-center gap-2 text-sm text-slate-600">
+                {pagination ? `${pagination.total} total` : 'Loading totals...'}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {error && (
+                <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                  {error}
+                </div>
+              )}
+
+              {loading && (
+                <div className="flex items-center gap-2 text-sm text-slate-600">
+                  <RefreshCw className="h-4 w-4 animate-spin" />
+                  Loading runs...
+                </div>
+              )}
+
+              {!loading && data && data.runs.length === 0 && (
+                <p className="text-sm text-slate-500">No runs match the current filters.</p>
+              )}
+
+              <div className="space-y-4">
+                {data?.runs.map((run) => (
+                  <RunRow key={run.executionId} run={run} onSelect={setSelectedRun} />
+                ))}
+              </div>
+
+              {pagination && (
+                <div className="flex items-center justify-between pt-2 text-sm text-slate-600">
+                  <span>
+                    Page {pagination.page} • Showing {data?.runs.length ?? 0} of {pagination.total}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <Button variant="outline" size="sm" disabled={!canGoPrev} onClick={() => canGoPrev && setPage((p) => p - 1)}>
+                      Previous
+                    </Button>
+                    <Button variant="outline" size="sm" disabled={!canGoNext} onClick={() => canGoNext && setPage((p) => p + 1)}>
+                      Next
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {selectedRun && (
+            <div className="grid gap-6 lg:grid-cols-[360px_1fr]">
+              <Card className="border border-slate-200">
+                <CardHeader>
+                  <CardTitle className="text-base font-semibold text-slate-800">Webhook Dedupe Activity</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {duplicateDetails.length === 0 ? (
+                    <p className="text-sm text-slate-500">No duplicate webhook deliveries recorded for this run.</p>
+                  ) : (
+                    <ScrollArea className="h-48">
+                      <div className="space-y-3 pr-2">
+                        {duplicateDetails.map((event) => (
+                          <div key={event.id} className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                            <div className="flex items-center justify-between">
+                              <span className="font-medium">{event.webhookId}</span>
+                              <span className="text-xs text-amber-700">
+                                {formatTimestamp(event.timestamp)}
+                              </span>
+                            </div>
+                            <p className="mt-1 text-xs text-amber-800">{event.error}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </ScrollArea>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card className="border border-slate-200">
+                <CardHeader>
+                  <CardTitle className="text-base font-semibold text-slate-800">Run Viewer</CardTitle>
+                </CardHeader>
+                <CardContent className="p-0">
+                  <RunViewer executionId={selectedRun.executionId} workflowId={selectedRun.workflowId} />
+                </CardContent>
+              </Card>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RunExplorer;

--- a/client/src/pages/__tests__/RunExplorer.test.tsx
+++ b/client/src/pages/__tests__/RunExplorer.test.tsx
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+import { JSDOM } from 'jsdom';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+import RunExplorer from '../RunExplorer';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost/' });
+
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+(global as any).navigator = dom.window.navigator;
+(global as any).HTMLElement = dom.window.HTMLElement;
+(global as any).SVGElement = dom.window.SVGElement;
+(global as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!('localStorage' in global)) {
+  (global as any).localStorage = dom.window.localStorage;
+}
+if (!('sessionStorage' in global)) {
+  (global as any).sessionStorage = dom.window.sessionStorage;
+}
+
+const originalFetch = global.fetch;
+const fetchCalls: string[] = [];
+
+beforeEach(() => {
+  cleanup();
+  fetchCalls.length = 0;
+  global.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    fetchCalls.push(url);
+
+    if (url.startsWith('/api/runs/search')) {
+      const responsePayload = {
+        success: true,
+        runs: [
+          {
+            executionId: 'exec-123',
+            workflowId: 'wf-1',
+            workflowName: 'Critical Workflow',
+            organizationId: 'org-1',
+            status: 'failed',
+            startTime: '2024-01-01T00:00:00.000Z',
+            endTime: '2024-01-01T00:01:00.000Z',
+            durationMs: 60000,
+            triggerType: 'webhook',
+            totalNodes: 3,
+            completedNodes: 2,
+            failedNodes: 1,
+            tags: ['prod'],
+            correlationId: 'corr-1',
+            requestId: 'req-1',
+            connectors: ['slack'],
+            duplicateEvents: [],
+            metadata: {},
+          },
+        ],
+        pagination: {
+          total: 1,
+          page: 1,
+          pageSize: 25,
+          hasMore: false,
+        },
+        facets: {
+          status: [
+            { value: 'failed', count: 1 },
+            { value: 'succeeded', count: 0 },
+          ],
+          connector: [{ value: 'slack', count: 1 }],
+        },
+      };
+      return Promise.resolve(
+        new Response(JSON.stringify(responsePayload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }
+
+    if (url.startsWith('/api/executions')) {
+      const executionsPayload = {
+        success: true,
+        executions: [
+          {
+            executionId: 'exec-123',
+            workflowId: 'wf-1',
+            workflowName: 'Critical Workflow',
+            status: 'failed',
+            startTime: '2024-01-01T00:00:00.000Z',
+            endTime: '2024-01-01T00:01:00.000Z',
+            duration: 60000,
+            totalNodes: 3,
+            completedNodes: 2,
+            failedNodes: 1,
+            nodeExecutions: [],
+            correlationId: 'corr-1',
+            tags: [],
+            metadata: { retryCount: 0, totalCostUSD: 0, totalTokensUsed: 0, cacheHitRate: 0, averageNodeDuration: 0 },
+          },
+        ],
+      };
+      return Promise.resolve(
+        new Response(JSON.stringify(executionsPayload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }
+
+    if (url.includes('/duplicate-events')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ success: true, events: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }
+
+    if (url.startsWith('/api/admin/executions')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ success: true, entries: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }
+
+    console.warn('Unhandled fetch in RunExplorer test:', url, init);
+    return Promise.resolve(new Response('{}', { status: 200 }));
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  global.fetch = originalFetch;
+});
+
+test('RunExplorer renders runs, toggles facets, and links to run viewer telemetry', async () => {
+  render(<RunExplorer />);
+
+  const workflowTitle = await screen.findByText('Critical Workflow');
+  assert.ok(workflowTitle, 'workflow should appear in results');
+
+  const connectorChip = await screen.findByText('slack');
+  assert.ok(connectorChip, 'connector facet should render');
+
+  const statusFacetButton = await screen.findByRole('button', { name: /failed/i });
+  fireEvent.click(statusFacetButton);
+
+  await waitFor(() => {
+    assert.ok(fetchCalls.some((url) => url.includes('status=failed')), 'status filter should trigger API call');
+  });
+
+  const runViewerButton = await screen.findByRole('button', { name: /Open in Run Viewer/i });
+  fireEvent.click(runViewerButton);
+
+  await waitFor(() => {
+    const logLink = screen.getByText(/Download JSON/i);
+    assert.ok(logLink, 'log link should be visible for run');
+  });
+
+  const dedupeMessage = await screen.findByText(/No duplicate webhook deliveries recorded/i);
+  assert.ok(dedupeMessage, 'dedupe panel should render message');
+});

--- a/client/src/services/runExplorer.ts
+++ b/client/src/services/runExplorer.ts
@@ -1,0 +1,92 @@
+export interface RunSummary {
+  executionId: string;
+  workflowId: string;
+  workflowName: string;
+  organizationId: string | null;
+  status: string;
+  startTime: string;
+  endTime?: string;
+  durationMs?: number;
+  triggerType?: string;
+  totalNodes?: number;
+  completedNodes?: number;
+  failedNodes?: number;
+  tags: string[];
+  correlationId: string | null;
+  requestId: string | null;
+  connectors: string[];
+  duplicateEvents: Array<{
+    id: string;
+    webhookId: string;
+    timestamp: string;
+    error: string;
+  }>;
+  metadata: Record<string, unknown>;
+}
+
+export interface RunFacetEntry {
+  value: string;
+  count: number;
+}
+
+export interface RunSearchResult {
+  success: boolean;
+  runs: RunSummary[];
+  pagination: {
+    total: number;
+    page: number;
+    pageSize: number;
+    hasMore: boolean;
+  };
+  facets: {
+    status: RunFacetEntry[];
+    connector: RunFacetEntry[];
+  };
+}
+
+export interface RunSearchParams {
+  organizationId?: string;
+  workflowId?: string;
+  statuses?: string[];
+  connectors?: string[];
+  page?: number;
+  pageSize?: number;
+}
+
+function appendArrayParam(params: URLSearchParams, key: string, values?: string[]) {
+  if (!values || values.length === 0) {
+    return;
+  }
+  values.forEach((value) => {
+    if (value) {
+      params.append(key, value);
+    }
+  });
+}
+
+export async function searchRuns(params: RunSearchParams): Promise<RunSearchResult> {
+  const query = new URLSearchParams();
+
+  if (params.organizationId) {
+    query.set('organizationId', params.organizationId);
+  }
+  if (params.workflowId) {
+    query.set('workflowId', params.workflowId);
+  }
+  appendArrayParam(query, 'status', params.statuses);
+  appendArrayParam(query, 'connectorId', params.connectors);
+
+  if (params.page && params.page > 0) {
+    query.set('page', String(params.page));
+  }
+  if (params.pageSize && params.pageSize > 0) {
+    query.set('pageSize', String(params.pageSize));
+  }
+
+  const response = await fetch(`/api/runs/search?${query.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Failed to load runs (status ${response.status})`);
+  }
+  const data = (await response.json()) as RunSearchResult;
+  return data;
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -22,6 +22,7 @@ import productionHealthRoutes from "./routes/production-health.js";
 import flowRoutes from "./routes/flows.js";
 import oauthRoutes from "./routes/oauth";
 import executionRoutes from "./routes/executions.js";
+import runExplorerRoutes from "./routes/run-explorer.js";
 import expressionRoutes from "./routes/expressions.js";
 import { RealAIService, ConversationManager } from "./realAIService";
 import organizationRoleRoutes from "./routes/organization-roles";
@@ -144,6 +145,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // P1-6: App parameter schema routes
   app.use('/api/app-schemas', appSchemaRoutes);
   app.use('/api/executions', executionRoutes);
+  app.use('/api/runs', runExplorerRoutes);
 
   app.use('/api/google', googleSheetsRoutes);
   app.use('/api/metadata', metadataRoutes);

--- a/server/routes/__tests__/run-explorer.test.ts
+++ b/server/routes/__tests__/run-explorer.test.ts
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import express from 'express';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+const originalNodeEnv = process.env.NODE_ENV;
+process.env.NODE_ENV = 'test';
+
+const { setDatabaseClientForTests } = await import('../../database/schema.js');
+const triggerPersistenceModule = await import('../../services/TriggerPersistenceService.js');
+
+class SelectBuilder {
+  constructor(private readonly result: any, private readonly resolveOn: 'offset' | 'limit' | 'where' | 'orderBy') {}
+
+  from() {
+    return this;
+  }
+
+  leftJoin() {
+    return this;
+  }
+
+  innerJoin() {
+    return this;
+  }
+
+  where() {
+    if (this.resolveOn === 'where') {
+      return Promise.resolve(this.result);
+    }
+    return this;
+  }
+
+  orderBy() {
+    if (this.resolveOn === 'orderBy') {
+      return Promise.resolve(this.result);
+    }
+    return this;
+  }
+
+  groupBy() {
+    return this;
+  }
+
+  limit() {
+    if (this.resolveOn === 'limit') {
+      return Promise.resolve(this.result);
+    }
+    return this;
+  }
+
+  offset() {
+    if (this.resolveOn === 'offset') {
+      return Promise.resolve(this.result);
+    }
+    return this;
+  }
+}
+
+const selectQueue = [
+  {
+    result: [
+      {
+        execution: {
+          executionId: 'exec-123',
+          workflowId: 'wf-1',
+          workflowName: 'Critical Workflow',
+          status: 'failed',
+          startTime: new Date('2024-01-01T00:00:00Z'),
+          endTime: new Date('2024-01-01T00:01:00Z'),
+          durationMs: 60000,
+          triggerType: 'webhook',
+          totalNodes: 3,
+          completedNodes: 2,
+          failedNodes: 1,
+          tags: ['prod'],
+          correlationId: 'trace-1',
+          metadata: { requestId: 'req-1' },
+        },
+        workflow: {
+          id: 'wf-1',
+          organizationId: 'org-1',
+          name: 'Critical Workflow',
+        },
+      },
+    ],
+    resolveOn: 'offset',
+  },
+  {
+    result: [{ value: 1 }],
+    resolveOn: 'limit',
+  },
+  {
+    result: [
+      {
+        executionId: 'exec-123',
+        nodeType: 'action.slack.send_message',
+        metadata: { connectorId: 'slack' },
+        status: 'succeeded',
+        startTime: new Date('2024-01-01T00:00:30Z'),
+      },
+    ],
+    resolveOn: 'where',
+  },
+  {
+    result: [
+      {
+        status: 'failed',
+        count: 1,
+      },
+    ],
+    resolveOn: 'orderBy',
+  },
+  {
+    result: [
+      {
+        connector: 'slack',
+        count: 1,
+      },
+    ],
+    resolveOn: 'limit',
+  },
+];
+
+const dbStub = {
+  select: () => {
+    const next = selectQueue.shift();
+    if (!next) {
+      throw new Error('Unexpected select invocation in test');
+    }
+    return new SelectBuilder(next.result, next.resolveOn);
+  },
+};
+
+setDatabaseClientForTests(dbStub as any);
+
+const originalListDuplicates = triggerPersistenceModule.triggerPersistenceService.listDuplicateWebhookEvents;
+(triggerPersistenceModule.triggerPersistenceService as any).listDuplicateWebhookEvents = async () => [
+  {
+    id: 'dup-1',
+    webhookId: 'hook-1',
+    timestamp: new Date('2024-01-01T00:00:10Z'),
+    error: 'duplicate delivery',
+  },
+];
+
+const app = express();
+app.use(express.json());
+
+const { registerRoutes } = await import('../../routes.ts');
+
+let server: Server | undefined;
+let exitCode = 0;
+
+try {
+  server = await registerRoutes(app);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  const response = await fetch(
+    `${baseUrl}/api/runs/search?organizationId=org-1&connectorId=slack&status=failed&page=1&pageSize=10`
+  );
+
+  assert.equal(response.status, 200, 'search endpoint should return 200');
+  const body = await response.json();
+  assert.equal(body.success, true, 'response should indicate success');
+  assert.equal(body.pagination.total, 1, 'total should reflect stub data');
+  assert.equal(body.pagination.page, 1, 'page should echo request');
+  assert.equal(body.pagination.pageSize, 10, 'pageSize should echo request');
+  assert.equal(body.pagination.hasMore, false, 'no additional pages expected');
+
+  assert.ok(Array.isArray(body.runs), 'runs should be an array');
+  assert.equal(body.runs.length, 1, 'one run expected');
+
+  const run = body.runs[0];
+  assert.equal(run.executionId, 'exec-123');
+  assert.equal(run.workflowId, 'wf-1');
+  assert.equal(run.status, 'failed');
+  assert.deepEqual(run.connectors, ['slack'], 'connector facets should be inferred');
+  assert.equal(run.requestId, 'req-1', 'request identifier should surface from metadata');
+  assert.ok(Array.isArray(run.duplicateEvents), 'duplicate webhook events should be included');
+  assert.equal(run.duplicateEvents.length, 1, 'one duplicate webhook event expected');
+  assert.equal(run.duplicateEvents[0].webhookId, 'hook-1');
+
+  assert.ok(body.facets, 'facets object should be present');
+  const statusFacet = body.facets.status.find((entry: any) => entry.value === 'failed');
+  assert.ok(statusFacet, 'status facet should include failed');
+  assert.equal(statusFacet.count, 1, 'status facet count should match stub');
+  const connectorFacet = body.facets.connector.find((entry: any) => entry.value === 'slack');
+  assert.ok(connectorFacet, 'connector facet should include slack');
+  assert.equal(connectorFacet.count, 1, 'connector facet count should match stub');
+
+  console.log('Run explorer search endpoint returns filtered runs with facets and dedupe context.');
+} catch (error) {
+  exitCode = 1;
+  console.error(error);
+} finally {
+  if (server) {
+    await new Promise<void>((resolve, reject) => server!.close((err) => (err ? reject(err) : resolve())));
+  }
+
+  (triggerPersistenceModule.triggerPersistenceService as any).listDuplicateWebhookEvents = originalListDuplicates;
+  setDatabaseClientForTests(null as any);
+
+  if (originalNodeEnv) {
+    process.env.NODE_ENV = originalNodeEnv;
+  } else {
+    delete process.env.NODE_ENV;
+  }
+
+  process.exit(exitCode);
+}

--- a/server/routes/run-explorer.ts
+++ b/server/routes/run-explorer.ts
@@ -1,0 +1,251 @@
+import { Router } from 'express';
+import { and, eq, inArray, or, sql, desc, asc, type SQL } from 'drizzle-orm';
+
+import { db, executionLogs, nodeLogs, workflows } from '../database/schema.js';
+import { triggerPersistenceService } from '../services/TriggerPersistenceService.js';
+import { getErrorMessage } from '../types/common.js';
+
+const MAX_PAGE_SIZE = 100;
+const DEFAULT_PAGE_SIZE = 25;
+
+const runsRouter = Router();
+
+function normalizeArrayParam(value: unknown): string[] | undefined {
+  if (!value) return undefined;
+  if (Array.isArray(value)) {
+    return value.map((entry) => String(entry).trim()).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return undefined;
+}
+
+function combineConditions(conditions: Array<SQL<unknown> | undefined>): SQL<unknown> | undefined {
+  const filtered = conditions.filter((condition): condition is SQL<unknown> => Boolean(condition));
+  if (filtered.length === 0) return undefined;
+  if (filtered.length === 1) return filtered[0];
+  return and(...filtered);
+}
+
+runsRouter.get('/search', async (req, res) => {
+  if (!db) {
+    return res.status(503).json({ success: false, error: 'Database not configured' });
+  }
+
+  try {
+    const organizationId = req.query.organizationId ? String(req.query.organizationId) : undefined;
+    const workflowIds = normalizeArrayParam(req.query.workflowId ?? req.query.workflowIds);
+    const statusFilters = normalizeArrayParam(req.query.status ?? req.query.statuses);
+    const connectorFilters = normalizeArrayParam(req.query.connectorId ?? req.query.connectorIds)?.map((value) =>
+      value.toLowerCase()
+    );
+
+    const page = req.query.page ? Math.max(1, parseInt(String(req.query.page), 10) || 1) : 1;
+    const pageSizeRaw = req.query.pageSize ?? req.query.limit;
+    const pageSize = pageSizeRaw ? Math.max(1, Math.min(MAX_PAGE_SIZE, parseInt(String(pageSizeRaw), 10) || DEFAULT_PAGE_SIZE)) : DEFAULT_PAGE_SIZE;
+    const offset = (page - 1) * pageSize;
+
+    const baseConditions: SQL<unknown>[] = [];
+
+    if (organizationId) {
+      baseConditions.push(eq(workflows.organizationId, organizationId));
+    }
+
+    if (workflowIds && workflowIds.length > 0) {
+      baseConditions.push(inArray(executionLogs.workflowId, workflowIds));
+    }
+
+    if (connectorFilters && connectorFilters.length > 0) {
+      const connectorClauses = connectorFilters.map((connector) =>
+        sql`EXISTS (
+          SELECT 1 FROM ${nodeLogs} nl
+          WHERE nl.execution_id = ${executionLogs.executionId}
+            AND (
+              lower(nl.metadata ->> 'connectorId') = ${connector}
+              OR lower(split_part(nl.node_type, '.', 2)) = ${connector}
+            )
+        )`
+      );
+
+      if (connectorClauses.length === 1) {
+        baseConditions.push(connectorClauses[0]);
+      } else if (connectorClauses.length > 1) {
+        baseConditions.push(or(...connectorClauses));
+      }
+    }
+
+    const statusCondition = statusFilters && statusFilters.length > 0 ? inArray(executionLogs.status, statusFilters) : undefined;
+
+    const whereClause = combineConditions([...baseConditions, statusCondition]);
+    const facetWhereClause = combineConditions(baseConditions);
+
+    const runs = await db
+      .select({
+        execution: executionLogs,
+        workflow: workflows,
+      })
+      .from(executionLogs)
+      .leftJoin(workflows, eq(workflows.id, executionLogs.workflowId))
+      .where(whereClause)
+      .orderBy(desc(executionLogs.startTime))
+      .limit(pageSize)
+      .offset(offset);
+
+    const [{ value: total = 0 } = { value: 0 }] = await db
+      .select({ value: sql<number>`count(*)` })
+      .from(executionLogs)
+      .leftJoin(workflows, eq(workflows.id, executionLogs.workflowId))
+      .where(whereClause ?? undefined)
+      .limit(1);
+
+    const executionIds = runs.map((row) => row.execution.executionId).filter(Boolean);
+
+    const nodeRows = executionIds.length
+      ? await db
+          .select({
+            executionId: nodeLogs.executionId,
+            nodeType: nodeLogs.nodeType,
+            metadata: nodeLogs.metadata,
+            status: nodeLogs.status,
+            startTime: nodeLogs.startTime,
+          })
+          .from(nodeLogs)
+          .where(inArray(nodeLogs.executionId, executionIds))
+      : [];
+
+    const connectorsByExecution = new Map<string, Set<string>>();
+    nodeRows.forEach((row) => {
+      const connectors = connectorsByExecution.get(row.executionId) ?? new Set<string>();
+      const metadata = (row.metadata ?? {}) as Record<string, any>;
+      const rawMetadataConnector = typeof metadata.connectorId === 'string' ? metadata.connectorId : undefined;
+      const normalizedMetadataConnector = rawMetadataConnector?.trim() ?? '';
+
+      if (normalizedMetadataConnector) {
+        connectors.add(normalizedMetadataConnector);
+      }
+
+      if (typeof row.nodeType === 'string') {
+        const parts = row.nodeType.split('.');
+        if (parts.length >= 2 && (parts[0] === 'action' || parts[0] === 'trigger')) {
+          connectors.add(parts[1]);
+        }
+      }
+
+      connectorsByExecution.set(row.executionId, connectors);
+    });
+
+    const uniqueWorkflowIds = Array.from(new Set(runs.map((row) => row.execution.workflowId).filter(Boolean)));
+    const duplicateEventsByWorkflow = new Map<string, Array<{ id: string; webhookId: string; timestamp: Date; error: string }>>();
+
+    await Promise.all(
+      uniqueWorkflowIds.map(async (workflowId) => {
+        try {
+          const events = await triggerPersistenceService.listDuplicateWebhookEvents({ workflowId, limit: 5 });
+          duplicateEventsByWorkflow.set(workflowId, events);
+        } catch (error) {
+          console.error('Failed to load duplicate webhook events for workflow', workflowId, error);
+          duplicateEventsByWorkflow.set(workflowId, []);
+        }
+      })
+    );
+
+    const items = runs.map((row) => {
+      const execution = row.execution;
+      const workflow = row.workflow;
+      const metadata = (execution.metadata && typeof execution.metadata === 'object') ? execution.metadata as Record<string, any> : {};
+      const connectors = Array.from(connectorsByExecution.get(execution.executionId) ?? []);
+      const duplicateEvents = duplicateEventsByWorkflow.get(execution.workflowId) ?? [];
+
+      return {
+        executionId: execution.executionId,
+        workflowId: execution.workflowId,
+        workflowName: execution.workflowName ?? workflow?.name ?? execution.workflowId,
+        organizationId: workflow?.organizationId ?? null,
+        status: execution.status,
+        startTime: execution.startTime,
+        endTime: execution.endTime,
+        durationMs: execution.durationMs,
+        triggerType: execution.triggerType,
+        totalNodes: execution.totalNodes,
+        completedNodes: execution.completedNodes,
+        failedNodes: execution.failedNodes,
+        tags: execution.tags ?? [],
+        correlationId: execution.correlationId ?? null,
+        requestId: typeof metadata.requestId === 'string' ? metadata.requestId : null,
+        connectors,
+        duplicateEvents: duplicateEvents.map((event) => ({
+          id: event.id,
+          webhookId: event.webhookId,
+          timestamp: event.timestamp,
+          error: event.error,
+        })),
+        metadata,
+      };
+    });
+
+    const statusFacetRows = await db
+      .select({
+        status: executionLogs.status,
+        count: sql<number>`count(*)`,
+      })
+      .from(executionLogs)
+      .leftJoin(workflows, eq(workflows.id, executionLogs.workflowId))
+      .where(facetWhereClause ?? undefined)
+      .groupBy(executionLogs.status)
+      .orderBy(asc(executionLogs.status));
+
+    const connectorFacetRows = await db
+      .select({
+        connector: sql<string>`LOWER(NULLIF(COALESCE(${nodeLogs.metadata} ->> 'connectorId', split_part(${nodeLogs.nodeType}, '.', 2)), ''))`,
+        count: sql<number>`COUNT(DISTINCT ${nodeLogs.executionId})`,
+      })
+      .from(nodeLogs)
+      .innerJoin(executionLogs, eq(nodeLogs.executionId, executionLogs.executionId))
+      .leftJoin(workflows, eq(workflows.id, executionLogs.workflowId))
+      .where(
+        combineConditions([
+          facetWhereClause ?? undefined,
+          sql`COALESCE(${nodeLogs.metadata} ->> 'connectorId', split_part(${nodeLogs.nodeType}, '.', 2)) IS NOT NULL`,
+        ]) ?? undefined
+      )
+      .groupBy(sql`LOWER(NULLIF(COALESCE(${nodeLogs.metadata} ->> 'connectorId', split_part(${nodeLogs.nodeType}, '.', 2)), ''))`)
+      .orderBy(desc(sql`COUNT(DISTINCT ${nodeLogs.executionId})`))
+      .limit(25);
+
+    const facets = {
+      status: statusFacetRows
+        .map((row) => ({
+          value: row.status,
+          count: Number(row.count ?? 0),
+        }))
+        .filter((entry) => entry.value),
+      connector: connectorFacetRows
+        .map((row) => ({
+          value: row.connector ?? '',
+          count: Number(row.count ?? 0),
+        }))
+        .filter((entry) => entry.value),
+    };
+
+    res.json({
+      success: true,
+      runs: items,
+      pagination: {
+        total,
+        page,
+        pageSize,
+        hasMore: offset + pageSize < total,
+      },
+      facets,
+    });
+  } catch (error) {
+    console.error('Failed to search runs', error);
+    res.status(500).json({ success: false, error: getErrorMessage(error) });
+  }
+});
+
+export default runsRouter;


### PR DESCRIPTION
## Summary
- add a dedicated `/api/runs/search` endpoint that filters executions by organization, workflow, status, and connector while returning pagination and facet metadata plus webhook dedupe context
- build a RunExplorer React page that surfaces filters, connector facets, trace/log links, webhook dedupe cards, and links into the existing RunViewer experience
- cover the new API and UI with integration and React Testing Library tests that exercise combined filter scenarios

## Testing
- npm run lint *(fails: missing `@types/node` and `vite/client` type definitions in environment)*
- npx tsx server/routes/__tests__/run-explorer.test.ts *(fails: registry access forbidden for tsx package in environment)*
- npx tsx client/src/pages/__tests__/RunExplorer.test.tsx *(fails: registry access forbidden for tsx package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b335dadc8331bd7907952bda8cf5