### PR TITLE
Add bootstrap secrets script for local development

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -8,10 +8,15 @@ This guide covers the quickest path to booting the platform locally with Docker 
    ```bash
    cp .env.example .env.development
    ```
-2. Edit `.env.development` to match your local setup. Sensitive values must be generated per developer:
+2. Bootstrap the required secrets before starting any services:
+   ```bash
+   npm run bootstrap:secrets
+   ```
+   This command ensures `ENCRYPTION_MASTER_KEY` and `JWT_SECRET` meet the entropy requirements enforced by `EncryptionService`.
+3. Review `.env.development` to match your local setup. The bootstrap script fills in the secrets, but you can regenerate them manually if you prefer:
    - `ENCRYPTION_MASTER_KEY`: generate a unique 32-byte value (`openssl rand -base64 32`).
    - `JWT_SECRET`: use a unique, high-entropy string (32+ characters). Avoid reusing production values.
-3. Fill in any provider API keys you plan to exercise (OpenAI, Anthropic, Claude, Google, Gemini). Leave them blank to disable those integrations locally.
+4. Fill in any provider API keys you plan to exercise (OpenAI, Anthropic, Claude, Google, Gemini). Leave them blank to disable those integrations locally.
 
 > ℹ️  When running outside of Docker Compose, either export the variables manually or copy `.env.development` to `.env` so `dotenv` can pick them up. Never commit personal secrets.
 
@@ -26,6 +31,8 @@ docker compose --env-file .env.development up --build
 The default configuration in `.env.example` assumes PostgreSQL and Redis are running inside the Compose stack. Adjust the hostnames or ports if you are using external services.
 
 ## 3. Next steps
+
+- Run `npm run bootstrap:secrets` again whenever you clone fresh or reset `.env.development` so secrets exist before `npm run dev` or any other dev server commands.
 
 - `npm run dev:server` starts the backend in watch mode.
 - `npm run dev:client` starts the frontend dev server.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev:rotation": "NODE_ENV=development tsx watch server/workers/encryption-rotation.ts",
     "dev:scheduler": "NODE_ENV=development tsx watch server/workers/scheduler.ts",
     "dev:stack": "tsx scripts/dev-stack.ts",
+    "bootstrap:secrets": "tsx scripts/bootstrap-secrets.ts",
     "build": "npm run check:deps && npm run build:client && npm run build:server",
     "build:client": "vite build",
     "build:server": "esbuild server/index.ts server/workers/execution.ts server/workers/scheduler.ts server/workers/timerDispatcher.ts server/workers/encryption-rotation.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --outbase=server",

--- a/scripts/bootstrap-secrets.ts
+++ b/scripts/bootstrap-secrets.ts
@@ -1,0 +1,101 @@
+import { existsSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import { resolve } from 'node:path';
+
+const ENV_FILE = resolve(process.cwd(), '.env.development');
+
+const secrets = [
+  { key: 'ENCRYPTION_MASTER_KEY', bytes: 32, description: 'AES-256 master encryption key' },
+  { key: 'JWT_SECRET', bytes: 48, description: 'JWT signing secret' },
+] as const;
+
+type SecretDefinition = (typeof secrets)[number];
+
+type SecretRecord = Record<string, string>;
+
+function generateSecret(bytes: number): string {
+  return randomBytes(bytes).toString('base64url');
+}
+
+function extractValue(content: string, key: string): string | undefined {
+  const pattern = new RegExp(`^${key}=(.*)$`, 'm');
+  const match = content.match(pattern);
+  if (!match) {
+    return undefined;
+  }
+  const value = match[1] ?? '';
+  return value.trim();
+}
+
+function upsert(content: string, key: string, value: string): string {
+  const assignment = `${key}=${value}`;
+  const pattern = new RegExp(`^${key}=.*$`, 'm');
+  if (pattern.test(content)) {
+    return content.replace(pattern, assignment);
+  }
+
+  const needsNewline = content.length > 0 && !content.endsWith('\n');
+  return `${content}${needsNewline ? '\n' : ''}${assignment}\n`;
+}
+
+function formatSecretOutput(secret: SecretDefinition, value: string): string {
+  return `${secret.key}=${value}  # ${secret.description}`;
+}
+
+async function writeSecrets(content: string, updates: SecretRecord): Promise<void> {
+  let next = content;
+  for (const [key, value] of Object.entries(updates)) {
+    next = upsert(next, key, value);
+  }
+
+  await writeFile(ENV_FILE, next, 'utf8');
+}
+
+async function bootstrap(): Promise<void> {
+  const generated: SecretRecord = {};
+
+  if (!existsSync(ENV_FILE)) {
+    for (const secret of secrets) {
+      generated[secret.key] = generateSecret(secret.bytes);
+    }
+
+    console.warn('⚠️  .env.development not found. Create it by copying .env.example:');
+    console.warn('    cp .env.example .env.development');
+    console.warn('Then add the generated secrets below and re-run the script if needed:\n');
+    for (const secret of secrets) {
+      console.log(formatSecretOutput(secret, generated[secret.key]));
+    }
+    return;
+  }
+
+  const currentContent = await readFile(ENV_FILE, 'utf8');
+
+  for (const secret of secrets) {
+    const existing = extractValue(currentContent, secret.key);
+    if (!existing) {
+      generated[secret.key] = generateSecret(secret.bytes);
+    }
+  }
+
+  if (Object.keys(generated).length === 0) {
+    console.log('✅ .env.development already contains the required secrets.');
+    return;
+  }
+
+  await writeSecrets(currentContent, generated);
+
+  console.log('🔐 Added missing secrets to .env.development:');
+  for (const secret of secrets) {
+    const value = generated[secret.key];
+    if (value) {
+      console.log(formatSecretOutput(secret, value));
+    }
+  }
+}
+
+bootstrap().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`❌ Failed to bootstrap secrets: ${message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a TypeScript helper that generates strong secrets and patches `.env.development`
- expose the helper through an npm script for convenient local bootstrapping
- update the local development guide to instruct new contributors to run the helper before starting dev servers

## Testing
- npm run bootstrap:secrets *(fails: `tsx` binary unavailable until dependencies are installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e809f9b08331912b2df3e1655bbd