### PR TITLE
Add worker operations health panel to admin settings

### DIFF
--- a/client/src/components/automation/WorkerStatusPanel.tsx
+++ b/client/src/components/automation/WorkerStatusPanel.tsx
@@ -1,0 +1,363 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Activity, AlertTriangle, Clock, HeartPulse, Server } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { useAuthStore } from '@/store/authStore';
+import { toast } from 'sonner';
+
+type WorkerStatus = {
+  id: string;
+  name: string;
+  queueDepth: number;
+  heartbeatAt?: string;
+  secondsSinceHeartbeat: number | null;
+  isHeartbeatStale: boolean;
+};
+
+type WorkerStatusResponse = {
+  workers?: unknown;
+  queueDepth?: unknown;
+  queue_depth?: unknown;
+  data?: unknown;
+};
+
+const QUEUE_DEPTH_WARNING = 100;
+const HEARTBEAT_STALE_SECONDS = 120;
+const POLL_INTERVAL_MS = 30000;
+
+const toNumber = (value: unknown): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+};
+
+const extractHeartbeat = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toISOString();
+    }
+  }
+  return undefined;
+};
+
+const toWorkerList = (raw: unknown): any[] => {
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  if (raw && typeof raw === 'object') {
+    const value = raw as Record<string, unknown>;
+    if (Array.isArray(value.workers)) {
+      return value.workers as any[];
+    }
+    if (Array.isArray(value.data)) {
+      return value.data as any[];
+    }
+    if (Array.isArray(value.items)) {
+      return value.items as any[];
+    }
+  }
+  return [];
+};
+
+const normalizeWorker = (raw: any, index: number): WorkerStatus => {
+  const id = String(
+    raw?.id ?? raw?.workerId ?? raw?.name ?? raw?.identifier ?? `worker-${index + 1}`
+  );
+  const name = String(raw?.name ?? raw?.displayName ?? id);
+  const queueDepth = toNumber(
+    raw?.queueDepth ?? raw?.queue_depth ?? raw?.queueSize ?? raw?.queue_size ?? raw?.queue
+  );
+  const heartbeatAt =
+    extractHeartbeat(
+      raw?.heartbeatAt ??
+        raw?.lastHeartbeatAt ??
+        raw?.heartbeat_at ??
+        raw?.lastHeartbeat ??
+        raw?.heartbeat
+    ) ?? undefined;
+
+  const secondsSinceHeartbeat = heartbeatAt
+    ? Math.max(0, Math.floor((Date.now() - new Date(heartbeatAt).getTime()) / 1000))
+    : null;
+
+  return {
+    id,
+    name,
+    queueDepth,
+    heartbeatAt,
+    secondsSinceHeartbeat,
+    isHeartbeatStale:
+      typeof secondsSinceHeartbeat === 'number' && secondsSinceHeartbeat > HEARTBEAT_STALE_SECONDS,
+  };
+};
+
+const formatRelativeTime = (secondsSince: number | null): string => {
+  if (secondsSince === null) {
+    return 'No heartbeat reported';
+  }
+  if (secondsSince < 60) {
+    return `${secondsSince}s ago`;
+  }
+  if (secondsSince < 3600) {
+    const minutes = Math.floor(secondsSince / 60);
+    return `${minutes}m ago`;
+  }
+  const hours = Math.floor(secondsSince / 3600);
+  return `${hours}h ago`;
+};
+
+const formatTimestamp = (iso?: string): string => {
+  if (!iso) {
+    return '';
+  }
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(new Date(iso));
+  } catch (error) {
+    return '';
+  }
+};
+
+export default function WorkerStatusPanel() {
+  const authFetch = useAuthStore((state) => state.authFetch);
+  const [workers, setWorkers] = useState<WorkerStatus[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
+  const toastStateRef = useRef<{ queue: Set<string>; heartbeat: Set<string> }>({
+    queue: new Set(),
+    heartbeat: new Set(),
+  });
+
+  const fetchStatus = useCallback(async () => {
+    setIsLoading((prev) => (workers.length === 0 ? true : prev));
+    try {
+      const response = await authFetch('/api/admin/workers/status');
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      const payload = (await response.json().catch(() => ({}))) as WorkerStatusResponse | any[];
+      let list = toWorkerList(payload).map(normalizeWorker);
+
+      if (
+        !list.length &&
+        payload &&
+        !Array.isArray(payload) &&
+        typeof payload === 'object'
+      ) {
+        const fallback = normalizeWorker(payload as Record<string, unknown>, 0);
+        if (fallback.queueDepth !== 0 || fallback.heartbeatAt) {
+          list = [fallback];
+        }
+      }
+
+      const now = new Date().toISOString();
+      const previousQueue = toastStateRef.current.queue;
+      const previousHeartbeat = toastStateRef.current.heartbeat;
+      const nextQueue = new Set<string>();
+      const nextHeartbeat = new Set<string>();
+
+      list.forEach((worker) => {
+        if (worker.queueDepth >= QUEUE_DEPTH_WARNING) {
+          nextQueue.add(worker.id);
+          if (!previousQueue.has(worker.id)) {
+            toast.warning(
+              `${worker.name} queue depth is ${worker.queueDepth}. Investigate worker throughput.`
+            );
+          }
+        }
+        if (worker.isHeartbeatStale) {
+          nextHeartbeat.add(worker.id);
+          if (!previousHeartbeat.has(worker.id)) {
+            toast.error(
+              `${worker.name} has not sent a heartbeat in ${formatRelativeTime(
+                worker.secondsSinceHeartbeat
+              )}.`
+            );
+          }
+        }
+      });
+
+      toastStateRef.current.queue = nextQueue;
+      toastStateRef.current.heartbeat = nextHeartbeat;
+
+      setWorkers(list);
+      setError(null);
+      setLastUpdated(now);
+    } catch (caughtError: any) {
+      const message = caughtError?.message || 'Unable to load worker status';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [authFetch, workers.length]);
+
+  useEffect(() => {
+    void fetchStatus();
+    const interval = window.setInterval(() => {
+      void fetchStatus();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [fetchStatus]);
+
+  const metrics = useMemo(() => {
+    if (!workers.length) {
+      return {
+        totalQueue: 0,
+        maxQueue: 0,
+        staleWorkers: 0,
+        healthyWorkers: 0,
+      };
+    }
+
+    const totalQueue = workers.reduce((acc, worker) => acc + worker.queueDepth, 0);
+    const maxQueue = workers.reduce((acc, worker) => Math.max(acc, worker.queueDepth), 0);
+    const staleWorkers = workers.filter((worker) => worker.isHeartbeatStale).length;
+    const healthyWorkers = workers.length - staleWorkers;
+
+    return { totalQueue, maxQueue, staleWorkers, healthyWorkers };
+  }, [workers]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Activity className="h-5 w-5 text-slate-600" />
+          Worker Operations Health
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error ? (
+          <div className="flex items-start gap-3 rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            <AlertTriangle className="h-5 w-5 text-red-500" aria-hidden />
+            <div>
+              <p className="font-medium">Unable to load worker status</p>
+              <p className="text-xs text-red-600/80">{error}</p>
+            </div>
+          </div>
+        ) : null}
+
+        {isLoading && workers.length === 0 && !error ? (
+          <p className="text-sm text-muted-foreground">Loading worker telemetry…</p>
+        ) : null}
+
+        {workers.length === 0 && !isLoading && !error ? (
+          <p className="text-sm text-muted-foreground">No worker telemetry available yet.</p>
+        ) : null}
+
+        {workers.length > 0 ? (
+          <>
+            <div className="grid gap-3 rounded-md border bg-slate-50 p-4 sm:grid-cols-2">
+              <div className="flex items-center gap-2">
+                <Server className="h-4 w-4 text-slate-500" aria-hidden />
+                <div>
+                  <p className="text-xs text-muted-foreground">Workers reporting</p>
+                  <p className="text-base font-semibold">{workers.length}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <HeartPulse className="h-4 w-4 text-emerald-500" aria-hidden />
+                <div>
+                  <p className="text-xs text-muted-foreground">Healthy workers</p>
+                  <p className="text-base font-semibold">{metrics.healthyWorkers}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Activity className="h-4 w-4 text-indigo-500" aria-hidden />
+                <div>
+                  <p className="text-xs text-muted-foreground">Total queued jobs</p>
+                  <p className="text-base font-semibold">{metrics.totalQueue}</p>
+                  <p className="text-[11px] text-muted-foreground">Peak queue depth {metrics.maxQueue}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4 text-amber-500" aria-hidden />
+                <div>
+                  <p className="text-xs text-muted-foreground">Stale heartbeats</p>
+                  <p className="text-base font-semibold">{metrics.staleWorkers}</p>
+                </div>
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-3">
+              {workers.map((worker) => {
+                const queueBadgeClasses =
+                  worker.queueDepth >= QUEUE_DEPTH_WARNING
+                    ? 'bg-amber-100 text-amber-700 border-amber-200'
+                    : 'bg-emerald-100 text-emerald-700 border-emerald-200';
+                const heartbeatBadgeClasses = worker.isHeartbeatStale
+                  ? 'bg-red-100 text-red-700 border-red-200'
+                  : 'bg-emerald-100 text-emerald-700 border-emerald-200';
+
+                return (
+                  <div key={worker.id} className="rounded-md border p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <p className="text-sm font-semibold text-slate-900">{worker.name}</p>
+                        <p className="text-xs text-muted-foreground">Identifier: {worker.id}</p>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge className={queueBadgeClasses} variant="outline">
+                          Queue depth: {worker.queueDepth}
+                        </Badge>
+                        <Badge className={heartbeatBadgeClasses} variant="outline">
+                          {worker.isHeartbeatStale ? 'Heartbeat stale' : 'Heartbeat healthy'}
+                        </Badge>
+                      </div>
+                    </div>
+                    <div className="mt-3 grid gap-3 text-xs text-muted-foreground sm:grid-cols-2">
+                      <div className="flex items-center gap-2">
+                        <Activity className="h-4 w-4 text-slate-500" aria-hidden />
+                        <span>Total queue depth</span>
+                        <span className="font-semibold text-slate-900">{worker.queueDepth}</span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Clock className="h-4 w-4 text-slate-500" aria-hidden />
+                        <span>Last heartbeat</span>
+                        <span className="font-semibold text-slate-900">
+                          {formatRelativeTime(worker.secondsSinceHeartbeat)}
+                        </span>
+                      </div>
+                      {worker.heartbeatAt ? (
+                        <div className="flex items-center gap-2 sm:col-span-2">
+                          <Clock className="h-4 w-4 text-slate-400" aria-hidden />
+                          <span>Reported at</span>
+                          <span className="font-medium text-slate-800">{formatTimestamp(worker.heartbeatAt)}</span>
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        ) : null}
+
+        {lastUpdated ? (
+          <p className="text-right text-xs text-muted-foreground">Last updated {formatTimestamp(lastUpdated)}</p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/automation/__tests__/WorkerStatusPanel.test.tsx
+++ b/client/src/components/automation/__tests__/WorkerStatusPanel.test.tsx
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+import { JSDOM } from 'jsdom';
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+
+import WorkerStatusPanel from '../WorkerStatusPanel';
+import { useAuthStore } from '@/store/authStore';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost/' });
+
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+(global as any).navigator = dom.window.navigator;
+(global as any).HTMLElement = dom.window.HTMLElement;
+(global as any).SVGElement = dom.window.SVGElement;
+(global as any).MutationObserver =
+  (dom.window as any).MutationObserver ||
+  class {
+    observe() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  };
+
+if (!('ResizeObserver' in global)) {
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+beforeEach(() => {
+  cleanup();
+  useAuthStore.setState((state) => ({
+    ...state,
+    authFetch: async () =>
+      new Response('offline', {
+        status: 500,
+        statusText: 'Server error',
+      }),
+  }));
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+test('renders error state when worker status endpoint fails', async () => {
+  render(<WorkerStatusPanel />);
+
+  await waitFor(() => screen.getByText('Unable to load worker status'));
+
+  const message = screen.getByText('Unable to load worker status');
+  assert.ok(message);
+});

--- a/client/src/pages/AdminSettings.tsx
+++ b/client/src/pages/AdminSettings.tsx
@@ -23,6 +23,7 @@ import {
   Flag
 } from 'lucide-react';
 import ConnectionManager from '@/components/connections/ConnectionManager';
+import WorkerStatusPanel from '@/components/automation/WorkerStatusPanel';
 import { useAuthStore } from '@/store/authStore';
 import { toast } from 'sonner';
 
@@ -405,6 +406,8 @@ export default function AdminSettings() {
       <main className="min-h-screen bg-gray-50 py-8">
         <div className="max-w-4xl mx-auto p-6 space-y-8">
           <ConnectionManager />
+
+          <WorkerStatusPanel />
 
           <Separator />
 


### PR DESCRIPTION
## Summary
- add a WorkerStatusPanel component that polls /api/admin/workers/status, normalizes responses, and raises toast alerts when queue depth or heartbeat thresholds are exceeded
- embed the worker operations panel alongside existing admin controls for quick visibility into queue depth and heartbeat freshness
- cover error rendering with a React Testing Library test harness

## Testing
- npx tsx client/src/components/automation/__tests__/WorkerStatusPanel.test.tsx *(fails: npm 403 when downloading tsx in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e386fd50833187f16df20785b9c8