### PR TITLE
Implement Azure AD client credentials for Power BI

### DIFF
--- a/connectors/powerbi/definition.json
+++ b/connectors/powerbi/definition.json
@@ -5,23 +5,34 @@
   "category": "Analytics",
   "icon": "powerbi",
   "color": "#F2C811",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "authentication": {
     "type": "oauth2",
     "config": {
-      "authUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-      "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      "grantType": "client_credentials",
+      "tokenUrl": "https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token",
       "scopes": [
         "https://analysis.windows.net/powerbi/api/.default"
+      ],
+      "clientIdRequired": true,
+      "clientSecretRequired": true,
+      "additionalFields": [
+        {
+          "id": "tenantId",
+          "name": "Directory (tenant) ID",
+          "type": "string",
+          "required": true,
+          "description": "Azure AD directory (tenant) identifier used for service principal authentication."
+        }
       ]
     }
   },
-  "baseUrl": "https://api.powerbi.com/v1.0/myorg",
+  "baseUrl": "https://api.powerbi.com/v1.0",
   "actions": [
     {
       "id": "test_connection",
       "name": "Test Connection",
-      "description": "Test the connection to Power BI",
+      "description": "Verify service principal access to the Power BI REST API",
       "parameters": {
         "type": "object",
         "properties": {},
@@ -31,14 +42,29 @@
     },
     {
       "id": "get_datasets",
-      "name": "Get Datasets",
-      "description": "Get list of datasets",
+      "name": "List Datasets",
+      "description": "Retrieve datasets available to the authenticated service principal",
       "parameters": {
         "type": "object",
         "properties": {
           "groupId": {
             "type": "string",
             "description": "Workspace ID (optional)"
+          },
+          "top": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 5000,
+            "description": "Maximum number of datasets to return"
+          },
+          "skip": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Number of datasets to skip"
+          },
+          "filter": {
+            "type": "string",
+            "description": "Optional OData filter expression"
           }
         },
         "required": [],
@@ -46,9 +72,9 @@
       }
     },
     {
-      "id": "refresh_dataset",
-      "name": "Refresh Dataset",
-      "description": "Trigger dataset refresh",
+      "id": "query_dataset",
+      "name": "Query Dataset",
+      "description": "Execute a DAX query against a dataset",
       "parameters": {
         "type": "object",
         "properties": {
@@ -59,6 +85,117 @@
           "groupId": {
             "type": "string",
             "description": "Workspace ID (optional)"
+          },
+          "sql": {
+            "type": "string",
+            "description": "DAX query text to execute"
+          },
+          "parameters": {
+            "type": "object",
+            "description": "Optional query parameters (name/value pairs)",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "datasetId",
+          "sql"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "id": "trigger_refresh",
+      "name": "Trigger Dataset Refresh",
+      "description": "Start a dataset refresh and optionally wait for completion",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "datasetId": {
+            "type": "string",
+            "description": "Dataset ID"
+          },
+          "groupId": {
+            "type": "string",
+            "description": "Workspace ID (optional)"
+          },
+          "notifyOption": {
+            "type": "string",
+            "enum": [
+              "MailOnCompletion",
+              "MailOnFailure",
+              "NoNotification"
+            ],
+            "description": "Notification preference for refresh completion"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Full",
+              "Calculate"
+            ],
+            "description": "Refresh type"
+          },
+          "commitMode": {
+            "type": "string",
+            "enum": [
+              "transactional",
+              "partialBatch"
+            ],
+            "description": "Commit mode used for the refresh"
+          },
+          "applyRefreshPolicy": {
+            "type": "boolean",
+            "description": "Respect incremental refresh policy when true"
+          },
+          "maxParallelism": {
+            "type": "number",
+            "minimum": 1,
+            "description": "Maximum number of parallel partitions refreshed"
+          },
+          "retryCount": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Number of retry attempts allowed by the service"
+          },
+          "objects": {
+            "type": "array",
+            "description": "Limit the refresh to specific tables or partitions",
+            "items": {
+              "type": "object",
+              "properties": {
+                "table": {
+                  "type": "string",
+                  "description": "Table name"
+                },
+                "partition": {
+                  "type": "string",
+                  "description": "Partition name"
+                }
+              },
+              "required": [
+                "table"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "waitForCompletion": {
+            "type": "boolean",
+            "default": true,
+            "description": "Wait for the refresh to reach a terminal state before returning"
+          },
+          "pollIntervalSeconds": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 60,
+            "default": 5,
+            "description": "Polling interval in seconds when waiting for completion"
+          },
+          "maxPollAttempts": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 120,
+            "default": 30,
+            "description": "Maximum polling attempts before timing out"
           }
         },
         "required": [
@@ -68,9 +205,78 @@
       }
     },
     {
+      "id": "get_refreshes",
+      "name": "List Refresh History",
+      "description": "Retrieve refresh history for a dataset",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "datasetId": {
+            "type": "string",
+            "description": "Dataset ID"
+          },
+          "groupId": {
+            "type": "string",
+            "description": "Workspace ID (optional)"
+          },
+          "top": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 500,
+            "description": "Maximum number of refresh entries to return"
+          },
+          "skip": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Number of refresh entries to skip"
+          }
+        },
+        "required": [
+          "datasetId"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "id": "add_rows",
+      "name": "Add Rows",
+      "description": "Append rows to a dataset table",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "datasetId": {
+            "type": "string",
+            "description": "Dataset ID"
+          },
+          "groupId": {
+            "type": "string",
+            "description": "Workspace ID (optional)"
+          },
+          "tableName": {
+            "type": "string",
+            "description": "Table name"
+          },
+          "rows": {
+            "type": "array",
+            "description": "Array of row objects to append",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "required": [
+          "datasetId",
+          "tableName",
+          "rows"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
       "id": "get_reports",
-      "name": "Get Reports",
-      "description": "Get list of reports",
+      "name": "List Reports",
+      "description": "Retrieve reports within a workspace",
       "parameters": {
         "type": "object",
         "properties": {
@@ -85,8 +291,8 @@
     },
     {
       "id": "get_dashboards",
-      "name": "Get Dashboards",
-      "description": "Get list of dashboards",
+      "name": "List Dashboards",
+      "description": "Retrieve dashboards within a workspace",
       "parameters": {
         "type": "object",
         "properties": {
@@ -102,19 +308,31 @@
   ],
   "triggers": [
     {
-      "id": "dataset_refreshed",
-      "name": "Dataset Refreshed",
-      "description": "Triggered when a dataset refresh completes",
-      "type": "webhook",
+      "id": "dataset_refresh_completed",
+      "name": "Dataset Refresh Completed",
+      "description": "Triggered when a dataset refresh enters a terminal state",
+      "type": "polling",
       "parameters": {
         "type": "object",
         "properties": {
+          "datasetId": {
+            "type": "string",
+            "description": "Dataset ID to monitor"
+          },
           "groupId": {
             "type": "string",
-            "description": "Filter by workspace ID"
+            "description": "Workspace ID (optional)"
+          },
+          "top": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 50,
+            "description": "Number of recent refreshes to evaluate"
           }
         },
-        "required": [],
+        "required": [
+          "datasetId"
+        ],
         "additionalProperties": false
       },
       "outputSchema": {
@@ -123,10 +341,25 @@
           "datasetId": {
             "type": "string"
           },
-          "refreshType": {
+          "groupId": {
+            "type": "string"
+          },
+          "refreshId": {
             "type": "string"
           },
           "status": {
+            "type": "string"
+          },
+          "refreshType": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "serviceExceptionJson": {
             "type": "string"
           }
         }
@@ -135,10 +368,10 @@
   ],
   "testConnection": {
     "method": "GET",
-    "endpoint": "/groups"
+    "endpoint": "/myorg/datasets?$top=1"
   },
   "release": {
-    "semver": "1.0.0",
+    "semver": "1.1.0",
     "status": "stable",
     "isBeta": false,
     "betaStartedAt": null,

--- a/server/integrations/PowerbiAPIClient.ts
+++ b/server/integrations/PowerbiAPIClient.ts
@@ -1,99 +1,520 @@
-// POWER BI API CLIENT
-// Auto-generated API client for Power BI integration
+import { APICredentials, APIResponse, BaseAPIClient } from './BaseAPIClient';
 
-import { BaseAPIClient } from './BaseAPIClient';
+type RefreshObject = {
+  table: string;
+  partition?: string;
+};
 
-export interface PowerbiAPIClientConfig {
-  accessToken: string;
-  refreshToken?: string;
-  clientId?: string;
-  clientSecret?: string;
+type ListDatasetsParams = {
+  groupId?: string;
+  top?: number;
+  skip?: number;
+  filter?: string;
+};
+
+type TriggerDatasetRefreshParams = {
+  datasetId: string;
+  groupId?: string;
+  notifyOption?: 'MailOnCompletion' | 'MailOnFailure' | 'NoNotification';
+  type?: 'Full' | 'Calculate';
+  commitMode?: 'transactional' | 'partialBatch';
+  applyRefreshPolicy?: boolean;
+  maxParallelism?: number;
+  retryCount?: number;
+  objects?: RefreshObject[];
+  advancedSettings?: Record<string, any>;
+  waitForCompletion?: boolean;
+  pollIntervalSeconds?: number;
+  maxPollAttempts?: number;
+};
+
+type ListDatasetRefreshesParams = {
+  datasetId: string;
+  groupId?: string;
+  top?: number;
+  skip?: number;
+};
+
+type DatasetRefreshTriggerParams = {
+  datasetId: string;
+  groupId?: string;
+  top?: number;
+};
+
+type ExecuteQueryParams = {
+  datasetId: string;
+  groupId?: string;
+  sql?: string;
+  query?: string;
+  parameters?: Record<string, unknown> | Array<{ name: string; value: unknown }>;
+};
+
+type AddRowsParams = {
+  datasetId: string;
+  groupId?: string;
+  tableName: string;
+  rows: Array<Record<string, any> | string>;
+};
+
+type ListReportsParams = {
+  groupId?: string;
+};
+
+type ListDashboardsParams = {
+  groupId?: string;
+};
+
+type PowerBICredentials = APICredentials & {
+  tenantId?: string;
+  tenant?: string;
+  authorityHost?: string;
+  tokenUrl?: string;
+  scope?: string;
+  baseUrl?: string;
+};
+
+const DEFAULT_BASE_URL = 'https://api.powerbi.com/v1.0';
+const DEFAULT_SCOPE = 'https://analysis.windows.net/powerbi/api/.default';
+const DEFAULT_AUTHORITY = 'https://login.microsoftonline.com';
+
+function parseExpiry(raw: unknown): number | undefined {
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return raw;
+  }
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    const parsed = Date.parse(raw);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+  return undefined;
 }
 
 export class PowerbiAPIClient extends BaseAPIClient {
-  protected baseUrl: string;
-  private config: PowerbiAPIClientConfig;
+  private readonly tokenEndpoint: string;
+  private readonly scope: string;
+  private readonly refreshSkewMs = 60_000;
+  private refreshPromise?: Promise<void>;
 
-  constructor(config: PowerbiAPIClientConfig) {
-    super();
-    this.config = config;
-    this.baseUrl = 'https://api.powerbi.com/v1.0';
+  constructor(credentials: PowerBICredentials) {
+    const baseUrl = (credentials.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+    super(baseUrl, credentials);
+
+    const tenantId = credentials.tenantId ?? credentials.tenant;
+    if (!tenantId) {
+      throw new Error('Power BI integration requires a tenantId in credentials');
+    }
+
+    const clientId = credentials.clientId ?? (credentials as Record<string, any>).client_id;
+    if (!clientId) {
+      throw new Error('Power BI integration requires a clientId');
+    }
+
+    const clientSecret = credentials.clientSecret ?? (credentials as Record<string, any>).client_secret;
+    if (!clientSecret) {
+      throw new Error('Power BI integration requires a clientSecret');
+    }
+
+    this.credentials.clientId = clientId;
+    this.credentials.clientSecret = clientSecret;
+
+    const authority = (credentials.authorityHost ?? DEFAULT_AUTHORITY).replace(/\/$/, '');
+    this.tokenEndpoint = credentials.tokenUrl ?? `${authority}/${tenantId}/oauth2/v2.0/token`;
+    this.scope = credentials.scope ?? DEFAULT_SCOPE;
+
+    this.registerAliasHandlers({
+      test_connection: 'testConnection',
+      get_datasets: 'listDatasets',
+      list_datasets: 'listDatasets',
+      get_reports: 'listReports',
+      get_dashboards: 'listDashboards',
+      trigger_refresh: 'triggerDatasetRefresh',
+      refresh_dataset: 'triggerDatasetRefresh',
+      get_refreshes: 'listDatasetRefreshes',
+      list_refreshes: 'listDatasetRefreshes',
+      query_dataset: 'executeQuery',
+      add_rows: 'addRows',
+      dataset_refresh_completed: 'pollDatasetRefreshCompleted'
+    });
   }
 
-  /**
-   * Get authentication headers
-   */
   protected getAuthHeaders(): Record<string, string> {
+    const token = this.credentials.accessToken;
+    if (!token) {
+      throw new Error('Power BI integration is missing an access token');
+    }
     return {
-      'Authorization': `Bearer ${this.config.accessToken}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'Apps-Script-Automation/1.0'
+      Authorization: `Bearer ${token}`
     };
   }
 
-  /**
-   * Test API connection
-   */
-  async testConnection(): Promise<boolean> {
+  protected override async makeRequest<T = any>(
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
+    endpoint: string,
+    data?: any,
+    headers: Record<string, string> = {}
+  ): Promise<APIResponse<T>> {
+    await this.ensureAccessToken();
+    return super.makeRequest(method, endpoint, data, headers);
+  }
+
+  private async ensureAccessToken(): Promise<void> {
+    const expiresAt = parseExpiry((this.credentials as Record<string, any>).expiresAt);
+    if (this.credentials.accessToken && (!expiresAt || expiresAt - Date.now() > this.refreshSkewMs)) {
+      return;
+    }
+
+    if (!this.refreshPromise) {
+      this.refreshPromise = (async () => {
+        try {
+          const clientId = this.credentials.clientId;
+          const clientSecret = this.credentials.clientSecret;
+          if (!clientId || !clientSecret) {
+            throw new Error('Power BI token acquisition requires clientId and clientSecret');
+          }
+
+          const body = new URLSearchParams({
+            grant_type: 'client_credentials',
+            client_id: clientId,
+            client_secret: clientSecret,
+            scope: this.scope,
+          });
+
+          const response = await fetch(this.tokenEndpoint, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+              Accept: 'application/json'
+            },
+            body
+          });
+
+          if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`Power BI token request failed: ${response.status} ${response.statusText} ${errorText}`);
+          }
+
+          const payload = await response.json();
+          const nextExpiry = typeof payload.expires_in === 'number'
+            ? Date.now() + Number(payload.expires_in) * 1000
+            : undefined;
+
+          await this.applyTokenRefresh({
+            accessToken: payload.access_token,
+            expiresAt: nextExpiry,
+            tokenType: payload.token_type,
+            scope: payload.scope
+          });
+        } finally {
+          this.refreshPromise = undefined;
+        }
+      })();
+    }
+
+    await this.refreshPromise;
+  }
+
+  private resolveGroupSegment(groupId?: string): string {
+    if (!groupId) {
+      return '/myorg';
+    }
+    return `/groups/${encodeURIComponent(groupId)}`;
+  }
+
+  private resolveDatasetPath(datasetId: string, groupId?: string): string {
+    return `${this.resolveGroupSegment(groupId)}/datasets/${encodeURIComponent(datasetId)}`;
+  }
+
+  private buildRefreshPayload(params: TriggerDatasetRefreshParams): Record<string, any> {
+    const payload: Record<string, any> = {};
+
+    if (params.notifyOption) {
+      payload.notifyOption = params.notifyOption;
+    }
+    if (params.type) {
+      payload.type = params.type;
+    }
+    if (params.commitMode) {
+      payload.commitMode = params.commitMode;
+    }
+    if (typeof params.applyRefreshPolicy === 'boolean') {
+      payload.applyRefreshPolicy = params.applyRefreshPolicy;
+    }
+    if (typeof params.maxParallelism === 'number') {
+      payload.maxParallelism = params.maxParallelism;
+    }
+    if (typeof params.retryCount === 'number') {
+      payload.retryCount = params.retryCount;
+    }
+    if (Array.isArray(params.objects) && params.objects.length > 0) {
+      payload.objects = params.objects.map(obj => ({
+        table: obj.table,
+        partition: obj.partition,
+      }));
+    }
+    if (params.advancedSettings && typeof params.advancedSettings === 'object') {
+      Object.assign(payload, params.advancedSettings);
+    }
+
+    return payload;
+  }
+
+  private extractRefreshId(location?: string): string | undefined {
+    if (!location) {
+      return undefined;
+    }
+
     try {
-      const response = await this.makeRequest('GET', '/');
-      return response.status === 200;
-      return true;
-    } catch (error) {
-      console.error(`❌ ${this.constructor.name} connection test failed:`, error);
-      return false;
+      const parsed = new URL(location, DEFAULT_BASE_URL);
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      return segments.length ? segments[segments.length - 1] : undefined;
+    } catch {
+      const parts = location.split('/').filter(Boolean);
+      return parts.length ? parts[parts.length - 1] : undefined;
     }
   }
 
-
-  /**
-   * Query a Power BI dataset
-   */
-  async queryDataset({ datasetId: string, sql: string }: { datasetId: string, sql: string }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/query_dataset', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Query Dataset failed: ${error}`);
-    }
-  }
-
-  /**
-   * Trigger a dataset refresh
-   */
-  async triggerRefresh({ datasetId: string }: { datasetId: string }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/trigger_refresh', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Trigger Refresh failed: ${error}`);
-    }
-  }
-
-  /**
-   * Add rows to a dataset table
-   */
-  async addRows({ datasetId: string, tableName: string, rows: any[] }: { datasetId: string, tableName: string, rows: any[] }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/add_rows', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Add Rows failed: ${error}`);
-    }
-  }
-
-
-  /**
-   * Poll for Triggered when a dataset refresh completes
-   */
-  async pollDatasetRefreshCompleted({ datasetId: string }: { datasetId: string }): Promise<any[]> {
-    try {
-      const response = await this.makeRequest('GET', '/api/dataset_refresh_completed', params);
-      const data = this.handleResponse(response);
-      return Array.isArray(data) ? data : [data];
-    } catch (error) {
-      console.error(`Polling Dataset Refresh Completed failed:`, error);
+  private normalizeRefreshList(data: any): any[] {
+    if (!data) {
       return [];
     }
+    if (Array.isArray(data)) {
+      return data;
+    }
+    if (Array.isArray(data.value)) {
+      return data.value;
+    }
+    if (Array.isArray(data.results)) {
+      return data.results;
+    }
+    return [];
+  }
+
+  private resolvePollingOptions(params: TriggerDatasetRefreshParams): { intervalMs: number; maxAttempts: number } {
+    const intervalSeconds = params.pollIntervalSeconds ?? 5;
+    const intervalMs = Math.max(0, intervalSeconds) * 1000;
+    const maxAttempts = Math.max(1, params.maxPollAttempts ?? 30);
+    return { intervalMs, maxAttempts };
+  }
+
+  private async pollRefreshUntilComplete(
+    location: string,
+    options: { datasetId: string; refreshId?: string; intervalMs: number; maxAttempts: number }
+  ): Promise<APIResponse<any>> {
+    let attempt = 0;
+    let lastResponse: APIResponse<any> | null = null;
+
+    while (attempt < options.maxAttempts) {
+      const statusResponse = await this.get(location);
+      if (!statusResponse.success) {
+        if (statusResponse.statusCode === 404 || statusResponse.statusCode === 202) {
+          attempt += 1;
+          if (options.intervalMs > 0) {
+            await this.sleep(options.intervalMs);
+          }
+          continue;
+        }
+        return statusResponse;
+      }
+
+      const record = statusResponse.data ?? {};
+      const status = typeof record?.status === 'string' ? record.status : undefined;
+      const normalizedStatus = status ? status.toLowerCase() : undefined;
+
+      if (!normalizedStatus || normalizedStatus === 'inprogress' || normalizedStatus === 'unknown') {
+        attempt += 1;
+        lastResponse = statusResponse;
+        if (options.intervalMs > 0) {
+          await this.sleep(options.intervalMs);
+        }
+        continue;
+      }
+
+      const refreshId = record.id ?? record.refreshId ?? options.refreshId ?? this.extractRefreshId(location);
+      const data = {
+        ...record,
+        datasetId: options.datasetId,
+        refreshId,
+        status: status,
+        location,
+      };
+
+      return {
+        success: true,
+        data,
+        statusCode: statusResponse.statusCode,
+        headers: statusResponse.headers,
+      };
+    }
+
+    return {
+      success: false,
+      error: `Timed out waiting for dataset refresh completion after ${options.maxAttempts} attempts.`,
+      data: lastResponse?.data,
+      statusCode: lastResponse?.statusCode,
+      headers: lastResponse?.headers,
+    };
+  }
+
+  public testConnection(): Promise<APIResponse<any>> {
+    return this.get('/myorg/datasets?$top=1');
+  }
+
+  public listDatasets(params: ListDatasetsParams = {}): Promise<APIResponse<any>> {
+    const queryParams: Record<string, any> = {};
+    if (typeof params.top === 'number') {
+      queryParams['$top'] = params.top;
+    }
+    if (typeof params.skip === 'number') {
+      queryParams['$skip'] = params.skip;
+    }
+    if (params.filter) {
+      queryParams['$filter'] = params.filter;
+    }
+
+    const endpoint = `${this.resolveGroupSegment(params.groupId)}/datasets${this.buildQueryString(queryParams)}`;
+    return this.get(endpoint);
+  }
+
+  public listReports(params: ListReportsParams = {}): Promise<APIResponse<any>> {
+    return this.get(`${this.resolveGroupSegment(params.groupId)}/reports`);
+  }
+
+  public listDashboards(params: ListDashboardsParams = {}): Promise<APIResponse<any>> {
+    return this.get(`${this.resolveGroupSegment(params.groupId)}/dashboards`);
+  }
+
+  public async triggerDatasetRefresh(params: TriggerDatasetRefreshParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as Record<string, unknown>, ['datasetId']);
+
+    const endpoint = `${this.resolveDatasetPath(params.datasetId, params.groupId)}/refreshes`;
+    const payload = this.buildRefreshPayload(params);
+    const requestBody = Object.keys(payload).length > 0 ? payload : undefined;
+    const response = await this.post(endpoint, requestBody);
+
+    if (!response.success) {
+      return response;
+    }
+
+    const location = response.headers?.location ?? response.headers?.Location;
+    const refreshId = this.extractRefreshId(location);
+
+    if (params.waitForCompletion === false || !location) {
+      return {
+        success: true,
+        data: {
+          status: 'Accepted',
+          datasetId: params.datasetId,
+          groupId: params.groupId,
+          refreshId,
+          location
+        },
+        statusCode: response.statusCode,
+        headers: response.headers
+      };
+    }
+
+    const options = this.resolvePollingOptions(params);
+    return this.pollRefreshUntilComplete(location, {
+      datasetId: params.datasetId,
+      refreshId,
+      intervalMs: options.intervalMs,
+      maxAttempts: options.maxAttempts
+    });
+  }
+
+  public listDatasetRefreshes(params: ListDatasetRefreshesParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as Record<string, unknown>, ['datasetId']);
+
+    const queryParams: Record<string, any> = {};
+    if (typeof params.top === 'number') {
+      queryParams['$top'] = params.top;
+    }
+    if (typeof params.skip === 'number') {
+      queryParams['$skip'] = params.skip;
+    }
+
+    const endpoint = `${this.resolveDatasetPath(params.datasetId, params.groupId)}/refreshes${this.buildQueryString(queryParams)}`;
+    return this.get(endpoint);
+  }
+
+  public async executeQuery(params: ExecuteQueryParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as Record<string, unknown>, ['datasetId']);
+    const queryText = params.query ?? params.sql;
+    if (!queryText) {
+      return { success: false, error: 'Query text is required (sql or query).' };
+    }
+
+    const payload: Record<string, any> = {
+      queries: [
+        {
+          query: queryText
+        }
+      ]
+    };
+
+    if (params.parameters) {
+      if (Array.isArray(params.parameters)) {
+        payload.parameters = params.parameters;
+      } else if (typeof params.parameters === 'object') {
+        payload.parameters = Object.entries(params.parameters).map(([name, value]) => ({
+          name,
+          value
+        }));
+      }
+    }
+
+    const endpoint = `${this.resolveDatasetPath(params.datasetId, params.groupId)}/executeQueries`;
+    return this.post(endpoint, payload);
+  }
+
+  public async addRows(params: AddRowsParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as Record<string, unknown>, ['datasetId', 'tableName', 'rows']);
+
+    if (!Array.isArray(params.rows) || params.rows.length === 0) {
+      return { success: false, error: 'rows must contain at least one row object.' };
+    }
+
+    const normalizedRows = params.rows.map(row => {
+      if (typeof row === 'string') {
+        try {
+          return JSON.parse(row);
+        } catch {
+          throw new Error('rows contains a string that is not valid JSON');
+        }
+      }
+      return row;
+    });
+
+    const endpoint = `${this.resolveDatasetPath(params.datasetId, params.groupId)}/tables/${encodeURIComponent(params.tableName)}/rows`;
+    return this.post(endpoint, { rows: normalizedRows });
+  }
+
+  public async pollDatasetRefreshCompleted(params: DatasetRefreshTriggerParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as Record<string, unknown>, ['datasetId']);
+
+    const historyResponse = await this.listDatasetRefreshes({
+      datasetId: params.datasetId,
+      groupId: params.groupId,
+      top: params.top ?? 10
+    });
+
+    if (!historyResponse.success) {
+      return historyResponse;
+    }
+
+    const records = this.normalizeRefreshList(historyResponse.data);
+    const completed = records
+      .filter(record => typeof record?.status === 'string' && record.status.toLowerCase() !== 'inprogress')
+      .map(record => ({
+        ...record,
+        datasetId: params.datasetId,
+        groupId: params.groupId,
+      }));
+
+    return {
+      success: true,
+      data: completed,
+      statusCode: historyResponse.statusCode,
+      headers: historyResponse.headers,
+    };
   }
 }

--- a/server/integrations/__tests__/AnalyticsAPIClients.test.ts
+++ b/server/integrations/__tests__/AnalyticsAPIClients.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+
+import { PowerbiAPIClient } from '../PowerbiAPIClient.js';
+import type { APIResponse } from '../BaseAPIClient.js';
+
+type MockResponse = {
+  status?: number;
+  body?: string;
+  headers?: Record<string, string>;
+};
+
+type RecordedRequest = {
+  url: string;
+  init: RequestInit;
+};
+
+const originalFetch = global.fetch;
+
+function useMockFetch(sequence: MockResponse[]): RecordedRequest[] {
+  const requests: RecordedRequest[] = [];
+  let index = 0;
+
+  global.fetch = (async (input: any, init?: RequestInit): Promise<Response> => {
+    const current = sequence[Math.min(index, sequence.length - 1)] ?? {};
+    index += 1;
+
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input?.url ?? String(input);
+
+    requests.push({ url, init: init ?? {} });
+
+    const status = current.status ?? 200;
+    const body = current.body ?? '{}';
+    const headers = current.headers ?? { 'Content-Type': 'application/json' };
+
+    return new Response(body, { status, headers });
+  }) as typeof fetch;
+
+  return requests;
+}
+
+async function testPowerbiListDatasets(): Promise<void> {
+  const requests = useMockFetch([
+    { body: '{"access_token":"access-token","token_type":"Bearer","expires_in":3600}' },
+    { body: '{"value":[{"id":"dataset-1","name":"Sales"}]}' }
+  ]);
+
+  const client = new PowerbiAPIClient({
+    tenantId: 'contoso',
+    clientId: 'client',
+    clientSecret: 'secret'
+  });
+
+  const response = await client.execute('get_datasets', { top: 5 });
+  assert.equal(response.success, true, 'Listing datasets should succeed');
+
+  assert.equal(requests.length, 2, 'Two requests expected (token + datasets)');
+
+  const tokenRequest = requests[0];
+  assert.equal(
+    tokenRequest.url,
+    'https://login.microsoftonline.com/contoso/oauth2/v2.0/token',
+    'Token endpoint should target the configured tenant'
+  );
+  const encodedBody = (tokenRequest.init.body as URLSearchParams | string | undefined)?.toString() ?? '';
+  assert.ok(
+    encodedBody.includes('grant_type=client_credentials'),
+    'Token request should use client_credentials grant'
+  );
+  assert.ok(encodedBody.includes('client_id=client'));
+  assert.ok(encodedBody.includes('client_secret=secret'));
+  assert.ok(encodedBody.includes(encodeURIComponent('https://analysis.windows.net/powerbi/api/.default')));
+
+  const datasetRequest = requests[1];
+  assert.equal(
+    datasetRequest.url,
+    'https://api.powerbi.com/v1.0/myorg/datasets?$top=5',
+    'Dataset request should target the myorg collection with $top applied'
+  );
+  assert.equal(datasetRequest.init.method ?? 'GET', 'GET');
+  assert.equal(
+    datasetRequest.init.headers?.['Authorization'],
+    'Bearer access-token',
+    'Dataset request should include the acquired access token'
+  );
+
+  const resultData = (response as APIResponse<any>).data;
+  assert.ok(Array.isArray(resultData?.value));
+  assert.equal(resultData.value[0].id, 'dataset-1');
+}
+
+async function testPowerbiRefreshPolling(): Promise<void> {
+  const location = 'https://api.powerbi.com/v1.0/myorg/datasets/dataset-123/refreshes/refresh-123';
+  const requests = useMockFetch([
+    { body: '{"access_token":"access-token","token_type":"Bearer","expires_in":3600}' },
+    { status: 202, headers: { Location: location }, body: '' },
+    { body: '{"status":"InProgress"}' },
+    { body: '{"status":"Completed","id":"refresh-123","refreshType":"Full"}' }
+  ]);
+
+  const client = new PowerbiAPIClient({
+    tenantId: 'contoso',
+    clientId: 'client',
+    clientSecret: 'secret'
+  });
+
+  const response = await client.execute('trigger_refresh', {
+    datasetId: 'dataset-123',
+    pollIntervalSeconds: 0,
+    waitForCompletion: true
+  });
+
+  assert.equal(response.success, true, 'Refresh operation should succeed');
+  assert.equal((response.data as any).status, 'Completed', 'Final status should be Completed');
+  assert.equal((response.data as any).refreshId, 'refresh-123');
+
+  assert.equal(requests.length, 4, 'Token, trigger, and two polling requests expected');
+  const refreshRequest = requests[1];
+  assert.equal(
+    refreshRequest.url,
+    'https://api.powerbi.com/v1.0/myorg/datasets/dataset-123/refreshes',
+    'Refresh trigger should target the dataset refreshes endpoint'
+  );
+  assert.equal(refreshRequest.init.method ?? 'POST', 'POST');
+
+  const pollRequestOne = requests[2];
+  const pollRequestTwo = requests[3];
+  assert.equal(pollRequestOne.url, location);
+  assert.equal(pollRequestTwo.url, location);
+}
+
+try {
+  await testPowerbiListDatasets();
+  await testPowerbiRefreshPolling();
+  console.log('Analytics API clients integration smoke tests passed.');
+} finally {
+  global.fetch = originalFetch;
+}

--- a/server/testing/fixtures/powerbi/dataset_refresh_completed.json
+++ b/server/testing/fixtures/powerbi/dataset_refresh_completed.json
@@ -1,0 +1,31 @@
+{
+  "description": "Simulated Power BI dataset_refresh_completed trigger emitting the latest completed refresh.",
+  "type": "trigger",
+  "metadata": {
+    "kind": "trigger"
+  },
+  "defaults": {
+    "credentials": {
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "clientId": "11111111-1111-1111-1111-111111111111",
+      "clientSecret": "simulated-powerbi-secret"
+    },
+    "notes": "Connector simulator fixture for Power BI dataset_refresh_completed"
+  },
+  "triggerParams": {
+    "datasetId": "dataset-123"
+  },
+  "result": {
+    "success": true,
+    "data": [
+      {
+        "datasetId": "dataset-123",
+        "refreshId": "refresh-789",
+        "status": "Completed",
+        "refreshType": "Full",
+        "startTime": "2024-01-01T00:00:00Z",
+        "endTime": "2024-01-01T00:01:00Z"
+      }
+    ]
+  }
+}

--- a/server/testing/fixtures/powerbi/query_dataset.json
+++ b/server/testing/fixtures/powerbi/query_dataset.json
@@ -1,0 +1,34 @@
+{
+  "description": "Simulated Power BI query_dataset action returning a small result set.",
+  "defaults": {
+    "credentials": {
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "clientId": "11111111-1111-1111-1111-111111111111",
+      "clientSecret": "simulated-powerbi-secret"
+    },
+    "notes": "Connector simulator fixture for Power BI query_dataset"
+  },
+  "params": {
+    "datasetId": "dataset-123",
+    "sql": "EVALUATE TOPN(1, SUMMARIZE('Sales', 'Sales'[OrderNumber]))"
+  },
+  "result": {
+    "success": true,
+    "data": {
+      "results": [
+        {
+          "tables": [
+            {
+              "name": "Table1",
+              "rows": [
+                {
+                  "OrderNumber": "SO-1000"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/server/testing/fixtures/powerbi/trigger_refresh.json
+++ b/server/testing/fixtures/powerbi/trigger_refresh.json
@@ -1,0 +1,27 @@
+{
+  "description": "Simulated Power BI trigger_refresh action returning a completed refresh summary.",
+  "defaults": {
+    "credentials": {
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "clientId": "11111111-1111-1111-1111-111111111111",
+      "clientSecret": "simulated-powerbi-secret"
+    },
+    "notes": "Connector simulator fixture for Power BI trigger_refresh"
+  },
+  "params": {
+    "datasetId": "dataset-123",
+    "waitForCompletion": true
+  },
+  "result": {
+    "success": true,
+    "data": {
+      "datasetId": "dataset-123",
+      "refreshId": "refresh-789",
+      "status": "Completed",
+      "refreshType": "Full",
+      "startTime": "2024-01-01T00:00:00Z",
+      "endTime": "2024-01-01T00:01:00Z",
+      "location": "https://api.powerbi.com/v1.0/myorg/datasets/dataset-123/refreshes/refresh-789"
+    }
+  }
+}

--- a/server/workflow/compiler/op-map.ts
+++ b/server/workflow/compiler/op-map.ts
@@ -23,6 +23,7 @@ import { GrafanaAPIClient } from '../../integrations/GrafanaAPIClient.js';
 import { PrometheusAPIClient } from '../../integrations/PrometheusAPIClient.js';
 import { NewrelicAPIClient } from '../../integrations/NewrelicAPIClient.js';
 import { SentryAPIClient } from '../../integrations/SentryAPIClient.js';
+import { PowerbiAPIClient } from '../../integrations/PowerbiAPIClient.js';
 import { BigCommerceAPIClient } from '../../integrations/BigCommerceAPIClient.js';
 import { MagentoAPIClient } from '../../integrations/MagentoAPIClient.js';
 import { WooCommerceAPIClient } from '../../integrations/WooCommerceAPIClient.js';
@@ -187,6 +188,31 @@ const RUNTIME_OPS: Record<string, RuntimeHandler> = {
     assertClientInstance(client, NewrelicAPIClient).getViolations(params),
   'action.newrelic:execute_nrql': (client, params = {}) =>
     assertClientInstance(client, NewrelicAPIClient).executeNrql(params),
+
+  'action.powerbi:test_connection': client =>
+    assertClientInstance(client, PowerbiAPIClient).testConnection(),
+  'action.powerbi:get_datasets': (client, params = {}) =>
+    assertClientInstance(client, PowerbiAPIClient).listDatasets(params),
+  'action.powerbi:list_datasets': (client, params = {}) =>
+    assertClientInstance(client, PowerbiAPIClient).listDatasets(params),
+  'action.powerbi:get_reports': (client, params = {}) =>
+    assertClientInstance(client, PowerbiAPIClient).listReports(params),
+  'action.powerbi:get_dashboards': (client, params = {}) =>
+    assertClientInstance(client, PowerbiAPIClient).listDashboards(params),
+  'action.powerbi:trigger_refresh': (client, params = {}) =>
+    assertClientInstance(client, PowerbiAPIClient).triggerDatasetRefresh(params),
+  'action.powerbi:refresh_dataset': (client, params = {}) =>
+    assertClientInstance(client, PowerbiAPIClient).triggerDatasetRefresh(params),
+  'action.powerbi:get_refreshes': (client, params = {}) =>
+    assertClientInstance(client, PowerbiAPIClient).listDatasetRefreshes(params),
+  'action.powerbi:list_refreshes': (client, params = {}) =>
+    assertClientInstance(client, PowerbiAPIClient).listDatasetRefreshes(params),
+  'action.powerbi:query_dataset': (client, params = {}) =>
+    assertClientInstance(client, PowerbiAPIClient).executeQuery(params),
+  'action.powerbi:add_rows': (client, params = {}) =>
+    assertClientInstance(client, PowerbiAPIClient).addRows(params),
+  'trigger.powerbi:dataset_refresh_completed': (client, params = {}) =>
+    assertClientInstance(client, PowerbiAPIClient).pollDatasetRefreshCompleted(params),
 
   'action.sentry:test_connection': client => assertClientInstance(client, SentryAPIClient).testConnection(),
   'action.sentry:get_organizations': (client, params = {}) =>


### PR DESCRIPTION
## Summary
- implement an Azure AD client-credentials OAuth flow in the Power BI API client and add dataset query/refresh helpers
- expand the Power BI connector definition with richer refresh payload options and a polling-based refresh trigger
- wire the new runtime handlers, add targeted integration tests, and provide simulator fixtures for dataset queries and refreshes

## Testing
- npx tsx server/integrations/__tests__/AnalyticsAPIClients.test.ts *(fails: npm registry access forbidden in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d11d60448331814e5d59b79e07f9