### PR TITLE
Update local dev docs for new dev scripts

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -27,10 +27,13 @@ The default configuration in `.env.example` assumes PostgreSQL and Redis are run
 
 ## 3. Next steps
 
-- `npm run dev:server` starts the backend in watch mode.
-- `npm run dev:client` starts the frontend dev server.
-- `npm run dev:stack` starts the API, scheduler, worker, and encryption rotation services together
-  with shared lifecycle and cleanup logic.
+- `npm run dev:api` starts the API in watch mode and automatically boots the Vite-powered frontend
+  development server.
+- `npm run dev:worker` runs the execution worker that processes queued jobs.
+- `npm run dev:scheduler` runs the polling scheduler responsible for enqueuing work.
+- `npm run dev:stack` starts the API, scheduler, execution worker, and encryption rotation worker
+  together with shared lifecycle and cleanup logic. Use this script whenever you need the queue
+  processing components (scheduler + execution worker) online alongside the API.
 - Consult `docs/operations/queue.md` if you need advanced Redis/BullMQ tuning.
 
 Shut the stack down with:

--- a/docs/operations/local-dev.md
+++ b/docs/operations/local-dev.md
@@ -37,7 +37,7 @@ The compose file starts Postgres, Redis, Jaeger, and three Node.js processes bou
 | postgres   | `postgres`             | `5432`        | Workflow metadata + trigger storage |
 | redis      | `redis-server`         | `6379`        | BullMQ queue backend |
 | jaeger     | all-in-one collector   | `16686`, `4318` | Trace UI + OTLP HTTP ingest |
-| api        | `npm run dev:api`      | `5000`        | HTTP API with hot reload |
+| api        | `npm run dev:api`      | `5000`        | HTTP + Vite frontend dev server |
 | worker     | `npm run dev:worker`   | _internal_    | Workflow execution worker |
 | scheduler  | `npm run dev:scheduler`| _internal_    | Polling trigger scheduler |
 
@@ -58,7 +58,7 @@ export QUEUE_REDIS_PORT=6379
 export QUEUE_REDIS_DB=0
 ```
 
-With Redis enabled, start the worker (`npm run dev:worker`) and scheduler (`npm run dev:scheduler`) alongside the API to consume queued jobs.
+With Redis enabled, start the worker (`npm run dev:worker`) and scheduler (`npm run dev:scheduler`) alongside the API so queued jobs are actually processed. The `npm run dev:stack` helper launches the API, scheduler, execution worker, and encryption rotation worker together and keeps their lifecycles in sync.
 
 ## Observability
 


### PR DESCRIPTION
## Summary
- replace outdated dev:server/dev:client references with the current dev:api, dev:scheduler, and dev:worker scripts
- note that the scheduler and execution worker must run alongside the API and point to the consolidated dev:stack helper
- clarify that the dev:api process also starts the Vite frontend when developing locally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e80183088331b489418ae8cbcca6