### PR TITLE
Refine Workday connector endpoints and smoke coverage

### DIFF
--- a/configs/connector-smoke.config.example.json
+++ b/configs/connector-smoke.config.example.json
@@ -49,5 +49,36 @@
     ],
     "skip": true,
     "notes": "Remove skip and supply a test workspace channel to exercise the Slack action."
+  },
+  "workday": {
+    "credentials": {
+      "accessToken": "YOUR_WORKDAY_ACCESS_TOKEN",
+      "tenant": "your-tenant",
+      "region": "wd5-impl-services1"
+    },
+    "actions": [
+      {
+        "id": "create_worker",
+        "parameters": {
+          "personalData": {
+            "firstName": "Smoke",
+            "lastName": "Tester"
+          },
+          "positionData": {
+            "positionId": "SMK-001"
+          },
+          "hireDate": "2024-01-01"
+        }
+      },
+      {
+        "id": "terminate_worker",
+        "parameters": {
+          "workerId": "SMK-001",
+          "terminationDate": "2024-01-31",
+          "reason": "Completed smoke test"
+        }
+      }
+    ],
+    "notes": "Provide tenant/region-specific credentials or run smoke tests with --use-simulator to exercise the bundled fixtures."
   }
 }

--- a/server/integrations/WorkdayAPIClient.ts
+++ b/server/integrations/WorkdayAPIClient.ts
@@ -1,151 +1,320 @@
-// WORKDAY API CLIENT
-// Auto-generated API client for Workday integration
+// Production-grade Workday API client
 
+import type { APIResponse } from './BaseAPIClient';
 import { BaseAPIClient } from './BaseAPIClient';
 
 export interface WorkdayAPIClientConfig {
   accessToken: string;
-  refreshToken?: string;
-  clientId?: string;
-  clientSecret?: string;
+  tenant: string;
+  region?: string;
+  hostname?: string;
 }
 
