### PR TITLE
Refactor sandbox provisioning for tenancy isolation

### DIFF
--- a/server/runtime/sandbox/types.ts
+++ b/server/runtime/sandbox/types.ts
@@ -1,0 +1,36 @@
+import type { SandboxScope, SandboxTenancyMetadata } from '../SandboxShared.js';
+import type { OrganizationNetworkPolicy } from '../../services/ConnectionService.js';
+import type { SandboxResourceLimits } from '../SandboxShared.js';
+
+export interface SandboxProvisionRequest {
+  scope: SandboxScope;
+  organizationId?: string;
+  executionId?: string;
+  workflowId?: string;
+  nodeId?: string;
+}
+
+export interface SandboxScopeDescriptor extends SandboxProvisionRequest {
+  key: string;
+}
+
+export interface SandboxTenancyConfiguration {
+  organizationId?: string;
+  dependencyAllowlist: string[];
+  secretScopes: string[];
+  networkPolicy: OrganizationNetworkPolicy;
+  resourceLimits?: SandboxResourceLimits;
+  policyVersion?: string | null;
+}
+
+export interface SandboxTelemetryAttributes {
+  scope: SandboxScope;
+  organizationId?: string;
+  executionId?: string;
+  workflowId?: string;
+  nodeId?: string;
+}
+
+export interface SandboxMetadataPayload {
+  tenancy: SandboxTenancyMetadata;
+}

--- a/server/runtime/sandbox/utils.ts
+++ b/server/runtime/sandbox/utils.ts
@@ -1,0 +1,41 @@
+import type { SandboxProvisionRequest, SandboxScopeDescriptor, SandboxTelemetryAttributes } from './types.js';
+
+export function createSandboxScopeKey(request: SandboxProvisionRequest): string {
+  const organization = request.organizationId ?? 'global';
+  if (request.scope === 'tenant') {
+    return `tenant:${organization}`;
+  }
+  const execution = request.executionId ?? 'execution';
+  const workflow = request.workflowId ?? 'workflow';
+  const node = request.nodeId ?? 'node';
+  return `exec:${organization}:${execution}:${workflow}:${node}`;
+}
+
+export function mergeStringSets(...lists: Array<string[] | undefined | null>): string[] {
+  const result = new Set<string>();
+  for (const list of lists) {
+    if (!Array.isArray(list)) {
+      continue;
+    }
+    for (const entry of list) {
+      if (typeof entry !== 'string') {
+        continue;
+      }
+      const trimmed = entry.trim();
+      if (trimmed.length > 0) {
+        result.add(trimmed);
+      }
+    }
+  }
+  return Array.from(result);
+}
+
+export function toTelemetryAttributes(descriptor: SandboxScopeDescriptor): SandboxTelemetryAttributes {
+  return {
+    scope: descriptor.scope,
+    organizationId: descriptor.organizationId,
+    executionId: descriptor.executionId,
+    workflowId: descriptor.workflowId,
+    nodeId: descriptor.nodeId,
+  };
+}


### PR DESCRIPTION
## Summary
- refactor the node sandbox into a tenancy-aware factory that provisions scoped sandboxes and enforces resource, network, and heartbeat policies
- surface sandbox lifecycle telemetry and health metrics while integrating org-specific policies, dependency allowlists, and secret scopes into workflow execution
- extend connection service tenancy configuration lookups and add shared isolation watchdog utilities for sandbox management

## Testing
- npm run check *(fails: missing type definitions for node and vite/client in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e10b770cc083319b9808a129c540a5