### PR TITLE
Refactor integration client pipeline and enforce plan quotas

### DIFF
--- a/server/integrations/AdobesignAPIClient.ts
+++ b/server/integrations/AdobesignAPIClient.ts
@@ -127,10 +127,11 @@ export class AdobesignAPIClient extends BaseAPIClient {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
     endpoint: string,
     data?: any,
-    headers: Record<string, string> = {}
+    headers: Record<string, string> = {},
+    options?: any
   ): Promise<APIResponse<T>> {
     await this.ensureAccessToken();
-    return super.makeRequest(method, endpoint, data, headers);
+    return super.makeRequest(method, endpoint, data, headers, options);
   }
 
   public async testConnection(): Promise<APIResponse<any>> {

--- a/server/integrations/AdpAPIClient.ts
+++ b/server/integrations/AdpAPIClient.ts
@@ -173,9 +173,10 @@ export class AdpAPIClient extends BaseAPIClient {
     endpoint: string,
     data?: any,
     headers: Record<string, string> = {},
+    options?: any,
   ): Promise<APIResponse<T>> {
     await this.ensureAccessToken();
-    return super.makeRequest(method, endpoint, data, headers);
+    return super.makeRequest(method, endpoint, data, headers, options);
   }
 
   private async ensureAccessToken(): Promise<void> {

--- a/server/integrations/DocusignAPIClient.ts
+++ b/server/integrations/DocusignAPIClient.ts
@@ -175,10 +175,11 @@ export class DocusignAPIClient extends BaseAPIClient {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
     endpoint: string,
     data?: any,
-    headers: Record<string, string> = {}
+    headers: Record<string, string> = {},
+    options?: any
   ): Promise<APIResponse<T>> {
     await this.ensureAccessToken();
-    return super.makeRequest(method, endpoint, data, headers);
+    return super.makeRequest(method, endpoint, data, headers, options);
   }
 
   public async testConnection(): Promise<APIResponse<any>> {

--- a/server/integrations/DropboxAPIClient.ts
+++ b/server/integrations/DropboxAPIClient.ts
@@ -18,7 +18,7 @@ export class DropboxAPIClient extends BaseAPIClient {
   }
 
   public async testConnection(): Promise<APIResponse<any>> {
-    return this.post('/users/get_current_account', {}, this.getAuthHeaders());
+    return this.post('/users/get_current_account', {});
   }
 
   public async listFiles(params: { path?: string; recursive?: boolean; limit?: number }): Promise<APIResponse<any>> {
@@ -28,26 +28,14 @@ export class DropboxAPIClient extends BaseAPIClient {
       limit: params.limit ?? 1000,
       include_mounted_folders: true
     };
-    return this.post('/files/list_folder', body, this.getAuthHeaders());
+    return this.post('/files/list_folder', body);
   }
 
   public async uploadFile(params: { path: string; content: string; mode?: 'add' | 'overwrite' | 'update' }): Promise<APIResponse<any>> {
-    const url = 'https://content.dropboxapi.com/2/files/upload';
     const arg = { path: params.path, mode: params.mode ?? 'add', mute: false, strict_conflict: false };
-    try {
-      const resp = await fetch(url, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${this.credentials.accessToken || this.credentials.token || ''}`,
-          'Content-Type': 'application/octet-stream',
-          'Dropbox-API-Arg': JSON.stringify(arg)
-        },
-        body: params.content
-      });
-      const data = await resp.json();
-      return resp.ok ? { success: true, data } : { success: false, error: `HTTP ${resp.status}` };
-    } catch (error) {
-      return { success: false, error: String(error) };
-    }
+    return this.makeRequest('POST', 'https://content.dropboxapi.com/2/files/upload', params.content, {
+      'Content-Type': 'application/octet-stream',
+      'Dropbox-API-Arg': JSON.stringify(arg),
+    });
   }
 }

--- a/server/integrations/GoogleAdminAPIClient.ts
+++ b/server/integrations/GoogleAdminAPIClient.ts
@@ -163,10 +163,11 @@ export class GoogleAdminAPIClient extends BaseAPIClient {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
     endpoint: string,
     data?: any,
-    headers: Record<string, string> = {}
+    headers: Record<string, string> = {},
+    options?: any
   ): Promise<APIResponse<T>> {
     await this.ensureAccessToken();
-    return super.makeRequest(method, endpoint, data, headers);
+    return super.makeRequest(method, endpoint, data, headers, options);
   }
 
   public async testConnection(): Promise<APIResponse<any>> {

--- a/server/integrations/MarketoAPIClient.ts
+++ b/server/integrations/MarketoAPIClient.ts
@@ -176,10 +176,11 @@ export class MarketoAPIClient extends BaseAPIClient {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
     endpoint: string,
     data?: any,
-    headers: Record<string, string> = {}
+    headers: Record<string, string> = {},
+    options?: any
   ): Promise<APIResponse<T>> {
     await this.ensureAccessToken();
-    return super.makeRequest<T>(method, endpoint, data, headers);
+    return super.makeRequest<T>(method, endpoint, data, headers, options);
   }
 
   public async testConnection(): Promise<APIResponse<any>> {

--- a/server/integrations/PardotAPIClient.ts
+++ b/server/integrations/PardotAPIClient.ts
@@ -151,10 +151,11 @@ export class PardotAPIClient extends BaseAPIClient {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
     endpoint: string,
     data?: any,
-    headers: Record<string, string> = {}
+    headers: Record<string, string> = {},
+    options?: any
   ): Promise<APIResponse<T>> {
     await this.ensureAccessToken();
-    return super.makeRequest<T>(method, endpoint, data, headers);
+    return super.makeRequest<T>(method, endpoint, data, headers, options);
   }
 
   public async testConnection(): Promise<APIResponse<any>> {

--- a/server/integrations/PowerbiAPIClient.ts
+++ b/server/integrations/PowerbiAPIClient.ts
@@ -150,10 +150,11 @@ export class PowerbiAPIClient extends BaseAPIClient {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
     endpoint: string,
     data?: any,
-    headers: Record<string, string> = {}
+    headers: Record<string, string> = {},
+    options?: any
   ): Promise<APIResponse<T>> {
     await this.ensureAccessToken();
-    return super.makeRequest(method, endpoint, data, headers);
+    return super.makeRequest(method, endpoint, data, headers, options);
   }
 
   private async ensureAccessToken(): Promise<void> {

--- a/server/integrations/TableauAPIClient.ts
+++ b/server/integrations/TableauAPIClient.ts
@@ -204,13 +204,14 @@ export class TableauAPIClient extends BaseAPIClient {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
     endpoint: string,
     data?: any,
-    headers: Record<string, string> = {}
+    headers: Record<string, string> = {},
+    options?: any
   ): Promise<APIResponse<T>> {
     if (!this.isAuthEndpoint(endpoint)) {
       await this.ensureAuthToken();
     }
 
-    return super.makeRequest(method, endpoint, data, headers);
+    return super.makeRequest(method, endpoint, data, headers, options);
   }
 
   private isAuthEndpoint(endpoint: string): boolean {


### PR DESCRIPTION
## Summary
- route Stripe, Dropbox, Egnyte and other integration overrides through the shared BaseAPIClient so rate limiting and retries execute consistently
- centralize HTTP backoff/penalty handling in RetryManager/BaseAPIClient and expose new response parsing options for binary payloads
- consult UsageMeteringService before enqueueing executions to enforce plan caps and emit quota overage events

## Testing
- npm run check *(fails: missing type definitions for node and vite/client in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1036c31e883318649645e84e4d950