### PR TITLE
Add WorkflowRuntimeService connector resolution regression test

### DIFF
--- a/server/workflow/__tests__/WorkflowRuntimeService.test.ts
+++ b/server/workflow/__tests__/WorkflowRuntimeService.test.ts
@@ -85,6 +85,173 @@ async function runSheetsAndTimeRegression(): Promise<void> {
   );
 }
 
+async function runConnectorParameterResolutionRegression(): Promise<void> {
+  const runtime = new WorkflowRuntimeService();
+
+  const context: ExecutionContext = {
+    workflowId: 'workflow-connector-resolution',
+    executionId: 'exec-resolution-1',
+    nodeOutputs: {
+      'transform-source': {
+        enriched: {
+          values: ['red', 'green', 'blue']
+        },
+        metadata: {
+          region: 'us-east-1'
+        }
+      }
+    },
+    timezone: 'UTC',
+    organizationId: 'org-inline'
+  };
+
+  const originalExecuteFunction = integrationManager.executeFunction;
+  const executions: Array<any> = [];
+
+  integrationManager.executeFunction = async (payload) => {
+    executions.push(payload);
+    return {
+      success: true,
+      data: {
+        appendStatus: 'complete',
+        resolvedParameters: payload.parameters
+      },
+      executionTime: 17
+    } as any;
+  };
+
+  try {
+    const actionNode = {
+      id: 'sheets-params-node',
+      app: 'sheets',
+      function: 'append_row',
+      params: {
+        spreadsheetId: { mode: 'static', value: 'sheet-123' },
+        rowValues: { mode: 'ref', nodeId: 'transform-source', path: 'enriched.values' },
+        metadata: { mode: 'static', value: { requestedBy: 'tester' } }
+      },
+      data: {
+        label: 'Append Colors',
+        app: 'sheets',
+        function: 'append_row',
+        credentials: { local: true, accessToken: 'inline-token' }
+      }
+    };
+
+    const actionResult = await runtime.executeNode(actionNode, context);
+
+    assert.equal(executions.length, 1, 'Action nodes should invoke integration manager once');
+    assert.deepEqual(
+      executions[0].parameters,
+      {
+        spreadsheetId: 'sheet-123',
+        rowValues: ['red', 'green', 'blue'],
+        metadata: { requestedBy: 'tester' }
+      },
+      'Resolved parameters should be forwarded to integration manager'
+    );
+    assert.equal(executions[0].appName, 'sheets', 'Connector app id should be normalized before invoking integration');
+    assert.equal(
+      executions[0].idempotencyKey,
+      'exec-resolution-1:sheets-params-node',
+      'Idempotency key should include execution and node ids'
+    );
+
+    assert.equal(actionResult.summary, 'Executed sheets.append_row', 'Action execution should return connector summary');
+    assert.deepEqual(
+      context.nodeOutputs['sheets-params-node'],
+      {
+        appendStatus: 'complete',
+        resolvedParameters: {
+          spreadsheetId: 'sheet-123',
+          rowValues: ['red', 'green', 'blue'],
+          metadata: { requestedBy: 'tester' }
+        }
+      },
+      'Connector outputs should be stored in execution context'
+    );
+
+    const transformNode = {
+      id: 'transform-node',
+      data: {
+        role: 'transform',
+        label: 'Local Formatter',
+        parameters: {
+          greeting: { mode: 'static', value: 'hello' },
+          region: { mode: 'ref', nodeId: 'transform-source', path: 'metadata.region' }
+        }
+      }
+    };
+
+    const transformResult = await runtime.executeNode(transformNode, context);
+
+    assert.equal(
+      executions.length,
+      1,
+      'Transform nodes should not invoke integration manager and must use specialized handler'
+    );
+    assert.equal(
+      transformResult.summary,
+      'Evaluated transform Local Formatter',
+      'Transform handler should return evaluation summary'
+    );
+    assert.deepEqual(
+      transformResult.output,
+      { greeting: 'hello', region: 'us-east-1' },
+      'Transform handler should directly return resolved parameters'
+    );
+    assert.deepEqual(
+      context.nodeOutputs['transform-node'],
+      { greeting: 'hello', region: 'us-east-1' },
+      'Transform node output should be written to execution context'
+    );
+
+    const llmNode = {
+      id: 'llm-node',
+      nodeType: 'transform.llm',
+      data: {
+        role: 'transform.llm',
+        label: 'AI Step',
+        parameters: {
+          prompt: { mode: 'static', value: 'Summarize the palette' },
+          temperature: { mode: 'static', value: 0.2 }
+        }
+      }
+    };
+
+    const llmResult = await runtime.executeNode(llmNode, context);
+
+    assert.equal(
+      executions.length,
+      1,
+      'LLM transform nodes should continue using their specialized handler without invoking the integration manager'
+    );
+    assert.equal(
+      llmResult.summary,
+      'Evaluated transform AI Step',
+      'LLM nodes should report transform execution summary'
+    );
+    assert.deepEqual(
+      llmResult.output,
+      {
+        prompt: 'Summarize the palette',
+        temperature: 0.2
+      },
+      'LLM transform handler should return resolved parameters without connector execution'
+    );
+    assert.deepEqual(
+      context.nodeOutputs['llm-node'],
+      {
+        prompt: 'Summarize the palette',
+        temperature: 0.2
+      },
+      'LLM transform results should be persisted in execution context'
+    );
+  } finally {
+    integrationManager.executeFunction = originalExecuteFunction;
+  }
+}
+
 async function runConnectionIdAuthRegression(): Promise<void> {
   const runtime = new WorkflowRuntimeService();
 
@@ -212,6 +379,7 @@ async function runConnectionIdAuthRegression(): Promise<void> {
 }
 
 try {
+  await runConnectorParameterResolutionRegression();
   await runSheetsAndTimeRegression();
   await runConnectionIdAuthRegression();
   console.log('WorkflowRuntimeService regressions passed.');


### PR DESCRIPTION
## Summary
- add a regression that mocks integrationManager.executeFunction and verifies connector nodes forward resolved parameters
- ensure transform and LLM nodes continue to use their specialized handlers while action nodes invoke the integration manager

## Testing
- npm run --silent test -- WorkflowRuntimeService *(fails: tsx not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e806362c8331895bb57e7f9c01f7