### PR TITLE
Implement Snowflake SQL API client and tests

### DIFF
--- a/server/integrations/SnowflakeAPIClient.ts
+++ b/server/integrations/SnowflakeAPIClient.ts
@@ -1,111 +1,410 @@
-// SNOWFLAKE API CLIENT
-// Auto-generated API client for Snowflake integration
+import { randomUUID } from 'node:crypto';
 
-import { BaseAPIClient } from './BaseAPIClient';
+import { APICredentials, APIResponse, BaseAPIClient } from './BaseAPIClient';
+import { getErrorMessage } from '../types/common';
 
-export interface SnowflakeAPIClientConfig {
-  accessToken: string;
-  refreshToken?: string;
-  clientId?: string;
-  clientSecret?: string;
+export interface SnowflakeAPIClientConfig extends APICredentials {
+  account: string;
+  warehouse?: string;
+  database?: string;
+  schema?: string;
+  role?: string;
+}
+
+export interface SnowflakeExecuteQueryParams {
+  sql: string;
+  warehouse?: string;
+  database?: string;
+  schema?: string;
+  role?: string;
+  timeout?: number;
+  parameters?: Record<string, any> | any[] | Map<string, any>;
+  requestId?: string;
+  describeOnly?: boolean;
+}
+
+export interface SnowflakeCancelQueryParams {
+  statementHandle: string;
+  requestId?: string;
+}
+
+export interface SnowflakeQueryResult {
+  statementHandle: string;
+  queryId?: string;
+  requestId: string;
+  rows: any[];
+  resultSetMetaData?: Record<string, any>;
+}
+
+interface SnowflakeBindingValue {
+  type: string;
+  value: any;
+}
+
+interface SnowflakeQueryRequestPayload {
+  requestId: string;
+  sqlText: string;
+  warehouse?: string;
+  database?: string;
+  schema?: string;
+  role?: string;
+  describeOnly?: boolean;
+  queryTimeout?: number;
+  bindings?: Record<string, SnowflakeBindingValue>;
+}
+
+interface SnowflakeQueryResponseBody {
+  success?: boolean;
+  statementHandle?: string;
+  statementStatusUrl?: string;
+  resultSetMetaData?: Record<string, any> | null;
+  data?: any[] | null;
+  rowset?: any[] | null;
+  rowSet?: any[] | null;
+  rows?: any[] | null;
+  nextUri?: string | null;
+  queryId?: string;
+  requestId?: string;
+  code?: string;
+  message?: string;
+  error?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  sqlState?: string;
 }
 
 export class SnowflakeAPIClient extends BaseAPIClient {
-  protected baseUrl: string;
-  private config: SnowflakeAPIClientConfig;
+  private readonly defaults: {
+    warehouse?: string;
+    database?: string;
+    schema?: string;
+    role?: string;
+  };
 
   constructor(config: SnowflakeAPIClientConfig) {
-    super();
-    this.config = config;
-    this.baseUrl = 'https://{account}.snowflakecomputing.com/api/v2';
+    if (!config || typeof config.account !== 'string' || config.account.trim().length === 0) {
+      throw new Error('Snowflake API client requires an account identifier');
+    }
+
+    const { account, warehouse, database, schema, role, ...credentials } = config;
+    const normalizedAccount = SnowflakeAPIClient.normalizeAccount(account);
+
+    super(`https://${normalizedAccount}.snowflakecomputing.com`, credentials as APICredentials);
+
+    this.defaults = { warehouse, database, schema, role };
+
+    this.registerHandlers({
+      'test_connection': async () => this.testConnection(),
+      'execute_query': this.executeQuery.bind(this),
+      'cancel_query': this.cancelQuery.bind(this)
+    });
   }
 
-  /**
-   * Get authentication headers
-   */
   protected getAuthHeaders(): Record<string, string> {
+    const token = this.credentials.accessToken ?? this.credentials.apiKey;
+    if (!token) {
+      throw new Error('Snowflake API client requires an access token or API key');
+    }
+
+    const formatted = token.startsWith('Bearer ') ? token : `Bearer ${token}`;
     return {
-      'Authorization': `Bearer ${this.config.accessToken}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'Apps-Script-Automation/1.0'
+      Authorization: formatted,
+      Accept: 'application/json'
     };
   }
 
-  /**
-   * Test API connection
-   */
-  async testConnection(): Promise<boolean> {
+  public async testConnection(): Promise<APIResponse<any>> {
+    const response = await this.get('/api/v2/accounts/current');
+    if (!response.success) {
+      return response;
+    }
+
+    return {
+      success: true,
+      data: response.data
+    };
+  }
+
+  public async executeQuery(params: SnowflakeExecuteQueryParams): Promise<APIResponse<SnowflakeQueryResult>> {
     try {
-      const response = await this.makeRequest('GET', '/');
-      return response.status === 200;
-      return true;
+      if (!params || typeof params.sql !== 'string' || params.sql.trim().length === 0) {
+        throw new Error('Snowflake execute_query requires a SQL statement');
+      }
+
+      const requestPayload = this.buildQueryPayload(params);
+      const response = await this.post<SnowflakeQueryResponseBody>('/queries/v1/query-request', requestPayload);
+      if (!response.success) {
+        return response;
+      }
+
+      const body = response.data;
+      if (!body || typeof body !== 'object') {
+        return { success: false, error: 'Snowflake query response was empty' };
+      }
+
+      const error = this.extractError(body);
+      if (error) {
+        return { success: false, error };
+      }
+
+      if (!body.statementHandle) {
+        return { success: false, error: 'Snowflake query did not return a statement handle' };
+      }
+
+      const { rows, finalPayload } = await this.collectQueryRows(body);
+
+      return {
+        success: true,
+        data: {
+          statementHandle: body.statementHandle,
+          queryId: body.queryId ?? finalPayload.queryId,
+          requestId: body.requestId ?? requestPayload.requestId,
+          rows,
+          resultSetMetaData: body.resultSetMetaData ?? finalPayload.resultSetMetaData ?? undefined
+        }
+      };
     } catch (error) {
-      console.error(`❌ ${this.constructor.name} connection test failed:`, error);
-      return false;
+      return { success: false, error: getErrorMessage(error) };
     }
   }
 
-
-  /**
-   * Execute a SQL query in Snowflake
-   */
-  async executeQuery({ sql: string, warehouse?: string, database?: string, schema?: string, timeout?: number }: { sql: string, warehouse?: string, database?: string, schema?: string, timeout?: number }): Promise<any> {
+  public async cancelQuery(params: SnowflakeCancelQueryParams): Promise<APIResponse<any>> {
     try {
-      const response = await this.makeRequest('POST', '/api/execute_query', params);
-      return this.handleResponse(response);
+      if (!params || typeof params.statementHandle !== 'string' || params.statementHandle.trim().length === 0) {
+        throw new Error('Snowflake cancel_query requires a statement handle');
+      }
+
+      const payload = {
+        statementHandle: params.statementHandle,
+        requestId: params.requestId ?? randomUUID()
+      };
+
+      return await this.post('/queries/v1/abort-request', payload);
     } catch (error) {
-      throw new Error(`Execute Query failed: ${error}`);
+      return { success: false, error: getErrorMessage(error) };
     }
   }
 
-  /**
-   * Load data into a Snowflake table
-   */
-  async copyIntoTable({ table_name: string, stage_location: string, file_format?: string, copy_options?: Record<string, any> }: { table_name: string, stage_location: string, file_format?: string, copy_options?: Record<string, any> }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/copy_into_table', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Copy Into Table failed: ${error}`);
+  private buildQueryPayload(params: SnowflakeExecuteQueryParams): SnowflakeQueryRequestPayload {
+    const requestId = params.requestId ?? randomUUID();
+    const payload: SnowflakeQueryRequestPayload = {
+      requestId,
+      sqlText: params.sql,
+      warehouse: params.warehouse ?? this.defaults.warehouse,
+      database: params.database ?? this.defaults.database,
+      schema: params.schema ?? this.defaults.schema,
+      role: params.role ?? this.defaults.role,
+      describeOnly: params.describeOnly ?? false
+    };
+
+    const timeout = this.resolveTimeout(params.timeout);
+    if (timeout !== undefined) {
+      payload.queryTimeout = timeout;
     }
+
+    const bindings = this.buildBindings(params.parameters);
+    if (bindings) {
+      payload.bindings = bindings;
+    }
+
+    return this.removeUndefined(payload);
   }
 
-  /**
-   * Create a new stage for data loading
-   */
-  async createStage({ stage_name: string, stage_type: string, location?: string, credentials?: Record<string, any> }: { stage_name: string, stage_type: string, location?: string, credentials?: Record<string, any> }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/create_stage', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Create Stage failed: ${error}`);
+  private resolveTimeout(timeout?: number): number | undefined {
+    if (timeout === undefined || timeout === null) {
+      return undefined;
     }
+
+    const numeric = Math.floor(Number(timeout));
+    if (!Number.isFinite(numeric) || numeric <= 0) {
+      return undefined;
+    }
+
+    const clamped = Math.min(Math.max(numeric, 1), 3600);
+    return clamped;
   }
 
-  /**
-   * Retrieve data from a Snowflake table
-   */
-  async getTableData({ table_name: string, limit?: number, where_clause?: string, order_by?: string }: { table_name: string, limit?: number, where_clause?: string, order_by?: string }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/get_table_data', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Get Table Data failed: ${error}`);
+  private buildBindings(parameters?: Record<string, any> | any[] | Map<string, any>): Record<string, SnowflakeBindingValue> | undefined {
+    if (!parameters) {
+      return undefined;
     }
+
+    const bindings: Record<string, SnowflakeBindingValue> = {};
+
+    if (parameters instanceof Map) {
+      for (const [key, value] of parameters.entries()) {
+        if (key === undefined || key === null) continue;
+        bindings[String(key)] = this.createBindingValue(value);
+      }
+    } else if (Array.isArray(parameters)) {
+      parameters.forEach((value, index) => {
+        bindings[String(index + 1)] = this.createBindingValue(value);
+      });
+    } else {
+      for (const [key, value] of Object.entries(parameters)) {
+        bindings[String(key)] = this.createBindingValue(value);
+      }
+    }
+
+    return Object.keys(bindings).length > 0 ? bindings : undefined;
   }
 
+  private createBindingValue(value: any): SnowflakeBindingValue {
+    if (value === null || value === undefined) {
+      return { type: 'NULL', value: null };
+    }
 
-  /**
-   * Poll for Triggered when a Snowflake task completes
-   */
-  async pollTaskCompleted(params: Record<string, any> = {}): Promise<any[]> {
-    try {
-      const response = await this.makeRequest('GET', '/api/task_completed', params);
-      const data = this.handleResponse(response);
-      return Array.isArray(data) ? data : [data];
-    } catch (error) {
-      console.error(`Polling Task Completed failed:`, error);
+    if (value instanceof Date) {
+      return { type: 'TIMESTAMP_LTZ', value: value.toISOString() };
+    }
+
+    const valueType = typeof value;
+
+    if (valueType === 'number' || valueType === 'bigint') {
+      const numeric = Number(value);
+      if (Number.isFinite(numeric) && !Number.isNaN(numeric)) {
+        const isInteger = Number.isInteger(numeric);
+        return { type: isInteger ? 'FIXED' : 'REAL', value: String(value) };
+      }
+      return { type: 'TEXT', value: String(value) };
+    }
+
+    if (valueType === 'boolean') {
+      return { type: 'BOOLEAN', value };
+    }
+
+    if (Array.isArray(value) || valueType === 'object') {
+      try {
+        return { type: 'VARIANT', value: JSON.stringify(value) };
+      } catch {
+        return { type: 'TEXT', value: String(value) };
+      }
+    }
+
+    return { type: 'TEXT', value: String(value) };
+  }
+
+  private extractError(payload?: SnowflakeQueryResponseBody | null): string | null {
+    if (!payload || typeof payload !== 'object') {
+      return 'Snowflake query returned an empty response';
+    }
+
+    if (payload.success === false) {
+      return payload.message ?? payload.errorMessage ?? payload.error ?? 'Snowflake query failed';
+    }
+
+    if (payload.error || payload.errorMessage) {
+      return payload.error ?? payload.errorMessage ?? null;
+    }
+
+    if (payload.errorCode || payload.sqlState) {
+      const parts: string[] = [];
+      if (payload.errorCode) parts.push(`error code ${payload.errorCode}`);
+      if (payload.sqlState) parts.push(`SQL state ${payload.sqlState}`);
+      if (payload.message) parts.push(payload.message);
+      return parts.length > 0 ? `Snowflake query failed: ${parts.join(' - ')}` : 'Snowflake query failed';
+    }
+
+    if (payload.code && payload.code !== '00000' && payload.code !== '0000') {
+      const message = payload.message ? `: ${payload.message}` : '';
+      return `Snowflake query failed with code ${payload.code}${message}`;
+    }
+
+    return null;
+  }
+
+  private async collectQueryRows(initial: SnowflakeQueryResponseBody): Promise<{ rows: any[]; finalPayload: SnowflakeQueryResponseBody; }> {
+    const rows = [...this.extractRows(initial)];
+    const visited = new Set<string>();
+    let nextUri = this.resolveNextUri(initial);
+    let current = initial;
+
+    while (nextUri && !visited.has(nextUri)) {
+      visited.add(nextUri);
+      const chunkResponse = await this.get<SnowflakeQueryResponseBody>(nextUri);
+      if (!chunkResponse.success) {
+        throw new Error(chunkResponse.error || `Failed to fetch Snowflake query results from ${nextUri}`);
+      }
+
+      const chunk = chunkResponse.data;
+      if (!chunk || typeof chunk !== 'object') {
+        break;
+      }
+
+      const error = this.extractError(chunk);
+      if (error) {
+        throw new Error(error);
+      }
+
+      rows.push(...this.extractRows(chunk));
+      current = chunk;
+      const resolvedNext = this.resolveNextUri(chunk);
+      if (!resolvedNext || visited.has(resolvedNext)) {
+        nextUri = undefined;
+      } else {
+        nextUri = resolvedNext;
+      }
+    }
+
+    return { rows, finalPayload: current };
+  }
+
+  private extractRows(payload: SnowflakeQueryResponseBody): any[] {
+    if (!payload) {
       return [];
     }
+
+    if (Array.isArray(payload.data)) {
+      return payload.data;
+    }
+    if (Array.isArray(payload.rowset)) {
+      return payload.rowset;
+    }
+    if (Array.isArray(payload.rowSet)) {
+      return payload.rowSet;
+    }
+    if (Array.isArray(payload.rows)) {
+      return payload.rows;
+    }
+
+    return [];
+  }
+
+  private resolveNextUri(payload: SnowflakeQueryResponseBody): string | undefined {
+    if (!payload) {
+      return undefined;
+    }
+
+    if (payload.nextUri && payload.nextUri.trim().length > 0) {
+      return payload.nextUri;
+    }
+
+    if (payload.statementStatusUrl && payload.statementStatusUrl.trim().length > 0) {
+      return payload.statementStatusUrl;
+    }
+
+    const meta = payload.resultSetMetaData as Record<string, any> | null | undefined;
+    const metaNext = meta && typeof meta === 'object' ? meta.nextUri : undefined;
+    if (typeof metaNext === 'string' && metaNext.trim().length > 0) {
+      return metaNext;
+    }
+
+    return undefined;
+  }
+
+  private removeUndefined<T extends Record<string, any>>(payload: T): T {
+    for (const key of Object.keys(payload)) {
+      if (payload[key] === undefined) {
+        delete payload[key];
+      }
+    }
+    return payload;
+  }
+
+  private static normalizeAccount(input: string): string {
+    const trimmed = input.trim();
+    const withoutProtocol = trimmed.replace(/^https?:\/\//i, '');
+    const withoutDomain = withoutProtocol.replace(/\.snowflakecomputing\.com.*$/i, '');
+    return withoutDomain;
   }
 }

--- a/server/integrations/__tests__/SnowflakeAPIClient.test.ts
+++ b/server/integrations/__tests__/SnowflakeAPIClient.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+
+import { SnowflakeAPIClient } from '../SnowflakeAPIClient.js';
+
+interface MockResponse {
+  status?: number;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+interface RecordedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+const originalFetch = global.fetch;
+
+function useMockFetch(sequence: MockResponse[]): RecordedRequest[] {
+  const requests: RecordedRequest[] = [];
+  let index = 0;
+
+  global.fetch = (async (input: any, init?: RequestInit): Promise<Response> => {
+    const current = sequence[Math.min(index, sequence.length - 1)] ?? {};
+    index += 1;
+
+    const url = typeof input === 'string' ? input : input.url ?? input.toString();
+    requests.push({ url, init: init ?? {} });
+
+    const status = current.status ?? 200;
+    const body = typeof current.body === 'string' ? current.body : JSON.stringify(current.body ?? {});
+    const headers = current.headers ?? { 'Content-Type': 'application/json' };
+
+    return new Response(body, { status, headers });
+  }) as typeof fetch;
+
+  return requests;
+}
+
+async function testExecuteQueryStreamsResults(): Promise<void> {
+  const requests = useMockFetch([
+    {
+      body: {
+        statementHandle: '01a',
+        queryId: 'ae-fake-query',
+        data: [[1, 'first']],
+        nextUri: '/queries/v1/query-request?requestId=fake&chunk=2',
+        requestId: 'initial-request',
+        resultSetMetaData: { rowType: [{ name: 'COL1' }] }
+      }
+    },
+    { body: { data: [[2, 'second']], nextUri: null } }
+  ]);
+
+  const client = new SnowflakeAPIClient({
+    accessToken: 'snow-token',
+    account: 'xy12345.us-east-1',
+    warehouse: 'COMPUTE_WH',
+    database: 'ANALYTICS',
+    schema: 'PUBLIC'
+  });
+
+  const response = await client.executeQuery({
+    sql: 'select * from example where limit = :limit',
+    parameters: { limit: 2 },
+    timeout: 45
+  });
+
+  assert.equal(response.success, true, 'Snowflake query should succeed');
+  assert.ok(response.data, 'Query response should include data');
+  assert.equal(response.data?.statementHandle, '01a');
+  assert.equal(response.data?.queryId, 'ae-fake-query');
+  assert.deepEqual(response.data?.rows, [[1, 'first'], [2, 'second']]);
+  assert.equal(response.data?.requestId, 'initial-request');
+
+  assert.equal(requests.length, 2, 'Should issue initial POST and follow-up GET for chunks');
+
+  const initialRequest = requests[0];
+  assert.ok(initialRequest.url.endsWith('/queries/v1/query-request'));
+  assert.equal(initialRequest.init.method, 'POST');
+  const initialBody = JSON.parse(initialRequest.init.body as string);
+  assert.equal(initialBody.sqlText, 'select * from example where limit = :limit');
+  assert.equal(initialBody.warehouse, 'COMPUTE_WH');
+  assert.equal(initialBody.database, 'ANALYTICS');
+  assert.equal(initialBody.schema, 'PUBLIC');
+  assert.equal(initialBody.queryTimeout, 45);
+  assert.equal(initialBody.bindings.limit.type, 'FIXED');
+  assert.equal(initialBody.bindings.limit.value, '2');
+  assert.equal(initialRequest.init.headers?.['Authorization'], 'Bearer snow-token');
+
+  const chunkRequest = requests[1];
+  assert.ok(chunkRequest.url.includes('/queries/v1/query-request?requestId=fake&chunk=2'));
+  assert.equal(chunkRequest.init.method, 'GET');
+}
+
+async function testCancelQuery(): Promise<void> {
+  const requests = useMockFetch([{ body: { success: true } }]);
+
+  const client = new SnowflakeAPIClient({
+    accessToken: 'cancel-token',
+    account: 'my-account'
+  });
+
+  const result = await client.cancelQuery({ statementHandle: 'handle-123' });
+  assert.equal(result.success, true, 'Cancel query should surface provider success');
+
+  assert.equal(requests.length, 1);
+  const request = requests[0];
+  assert.ok(request.url.endsWith('/queries/v1/abort-request'));
+  assert.equal(request.init.method, 'POST');
+  const body = JSON.parse(request.init.body as string);
+  assert.equal(body.statementHandle, 'handle-123');
+  assert.ok(body.requestId, 'Cancellation should include a generated request ID');
+}
+
+async function testExecuteQueryErrorHandling(): Promise<void> {
+  const requests = useMockFetch([
+    {
+      body: {
+        success: false,
+        errorCode: '001003',
+        message: 'Syntax error in SQL statement'
+      }
+    }
+  ]);
+
+  const client = new SnowflakeAPIClient({ accessToken: 'token', account: 'error-account' });
+  const result = await client.executeQuery({ sql: 'select bad syntax' });
+
+  assert.equal(result.success, false, 'Query failure should be reported');
+  assert.ok(result.error, 'Error response should include a message');
+  assert.match(result.error ?? '', /syntax error/i);
+  assert.equal(requests.length, 1, 'Failure should not trigger chunk polling');
+}
+
+await testExecuteQueryStreamsResults();
+await testCancelQuery();
+await testExecuteQueryErrorHandling();
+
+global.fetch = originalFetch;
+
+console.log('Snowflake API client verified.');


### PR DESCRIPTION
## Summary
- replace the placeholder Snowflake API client with an account-aware implementation that builds SQL API payloads, supports bindings, and streams paginated results
- add query cancellation support and expose it through the connector handler registry
- cover query success, cancellation, and error paths with dedicated Snowflake API client tests

## Testing
- ⚠️ `npx tsx server/integrations/__tests__/SnowflakeAPIClient.test.ts` *(fails: npm returned E403 when attempting to download tsx in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d11967748331ba124088d77b8b84