### PR TITLE
Add simulator coverage for Dynamics, Workday, and Databricks connectors

### DIFF
--- a/configs/connector-smoke.config.example.json
+++ b/configs/connector-smoke.config.example.json
@@ -49,5 +49,57 @@
     ],
     "skip": true,
     "notes": "Remove skip and supply a test workspace channel to exercise the Slack action."
+  },
+  "dynamics365": {
+    "credentials": {
+      "accessToken": "YOUR_DYNAMICS365_ACCESS_TOKEN",
+      "instanceUrl": "https://your-org.crm.dynamics.com"
+    },
+    "actions": [
+      {
+        "id": "create_account",
+        "parameters": {
+          "name": "Automation Smoke Test Account",
+          "websiteurl": "https://example.invalid",
+          "emailaddress1": "automation@example.invalid"
+        }
+      }
+    ],
+    "notes": "Provide a valid OAuth access token and organization URL when running against a live Dynamics 365 sandbox."
+  },
+  "workday": {
+    "credentials": {
+      "accessToken": "YOUR_WORKDAY_ACCESS_TOKEN",
+      "refreshToken": "YOUR_WORKDAY_REFRESH_TOKEN",
+      "clientId": "YOUR_WORKDAY_CLIENT_ID",
+      "clientSecret": "YOUR_WORKDAY_CLIENT_SECRET"
+    },
+    "actions": [
+      {
+        "id": "search_workers",
+        "parameters": {
+          "searchTerm": "Automation",
+          "limit": 1
+        }
+      }
+    ],
+    "notes": "Set Workday OAuth credentials to call the tenant API; otherwise rely on the simulator fixtures in CI."
+  },
+  "databricks": {
+    "credentials": {
+      "accessToken": "dapiYOUR_DATABRICKS_TOKEN"
+    },
+    "additionalConfig": {
+      "workspaceUrl": "https://adb-1234567890.0.azuredatabricks.net"
+    },
+    "actions": [
+      {
+        "id": "list_clusters",
+        "parameters": {
+          "can_use_client": "NOTEBOOK"
+        }
+      }
+    ],
+    "notes": "Populate the personal access token and workspace URL before running against an actual Databricks environment."
   }
 }

--- a/server/testing/fixtures/databricks/__meta__.json
+++ b/server/testing/fixtures/databricks/__meta__.json
@@ -1,0 +1,12 @@
+{
+  "description": "Connector simulator defaults for Databricks smoke tests.",
+  "defaults": {
+    "credentials": {
+      "accessToken": "dapi-simulated-databricks-token"
+    },
+    "additionalConfig": {
+      "workspaceUrl": "https://adb-1234567890.0.azuredatabricks.net"
+    },
+    "notes": "Databricks smoke scenarios execute against offline fixtures."
+  }
+}

--- a/server/testing/fixtures/databricks/list_clusters.json
+++ b/server/testing/fixtures/databricks/list_clusters.json
@@ -1,0 +1,54 @@
+{
+  "description": "Simulated Databricks list_clusters action showing a single workspace cluster.",
+  "type": "action",
+  "defaults": {
+    "credentials": {
+      "accessToken": "dapi-simulated-databricks-token"
+    },
+    "additionalConfig": {
+      "workspaceUrl": "https://adb-1234567890.0.azuredatabricks.net"
+    }
+  },
+  "params": {
+    "can_use_client": "NOTEBOOK"
+  },
+  "request": {
+    "method": "GET",
+    "url": "https://adb-1234567890.0.azuredatabricks.net/api/2.0/clusters/list",
+    "headers": {
+      "Authorization": "Bearer dapi-simulated-databricks-token"
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "clusters": [
+        {
+          "cluster_id": "sim-cluster-1",
+          "cluster_name": "simulated-shared-cluster",
+          "state": "RUNNING",
+          "spark_version": "13.3.x-scala2.12",
+          "node_type_id": "Standard_DS3_v2"
+        }
+      ]
+    }
+  },
+  "result": {
+    "success": true,
+    "data": {
+      "clusters": [
+        {
+          "cluster_id": "sim-cluster-1",
+          "cluster_name": "simulated-shared-cluster",
+          "state": "RUNNING",
+          "spark_version": "13.3.x-scala2.12",
+          "node_type_id": "Standard_DS3_v2"
+        }
+      ],
+      "count": 1
+    }
+  }
+}

