### PR TITLE
Harden environment loader secret validation

### DIFF
--- a/server/__tests__/env.loader.test.ts
+++ b/server/__tests__/env.loader.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const originalCwd = process.cwd();
+const envModuleUrl = pathToFileURL(resolve(originalCwd, 'server/env.ts')).href;
+
+const keysToRestore = ['NODE_ENV', 'DATABASE_URL', 'ENCRYPTION_MASTER_KEY', 'JWT_SECRET'] as const;
+const originalEnv: Record<string, string | undefined> = {};
+for (const key of keysToRestore) {
+  originalEnv[key] = process.env[key];
+}
+
+const tempDir = await mkdtemp(join(tmpdir(), 'env-loader-'));
+
+try {
+  process.chdir(tempDir);
+
+  for (const key of keysToRestore) {
+    delete process.env[key];
+  }
+
+  process.env.NODE_ENV = 'test';
+
+  await assert.rejects(
+    async () => {
+      await import(`${envModuleUrl}?t=${Date.now()}`);
+    },
+    (error: unknown) => {
+      assert.ok(error instanceof Error, 'expected an error instance');
+      assert.match(
+        error.message,
+        /Missing required environment variables: DATABASE_URL/,
+        'loader should refuse to start without DATABASE_URL'
+      );
+      return true;
+    },
+    'env loader should throw when DATABASE_URL is missing'
+  );
+
+  const envLocalPath = resolve(tempDir, '.env.local');
+  const envLocalContents = await readFile(envLocalPath, 'utf8');
+  assert.match(envLocalContents, /^ENCRYPTION_MASTER_KEY=/m, 'generated file includes encryption key');
+  assert.match(envLocalContents, /^JWT_SECRET=/m, 'generated file includes JWT secret');
+  assert.ok(process.env.ENCRYPTION_MASTER_KEY, 'encryption key should be populated in process.env');
+  assert.ok(process.env.JWT_SECRET, 'jwt secret should be populated in process.env');
+} finally {
+  process.chdir(originalCwd);
+  await rm(tempDir, { recursive: true, force: true });
+  for (const key of keysToRestore) {
+    const value = originalEnv[key];
+    if (typeof value === 'undefined') {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}

--- a/server/integrations/__tests__/BaseAPIClient.rateLimits.test.ts
+++ b/server/integrations/__tests__/BaseAPIClient.rateLimits.test.ts
@@ -1,9 +1,17 @@
 import assert from 'node:assert/strict';
 
 import type { APIResponse } from '../BaseAPIClient.js';
-import { BaseAPIClient } from '../BaseAPIClient.js';
-import { rateLimiter } from '../RateLimiter.js';
-import { getConnectorRateBudgetSnapshot, updateConnectorRateBudgetMetric } from '../../observability/index.js';
+
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://localhost:5432/test-db';
+process.env.ENCRYPTION_MASTER_KEY = process.env.ENCRYPTION_MASTER_KEY ?? 'a'.repeat(32);
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-jwt-secret';
+
+const { BaseAPIClient } = await import('../BaseAPIClient.js');
+const { rateLimiter } = await import('../RateLimiter.js');
+const { getConnectorRateBudgetSnapshot, updateConnectorRateBudgetMetric } = await import(
+  '../../observability/index.js'
+);
 
 type TestResponse = { ok: boolean };
 

--- a/server/integrations/__tests__/IntegrationManager.test.ts
+++ b/server/integrations/__tests__/IntegrationManager.test.ts
@@ -1,10 +1,16 @@
 import assert from 'node:assert/strict';
 import { resolve } from 'node:path';
 
-import { IntegrationManager } from '../IntegrationManager.js';
-import { APICredentials } from '../BaseAPIClient.js';
-import { IMPLEMENTED_CONNECTOR_IDS } from '../supportedApps.js';
-import { ConnectorSimulator } from '../../testing/ConnectorSimulator.js';
+import type { APICredentials } from '../BaseAPIClient.js';
+
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://localhost:5432/test-db';
+process.env.ENCRYPTION_MASTER_KEY = process.env.ENCRYPTION_MASTER_KEY ?? 'a'.repeat(32);
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-jwt-secret';
+
+const { IntegrationManager } = await import('../IntegrationManager.js');
+const { IMPLEMENTED_CONNECTOR_IDS } = await import('../supportedApps.js');
+const { ConnectorSimulator } = await import('../../testing/ConnectorSimulator.js');
 
 const manager = new IntegrationManager();
 

--- a/server/routes/__tests__/oauth-flow.test.ts
+++ b/server/routes/__tests__/oauth-flow.test.ts
@@ -31,6 +31,7 @@ process.env.BASE_URL = 'http://localhost:5000';
 process.env.ENCRYPTION_MASTER_KEY = '12345678901234567890123456789012';
 process.env.JWT_SECRET = 'test-jwt-secret';
 process.env.ALLOW_FILE_CONNECTION_STORE = 'true';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://localhost:5432/test-db';
 process.env.GMAIL_CLIENT_ID = 'test-gmail-client-id';
 process.env.GMAIL_CLIENT_SECRET = 'test-gmail-client-secret';
 process.env.SLACK_CLIENT_ID = 'test-slack-client-id';

--- a/server/services/__tests__/ConnectionService.encryption.test.ts
+++ b/server/services/__tests__/ConnectionService.encryption.test.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 process.env.NODE_ENV = 'development';
 process.env.ENCRYPTION_MASTER_KEY = 'a'.repeat(32);
 process.env.ALLOW_FILE_CONNECTION_STORE = 'true';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://localhost:5432/test-db';
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-jwt-secret';
 
 const tempDir = await mkdtemp(path.join(os.tmpdir(), 'connection-service-'));
 process.env.CONNECTION_STORE_PATH = path.join(tempDir, 'connections.json');

--- a/server/services/__tests__/ConnectionService.test.ts
+++ b/server/services/__tests__/ConnectionService.test.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 process.env.NODE_ENV = 'development';
 process.env.ENCRYPTION_MASTER_KEY = process.env.ENCRYPTION_MASTER_KEY ?? 'a'.repeat(32);
 process.env.ALLOW_FILE_CONNECTION_STORE = 'true';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://localhost:5432/test-db';
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-jwt-secret';
 
 const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'connection-service-'));
 const storePath = path.join(tempDir, 'connections.json');

