### PR TITLE
Add Workflow Runtime interaction documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -156,6 +156,8 @@ Result: 0-touch onboarding, 40% faster activation
          └─────────────────────────────────────────────────┘
 ```
 
+- **[Workflow Runtime Interaction Guide](./architecture/workflow-runtime-interactions.md)** – Detailed look at how WorkflowRuntime, IntegrationManager, GenericExecutor, and RetryManager coordinate runtime execution and fallbacks.
+
 ### **🔧 Technology Stack**
 
 **Frontend:**

--- a/docs/architecture/workflow-runtime-interactions.md
+++ b/docs/architecture/workflow-runtime-interactions.md
@@ -1,0 +1,60 @@
+# Workflow Runtime Interaction Guide
+
+This document explains how the workflow execution stack coordinates the **WorkflowRuntime**, **IntegrationManager**, **GenericExecutor**, and **RetryManager** components when running a node. It highlights how fallbacks and retries are orchestrated and when the `FLAGS.GENERIC_EXECUTOR_ENABLED` feature flag changes behavior.
+
+## Execution Flow Overview
+
+1. **WorkflowRuntime** resolves node metadata, prepares credentials, and generates an idempotency key before delegating execution to `RetryManager.executeWithRetry` so that every attempt is tracked and deduplicated.【F:server/core/WorkflowRuntime.ts†L498-L561】【F:server/core/RetryManager.ts†L360-L419】
+2. **RetryManager** looks for cached results, enforces retry policy, and applies circuit breaker state per connector. It invokes the node executor (provided by WorkflowRuntime) and persists the most recent outcome for observability and idempotent replays.【F:server/core/RetryManager.ts†L360-L479】
+3. **IntegrationManager** receives the call first and tries to execute the app-specific client. When a bespoke client is not available or fails, it can defer to the generic path when feature flags allow it.【F:server/integrations/IntegrationManager.ts†L336-L417】
+4. **GenericExecutor** executes OpenAPI/JSON manifest-driven requests, normalizes responses, and returns control to IntegrationManager so WorkflowRuntime can record metadata (including which executor ran).【F:server/core/WorkflowRuntime.ts†L575-L610】
+5. **RetryManager** captures the successful result (or propagates the failure) and updates circuit state and actionable error logs for downstream monitoring.【F:server/core/RetryManager.ts†L420-L479】
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Runtime as WorkflowRuntime
+    participant Retry as RetryManager
+    participant Manager as IntegrationManager
+    participant Generic as GenericExecutor
+
+    Runtime->>Retry: executeWithRetry(node executor)
+    activate Retry
+    Retry->>Runtime: invoke node executor
+    activate Runtime
+    Runtime->>Manager: executeFunction(appId, functionId, params)
+    activate Manager
+    Manager-->>Runtime: Bespoke result or error
+    alt Bespoke client succeeded
+        Runtime-->>Retry: return success
+    else Bespoke path failed & FLAGS.GENERIC_EXECUTOR_ENABLED
+        Manager->>Generic: execute(appId, functionId, params)
+        activate Generic
+        Generic-->>Manager: normalized result
+        deactivate Generic
+        Manager-->>Runtime: fallback success metadata
+    else Bespoke path failed & flag disabled
+        Runtime-->>Retry: surface integration error
+    end
+    deactivate Manager
+    Runtime-->>Retry: node output or error
+    deactivate Runtime
+    Retry->>Retry: record attempt, update circuit & idempotency cache
+    Retry-->>Runtime: final outcome
+    deactivate Retry
+```
+
+## Feature Flag Behavior
+
+- `FLAGS.GENERIC_EXECUTOR_ENABLED` mirrors the `GENERIC_EXECUTOR_ENABLED` environment variable and unlocks fallback execution through GenericExecutor when bespoke clients fail or are missing.【F:server/env.ts†L143-L148】【F:server/integrations/IntegrationManager.ts†L231-L418】
+- WorkflowRuntime checks the flag before triggering a fallback so that environments without the generic executor continue to fail fast when bespoke implementations are required.【F:server/core/WorkflowRuntime.ts†L575-L610】
+
+## Operational Considerations
+
+- **Idempotency & persistence:** RetryManager stores successful results keyed by node idempotency values, letting reruns skip rework when a node has already produced an output.【F:server/core/RetryManager.ts†L360-L419】
+- **Circuit breakers:** Each connector/node pair has independent failure thresholds so noisy integrations can trip into cooldown without impacting other nodes.【F:server/core/RetryManager.ts†L360-L447】
+- **Metadata capture:** WorkflowRuntime attaches executor type, execution time, and fallback reason to node metadata, making it easier to audit when the generic path was used.【F:server/core/WorkflowRuntime.ts†L598-L610】
+- **Observability hooks:** RetryManager emits actionable error events so operators can alert on repeated fallbacks or rate limiting before end users feel the impact.【F:server/core/RetryManager.ts†L420-L479】
+
+Use this flow as a reference when adding new connector features or adjusting retry/fallback policies so that changes remain compatible with the runtime’s orchestration guarantees.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -2,6 +2,8 @@
 
 This guide covers the quickest path to booting the platform locally with Docker Compose.
 
+> 📘 **Need a mental model for the runtime?** Read the [Workflow Runtime Interaction Guide](./architecture/workflow-runtime-interactions.md) to understand how WorkflowRuntime, IntegrationManager, GenericExecutor, and RetryManager coordinate while you run local flows.
+
 ## 1. Prepare environment variables
 
 1. Copy the sample environment file and use it as your personal development configuration:

--- a/docs/operations/local-dev.md
+++ b/docs/operations/local-dev.md
@@ -2,6 +2,8 @@
 
 This guide describes how to run the API, background workers, and observability stack locally with Docker Compose. It also explains how to switch between the in-memory development queue and the Redis-backed BullMQ queue used in production.
 
+> 📘 **New to the runtime stack?** Review the [Workflow Runtime Interaction Guide](../architecture/workflow-runtime-interactions.md) to see how WorkflowRuntime, IntegrationManager, GenericExecutor, and RetryManager collaborate during executions.
+
 ## Prerequisites
 
 1. Install Docker and Docker Compose v2.


### PR DESCRIPTION
## Summary
- add a workflow runtime interaction guide detailing how WorkflowRuntime, IntegrationManager, GenericExecutor, and RetryManager coordinate
- embed a sequence diagram and reference the Generic Executor feature flag
- link the new guide from the docs landing page and onboarding materials

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e0e80985648331bf45423d2019eed7