### PR TITLE
Implement real Workday and Databricks API clients

### DIFF
--- a/configs/connector-smoke.config.example.json
+++ b/configs/connector-smoke.config.example.json
@@ -72,7 +72,9 @@
       "accessToken": "YOUR_WORKDAY_ACCESS_TOKEN",
       "refreshToken": "YOUR_WORKDAY_REFRESH_TOKEN",
       "clientId": "YOUR_WORKDAY_CLIENT_ID",
-      "clientSecret": "YOUR_WORKDAY_CLIENT_SECRET"
+      "clientSecret": "YOUR_WORKDAY_CLIENT_SECRET",
+      "tenant": "YOUR_WORKDAY_TENANT",
+      "host": "https://wd5.myworkday.com"
     },
     "actions": [
       {
@@ -87,10 +89,8 @@
   },
   "databricks": {
     "credentials": {
-      "accessToken": "dapiYOUR_DATABRICKS_TOKEN"
-    },
-    "additionalConfig": {
-      "workspaceUrl": "https://adb-1234567890.0.azuredatabricks.net"
+      "accessToken": "dapiYOUR_DATABRICKS_TOKEN",
+      "host": "adb-1234567890.0.azuredatabricks.net"
     },
     "actions": [
       {

--- a/connectors/databricks/definition.json
+++ b/connectors/databricks/definition.json
@@ -14,12 +14,26 @@
       "prefix": "Bearer"
     }
   },
-  "baseUrl": "https://{workspace}.cloud.databricks.com/api/2.0",
+  "baseUrl": "https://{host}/api/2.0",
+  "connection": {
+    "fields": [
+      {
+        "id": "host",
+        "label": "Workspace URL",
+        "type": "text",
+        "placeholder": "adb-1234567890.0.azuredatabricks.net",
+        "required": true,
+        "helpText": "Enter the Databricks workspace hostname without protocol."
+      }
+    ]
+  },
   "actions": [
     {
       "id": "test_connection",
       "name": "Test Connection",
       "description": "Test the connection to Databricks",
+      "method": "POST",
+      "endpoint": "/clusters/list",
       "parameters": {
         "type": "object",
         "properties": {},
@@ -31,6 +45,8 @@
       "id": "list_clusters",
       "name": "List Clusters",
       "description": "List available clusters",
+      "method": "POST",
+      "endpoint": "/clusters/list",
       "parameters": {
         "type": "object",
         "properties": {
@@ -47,6 +63,8 @@
       "id": "get_cluster",
       "name": "Get Cluster",
       "description": "Get cluster information",
+      "method": "GET",
+      "endpoint": "/clusters/get",
       "parameters": {
         "type": "object",
         "properties": {
@@ -65,6 +83,8 @@
       "id": "start_cluster",
       "name": "Start Cluster",
       "description": "Start a cluster",
+      "method": "POST",
+      "endpoint": "/clusters/start",
       "parameters": {
         "type": "object",
         "properties": {
@@ -83,6 +103,8 @@
       "id": "stop_cluster",
       "name": "Stop Cluster",
       "description": "Stop a cluster",
+      "method": "POST",
+      "endpoint": "/clusters/delete",
       "parameters": {
         "type": "object",
         "properties": {
@@ -101,6 +123,8 @@
       "id": "submit_run",
       "name": "Submit Run",
       "description": "Submit a new job run",
+      "method": "POST",
+      "endpoint": "/jobs/runs/submit",
       "parameters": {
         "type": "object",
         "properties": {
@@ -198,6 +222,8 @@
       "id": "get_run",
       "name": "Get Run",
       "description": "Get run information",
+      "method": "GET",
+      "endpoint": "/jobs/runs/get",
       "parameters": {
         "type": "object",
         "properties": {
@@ -220,6 +246,8 @@
       "id": "cancel_run",
       "name": "Cancel Run",
       "description": "Cancel a run",
+      "method": "POST",
+      "endpoint": "/jobs/runs/cancel",
       "parameters": {
         "type": "object",
         "properties": {
@@ -238,6 +266,8 @@
       "id": "list_jobs",
       "name": "List Jobs",
       "description": "List jobs",
+      "method": "GET",
+      "endpoint": "/jobs/list",
       "parameters": {
         "type": "object",
         "properties": {
@@ -265,6 +295,8 @@
       "id": "create_job",
       "name": "Create Job",
       "description": "Create a new job",
+      "method": "POST",
+      "endpoint": "/jobs/create",
       "parameters": {
         "type": "object",
         "properties": {

--- a/connectors/workday/definition.json
+++ b/connectors/workday/definition.json
@@ -9,8 +9,8 @@
   "authentication": {
     "type": "oauth2",
     "config": {
-      "authUrl": "https://wd5-impl-services1.workday.com/ccx/oauth2/authorize",
-      "tokenUrl": "https://wd5-impl-services1.workday.com/ccx/oauth2/token",
+      "authUrl": "https://{host}/ccx/oauth2/authorize",
+      "tokenUrl": "https://{host}/ccx/oauth2/token",
       "scopes": [
         "staffing",
         "compensation",
@@ -19,12 +19,38 @@
       ]
     }
   },
-  "baseUrl": "https://wd5-impl-services1.workday.com/ccx/api/v1",
+  "baseUrl": "https://{host}/ccx/api/v1/{tenant}",
+  "connection": {
+    "fields": [
+      {
+        "id": "host",
+        "label": "Workday Hostname",
+        "type": "text",
+        "placeholder": "wd5-impl-services1.workday.com",
+        "required": true,
+        "helpText": "Enter the Workday domain for your tenant (for example wd5.myworkday.com)."
+      },
+      {
+        "id": "tenant",
+        "label": "Tenant Identifier",
+        "type": "text",
+        "placeholder": "acme",
+        "required": true,
+        "helpText": "Provide the Workday tenant used in REST URLs."
+      }
+    ]
+  },
   "actions": [
     {
       "id": "test_connection",
       "name": "Test Connection",
       "description": "Test the connection to Workday",
+      "method": "GET",
+      "endpoint": "/human_resources/workers",
+      "query": {
+        "$top": "1",
+        "$select": "worker_id"
+      },
       "parameters": {
         "type": "object",
         "properties": {},
@@ -36,6 +62,8 @@
       "id": "get_worker",
       "name": "Get Worker",
       "description": "Get worker details by ID",
+      "method": "GET",
+      "endpoint": "/human_resources/workers/{workerId}",
       "parameters": {
         "type": "object",
         "properties": {
@@ -54,6 +82,8 @@
       "id": "search_workers",
       "name": "Search Workers",
       "description": "Search for workers",
+      "method": "GET",
+      "endpoint": "/human_resources/workers",
       "parameters": {
         "type": "object",
         "properties": {
@@ -103,6 +133,8 @@
       "id": "create_worker",
       "name": "Create Worker",
       "description": "Create a new worker",
+      "method": "POST",
+      "endpoint": "/human_resources/workers",
       "parameters": {
         "type": "object",
         "properties": {
@@ -230,6 +262,8 @@
       "id": "update_worker",
       "name": "Update Worker",
       "description": "Update an existing worker",
+      "method": "PATCH",
+      "endpoint": "/human_resources/workers/{workerId}",
       "parameters": {
         "type": "object",
         "properties": {
@@ -356,6 +390,8 @@
       "id": "terminate_worker",
       "name": "Terminate Worker",
       "description": "Terminate a worker's employment",
+      "method": "POST",
+      "endpoint": "/human_resources/workers/{workerId}/terminate",
       "parameters": {
         "type": "object",
         "properties": {

--- a/scripts/connector-smoke.ts
+++ b/scripts/connector-smoke.ts
@@ -75,12 +75,26 @@ const DEFAULT_SMOKE_PLANS: Record<string, { actions?: SmokeActionConfig[]; trigg
     ],
     notes: 'Default ADP smoke plan validates OAuth client credential flow and payroll event wiring using non-production defaults.',
   },
+  databricks: {
+    actions: [
+      { id: 'test_connection' },
+      { id: 'list_clusters', parameters: { can_use_client: 'NOTEBOOK' } },
+    ],
+    notes: 'Databricks smoke plan exercises PAT authentication and cluster listings via the REST API.',
+  },
   dynamics365: {
     actions: [
       { id: 'test_connection' },
       { id: 'list_accounts', parameters: { '$top': 1, '$select': 'accountid' } },
     ],
     notes: 'Default smoke plan exercises Dynamics 365 connection and Dataverse account listing.',
+  },
+  workday: {
+    actions: [
+      { id: 'test_connection' },
+      { id: 'search_workers', parameters: { searchTerm: 'Automation', limit: 1 } },
+    ],
+    notes: 'Workday smoke plan validates tenant-scoped OAuth tokens and worker search via the Human Resources REST API.',
   },
 };
 

--- a/server/integrations/DatabricksAPIClient.ts
+++ b/server/integrations/DatabricksAPIClient.ts
@@ -1,137 +1,146 @@
-// DATABRICKS API CLIENT
-// Auto-generated API client for Databricks integration
-
+import type { APICredentials, APIResponse } from './BaseAPIClient';
 import { BaseAPIClient } from './BaseAPIClient';
 
-export interface DatabricksAPIClientConfig {
-  accessToken: string;
-  refreshToken?: string;
-  clientId?: string;
-  clientSecret?: string;
+interface DatabricksListClustersParams {
+  can_use_client?: string;
+}
+
+interface DatabricksClusterActionParams {
+  cluster_id: string;
+}
+
+interface DatabricksSubmitRunParams {
+  run_name?: string;
+  new_cluster?: Record<string, any>;
+  existing_cluster_id?: string;
+  notebook_task?: Record<string, any>;
+  spark_jar_task?: Record<string, any>;
+  spark_python_task?: Record<string, any>;
+  libraries?: any[];
+  timeout_seconds?: number;
+  idempotency_token?: string;
+}
+
+interface DatabricksGetRunParams {
+  run_id: number;
+  include_history?: boolean;
+}
+
+interface DatabricksCancelRunParams {
+  run_id: number;
+}
+
+interface DatabricksListJobsParams {
+  limit?: number;
+  offset?: number;
+  expand_tasks?: boolean;
+}
+
+interface DatabricksCreateJobParams extends Record<string, any> {}
+
+function normalizeDatabricksHost(candidate?: string | null): string {
+  const raw = `${candidate ?? ''}`.trim();
+  if (!raw) {
+    throw new Error('Databricks connector requires a workspace URL (for example https://adb-123.45.azuredatabricks.net).');
+  }
+
+  const prefixed = raw.startsWith('http://') || raw.startsWith('https://') ? raw : `https://${raw}`;
+  return prefixed.replace(/\/$/, '');
+}
+
+function resolveDatabricksHost(credentials: APICredentials, additionalConfig?: Record<string, any>): string {
+  return (
+    (additionalConfig?.workspaceUrl as string | undefined) ??
+    (credentials as any).workspaceUrl ??
+    (credentials as any).instanceUrl ??
+    (credentials as any).host ??
+    credentials.baseUrl ??
+    ''
+  );
 }
 
 export class DatabricksAPIClient extends BaseAPIClient {
-  protected baseUrl: string;
-  private config: DatabricksAPIClientConfig;
+  constructor(
+    credentials: APICredentials & { workspaceUrl?: string; instanceUrl?: string; host?: string },
+    additionalConfig?: Record<string, any>
+  ) {
+    const host = normalizeDatabricksHost(resolveDatabricksHost(credentials, additionalConfig));
+    const baseURL = `${host}/api/2.0`;
 
-  constructor(config: DatabricksAPIClientConfig) {
-    super();
-    this.config = config;
-    this.baseUrl = 'https://api.example.com';
+    super(baseURL, credentials, { connectorId: 'databricks' });
+
+    this.registerHandlers({
+      test_connection: this.testConnection.bind(this) as any,
+      list_clusters: this.listClusters.bind(this) as any,
+      get_cluster: this.getCluster.bind(this) as any,
+      start_cluster: this.startCluster.bind(this) as any,
+      stop_cluster: this.stopCluster.bind(this) as any,
+      submit_run: this.submitRun.bind(this) as any,
+      get_run: this.getRun.bind(this) as any,
+      cancel_run: this.cancelRun.bind(this) as any,
+      list_jobs: this.listJobs.bind(this) as any,
+      create_job: this.createJob.bind(this) as any,
+    });
   }
 
-  /**
-   * Get authentication headers
-   */
   protected getAuthHeaders(): Record<string, string> {
-    return {
-      'Authorization': `Bearer ${this.config.accessToken}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'Apps-Script-Automation/1.0'
-    };
+    const token = this.credentials.accessToken ?? this.credentials.apiKey;
+    if (!token) {
+      throw new Error('Databricks connector requires a personal access token.');
+    }
+    return { Authorization: `Bearer ${token}` };
   }
 
-  /**
-   * Test API connection
-   */
-  async testConnection(): Promise<boolean> {
-    try {
-      const response = await this.makeRequest('GET', '/');
-      return response.status === 200;
-      return true;
-    } catch (error) {
-      console.error(`❌ ${this.constructor.name} connection test failed:`, error);
-      return false;
-    }
+  public async testConnection(): Promise<APIResponse<any>> {
+    return this.post('/clusters/list', {}, undefined, { retry: { maxAttempts: 1 } });
   }
 
-
-  /**
-   * Create a new record in Databricks
-   */
-  async createRecord({ data: Record<string, any> }: { data: Record<string, any> }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/create_record', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Create Record failed: ${error}`);
-    }
+  public async listClusters(params: DatabricksListClustersParams = {}): Promise<APIResponse<any>> {
+    return this.post('/clusters/list', params);
   }
 
-  /**
-   * Update an existing record in Databricks
-   */
-  async updateRecord({ id: string, data: Record<string, any> }: { id: string, data: Record<string, any> }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/update_record', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Update Record failed: ${error}`);
-    }
+  public async getCluster(params: DatabricksClusterActionParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['cluster_id']);
+    return this.get(`/clusters/get${this.buildQueryString({ cluster_id: params.cluster_id })}`);
   }
 
-  /**
-   * Retrieve a record from Databricks
-   */
-  async getRecord({ id: string }: { id: string }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/get_record', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Get Record failed: ${error}`);
-    }
+  public async startCluster(params: DatabricksClusterActionParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['cluster_id']);
+    return this.post('/clusters/start', { cluster_id: params.cluster_id });
   }
 
-  /**
-   * List records from Databricks
-   */
-  async listRecords({ limit?: number, filter?: Record<string, any> }: { limit?: number, filter?: Record<string, any> }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/list_records', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`List Records failed: ${error}`);
-    }
+  public async stopCluster(params: DatabricksClusterActionParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['cluster_id']);
+    return this.post('/clusters/delete', { cluster_id: params.cluster_id });
   }
 
-  /**
-   * Delete a record from Databricks
-   */
-  async deleteRecord({ id: string }: { id: string }): Promise<any> {
-    try {
-      const response = await this.makeRequest('POST', '/api/delete_record', params);
-      return this.handleResponse(response);
-    } catch (error) {
-      throw new Error(`Delete Record failed: ${error}`);
+  public async submitRun(params: DatabricksSubmitRunParams): Promise<APIResponse<any>> {
+    const hasTask = Boolean(params.notebook_task || params.spark_python_task || params.spark_jar_task);
+    if (!hasTask) {
+      throw new Error('Databricks run submissions require a notebook_task, spark_python_task, or spark_jar_task.');
     }
+
+    return this.post('/jobs/runs/submit', params);
   }
 
-
-  /**
-   * Poll for Triggered when a new record is created in Databricks
-   */
-  async pollRecordCreated(params: Record<string, any> = {}): Promise<any[]> {
-    try {
-      const response = await this.makeRequest('GET', '/api/record_created', params);
-      const data = this.handleResponse(response);
-      return Array.isArray(data) ? data : [data];
-    } catch (error) {
-      console.error(`Polling Record Created failed:`, error);
-      return [];
-    }
+  public async getRun(params: DatabricksGetRunParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as Record<string, any>, ['run_id']);
+    return this.get(`/jobs/runs/get${this.buildQueryString({ run_id: params.run_id, include_history: params.include_history })}`);
   }
 
-  /**
-   * Poll for Triggered when a record is updated in Databricks
-   */
-  async pollRecordUpdated(params: Record<string, any> = {}): Promise<any[]> {
-    try {
-      const response = await this.makeRequest('GET', '/api/record_updated', params);
-      const data = this.handleResponse(response);
-      return Array.isArray(data) ? data : [data];
-    } catch (error) {
-      console.error(`Polling Record Updated failed:`, error);
-      return [];
-    }
+  public async cancelRun(params: DatabricksCancelRunParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params as Record<string, any>, ['run_id']);
+    return this.post('/jobs/runs/cancel', { run_id: params.run_id });
+  }
+
+  public async listJobs(params: DatabricksListJobsParams = {}): Promise<APIResponse<any>> {
+    return this.get(
+      `/jobs/list${this.buildQueryString({ limit: params.limit, offset: params.offset, expand_tasks: params.expand_tasks })}`
+    );
+  }
+
+  public async createJob(params: DatabricksCreateJobParams): Promise<APIResponse<any>> {
+    this.validateRequiredParams(params, ['name']);
+    return this.post('/jobs/create', params);
   }
 }

--- a/server/testing/fixtures/databricks/__meta__.json
+++ b/server/testing/fixtures/databricks/__meta__.json
@@ -2,10 +2,8 @@
   "description": "Connector simulator defaults for Databricks smoke tests.",
   "defaults": {
     "credentials": {
-      "accessToken": "dapi-simulated-databricks-token"
-    },
-    "additionalConfig": {
-      "workspaceUrl": "https://adb-1234567890.0.azuredatabricks.net"
+      "accessToken": "dapi-simulated-databricks-token",
+      "host": "adb-1234567890.0.azuredatabricks.net"
     },
     "notes": "Databricks smoke scenarios execute against offline fixtures."
   }

--- a/server/testing/fixtures/databricks/list_clusters.json
+++ b/server/testing/fixtures/databricks/list_clusters.json
@@ -3,20 +3,22 @@
   "type": "action",
   "defaults": {
     "credentials": {
-      "accessToken": "dapi-simulated-databricks-token"
-    },
-    "additionalConfig": {
-      "workspaceUrl": "https://adb-1234567890.0.azuredatabricks.net"
+      "accessToken": "dapi-simulated-databricks-token",
+      "host": "adb-1234567890.0.azuredatabricks.net"
     }
   },
   "params": {
     "can_use_client": "NOTEBOOK"
   },
   "request": {
-    "method": "GET",
+    "method": "POST",
     "url": "https://adb-1234567890.0.azuredatabricks.net/api/2.0/clusters/list",
     "headers": {
-      "Authorization": "Bearer dapi-simulated-databricks-token"
+      "Authorization": "Bearer dapi-simulated-databricks-token",
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "can_use_client": "NOTEBOOK"
     }
   },
   "response": {

--- a/server/testing/fixtures/workday/__meta__.json
+++ b/server/testing/fixtures/workday/__meta__.json
@@ -5,7 +5,9 @@
       "accessToken": "simulated-workday-access-token",
       "refreshToken": "simulated-workday-refresh-token",
       "clientId": "simulated-workday-client-id",
-      "clientSecret": "simulated-workday-client-secret"
+      "clientSecret": "simulated-workday-client-secret",
+      "tenant": "simulated",
+      "host": "https://wd5-impl-services1.workday.com"
     },
     "notes": "Workday smoke tests rely on offline fixtures in CI."
   }

--- a/server/testing/fixtures/workday/search_workers.json
+++ b/server/testing/fixtures/workday/search_workers.json
@@ -3,7 +3,9 @@
   "type": "action",
   "defaults": {
     "credentials": {
-      "accessToken": "simulated-workday-access-token"
+      "accessToken": "simulated-workday-access-token",
+      "tenant": "simulated",
+      "host": "https://wd5-impl-services1.workday.com"
     }
   },
   "params": {
@@ -12,7 +14,7 @@
   },
   "request": {
     "method": "GET",
-    "url": "https://wd5-impl-services1.workday.com/ccx/api/v1/workers",
+    "url": "https://wd5-impl-services1.workday.com/ccx/api/v1/simulated/human_resources/workers?$search=%22Sim%22&$top=1&$skip=0",
     "headers": {
       "Authorization": "Bearer simulated-workday-access-token"
     },
@@ -24,13 +26,23 @@
       "Content-Type": "application/json"
     },
     "body": {
-      "workers": [
+      "value": [
         {
-          "id": "SIM-0001",
-          "name": "Simulated Worker",
-          "title": "QA Analyst",
-          "department": "Engineering",
-          "email": "sim.worker@example.invalid"
+          "Worker": {
+            "ID": "SIM-0001",
+            "Name": "Simulated Worker",
+            "JobProfile": {
+              "JobTitle": "QA Analyst"
+            },
+            "Organizations": [
+              {
+                "OrganizationName": "Engineering"
+              }
+            ],
+            "Contact": {
+              "Email": "sim.worker@example.invalid"
+            }
+          }
         }
       ]
     }
@@ -38,13 +50,23 @@
   "result": {
     "success": true,
     "data": {
-      "workers": [
+      "value": [
         {
-          "id": "SIM-0001",
-          "name": "Simulated Worker",
-          "title": "QA Analyst",
-          "department": "Engineering",
-          "email": "sim.worker@example.invalid"
+          "Worker": {
+            "ID": "SIM-0001",
+            "Name": "Simulated Worker",
+            "JobProfile": {
+              "JobTitle": "QA Analyst"
+            },
+            "Organizations": [
+              {
+                "OrganizationName": "Engineering"
+              }
+            ],
+            "Contact": {
+              "Email": "sim.worker@example.invalid"
+            }
+          }
         }
       ],
       "count": 1


### PR DESCRIPTION
## Summary
- replace the Workday client with a tenant-aware implementation that targets the Human Resources REST endpoints and supports worker mutations and polling
- implement a Databricks REST client that normalizes workspace hosts, wires cluster/job operations to their official endpoints, and enforces task payload validation
- document connection requirements in the Workday and Databricks connector definitions, refresh simulator fixtures, and add default smoke plans for both connectors

## Testing
- npm run smoke:connectors -- --only workday,databricks --use-simulator --fixtures server/testing/fixtures *(fails: tsx binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e10b7aabf8833194aed81d8fb3f814