--- a/server/testing/fixtures/dynamics365/__meta__.json
+++ b/server/testing/fixtures/dynamics365/__meta__.json
@@ -1,0 +1,10 @@
+{
+  "description": "Connector simulator defaults for Microsoft Dynamics 365 smoke coverage.",
+  "defaults": {
+    "credentials": {
+      "accessToken": "simulated-dynamics365-access-token",
+      "instanceUrl": "https://contoso.crm.dynamics.com"
+    },
+    "notes": "Using offline fixtures for Dynamics 365 smoke tests."
+  }
+}

--- a/server/testing/fixtures/dynamics365/create_account.json
+++ b/server/testing/fixtures/dynamics365/create_account.json
@@ -1,0 +1,47 @@
+{
+  "description": "Simulated Dynamics 365 create_account action.",
+  "notes": "Represents creating a basic account record via the CRM API.",
+  "type": "action",
+  "defaults": {
+    "credentials": {
+      "accessToken": "simulated-dynamics365-access-token",
+      "instanceUrl": "https://contoso.crm.dynamics.com"
+    }
+  },
+  "params": {
+    "name": "Connector Simulator Test Account",
+    "websiteurl": "https://example.invalid",
+    "telephone1": "+1-555-0100",
+    "emailaddress1": "smoke-test@example.invalid"
+  },
+  "request": {
+    "method": "POST",
+    "url": "https://contoso.crm.dynamics.com/api/data/v9.2/accounts",
+    "headers": {
+      "OData-Version": "4.0",
+      "OData-MaxVersion": "4.0",
+      "Content-Type": "application/json",
+      "Authorization": "Bearer simulated-dynamics365-access-token"
+    },
+    "body": {
+      "name": "Connector Simulator Test Account",
+      "websiteurl": "https://example.invalid",
+      "telephone1": "+1-555-0100",
+      "emailaddress1": "smoke-test@example.invalid"
+    }
+  },
+  "response": {
+    "status": 204,
+    "headers": {
+      "OData-EntityId": "https://contoso.crm.dynamics.com/api/data/v9.2/accounts(00000000-0000-0000-0000-000000000001)"
+    }
+  },
+  "result": {
+    "success": true,
+    "data": {
+      "accountId": "00000000-0000-0000-0000-000000000001",
+      "name": "Connector Simulator Test Account",
+      "status": "created"
+    }
+  }
+}

--- a/server/testing/fixtures/workday/__meta__.json
+++ b/server/testing/fixtures/workday/__meta__.json
@@ -1,0 +1,12 @@
+{
+  "description": "Connector simulator defaults for Workday smoke scenarios.",
+  "defaults": {
+    "credentials": {
+      "accessToken": "simulated-workday-access-token",
+      "refreshToken": "simulated-workday-refresh-token",
+      "clientId": "simulated-workday-client-id",
+      "clientSecret": "simulated-workday-client-secret"
+    },
+    "notes": "Workday smoke tests rely on offline fixtures in CI."
+  }
+}

--- a/server/testing/fixtures/workday/search_workers.json
+++ b/server/testing/fixtures/workday/search_workers.json
@@ -1,0 +1,53 @@
+{
+  "description": "Simulated Workday search_workers action returning a minimal worker list.",
+  "type": "action",
+  "defaults": {
+    "credentials": {
+      "accessToken": "simulated-workday-access-token"
+    }
+  },
+  "params": {
+    "searchTerm": "Sim",
+    "limit": 1
+  },
+  "request": {
+    "method": "GET",
+    "url": "https://wd5-impl-services1.workday.com/ccx/api/v1/workers",
+    "headers": {
+      "Authorization": "Bearer simulated-workday-access-token"
+    },
+    "body": null
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "workers": [
+        {
+          "id": "SIM-0001",
+          "name": "Simulated Worker",
+          "title": "QA Analyst",
+          "department": "Engineering",
+          "email": "sim.worker@example.invalid"
+        }
+      ]
+    }
+  },
+  "result": {
+    "success": true,
+    "data": {
+      "workers": [
+        {
+          "id": "SIM-0001",
+          "name": "Simulated Worker",
+          "title": "QA Analyst",
+          "department": "Engineering",
+          "email": "sim.worker@example.invalid"
+        }
+      ],
+      "count": 1
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add placeholder credentials and smoke actions for Dynamics 365, Workday, and Databricks in the sample connector config
- create simulator fixture suites for the new connectors so smoke tests can run without real credentials

## Testing
- npm run ci:smoke *(fails: `tsx` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d0ff19488331acf2763896d62160