### PR TITLE
refactor: create http server in index

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ console.log('🔑 LLM API Keys:', {
   CLAUDE: !!process.env.CLAUDE_API_KEY 
 });
 import express, { type Request, Response, NextFunction } from "express";
+import { createServer } from "http";
 import { context as otelContext, propagation, SpanKind, SpanStatusCode, trace as otelTrace } from '@opentelemetry/api';
 import { randomUUID } from 'crypto';
 import { redactSecrets } from './utils/redact';
@@ -124,7 +125,8 @@ app.use((req, res, next) => {
     console.warn('LLM features will be unavailable');
   }
 
-  const server = await registerRoutes(app);
+  await registerRoutes(app);
+  const server = createServer(app);
   try {
     const { executionQueueService } = await import('./services/ExecutionQueueService.js');
     const { WebhookManager } = await import('./webhooks/WebhookManager.js');

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,5 +1,4 @@
 import type { Express, Request, Response } from "express";
-import { createServer, type Server } from "http";
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { storage } from "./storage";
@@ -101,7 +100,7 @@ import {
 // Error handling utilities
 import { getErrorMessage, formatError, APIResponse } from "./types/common";
 
-export async function registerRoutes(app: Express): Promise<Server> {
+export async function registerRoutes(app: Express): Promise<void> {
 
   const mapOrganization = (org: any) => ({
     id: org.id,
@@ -6795,7 +6794,4 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  const httpServer = createServer(app);
-
-  return httpServer;
 }

--- a/server/routes/__tests__/oauth-flow.test.ts
+++ b/server/routes/__tests__/oauth-flow.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import express from 'express';
-import type { Server } from 'node:http';
+import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
@@ -169,7 +169,8 @@ try {
     },
   });
 
-  server = await registerRoutes(app);
+  await registerRoutes(app);
+  server = createServer(app);
 
   await new Promise<void>((resolve) => {
     server!.listen(0, () => resolve());

--- a/server/routes/__tests__/run-explorer.test.ts
+++ b/server/routes/__tests__/run-explorer.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import express from 'express';
-import type { Server } from 'node:http';
+import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
 const originalNodeEnv = process.env.NODE_ENV;
@@ -153,7 +153,8 @@ let server: Server | undefined;
 let exitCode = 0;
 
 try {
-  server = await registerRoutes(app);
+  await registerRoutes(app);
+  server = createServer(app);
   await new Promise<void>((resolve) => server!.listen(0, resolve));
   const address = server.address() as AddressInfo;
   const baseUrl = `http://127.0.0.1:${address.port}`;

--- a/server/routes/__tests__/webhook-verification-failures.test.ts
+++ b/server/routes/__tests__/webhook-verification-failures.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import express from 'express';
-import type { Server } from 'node:http';
+import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
 type VerificationFailureStub = {
@@ -52,7 +52,8 @@ let server: Server | undefined;
 let exitCode = 0;
 
 try {
-  server = await registerRoutes(app);
+  await registerRoutes(app);
+  server = createServer(app);
   await new Promise<void>((resolve) => server!.listen(0, resolve));
   const address = server.address() as AddressInfo;
   const baseUrl = `http://127.0.0.1:${address.port}`;

--- a/server/routes/__tests__/workflow-deploy.test.ts
+++ b/server/routes/__tests__/workflow-deploy.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import express from 'express';
-import type { Server } from 'node:http';
+import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
 const originalNodeEnv = process.env.NODE_ENV;
@@ -44,7 +44,8 @@ let server: Server | undefined;
 let exitCode = 0;
 
 try {
-  server = await registerRoutes(app);
+  await registerRoutes(app);
+  server = createServer(app);
 
   await new Promise<void>((resolve) => {
     server!.listen(0, () => resolve());


### PR DESCRIPTION
## Summary
- create the HTTP server in `server/index.ts` and keep `registerRoutes` focused on middleware setup
- update `registerRoutes` to return void and adjust dependent tests to create their own HTTP server instances
- continue passing the Express server into Vite's dev setup for HMR compatibility

## Testing
- npm run dev *(fails: dependency check script reports many missing packages in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d0e855308331aeb7d9c2b94b1a2f