### PR TITLE
refactor: unify connector metadata resolution and expose metadata API

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -121,172 +121,15 @@ interface NodeTemplate {
 
 // Icon mapping for different applications (deduplicated)
 const appIconsMap: Record<string, LucideIcon> = {
-  // Built-in defaults
-  'default': Zap,
-  'core': AppWindow,
-  'built_in': AppWindow,
+  default: Zap,
+  core: AppWindow,
+  built_in: AppWindow,
   'built-in': AppWindow,
-  'time': Clock,
+  time: Clock,
   'time-trigger': Clock,
-  'http': Globe,
+  http: Globe,
   'http-request': Globe,
-  'webhook': Link,
-  
-  // Google Workspace
-  'gmail': Mail,
-  'gmail-enhanced': Mail,
-  'google-admin': Shield,
-  'google-calendar': Calendar,
-  'google-chat': MessageSquare,
-  'google-contacts': Users,
-  'google-docs': FileText,
-  'google-drive': Folder,
-  'google-forms': FileText,
-  'google-meet': Video,
-  'google-sheets': Sheet,
-  'google-sheets-enhanced': Sheet,
-  'google-slides': FileText,
-  
-  // Microsoft
-  'excel-online': Sheet,
-  'microsoft-teams': Video,
-  'microsoft-todo': Settings,
-  'onedrive': Folder,
-  'outlook': Mail,
-  'sharepoint': Folder,
-  
-  // Communication
-  'slack': MessageSquare,
-  'slack-enhanced': MessageSquare,
-  'webex': Video,
-  'ringcentral': Phone,
-  'twilio': Phone,
-  'intercom': MessageSquare,
-  
-  // CRM & Sales
-  'salesforce': Database,
-  'salesforce-enhanced': Database,
-  'hubspot': Database,
-  'hubspot-enhanced': Database,
-  'pipedrive': Database,
-  'dynamics365': Database,
-  'zoho-crm': Database,
-  
-  // E-commerce & Payments
-  'shopify': Database,
-  'shopify-enhanced': ShoppingCart,
-  'bigcommerce': ShoppingCart,
-  'magento': ShoppingCart,
-  'woocommerce': ShoppingCart,
-  'paypal': CreditCard,
-  'square': CreditCard,
-  'stripe-enhanced': CreditCard,
-  'adyen': CreditCard,
-  'ramp': CreditCard,
-  'brex': CreditCard,
-  'razorpay': CreditCard,
-  
-  // Project Management & Productivity
-  'jira': Settings,
-  'jira-service-management': Settings,
-  'confluence': FileText,
-  'basecamp': Box,
-  'clickup': Settings,
-  'linear': Settings,
-  'monday-enhanced': Settings,
-  'notion': FileText,
-  'notion-enhanced': FileText,
-  'smartsheet': Sheet,
-  'trello-enhanced': Settings,
-  'workfront': Settings,
-  
-  // Development & DevOps
-  'github': Settings,
-  'github-enhanced': Settings,
-  'gitlab': Settings,
-  'jenkins': Settings,
-  'circleci': Settings,
-  'bitbucket': Settings,
-  
-  // Data & Analytics
-  'bigquery': Database,
-  'databricks': BarChart,
-  'snowflake': Database,
-  'tableau': BarChart,
-  'looker': BarChart,
-  'powerbi': BarChart,
-  'powerbi-enhanced': BarChart,
-  
-  // HR & Recruitment
-  'workday': Users,
-  'bamboohr': Users,
-  'greenhouse': Users,
-  'lever': Users,
-  'successfactors': Users,
-  'adp': DollarSign,
-  
-  // Finance & Accounting
-  'quickbooks': DollarSign,
-  'xero': Calculator,
-  'zoho-books': Calculator,
-  'netsuite': Database,
-  'sageintacct': Calculator,
-  'concur': DollarSign,
-  'expensify': DollarSign,
-  
-  // Marketing & Email
-  'marketo': BarChart,
-  'pardot': BarChart,
-  'iterable': Mail,
-  'braze': Mail,
-  'mailchimp': Mail,
-  'mailchimp-enhanced': Mail,
-  'klaviyo': Mail,
-  'sendgrid': Mail,
-  
-  // Monitoring & Security
-  'sentry': AlertTriangle,
-  'newrelic': Activity,
-  'datadog': Activity,
-  'okta': Shield,
-  'pagerduty': AlertTriangle,
-  'opsgenie': AlertTriangle,
-  'victorops': AlertTriangle,
-  
-  // File Storage & Docs
-  'dropbox': Folder,
-  'dropbox-enhanced': Folder,
-  'box': Folder,
-  'egnyte': Folder,
-  'coda': FileText,
-  'guru': BookOpen,
-  'slab': BookOpen,
-  
-  // E-signature
-  'docusign': FileText,
-  'adobesign': FileText,
-  'hellosign': FileText,
-  
-  // Scheduling
-  'calendly': Calendar,
-  'caldotcom': Calendar,
-  
-  // Surveys & Forms
-  'typeform': FileText,
-  'jotform': FileText,
-  'qualtrics': BarChart,
-  'surveymonkey': BarChart,
-  
-  // Enhanced & Miscellaneous
-  'airtable-enhanced': Database,
-  'asana-enhanced': Settings,
-  'servicenow': Settings,
-  'freshdesk': Users,
-  'zendesk': Users,
-  'coupa': DollarSign,
-  'navan': MapPin,
-  'sap-ariba': Database,
-  'zoom-enhanced': Video
+  webhook: Link,
 };
 
 type ExecutionStatus = 'idle' | 'running' | 'success' | 'error';
@@ -1040,9 +883,18 @@ export const NodeSidebar = ({ onAddNode, catalog, loading: catalogLoading, conne
         }
         const definition = resolveDefinition(appId);
         const appName = definition?.name || def.name || appId;
-        const category = definition?.category || def.category || 'Business Apps';
-        if (category) {
-          catSet.add(category);
+        const primaryCategory =
+          (definition?.categories && definition.categories[0]) ||
+          definition?.category ||
+          def.category ||
+          'Business Apps';
+        if (primaryCategory) {
+          catSet.add(primaryCategory);
+        }
+        if (Array.isArray(definition?.categories)) {
+          definition.categories
+            .filter((cat): cat is string => typeof cat === 'string' && cat.trim().length > 0)
+            .forEach((cat) => catSet.add(cat));
         }
 
         const iconName = definition?.icon || def.icon || appId;
@@ -1068,7 +920,7 @@ export const NodeSidebar = ({ onAddNode, catalog, loading: catalogLoading, conne
         nextApps[appId] = {
           appId,
           appName,
-          category,
+          category: primaryCategory,
           iconName,
           actions,
           triggers,
@@ -1217,6 +1069,9 @@ export const NodeSidebar = ({ onAddNode, catalog, loading: catalogLoading, conne
                       {(() => {
                         const lifecycle = app.lifecycle;
                         const releaseStatus = app.release?.status;
+                        const lifecycleBadges = Array.isArray(lifecycle?.badges)
+                          ? lifecycle.badges
+                          : [];
 
                         const badgeContent = (() => {
                           if (releaseStatus === 'deprecated' || releaseStatus === 'sunset') {
@@ -1236,6 +1091,49 @@ export const NodeSidebar = ({ onAddNode, catalog, loading: catalogLoading, conne
                                   {label === 'Sunset'
                                     ? 'This connector is being sunset and will be removed soon.'
                                     : 'This connector is deprecated and may be removed in the future.'}
+                                </TooltipContent>
+                              </Tooltip>
+                            );
+                          }
+
+                          if (lifecycleBadges.length > 0) {
+                            const primary = lifecycleBadges[0];
+                            const tone = primary?.tone ?? 'neutral';
+                            const variant = tone === 'critical' ? 'destructive' : tone === 'warning' ? 'outline' : 'secondary';
+                            const tooltip = (() => {
+                              switch (primary?.id) {
+                                case 'alpha':
+                                  return 'Alpha connectors are experimental previews and may change without notice.';
+                                case 'beta':
+                                  return 'Beta connectors are near launch but may still receive minor updates or fixes.';
+                                case 'deprecated':
+                                  return 'This connector is deprecated and may be removed in the future.';
+                                case 'sunset':
+                                  return 'This connector is being sunset and will be removed soon.';
+                                default:
+                                  return undefined;
+                              }
+                            })();
+
+                            const badgeNode = (
+                              <Badge
+                                data-testid={`lifecycle-badge-${app.appId}`}
+                                className="text-[10px]"
+                                variant={variant}
+                              >
+                                {primary?.label ?? primary?.id ?? 'Status'}
+                              </Badge>
+                            );
+
+                            if (!tooltip) {
+                              return badgeNode;
+                            }
+
+                            return (
+                              <Tooltip>
+                                <TooltipTrigger asChild>{badgeNode}</TooltipTrigger>
+                                <TooltipContent className="max-w-[220px] text-xs leading-relaxed">
+                                  {tooltip}
                                 </TooltipContent>
                               </Tooltip>
                             );

--- a/client/src/components/workflow/__tests__/NodeSidebar.connectors.test.tsx
+++ b/client/src/components/workflow/__tests__/NodeSidebar.connectors.test.tsx
@@ -16,7 +16,10 @@ describe('NodeSidebar connector metadata integration', () => {
           ],
           triggers: [],
           release: { status: 'beta', semver: '0.9.0', isBeta: true },
-          lifecycle: { alpha: false, beta: true, stable: false },
+          lifecycle: {
+            status: 'beta',
+            badges: [{ id: 'beta', label: 'Beta', tone: 'warning' }],
+          },
         },
       },
     };
@@ -31,7 +34,10 @@ describe('NodeSidebar connector metadata integration', () => {
         actions: [],
         triggers: [],
         release: { status: 'beta', semver: '1.0.0', isBeta: true },
-        lifecycle: { alpha: false, beta: true, stable: false },
+        lifecycle: {
+          status: 'beta',
+          badges: [{ id: 'beta', label: 'Beta', tone: 'warning' }],
+        },
       },
     };
 

--- a/client/src/components/workflow/__tests__/NodeSidebar.lifecycle.test.tsx
+++ b/client/src/components/workflow/__tests__/NodeSidebar.lifecycle.test.tsx
@@ -16,7 +16,10 @@ describe('NodeSidebar lifecycle badges', () => {
         hasImplementation: true,
         availability: 'stable',
         release: { status: 'beta', semver: '1.0.0', isBeta: true },
-        lifecycle: { alpha: false, beta: true, stable: false },
+        lifecycle: {
+          status: 'beta',
+          badges: [{ id: 'beta', label: 'Beta', tone: 'warning' }],
+        },
       },
       stableApp: {
         name: 'Stable App',
@@ -28,7 +31,10 @@ describe('NodeSidebar lifecycle badges', () => {
         hasImplementation: true,
         availability: 'stable',
         release: { status: 'stable', semver: '2.0.0', isBeta: false },
-        lifecycle: { alpha: false, beta: false, stable: true },
+        lifecycle: {
+          status: 'stable',
+          badges: [],
+        },
       },
     },
   };

--- a/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
+++ b/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
@@ -503,6 +503,59 @@ assert.ok(
   );
 }
 
+{
+  const upstreamBefore: UpstreamNodeSummary = {
+    id: "spreadsheet-node",
+    data: {
+      label: "Initial Sheet",
+      metadata: {
+        columns: ["id", "name"],
+        sample: { id: "1", name: "Original" }
+      },
+      outputMetadata: {
+        schema: {
+          id: { type: "string" },
+          name: { type: "string" }
+        }
+      }
+    }
+  };
+
+  const upstreamAfter: UpstreamNodeSummary = {
+    id: "spreadsheet-node",
+    data: {
+      label: "Updated Sheet",
+      metadata: {
+        columns: ["id", "name", "status"],
+        sample: { id: "1", name: "Revised", status: "Active" }
+      },
+      outputMetadata: {
+        schema: {
+          id: { type: "string" },
+          name: { type: "string" },
+          status: { type: "string" }
+        }
+      }
+    }
+  };
+
+  const beforeSuggestions = computeMetadataSuggestions([upstreamBefore]);
+  const afterSuggestions = computeMetadataSuggestions([upstreamAfter]);
+
+  const beforePaths = beforeSuggestions.map((entry) => entry.path);
+  const afterPaths = afterSuggestions.map((entry) => entry.path);
+
+  assert.notDeepEqual(
+    beforePaths,
+    afterPaths,
+    "metadata suggestions should refresh when upstream schemas change"
+  );
+  assert.ok(
+    afterPaths.includes("status"),
+    "updated suggestions should include newly introduced fields"
+  );
+}
+
 const paramSyncBase = {
   label: "Mailer",
   params: { old: "value" },

--- a/client/src/services/connectorDefinitionsService.ts
+++ b/client/src/services/connectorDefinitionsService.ts
@@ -5,6 +5,7 @@ export interface ConnectorDefinitionSummary {
   name: string;
   description?: string;
   category?: string;
+  categories?: string[];
   icon?: string;
   color?: string;
   availability?: string;
@@ -57,6 +58,11 @@ const normalizeConnectorPayload = (raw: any): ConnectorDefinitionMap => {
       name: payload.name ?? payload.displayName ?? payload.id ?? id ?? normalizedId,
       description: payload.description ?? payload.summary,
       category: payload.category ?? payload.categoryName ?? payload.vertical,
+      categories: Array.isArray(payload.categories)
+        ? payload.categories
+            .map((entry: unknown) => (typeof entry === 'string' ? entry.trim() : ''))
+            .filter((entry): entry is string => Boolean(entry))
+        : undefined,
       icon: payload.icon ?? payload.iconName ?? payload.logo ?? payload.iconId,
       color: payload.color ?? payload.brandColor,
       availability: payload.availability ?? payload.status,
@@ -92,7 +98,7 @@ const normalizeConnectorPayload = (raw: any): ConnectorDefinitionMap => {
 };
 
 const fetchFromMetadataEndpoint = async (headers: HeadersInit): Promise<ConnectorDefinitionMap> => {
-  const response = await fetch('/api/metadata/connectors', { headers });
+  const response = await fetch('/api/metadata/v1/connectors', { headers });
   if (!response.ok) {
     throw new Error(`Failed to fetch connector metadata (${response.status})`);
   }

--- a/server/routes/metadata.ts
+++ b/server/routes/metadata.ts
@@ -3,6 +3,82 @@ import { authenticateToken, requirePermission } from '../middleware/auth';
 import { connectionService } from '../services/ConnectionService';
 import { connectorMetadataService } from '../services/metadata/ConnectorMetadataService';
 import { getErrorMessage } from '../types/common';
+import { ConnectorRegistry } from '../ConnectorRegistry';
+
+const normalizeLifecycleBadges = (entry: any) => {
+  const badges: Array<{ id: string; label: string; tone: 'neutral' | 'success' | 'warning' | 'critical' }> = [];
+  const status: string | undefined = typeof entry?.release?.status === 'string' ? entry.release.status : undefined;
+  const lifecycleFlags = {
+    beta: Boolean(entry?.status?.beta || status === 'beta' || entry?.release?.isBeta),
+    alpha: Boolean(entry?.status?.privatePreview || status === 'alpha'),
+    deprecated: Boolean(entry?.status?.deprecated || status === 'deprecated'),
+    sunset: Boolean(status === 'sunset'),
+  };
+
+  if (lifecycleFlags.alpha) {
+    badges.push({ id: 'alpha', label: 'Alpha', tone: 'warning' });
+  }
+  if (lifecycleFlags.beta) {
+    badges.push({ id: 'beta', label: 'Beta', tone: 'warning' });
+  }
+  if (!lifecycleFlags.alpha && !lifecycleFlags.beta && entry?.status?.privatePreview) {
+    badges.push({ id: 'preview', label: 'Preview', tone: 'warning' });
+  }
+  if (lifecycleFlags.deprecated) {
+    badges.push({ id: 'deprecated', label: 'Deprecated', tone: 'critical' });
+  }
+  if (lifecycleFlags.sunset) {
+    badges.push({ id: 'sunset', label: 'Sunset', tone: 'critical' });
+  }
+
+  if (badges.length === 0) {
+    badges.push({ id: 'stable', label: 'Stable', tone: 'success' });
+  }
+
+  return {
+    status: status ?? (lifecycleFlags.beta ? 'beta' : lifecycleFlags.alpha ? 'alpha' : lifecycleFlags.deprecated ? 'deprecated' : 'stable'),
+    badges,
+    raw: {
+      release: entry?.release ?? null,
+      status: entry?.status ?? null,
+    },
+  };
+};
+
+const serializeConnector = (entry: any) => {
+  const lifecycle = normalizeLifecycleBadges(entry);
+  return {
+    id: entry.id,
+    name: entry.displayName ?? entry.name ?? entry.id,
+    description: entry.description ?? '',
+    category: entry.category ?? 'General',
+    categories: Array.isArray(entry.labels) ? entry.labels : [],
+    icon: entry.icon ?? entry.id,
+    color: entry.color ?? null,
+    availability: entry.availability ?? 'stable',
+    pricingTier: entry.pricingTier ?? 'free',
+    lifecycle,
+    release: entry.release ?? null,
+    status: entry.status ?? null,
+    hasImplementation: entry.hasImplementation ?? true,
+    actions: Array.isArray(entry.actions)
+      ? entry.actions.map((action: any) => ({
+          id: action.id,
+          name: action.name,
+          description: action.description,
+          params: action.params ?? action.parameters ?? {},
+        }))
+      : [],
+    triggers: Array.isArray(entry.triggers)
+      ? entry.triggers.map((trigger: any) => ({
+          id: trigger.id,
+          name: trigger.name,
+          description: trigger.description,
+          params: trigger.params ?? trigger.parameters ?? {},
+        }))
+      : [],
+  };
+};
 
 const router = Router();
 
@@ -61,5 +137,27 @@ router.post('/resolve', authenticateToken, requirePermission('integration:metada
     return res.status(500).json({ success: false, error: getErrorMessage(error) });
   }
 });
+
+router.get(
+  '/v1/connectors',
+  authenticateToken,
+  requirePermission('integration:metadata:read'),
+  async (req, res) => {
+    try {
+      const registry = ConnectorRegistry.getInstance();
+      const connectors = await registry.listConnectors({
+        includeExperimental: true,
+        includeHidden: false,
+        organizationId: (req as any)?.organizationId,
+      });
+
+      const payload = connectors.map(serializeConnector);
+      return res.json({ success: true, data: { connectors: payload } });
+    } catch (error) {
+      console.error('Failed to list connector metadata:', error);
+      return res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  }
+);
 
 export default router;

--- a/server/workflow/metadata-resolvers/default-resolver.ts
+++ b/server/workflow/metadata-resolvers/default-resolver.ts
@@ -1,0 +1,391 @@
+import {
+  canonicalizeMetadataKey,
+  createMetadataPlaceholder,
+  inferWorkflowValueType,
+  mergeWorkflowMetadata,
+  toMetadataLookupKey,
+  type WorkflowMetadata,
+  type WorkflowMetadataSample,
+} from '@shared/workflow/metadata';
+import type { WorkflowNode } from '../../../common/workflow-types';
+import type { ConnectorDefinition, MetadataResolverContext, MetadataResolverResult } from './index';
+
+const canonicalize = canonicalizeMetadataKey;
+
+const normalizeOperationId = (operation?: string): string => {
+  if (!operation) return '';
+  const cleaned = operation.split(/[.:]/).pop() ?? operation;
+  return canonicalize(cleaned);
+};
+
+const unique = <T,>(values: Iterable<T>): T[] => {
+  const seen = new Set<T>();
+  const result: T[] = [];
+  for (const value of values) {
+    if (
+      !seen.has(value) &&
+      value !== undefined &&
+      value !== null &&
+      (typeof value !== 'string' || value.trim() !== '')
+    ) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+};
+
+const collectColumnsFromValue = (value: unknown): string[] => {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) =>
+        typeof entry === 'string'
+          ? entry
+          : typeof entry === 'object' && entry
+            ? Object.keys(entry)
+            : []
+      )
+      .flat()
+      .map((entry) => (typeof entry === 'string' ? entry : ''))
+      .filter((entry) => entry && entry.trim().length > 0);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/[\n,|]/)
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0);
+  }
+  if (typeof value === 'object') {
+    return Object.keys(value as Record<string, any>);
+  }
+  return [];
+};
+
+const collectColumnsFromSource = (source: unknown): string[] => {
+  if (!source || typeof source !== 'object') return [];
+  const result = new Set<string>();
+  const entries = Object.entries(source as Record<string, any>);
+  for (const [key, value] of entries) {
+    const lowerKey = key.toLowerCase();
+    if (
+      ['columns', 'headers', 'fields', 'fieldnames', 'selectedcolumns', 'columnnames'].some(
+        (token) => lowerKey.includes(token)
+      )
+    ) {
+      collectColumnsFromValue(value).forEach((col) => result.add(col));
+    } else if (typeof value === 'object' && value) {
+      collectColumnsFromValue(value).forEach((col) => result.add(col));
+    }
+  }
+  return Array.from(result);
+};
+
+const lookupValue = (source: unknown, key: string, depth = 0): any => {
+  if (!source || depth > 3) return undefined;
+  if (Array.isArray(source)) {
+    for (const entry of source) {
+      const value = lookupValue(entry, key, depth + 1);
+      if (value !== undefined) return value;
+    }
+    return undefined;
+  }
+  if (typeof source !== 'object') return undefined;
+  for (const [entryKey, entryValue] of Object.entries(source as Record<string, any>)) {
+    const normalized = toMetadataLookupKey(entryKey);
+    if (normalized === key || normalized.replace(/_/g, '') === key.replace(/_/g, '')) {
+      return entryValue;
+    }
+    if (typeof entryValue === 'object' && entryValue !== null) {
+      const nested = lookupValue(entryValue, key, depth + 1);
+      if (nested !== undefined) return nested;
+    }
+  }
+  return undefined;
+};
+
+const createPlaceholder = (column: string): string => createMetadataPlaceholder(column);
+
+const inferType = (value: any): string => inferWorkflowValueType(value);
+
+const operationMatches = (candidate: any, target: string): boolean => {
+  if (!candidate) return false;
+  const id = canonicalize(candidate.id);
+  const name = canonicalize(candidate.name ?? candidate.title);
+  const candidateTokens = unique([
+    id,
+    name,
+    id.replace(/-/g, ''),
+    id.replace(/-/g, '_'),
+    name.replace(/-/g, ''),
+    name.replace(/-/g, '_'),
+  ]);
+  const targetTokens = unique([target, target.replace(/-/g, ''), target.replace(/-/g, '_')]);
+  for (const token of candidateTokens) {
+    if (!token) continue;
+    if (targetTokens.includes(token)) return true;
+  }
+  return false;
+};
+
+const findOperation = (
+  connector: ConnectorDefinition | undefined,
+  nodeType: string,
+  operationId: string
+): { parameters?: { properties?: Record<string, any> } } | undefined => {
+  if (!connector || !operationId) return undefined;
+  const target = normalizeOperationId(operationId);
+  if (!target) return undefined;
+  const pools: Array<Array<any> | undefined> = [];
+  if (nodeType.startsWith('trigger')) {
+    pools.push(connector.triggers, connector.actions);
+  } else {
+    pools.push(connector.actions, connector.triggers);
+  }
+  for (const pool of pools) {
+    if (!pool) continue;
+    for (const candidate of pool) {
+      if (operationMatches(candidate, target)) return candidate as any;
+    }
+  }
+  return undefined;
+};
+
+const buildSampleRow = (
+  columns: string[],
+  params: Record<string, any>,
+  answers: Record<string, any>,
+  existingSample: any
+): Record<string, any> => {
+  const sample: Record<string, any> = {};
+  const valuesArray = Array.isArray(params?.values) ? params.values : null;
+  columns.forEach((column, index) => {
+    const normalized = toMetadataLookupKey(column);
+    const direct = lookupValue(params, normalized);
+    if (direct !== undefined && direct !== null && direct !== '') {
+      sample[column] = direct;
+      return;
+    }
+    if (valuesArray && index < valuesArray.length) {
+      sample[column] = valuesArray[index];
+      return;
+    }
+    const fromAnswers = lookupValue(answers, normalized);
+    if (fromAnswers !== undefined && fromAnswers !== null && fromAnswers !== '') {
+      sample[column] = fromAnswers;
+      return;
+    }
+    if (existingSample && typeof existingSample === 'object' && !Array.isArray(existingSample) && column in existingSample) {
+      sample[column] = (existingSample as Record<string, any>)[column];
+      return;
+    }
+    sample[column] = createPlaceholder(column);
+  });
+  return sample;
+};
+
+const buildSchemaFromConnector = (
+  properties?: Record<string, any>
+): Record<string, any> | undefined => {
+  if (!properties) return undefined;
+  const schema: Record<string, any> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    schema[key] = {
+      type: value?.type ?? (value?.enum ? 'string' : inferType(value?.default)),
+      description: value?.description,
+      enum: value?.enum,
+      format: value?.format,
+      default: value?.default,
+    };
+  }
+  return Object.keys(schema).length > 0 ? schema : undefined;
+};
+
+const deriveMetadata = (
+  node: Partial<WorkflowNode>,
+  connector: ConnectorDefinition | undefined,
+  params: Record<string, any>,
+  answers: Record<string, any>,
+  existing: WorkflowMetadata,
+  operationName?: string
+): WorkflowMetadata => {
+  const metadata: WorkflowMetadata = {};
+  const derivedFrom: string[] = [];
+  const existingColumns = unique([...(existing.columns ?? []), ...(existing.headers ?? [])]);
+
+  const nodeType = typeof node.type === 'string' ? node.type : (node?.data as any)?.nodeType ?? '';
+  const app = node.app ?? (node.data as any)?.app ?? (node.data as any)?.connectorId ?? '';
+  const op = operationName ?? node.op ?? (node.data as any)?.operation ?? (node.data as any)?.actionId ?? '';
+  const operationId = normalizeOperationId(op);
+
+  const connectorDefinition = connector;
+  const opDefinition = findOperation(connectorDefinition, nodeType ?? '', operationId);
+  const schemaFromConnector = buildSchemaFromConnector(opDefinition?.parameters?.properties);
+
+  if (schemaFromConnector) {
+    metadata.schema = schemaFromConnector;
+    metadata.outputSchema = schemaFromConnector;
+    derivedFrom.push(`connector:${canonicalize(connectorDefinition?.id ?? app)}`);
+    const schemaColumns = Object.keys(schemaFromConnector);
+    if (schemaColumns.length > 0) {
+      metadata.columns = unique([...(metadata.columns ?? existingColumns), ...schemaColumns]);
+    }
+  }
+
+  const configColumns = collectColumnsFromSource(params);
+  if (configColumns.length > 0) {
+    metadata.columns = unique([...(metadata.columns ?? existingColumns), ...configColumns]);
+    derivedFrom.push('config');
+  }
+
+  const answerColumns = collectColumnsFromSource(answers);
+  if (answerColumns.length > 0) {
+    metadata.columns = unique([...(metadata.columns ?? existingColumns), ...answerColumns]);
+    derivedFrom.push('answers');
+  }
+
+  const columns = metadata.columns ?? existingColumns;
+  if (columns.length > 0) {
+    const existingSample = existing.sample ?? existing.sampleRow ?? existing.outputSample;
+    const sampleRow = buildSampleRow(columns, params, answers, existingSample);
+    if (Object.keys(sampleRow).length > 0) {
+      metadata.sample = sampleRow;
+      metadata.sampleRow = sampleRow;
+      metadata.outputSample = sampleRow;
+    }
+    if (!metadata.schema) {
+      const schema: Record<string, any> = {};
+      columns.forEach((column) => {
+        const normalized = toMetadataLookupKey(column);
+        const fromSample = sampleRow[column];
+        schema[column] = {
+          type: inferType(fromSample),
+          example: fromSample,
+        };
+        const existingSchema = existing.schema?.[column];
+        if (existingSchema) {
+          schema[column] = { ...existingSchema, ...schema[column] };
+        }
+      });
+      metadata.schema = schema;
+      metadata.outputSchema = { ...(metadata.outputSchema ?? {}), ...schema };
+    }
+  }
+
+  const headerValues = unique([
+    ...(metadata.headers ?? existing.headers ?? []),
+    ...(metadata.columns ?? []),
+  ]);
+  if (headerValues.length > 0) {
+    metadata.headers = headerValues;
+  }
+
+  if (derivedFrom.length > 0) {
+    metadata.derivedFrom = unique([...(existing.derivedFrom ?? []), ...derivedFrom]);
+  }
+
+  return metadata;
+};
+
+const coerceSamples = (metadata: WorkflowMetadata): WorkflowMetadataSample[] | undefined => {
+  if (Array.isArray(metadata.samples) && metadata.samples.length > 0) {
+    return metadata.samples;
+  }
+  if (metadata.sample && typeof metadata.sample === 'object') {
+    return [{ data: metadata.sample }];
+  }
+  if (metadata.sampleRow && typeof metadata.sampleRow === 'object') {
+    return [{ data: metadata.sampleRow }];
+  }
+  if (metadata.outputSample && typeof metadata.outputSample === 'object') {
+    return [{ data: metadata.outputSample }];
+  }
+  return undefined;
+};
+
+const normalizeLifecycle = (value: any):
+  | {
+      status?: string;
+      badges: Array<{ id: string; label: string; tone: 'neutral' | 'success' | 'warning' | 'critical' }>;
+      raw?: any;
+    }
+  | undefined => {
+  if (!value || typeof value !== 'object') return undefined;
+  const status: string | undefined = typeof value.status === 'string' ? value.status : undefined;
+  const badges: Array<{ id: string; label: string; tone: 'neutral' | 'success' | 'warning' | 'critical' }> = [];
+
+  const flags = {
+    alpha: Boolean((value as any).alpha),
+    beta: Boolean((value as any).beta),
+    deprecated: Boolean((value as any).deprecated),
+    stable: (value as any).stable !== false,
+    privatePreview: Boolean((value as any).privatePreview),
+    sunset: Boolean((value as any).sunset),
+  };
+
+  if (flags.alpha) {
+    badges.push({ id: 'alpha', label: 'Alpha', tone: 'warning' });
+  }
+  if (flags.beta) {
+    badges.push({ id: 'beta', label: 'Beta', tone: 'warning' });
+  }
+  if (flags.privatePreview && !flags.alpha && !flags.beta) {
+    badges.push({ id: 'preview', label: 'Preview', tone: 'warning' });
+  }
+  if (flags.deprecated) {
+    badges.push({ id: 'deprecated', label: 'Deprecated', tone: 'critical' });
+  }
+  if ((value as any).sunset || status === 'sunset') {
+    badges.push({ id: 'sunset', label: 'Sunset', tone: 'critical' });
+  }
+  if (!status && badges.length === 0 && flags.stable) {
+    badges.push({ id: 'stable', label: 'Stable', tone: 'success' });
+  }
+
+  return {
+    status: status ?? (flags.beta ? 'beta' : flags.alpha ? 'alpha' : flags.deprecated ? 'deprecated' : undefined),
+    badges,
+    raw: value,
+  };
+};
+
+export const runDefaultMetadataResolution = (
+  context: MetadataResolverContext
+): MetadataResolverResult => {
+  const params = context.params ?? {};
+  const answers = context.answers ?? {};
+
+  const existingMetadata = mergeWorkflowMetadata(
+    (context.node as any)?.metadata,
+    (context.node?.data as any)?.metadata
+  );
+  const existingOutput = mergeWorkflowMetadata(
+    (context.node as any)?.outputMetadata,
+    (context.node?.data as any)?.outputMetadata
+  );
+  const combinedExisting = mergeWorkflowMetadata(existingMetadata, existingOutput);
+
+  const derived = deriveMetadata(
+    context.node,
+    context.connector,
+    params,
+    answers,
+    combinedExisting,
+    context.operation
+  );
+  const metadata = mergeWorkflowMetadata(combinedExisting, derived);
+  const outputMetadata = mergeWorkflowMetadata(existingOutput, metadata);
+
+  return {
+    metadata,
+    outputMetadata,
+    connector: {
+      inputs: metadata,
+      outputs: outputMetadata,
+      samples: coerceSamples(metadata),
+      lifecycle: normalizeLifecycle(
+        context.node?.data?.lifecycle ?? (context.connector as any)?.lifecycle
+      ),
+    },
+  };
+};

--- a/server/workflow/node-metadata.ts
+++ b/server/workflow/node-metadata.ts
@@ -4,12 +4,8 @@ import { fileURLToPath } from 'node:url';
 
 import {
   canonicalizeMetadataKey,
-  createMetadataPlaceholder,
-  inferWorkflowValueType,
   mergeWorkflowMetadata,
-  toMetadataLookupKey,
   type WorkflowMetadata,
-  type WorkflowMetadataSource,
 } from '@shared/workflow/metadata';
 import type { WorkflowGraph, WorkflowNode } from '../../common/workflow-types';
 import {
@@ -18,8 +14,6 @@ import {
 } from './metadata-resolvers';
 
 export type { WorkflowMetadata as WorkflowNodeMetadata } from '@shared/workflow/metadata';
-
-type MetadataSource = WorkflowMetadataSource;
 
 const canonicalize = canonicalizeMetadataKey;
 
@@ -31,24 +25,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONNECTOR_DIR = path.resolve(__dirname, '../../connectors');
 
 let connectorCache: Array<{ definition: ConnectorDefinition; tokens: Set<string> }> | null = null;
-
-const normalizeOperationId = (operation?: string): string => {
-  if (!operation) return '';
-  const cleaned = operation.split(/[.:]/).pop() ?? operation;
-  return canonicalize(cleaned);
-};
-
-const unique = <T,>(values: Iterable<T>): T[] => {
-  const seen = new Set<T>();
-  const result: T[] = [];
-  for (const value of values) {
-    if (!seen.has(value) && value !== undefined && value !== null && (typeof value !== 'string' || value.trim() !== '')) {
-      seen.add(value);
-      result.push(value);
-    }
-  }
-  return result;
-};
 
 const ensureConnectorCache = () => {
   if (connectorCache) return connectorCache;
@@ -105,85 +81,6 @@ const findConnector = (app?: string): ConnectorDefinition | undefined => {
   return fallback;
 };
 
-const operationMatches = (candidate: any, target: string): boolean => {
-  if (!candidate) return false;
-  const id = canonicalize(candidate.id);
-  const name = canonicalize(candidate.name ?? candidate.title);
-  const candidateTokens = unique([
-    id,
-    name,
-    id.replace(/-/g, ''),
-    id.replace(/-/g, '_'),
-    name.replace(/-/g, ''),
-    name.replace(/-/g, '_'),
-  ]);
-  const targetTokens = unique([target, target.replace(/-/g, ''), target.replace(/-/g, '_')]);
-  for (const token of candidateTokens) {
-    if (!token) continue;
-    if (targetTokens.includes(token)) return true;
-  }
-  return false;
-};
-
-const findOperation = (
-  connector: ConnectorDefinition | undefined,
-  nodeType: string,
-  operationId: string
-): { parameters?: { properties?: Record<string, any> } } | undefined => {
-  if (!connector || !operationId) return undefined;
-  const target = normalizeOperationId(operationId);
-  if (!target) return undefined;
-  const pools: Array<Array<any> | undefined> = [];
-  if (nodeType.startsWith('trigger')) {
-    pools.push(connector.triggers, connector.actions);
-  } else {
-    pools.push(connector.actions, connector.triggers);
-  }
-  for (const pool of pools) {
-    if (!pool) continue;
-    for (const candidate of pool) {
-      if (operationMatches(candidate, target)) return candidate as any;
-    }
-  }
-  return undefined;
-};
-
-const collectColumnsFromValue = (value: unknown): string[] => {
-  if (!value) return [];
-  if (Array.isArray(value)) {
-    return value
-      .map((entry) => (typeof entry === 'string' ? entry : typeof entry === 'object' && entry ? Object.keys(entry) : []))
-      .flat()
-      .map((entry) => (typeof entry === 'string' ? entry : ''))
-      .filter((entry) => entry && entry.trim().length > 0);
-  }
-  if (typeof value === 'string') {
-    return value
-      .split(/[\n,|]/)
-      .map((v) => v.trim())
-      .filter((v) => v.length > 0);
-  }
-  if (typeof value === 'object') {
-    return Object.keys(value as Record<string, any>);
-  }
-  return [];
-};
-
-const collectColumnsFromSource = (source: unknown): string[] => {
-  if (!source || typeof source !== 'object') return [];
-  const result = new Set<string>();
-  const entries = Object.entries(source as Record<string, any>);
-  for (const [key, value] of entries) {
-    const lowerKey = key.toLowerCase();
-    if (['columns', 'headers', 'fields', 'fieldnames', 'selectedcolumns', 'columnnames'].some((token) => lowerKey.includes(token))) {
-      collectColumnsFromValue(value).forEach((col) => result.add(col));
-    } else if (typeof value === 'object' && value) {
-      collectColumnsFromValue(value).forEach((col) => result.add(col));
-    }
-  }
-  return Array.from(result);
-};
-
 // Connector authors can pre-populate metadata by returning the shared
 // `WorkflowMetadata` shape. A minimal example looks like:
 // {
@@ -198,166 +95,6 @@ const collectColumnsFromSource = (source: unknown): string[] => {
 //
 // The enrichment logic below merges connector-provided metadata with
 // heuristics derived from params, answers and connector schemas.
-const mergeMetadataSources = (...sources: MetadataSource[]): WorkflowMetadata =>
-  mergeWorkflowMetadata(...sources);
-
-const lookupValue = (source: unknown, key: string, depth = 0): any => {
-  if (!source || depth > 3) return undefined;
-  if (Array.isArray(source)) {
-    for (const entry of source) {
-      const value = lookupValue(entry, key, depth + 1);
-      if (value !== undefined) return value;
-    }
-    return undefined;
-  }
-  if (typeof source !== 'object') return undefined;
-  for (const [entryKey, entryValue] of Object.entries(source as Record<string, any>)) {
-    const normalized = toMetadataLookupKey(entryKey);
-    if (normalized === key || normalized.replace(/_/g, '') === key.replace(/_/g, '')) {
-      return entryValue;
-    }
-    if (typeof entryValue === 'object' && entryValue !== null) {
-      const nested = lookupValue(entryValue, key, depth + 1);
-      if (nested !== undefined) return nested;
-    }
-  }
-  return undefined;
-};
-
-const createPlaceholder = (column: string): string => createMetadataPlaceholder(column);
-
-const inferType = (value: any): string => inferWorkflowValueType(value);
-
-const buildSampleRow = (
-  columns: string[],
-  params: Record<string, any>,
-  answers: Record<string, any>,
-  existingSample: any
-): Record<string, any> => {
-  const sample: Record<string, any> = {};
-  const valuesArray = Array.isArray(params?.values) ? params.values : null;
-  columns.forEach((column, index) => {
-    const normalized = toMetadataLookupKey(column);
-    const direct = lookupValue(params, normalized);
-    if (direct !== undefined && direct !== null && direct !== '') {
-      sample[column] = direct;
-      return;
-    }
-    if (valuesArray && index < valuesArray.length) {
-      sample[column] = valuesArray[index];
-      return;
-    }
-    const fromAnswers = lookupValue(answers, normalized);
-    if (fromAnswers !== undefined && fromAnswers !== null && fromAnswers !== '') {
-      sample[column] = fromAnswers;
-      return;
-    }
-    if (existingSample && typeof existingSample === 'object' && !Array.isArray(existingSample) && column in existingSample) {
-      sample[column] = (existingSample as Record<string, any>)[column];
-      return;
-    }
-    sample[column] = createPlaceholder(column);
-  });
-  return sample;
-};
-
-const buildSchemaFromConnector = (properties?: Record<string, any>): Record<string, any> | undefined => {
-  if (!properties) return undefined;
-  const schema: Record<string, any> = {};
-  for (const [key, value] of Object.entries(properties)) {
-    schema[key] = {
-      type: value?.type ?? (value?.enum ? 'string' : inferType(value?.default)),
-      description: value?.description,
-      enum: value?.enum,
-      format: value?.format,
-      default: value?.default,
-    };
-  }
-  return Object.keys(schema).length > 0 ? schema : undefined;
-};
-
-const deriveMetadata = (
-  node: Partial<WorkflowNode>,
-  connector: ConnectorDefinition | undefined,
-  params: Record<string, any>,
-  answers: Record<string, any>,
-  existing: WorkflowMetadata
-): WorkflowMetadata => {
-  const metadata: WorkflowMetadata = {};
-  const derivedFrom: string[] = [];
-  const existingColumns = unique([...(existing.columns ?? []), ...(existing.headers ?? [])]);
-
-  const nodeType = typeof node.type === 'string' ? node.type : node?.data?.nodeType ?? '';
-  const app = node.app ?? node.data?.app ?? node.data?.connectorId ?? '';
-  const op = node.op ?? node.data?.operation ?? node.data?.actionId ?? '';
-  const operationId = normalizeOperationId(op);
-
-  const connectorDefinition = connector;
-  const opDefinition = findOperation(connectorDefinition, nodeType ?? '', operationId);
-  const schemaFromConnector = buildSchemaFromConnector(opDefinition?.parameters?.properties);
-
-  if (schemaFromConnector) {
-    metadata.schema = schemaFromConnector;
-    metadata.outputSchema = schemaFromConnector;
-    derivedFrom.push(`connector:${canonicalize(connectorDefinition?.id ?? app)}`);
-    const schemaColumns = Object.keys(schemaFromConnector);
-    if (schemaColumns.length > 0) {
-      metadata.columns = unique([...(metadata.columns ?? existingColumns), ...schemaColumns]);
-    }
-  }
-
-  const configColumns = collectColumnsFromSource(params);
-  if (configColumns.length > 0) {
-    metadata.columns = unique([...(metadata.columns ?? existingColumns), ...configColumns]);
-    derivedFrom.push('config');
-  }
-
-  const answerColumns = collectColumnsFromSource(answers);
-  if (answerColumns.length > 0) {
-    metadata.columns = unique([...(metadata.columns ?? existingColumns), ...answerColumns]);
-    derivedFrom.push('answers');
-  }
-
-  const columns = metadata.columns ?? existingColumns;
-  if (columns.length > 0) {
-    const existingSample = existing.sample ?? existing.sampleRow ?? existing.outputSample;
-    const sampleRow = buildSampleRow(columns, params, answers, existingSample);
-    if (Object.keys(sampleRow).length > 0) {
-      metadata.sample = sampleRow;
-      metadata.sampleRow = sampleRow;
-      metadata.outputSample = sampleRow;
-    }
-    if (!metadata.schema) {
-      const schema: Record<string, any> = {};
-      columns.forEach((column) => {
-        const normalized = toMetadataLookupKey(column);
-        const fromSample = sampleRow[column];
-        schema[column] = {
-          type: inferType(fromSample),
-          example: fromSample,
-        };
-        const existingSchema = existing.schema?.[column];
-        if (existingSchema) {
-          schema[column] = { ...existingSchema, ...schema[column] };
-        }
-      });
-      metadata.schema = schema;
-      metadata.outputSchema = { ...(metadata.outputSchema ?? {}), ...schema };
-    }
-  }
-
-  const headerValues = unique([...(metadata.headers ?? existing.headers ?? []), ...(metadata.columns ?? [])]);
-  if (headerValues.length > 0) {
-    metadata.headers = headerValues;
-  }
-
-  if (derivedFrom.length > 0) {
-    metadata.derivedFrom = unique([...(existing.derivedFrom ?? []), ...derivedFrom]);
-  }
-
-  return metadata;
-};
-
 export const enrichWorkflowNode = <T extends WorkflowNode>(
   node: T,
   context: EnrichContext = {}
@@ -404,23 +141,13 @@ export const enrichWorkflowNode = <T extends WorkflowNode>(
     operation: rawOperation,
     auth,
   });
-  const resolverMetadata = resolverResult.metadata;
-  const resolverOutputMetadata = resolverResult.outputMetadata ?? resolverResult.metadata;
 
-  const existingOutput = mergeMetadataSources(
-    node.data?.outputMetadata as any,
-    (node as any)?.outputMetadata,
-    resolverOutputMetadata
+  const metadata = mergeWorkflowMetadata(resolverResult.metadata);
+  const outputMetadata = mergeWorkflowMetadata(
+    resolverResult.outputMetadata ?? resolverResult.metadata
   );
-  const combinedExisting = mergeMetadataSources(
-    node.metadata as any,
-    node.data?.metadata as any,
-    resolverMetadata,
-    existingOutput
-  );
-  const derived = deriveMetadata(node, connector, params, answers, combinedExisting);
-  const metadata = mergeMetadataSources(combinedExisting, derived);
-  const outputMetadata = mergeMetadataSources(existingOutput, metadata);
+
+  const lifecycle = resolverResult.connector?.lifecycle;
 
   const data = {
     ...(node.data || {}),
@@ -430,6 +157,8 @@ export const enrichWorkflowNode = <T extends WorkflowNode>(
     config: node.data?.config ?? params,
     metadata,
     outputMetadata,
+    lifecycle: lifecycle ?? node.data?.lifecycle,
+    connectorMetadata: resolverResult.connector,
   };
 
   return {


### PR DESCRIPTION
## Summary
- move workflow node metadata heuristics into a shared metadata resolver and surface lifecycle/sample details in a unified connector metadata envelope
- expose connector metadata via a versioned `/api/metadata/v1/connectors` endpoint and update the workflow builder to consume backend-driven icons, categories, and lifecycle badges
- refresh downstream parameter suggestions when upstream schemas change and extend coverage for lifecycle badges and dynamic metadata updates

## Testing
- npm test -- --runInBand --selectProjects client --testPathPattern "SmartParametersPanel|NodeSidebar" *(fails: `tsx` missing before install)*
- npm install *(fails: registry returned 403 for @aws-sdk/client-cloudformation)*

------
https://chatgpt.com/codex/tasks/task_e_68e1086e38b083318f47838910ffc509