### PR TITLE
Add admin telemetry endpoint for worker status

### DIFF
--- a/server/observability/index.ts
+++ b/server/observability/index.ts
@@ -271,6 +271,15 @@ export function updateQueueDepthMetric<Name extends QueueName>(
   latestQueueDepths.set(queueName, stateCounts);
 }
 
+export function getQueueDepthSnapshot(): Record<string, QueueDepthByState> {
+  return Object.fromEntries(
+    Array.from(latestQueueDepths.entries()).map(([queueName, counts]) => [
+      queueName,
+      { ...counts },
+    ])
+  );
+}
+
 export function recordCrossRegionViolation(context: {
   subsystem: string;
   expectedRegion: OrganizationRegion;


### PR DESCRIPTION
## Summary
- add an admin-only `/api/admin/workers/status` route that surfaces execution worker telemetry and scheduler lock state
- expose telemetry snapshots from the execution queue service, scheduler lock service, and queue depth registry for reuse in dashboards
- document how to poll the new endpoint during incident response playbooks

## Testing
- npm run check *(fails: missing local `@types/node`/`vite` definitions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e380aa0483319acadcf23fafa34e