--- a/server/services/__tests__/ExecutionQueueService.quota.test.ts
+++ b/server/services/__tests__/ExecutionQueueService.quota.test.ts
@@ -1,14 +1,22 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'crypto';
 
-import { executionQueueService } from '../ExecutionQueueService.js';
-import { executionQuotaService, ExecutionQuotaExceededError } from '../ExecutionQuotaService.js';
-import { WorkflowRepository } from '../../workflow/WorkflowRepository.js';
-import { organizationService } from '../OrganizationService.js';
-import {
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://localhost:5432/test-db';
+process.env.ENCRYPTION_MASTER_KEY = process.env.ENCRYPTION_MASTER_KEY ?? 'a'.repeat(32);
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-jwt-secret';
+
+const { executionQueueService } = await import('../ExecutionQueueService.js');
+const {
+  executionQuotaService,
+  ExecutionQuotaExceededError,
+} = await import('../ExecutionQuotaService.js');
+const { WorkflowRepository } = await import('../../workflow/WorkflowRepository.js');
+const { organizationService } = await import('../OrganizationService.js');
+const {
   connectorConcurrencyService,
   ConnectorConcurrencyExceededError,
-} from '../ConnectorConcurrencyService.js';
+} = await import('../ConnectorConcurrencyService.js');
 
 const baseWorkflowId = 'quota-test-workflow';
 


### PR DESCRIPTION
## Summary
- require secret configuration during startup by generating deterministic local values for missing encryption and JWT secrets while logging their location
- ensure the environment loader throws when DATABASE_URL is absent and persist generated secrets into a .env.local file
- add targeted env loader coverage and update existing tests to preload required environment variables before importing modules that depend on them

## Testing
- ⚠️ `npx tsx server/__tests__/env.loader.test.ts` *(fails: npm registry access is blocked in this environment, preventing installation/execution of tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e36e3e4c8331a1f499b85aaa27bb