+type WorkerIdentifier = { workerId: string };
+
+type GetWorkerParams = WorkerIdentifier & {
+  include?: string;
+};
+
+type SearchWorkersParams = {
+  searchTerm?: string;
+  location?: string;
+  department?: string;
+  jobTitle?: string;
+  manager?: string;
+  isActive?: boolean;
+  limit?: number;
+  offset?: number;
+};
+
+type CreateWorkerParams = {
+  personalData: Record<string, any>;
+  positionData: Record<string, any>;
+  hireDate: string;
+  onboardingData?: Record<string, any>;
+};
+
+type UpdateWorkerParams = WorkerIdentifier & {
+  personalData?: Record<string, any>;
+  positionData?: Record<string, any>;
+};
+
+type TerminateWorkerParams = WorkerIdentifier & {
+  terminationDate: string;
+  reason?: string;
+  lastDayWorked?: string;
+};
+
+type CreatePositionParams = {
+  positionTitle: string;
+  department?: string;
+  jobProfile?: string;
+  location?: string;
+  costCenter?: string;
+};
+
+type UpdatePositionParams = {
+  positionId: string;
+  updates: Record<string, any>;
+};
+
+type WorkerEventPollParams = {
+  department?: string;
+  location?: string;
+  terminationReason?: string;
+  timeOffType?: string;
+  since?: string;
+  limit?: number;
+};
+
+const DEFAULT_HOST = 'wd5-impl-services1.workday.com';
+
 export class WorkdayAPIClient extends BaseAPIClient {
-  protected baseUrl: string;
-  private config: WorkdayAPIClientConfig;
+  private readonly tenant: string;
+  private readonly host: string;
 
   constructor(config: WorkdayAPIClientConfig) {
-    super();
-    this.config = config;
-    this.baseUrl = 'https://wd5-impl-services1.workday.com/ccx/api/v1';
+    const tenant = WorkdayAPIClient.requireTenant(config.tenant);
+    const host = WorkdayAPIClient.resolveHost(config);
+    const baseURL = WorkdayAPIClient.buildBaseUrl(host, tenant);
+
+    super(baseURL, { accessToken: config.accessToken, tenant, region: config.region, hostname: config.hostname });
+
+    this.tenant = tenant;
+    this.host = host;
+
+    this.registerHandlers({
+      'test_connection': () => this.testConnection(),
+      'get_worker': params => this.getWorker(params as GetWorkerParams),
+      'search_workers': params => this.searchWorkers(params as SearchWorkersParams),
+      'create_worker': params => this.createWorker(params as CreateWorkerParams),
+      'update_worker': params => this.updateWorker(params as UpdateWorkerParams),
+      'terminate_worker': params => this.terminateWorker(params as TerminateWorkerParams),
+      'create_position': params => this.createPosition(params as CreatePositionParams),
+      'update_position': params => this.updatePosition(params as UpdatePositionParams),
+    });
   }
 
-  /**
-   * Get authentication headers
-   */
+  private static requireTenant(value: string | undefined): string {
+    const tenant = (value ?? '').trim();
+    if (!tenant) {
+      throw new Error('Workday tenant is required to initialize the API client.');
+    }
+    return tenant;
+  }
+
+  private static normalizeHost(value: string | undefined): string | null {
+    if (!value) {
+      return null;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const withoutProtocol = trimmed.replace(/^https?:\/\//i, '').replace(/\/.*$/, '');
+    return withoutProtocol || null;
+  }
+
+  private static resolveHost(config: WorkdayAPIClientConfig): string {
+    const override =
+      WorkdayAPIClient.normalizeHost(config.hostname) ??
+      WorkdayAPIClient.normalizeHost(config.region);
+
+    if (!override) {
+      return DEFAULT_HOST;
+    }
+
+    if (override.includes('.')) {
+      return override;
+    }
+
+    return `${override}.workday.com`;
+  }
+
+  private static buildBaseUrl(host: string, tenant: string): string {
+    const normalisedHost = host.replace(/\/+$/, '');
+    const encodedTenant = encodeURIComponent(tenant);
+    return `https://${normalisedHost}/ccx/api/v1/${encodedTenant}`;
+  }
+
   protected getAuthHeaders(): Record<string, string> {
     return {
-      'Authorization': `Bearer ${this.config.accessToken}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'Apps-Script-Automation/1.0'
+      Authorization: `Bearer ${this.credentials.accessToken}`,
+      Accept: 'application/json'
     };
   }
 
-  /**
-   * Test API connection
-   */
-  async testConnection(): Promise<boolean> {
-    try {
-      const response = await this.makeRequest('GET', '/');
-      return response.status === 200;
-      return true;
-    } catch (error) {
-      console.error(`❌ ${this.constructor.name} connection test failed:`, error);
-      return false;
-    }
+  public async testConnection(): Promise<APIResponse<any>> {
+    return this.get('/workers?limit=1');
   }
 
-
-  /**
-   * Create a new worker in Workday
-   */
-  async createWorker({ personalData: Record<string, any>, positionData: Record<string, any>, hireDate: string }: { personalData: Record<string, any>, positionData: Record<string, any>, hireDate: string }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/create_worker', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Create Worker failed: ${error}`);
+  public async getWorker(params: GetWorkerParams): Promise<APIResponse<any>> {
+    if (!params?.workerId) {
+      return { success: false, error: 'workerId is required to retrieve a Workday worker.' };
     }
+
+    const query = params.include ? `?include=${encodeURIComponent(params.include)}` : '';
+    return this.get(`/workers/${encodeURIComponent(params.workerId)}${query}`);
   }
 
-  /**
-   * Update worker information
-   */
-  async updateWorker({ workerId: string, personalData?: Record<string, any>, positionData?: Record<string, any> }: { workerId: string, personalData?: Record<string, any>, positionData?: Record<string, any> }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/update_worker', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Update Worker failed: ${error}`);
-    }
+  public async searchWorkers(params: SearchWorkersParams = {}): Promise<APIResponse<any>> {
+    const query = this.buildQueryString({
+      search: params.searchTerm,
+      location: params.location,
+      department: params.department,
+      jobTitle: params.jobTitle,
+      manager: params.manager,
+      isActive: params.isActive,
+      limit: params.limit,
+      offset: params.offset,
+    });
+
+    return this.get(`/workers${query}`);
   }
 
-  /**
-   * Terminate a worker's employment
-   */
-  async terminateWorker({ workerId: string, terminationDate: string, reason: string }: { workerId: string, terminationDate: string, reason: string }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/terminate_worker', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Terminate Worker failed: ${error}`);
+  public async createWorker(params: CreateWorkerParams): Promise<APIResponse<any>> {
+    if (!params?.personalData || !params?.positionData || !params?.hireDate) {
+      return { success: false, error: 'personalData, positionData, and hireDate are required to create a worker.' };
     }
+
+    const payload = this.pruneUndefined({
+      personalData: params.personalData,
+      positionData: params.positionData,
+      hireDate: params.hireDate,
+      onboardingData: params.onboardingData,
+    });
+
+    return this.post('/workers', payload);
   }
 
-  /**
-   * Create a new position
-   */
-  async createPosition({ positionTitle: string, department: string, jobProfile: string }: { positionTitle: string, department: string, jobProfile: string }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/create_position', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Create Position failed: ${error}`);
+  public async updateWorker(params: UpdateWorkerParams): Promise<APIResponse<any>> {
+    if (!params?.workerId) {
+      return { success: false, error: 'workerId is required to update a worker.' };
     }
+
+    const payload = this.pruneUndefined({
+      personalData: params.personalData,
+      positionData: params.positionData,
+    });
+
+    if (!Object.keys(payload).length) {
+      return { success: false, error: 'At least one of personalData or positionData must be provided to update a worker.' };
+    }
+
+    return this.patch(`/workers/${encodeURIComponent(params.workerId)}`, payload);
   }
 
-  /**
-   * Update position details
-   */
-  async updatePosition({ positionId: string, updates: Record<string, any> }: { positionId: string, updates: Record<string, any> }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/update_position', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Update Position failed: ${error}`);
+  public async terminateWorker(params: TerminateWorkerParams): Promise<APIResponse<any>> {
+    if (!params?.workerId) {
+      return { success: false, error: 'workerId is required to terminate a worker.' };
     }
+
+    if (!params.terminationDate) {
+      return { success: false, error: 'terminationDate is required to terminate a worker.' };
+    }
+
+    const payload = this.pruneUndefined({
+      terminationDate: params.terminationDate,
+      reason: params.reason,
+      lastDayWorked: params.lastDayWorked,
+    });
+
+    return this.post(`/workers/${encodeURIComponent(params.workerId)}/terminate`, payload);
   }
 
-
-  /**
-   * Poll for Triggered when a new worker is hired
-   */
-  async pollWorkerHired(params: Record<string, any> = {}): Promise<any[]> {
-    try {
-      const response = await this.makeRequest('GET', '/api/worker_hired', params);
-      const data = this.handleResponse(response);
-      return Array.isArray(data) ? data : [data];
-    } catch (error) {
-      console.error(`Polling Worker Hired failed:`, error);
-      return [];
+  public async createPosition(params: CreatePositionParams): Promise<APIResponse<any>> {
+    if (!params?.positionTitle) {
+      return { success: false, error: 'positionTitle is required to create a position.' };
     }
+
+    const payload = this.pruneUndefined({
+      positionTitle: params.positionTitle,
+      department: params.department,
+      jobProfile: params.jobProfile,
+      location: params.location,
+      costCenter: params.costCenter,
+    });
+
+    return this.post('/positions', payload);
   }
 
-  /**
-   * Poll for Triggered when a worker is terminated
-   */
-  async pollWorkerTerminated(params: Record<string, any> = {}): Promise<any[]> {
-    try {
-      const response = await this.makeRequest('GET', '/api/worker_terminated', params);
-      const data = this.handleResponse(response);
-      return Array.isArray(data) ? data : [data];
-    } catch (error) {
-      console.error(`Polling Worker Terminated failed:`, error);
-      return [];
+  public async updatePosition(params: UpdatePositionParams): Promise<APIResponse<any>> {
+    if (!params?.positionId) {
+      return { success: false, error: 'positionId is required to update a position.' };
     }
+
+    if (!params.updates || Object.keys(params.updates).length === 0) {
+      return { success: false, error: 'updates must contain at least one field to update a position.' };
+    }
+
+    return this.patch(`/positions/${encodeURIComponent(params.positionId)}`, params.updates);
   }
 
-  /**
-   * Poll for Triggered when time off is requested
-   */
-  async pollTimeOffRequested(params: Record<string, any> = {}): Promise<any[]> {
-    try {
-      const response = await this.makeRequest('GET', '/api/time_off_requested', params);
-      const data = this.handleResponse(response);
-      return Array.isArray(data) ? data : [data];
-    } catch (error) {
-      console.error(`Polling Time Off Requested failed:`, error);
-      return [];
+  public async pollWorkerHired(params: WorkerEventPollParams = {}): Promise<APIResponse<any>> {
+    return this.get(this.buildWorkerEventEndpoint('HIRE', params));
+  }
+
+  public async pollWorkerTerminated(params: WorkerEventPollParams = {}): Promise<APIResponse<any>> {
+    return this.get(this.buildWorkerEventEndpoint('TERMINATION', params));
+  }
+
+  public async pollTimeOffRequested(params: WorkerEventPollParams = {}): Promise<APIResponse<any>> {
+    const query = this.buildQueryString({
+      eventType: 'TIME_OFF_REQUEST',
+      department: params.department,
+      timeOffType: params.timeOffType,
+      since: params.since,
+      limit: params.limit,
+    });
+    return this.get(`/notifications/timeOff${query}`);
+  }
+
+  private buildWorkerEventEndpoint(eventType: string, params: WorkerEventPollParams): string {
+    const query = this.buildQueryString({
+      eventType,
+      department: params.department,
+      location: params.location,
+      terminationReason: params.terminationReason,
+      since: params.since,
+      limit: params.limit,
+    });
+
+    return `/notifications/workerEvents${query}`;
+  }
+
+  private buildQueryString(values: Record<string, any>): string {
+    const searchParams = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(values)) {
+      if (value === undefined || value === null || value === '') {
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        for (const entry of value) {
+          if (entry === undefined || entry === null) {
+            continue;
+          }
+          searchParams.append(key, String(entry));
+        }
+        continue;
+      }
+
+      if (typeof value === 'boolean') {
+        searchParams.append(key, value ? 'true' : 'false');
+        continue;
+      }
+
+      searchParams.append(key, String(value));
     }
+
+    const query = searchParams.toString();
+    return query ? `?${query}` : '';
+  }
+
+  private pruneUndefined<T extends Record<string, any>>(input: T): T {
+    return Object.fromEntries(
+      Object.entries(input).filter(([, value]) => value !== undefined && value !== null)
+    ) as T;
   }
 }

--- a/server/integrations/__tests__/WorkdayAPIClient.test.ts
+++ b/server/integrations/__tests__/WorkdayAPIClient.test.ts
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+
+import { WorkdayAPIClient } from '../WorkdayAPIClient.js';
+
+interface MockResponse {
+  status?: number;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+interface RecordedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+const originalFetch = global.fetch;
+
+function setupMockFetch(sequence: MockResponse[]) {
+  const requests: RecordedRequest[] = [];
+  let index = 0;
+
+  global.fetch = (async (input: any, init?: RequestInit): Promise<Response> => {
+    const current = sequence[Math.min(index, sequence.length - 1)] ?? {};
+    index += 1;
+    const url = typeof input === 'string' ? input : input.toString();
+    requests.push({ url, init: init ?? {} });
+
+    const status = current.status ?? 200;
+    const headers = current.headers ?? { 'Content-Type': 'application/json' };
+    const body =
+      typeof current.body === 'string'
+        ? current.body
+        : JSON.stringify(current.body ?? {});
+
+    return new Response(body, { status, headers });
+  }) as typeof fetch;
+
+  return {
+    requests,
+    restore: () => {
+      global.fetch = originalFetch;
+    },
+  };
+}
+
+function createClient(overrides: Partial<ConstructorParameters<typeof WorkdayAPIClient>[0]> = {}) {
+  return new WorkdayAPIClient({
+    accessToken: 'token-123',
+    tenant: 'acme-co',
+    region: 'wd7-impl-services1',
+    ...overrides,
+  });
+}
+
+async function testTenantAndRegionUrlConstruction(): Promise<void> {
+  const mock = setupMockFetch([{ body: { data: [] } }]);
+  const client = createClient({ region: 'wd2-impl-services1' });
+
+  const response = await client.searchWorkers({ searchTerm: 'Ada', isActive: true, limit: 5 });
+  assert.equal(response.success, true, 'Search workers should report success when the API responds with 200.');
+
+  const request = mock.requests[0];
+  assert.ok(
+    request.url.startsWith('https://wd2-impl-services1.workday.com/ccx/api/v1/acme-co/workers'),
+    'Requests should target the tenant-specific path for the configured region.'
+  );
+  assert.ok(request.url.includes('search=Ada'));
+  assert.ok(request.url.includes('isActive=true'));
+  assert.ok(request.url.includes('limit=5'));
+  assert.equal(request.init.method, 'GET');
+  assert.equal(request.init.headers?.['Authorization'], 'Bearer token-123');
+
+  mock.restore();
+}
+
+async function testCreateWorkerSuccessFlow(): Promise<void> {
+  const mock = setupMockFetch([{ status: 201, body: { id: 'W-123' } }]);
+  const client = createClient({ hostname: 'custom.workday.com' });
+
+  const payload = {
+    personalData: { firstName: 'Grace', lastName: 'Hopper' },
+    positionData: { positionId: 'ENG-1' },
+    hireDate: '2024-01-15',
+  };
+
+  const response = await client.createWorker(payload);
+  assert.equal(response.success, true, 'createWorker should return success when Workday accepts the payload.');
+  assert.deepEqual(response.data, { id: 'W-123' });
+
+  const request = mock.requests[0];
+  assert.equal(request.init.method, 'POST');
+  assert.equal(
+    request.url,
+    'https://custom.workday.com/ccx/api/v1/acme-co/workers',
+    'createWorker should post to the tenant workers collection.'
+  );
+
+  const body = JSON.parse(request.init.body as string);
+  assert.deepEqual(body.personalData, payload.personalData);
+  assert.deepEqual(body.positionData, payload.positionData);
+  assert.equal(body.hireDate, '2024-01-15');
+
+  mock.restore();
+}
+
+async function testCreateWorkerFailureFlow(): Promise<void> {
+  const mock = setupMockFetch([{ status: 400, body: { error: 'Validation failed' } }]);
+  const client = createClient();
+
+  const response = await client.createWorker({
+    personalData: { firstName: 'Linus', lastName: 'Torvalds' },
+    positionData: { positionId: 'ENG-2' },
+    hireDate: '2024-02-01',
+  });
+
+  assert.equal(response.success, false, 'createWorker should surface Workday validation errors.');
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.data, { error: 'Validation failed' });
+
+  mock.restore();
+}
+
+async function testTerminateWorkerEndpoint(): Promise<void> {
+  const mock = setupMockFetch([{ status: 200, body: { workerId: 'W-123', status: 'TERMINATED' } }]);
+  const client = createClient();
+
+  const response = await client.terminateWorker({
+    workerId: 'W-123',
+    terminationDate: '2024-03-31',
+    reason: 'Resigned',
+  });
+
+  assert.equal(response.success, true, 'terminateWorker should succeed when Workday acknowledges the termination.');
+  assert.deepEqual(response.data, { workerId: 'W-123', status: 'TERMINATED' });
+
+  const request = mock.requests[0];
+  assert.equal(request.init.method, 'POST');
+  assert.equal(
+    request.url,
+    'https://wd7-impl-services1.workday.com/ccx/api/v1/acme-co/workers/W-123/terminate',
+    'terminateWorker should call the worker termination endpoint.'
+  );
+
+  const body = JSON.parse(request.init.body as string);
+  assert.equal(body.terminationDate, '2024-03-31');
+  assert.equal(body.reason, 'Resigned');
+
+  mock.restore();
+}
+
+async function testTestConnection(): Promise<void> {
+  const mock = setupMockFetch([{ status: 200, body: { data: [] } }]);
+  const client = createClient();
+
+  const response = await client.testConnection();
+  assert.equal(response.success, true, 'testConnection should succeed when the /workers probe returns 200.');
+
+  const request = mock.requests[0];
+  assert.equal(request.url, 'https://wd7-impl-services1.workday.com/ccx/api/v1/acme-co/workers?limit=1');
+  assert.equal(request.init.method, 'GET');
+
+  mock.restore();
+}
+
+try {
+  await testTenantAndRegionUrlConstruction();
+  await testCreateWorkerSuccessFlow();
+  await testCreateWorkerFailureFlow();
+  await testTerminateWorkerEndpoint();
+  await testTestConnection();
+  console.log('Workday API client tests passed.');
+} finally {
+  global.fetch = originalFetch;
+}

--- a/server/testing/fixtures/workday/create_worker.json
+++ b/server/testing/fixtures/workday/create_worker.json
@@ -1,0 +1,52 @@
+{
+  "description": "Simulated Workday create_worker action for smoke testing.",
+  "defaults": {
+    "credentials": {
+      "accessToken": "simulated-workday-token",
+      "tenant": "acme-co",
+      "region": "wd5-impl-services1"
+    },
+    "notes": "Connector simulator fixture for Workday worker creation."
+  },
+  "params": {
+    "personalData": {
+      "firstName": "Simulated",
+      "lastName": "Employee"
+    },
+    "positionData": {
+      "positionId": "SIM-POS-001"
+    },
+    "hireDate": "2024-01-02"
+  },
+  "request": {
+    "method": "POST",
+    "url": "https://wd5-impl-services1.workday.com/ccx/api/v1/acme-co/workers",
+    "body": {
+      "personalData": {
+        "firstName": "Simulated",
+        "lastName": "Employee"
+      },
+      "positionData": {
+        "positionId": "SIM-POS-001"
+      },
+      "hireDate": "2024-01-02"
+    }
+  },
+  "response": {
+    "status": 201,
+    "headers": {
+      "content-type": "application/json"
+    },
+    "body": {
+      "id": "SIM-WORKER-001",
+      "status": "ACTIVE"
+    }
+  },
+  "result": {
+    "success": true,
+    "data": {
+      "id": "SIM-WORKER-001",
+      "status": "ACTIVE"
+    }
+  }
+}

--- a/server/testing/fixtures/workday/terminate_worker.json
+++ b/server/testing/fixtures/workday/terminate_worker.json
@@ -1,0 +1,40 @@
+{
+  "description": "Simulated Workday terminate_worker action for smoke testing.",
+  "defaults": {
+    "credentials": {
+      "accessToken": "simulated-workday-token",
+      "tenant": "acme-co",
+      "region": "wd5-impl-services1"
+    }
+  },
+  "params": {
+    "workerId": "SIM-WORKER-001",
+    "terminationDate": "2024-03-31",
+    "reason": "Voluntary"
+  },
+  "request": {
+    "method": "POST",
+    "url": "https://wd5-impl-services1.workday.com/ccx/api/v1/acme-co/workers/SIM-WORKER-001/terminate",
+    "body": {
+      "terminationDate": "2024-03-31",
+      "reason": "Voluntary"
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "content-type": "application/json"
+    },
+    "body": {
+      "workerId": "SIM-WORKER-001",
+      "status": "TERMINATED"
+    }
+  },
+  "result": {
+    "success": true,
+    "data": {
+      "workerId": "SIM-WORKER-001",
+      "status": "TERMINATED"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- update the Workday API client to derive tenant-aware URLs and call the published REST endpoints with proper payload validation
- add targeted Workday unit tests that exercise successful worker creation and termination flows plus provider error handling
- provide Workday connector smoke fixtures and document simulator-friendly defaults in the sample smoke configuration

## Testing
- ❌ `npx tsx server/integrations/__tests__/WorkdayAPIClient.test.ts` *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d115aafc8331891e5ec2ae9edddf