### PR TITLE
Add dev stack orchestration script

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -29,6 +29,8 @@ The default configuration in `.env.example` assumes PostgreSQL and Redis are run
 
 - `npm run dev:server` starts the backend in watch mode.
 - `npm run dev:client` starts the frontend dev server.
+- `npm run dev:stack` starts the API, scheduler, worker, and encryption rotation services together
+  with shared lifecycle and cleanup logic.
 - Consult `docs/operations/queue.md` if you need advanced Redis/BullMQ tuning.
 
 Shut the stack down with:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev:worker": "NODE_ENV=development tsx watch server/workers/execution.ts",
     "dev:rotation": "NODE_ENV=development tsx watch server/workers/encryption-rotation.ts",
     "dev:scheduler": "NODE_ENV=development tsx watch server/workers/scheduler.ts",
+    "dev:stack": "tsx scripts/dev-stack.ts",
     "build": "npm run check:deps && npm run build:client && npm run build:server",
     "build:client": "vite build",
     "build:server": "esbuild server/index.ts server/workers/execution.ts server/workers/scheduler.ts server/workers/timerDispatcher.ts server/workers/encryption-rotation.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --outbase=server",

--- a/scripts/dev-stack.ts
+++ b/scripts/dev-stack.ts
@@ -1,0 +1,124 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import process from 'node:process';
+
+type ManagedProcess = {
+  script: string;
+  child: ChildProcess;
+};
+
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const scriptsToRun = ['dev:api', 'dev:scheduler', 'dev:worker', 'dev:rotation'];
+const managedProcesses: ManagedProcess[] = [];
+
+let shuttingDown = false;
+let exitCode = 0;
+
+process.env.NODE_ENV ??= 'development';
+
+const logPrefix = '[dev:stack]';
+
+function log(message: string) {
+  console.log(`${logPrefix} ${message}`);
+}
+
+function terminateAll(signal: NodeJS.Signals = 'SIGTERM') {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+
+  for (const { script, child } of managedProcesses) {
+    if (child.killed) {
+      continue;
+    }
+
+    log(`Sending ${signal} to ${script}...`);
+
+    try {
+      child.kill(signal);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(`Failed to terminate ${script}: ${message}`);
+    }
+  }
+}
+
+function setupSignalHandlers() {
+  const shutdownHandler = (signal: NodeJS.Signals) => {
+    log(`Received ${signal}. Cleaning up child processes...`);
+    exitCode = exitCode || 0;
+    terminateAll(signal);
+  };
+
+  process.on('SIGINT', () => shutdownHandler('SIGINT'));
+  process.on('SIGTERM', () => shutdownHandler('SIGTERM'));
+}
+
+async function main() {
+  setupSignalHandlers();
+
+  const exitPromises = scriptsToRun.map((script) => {
+    return new Promise<void>((resolve) => {
+      const child = spawn(npmCommand, ['run', script], {
+        stdio: 'inherit',
+        env: { ...process.env },
+      });
+
+      const managed: ManagedProcess = { script, child };
+      managedProcesses.push(managed);
+      log(`Started ${script}`);
+
+      let settled = false;
+
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        resolve();
+      };
+
+      child.on('error', (error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        log(`Failed to start ${script}: ${message}`);
+        exitCode = exitCode || 1;
+        terminateAll();
+        finish();
+      });
+
+      child.on('exit', (code, signal) => {
+        if (!shuttingDown) {
+          if (code !== null && code !== 0) {
+            log(`${script} exited with code ${code}. Shutting down remaining processes.`);
+            exitCode = exitCode || code;
+            terminateAll();
+          } else if (signal) {
+            log(`${script} exited due to signal ${signal}. Shutting down remaining processes.`);
+            exitCode = exitCode || 0;
+            terminateAll(signal);
+          } else {
+            log(`${script} exited. Shutting down remaining processes.`);
+            exitCode = exitCode || 0;
+            terminateAll();
+          }
+        }
+
+        finish();
+      });
+    });
+  });
+
+  await Promise.all(exitPromises);
+}
+
+main()
+  .catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`${logPrefix} Unhandled error: ${message}`);
+    exitCode = exitCode || 1;
+  })
+  .finally(() => {
+    process.exit(exitCode);
+  });


### PR DESCRIPTION
## Summary
- add a dev:stack npm script to orchestrate the API, scheduler, worker, and rotation services
- implement a tsx-based runner that forwards signals and shuts down child processes together
- document the new workflow command in the local development guide

## Testing
- `npm run check -- --pretty false` *(fails: missing Node and Vite type definitions in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e36aa94083318820103eead2b688