### PR TITLE
Integrate JSONata-style expression runtime

### DIFF
--- a/server/core/__tests__/ParameterResolver.expr.test.ts
+++ b/server/core/__tests__/ParameterResolver.expr.test.ts
@@ -1,60 +1,116 @@
 import assert from 'node:assert/strict';
 
 import { resolveParamValue } from '../ParameterResolver.js';
+import { expressionEvaluator } from '../ExpressionEvaluator.js';
 
 const context = {
   nodeOutputs: {
-    trigger1: {
-      value: 21,
-      email: {
-        subject: 'hello world',
+    trigger: {
+      opportunity: {
+        id: 'OPP-001',
+        amount: 5000,
+        owner: { name: 'Alice Johnson', email: 'alice@example.com' },
+      },
+      metadata: {
+        receivedAt: '2024-05-20T12:30:00.000Z',
       },
     },
-    transform1: {
-      score: 0.92,
+    salesforceOpportunity: {
+      id: 'OPP-001',
+      stage: 'Prospecting',
+      amount: 5000,
+      probability: 0.45,
+    },
+    enrichment: {
+      multiplier: 1.2,
+      recommendations: [
+        { product: 'Premium Support', score: 0.92 },
+        { product: 'Analytics Add-on', score: 0.81 },
+      ],
+    },
+    slackNotify: {
+      channel: '#sales',
+      ts: '1727548200.000200',
+      message: 'New opportunity created for Alice Johnson',
     },
   },
-  currentNodeId: 'transform1',
+  currentNodeId: 'slackNotify',
   workflowId: 'workflow-123',
   executionId: 'execution-456',
   userId: 'user-789',
+  variables: {
+    region: 'EMEA',
+    threshold: 0.85,
+  },
+  trigger: {
+    opportunity: {
+      id: 'OPP-001',
+      amount: 5000,
+      owner: { name: 'Alice Johnson', email: 'alice@example.com' },
+    },
+  },
 };
 
 const main = async () => {
-  const mathResult = await resolveParamValue(
-    { mode: 'expr', expression: 'nodeOutputs.trigger1.value * 2' },
+  const filteredProducts = await resolveParamValue(
+    { mode: 'expr', expression: 'steps.enrichment.recommendations[score > 0.9].product' },
     context as any
   );
-  assert.equal(mathResult, 42);
+  assert.deepEqual(filteredProducts, ['Premium Support']);
 
-  const stringResult = await resolveParamValue(
+  const triggerEmail = await resolveParamValue(
     {
       mode: 'expr',
-      expression: 'string.toUpperCase(nodeOutputs.trigger1.email.subject)',
+      expression: '$uppercase(trigger.opportunity.owner.email)',
     },
     context as any
   );
-  assert.equal(stringResult, 'HELLO WORLD');
+  assert.equal(triggerEmail, 'ALICE@EXAMPLE.COM');
 
-  const varsResult = await resolveParamValue(
+  const multipliedAmount = await resolveParamValue(
     {
       mode: 'expr',
-      expression: 'bonus + nodeOutputs.trigger1.value',
-      vars: { bonus: 9 },
+      expression: 'steps.salesforceOpportunity.amount * steps.enrichment.multiplier',
     },
     context as any
   );
-  assert.equal(varsResult, 30);
+  assert.equal(multipliedAmount, 6000);
+
+  const contextVariable = await resolveParamValue(
+    {
+      mode: 'expr',
+      expression: 'region',
+    },
+    context as any
+  );
+  assert.equal(contextVariable, 'EMEA');
 
   const fallbackResult = await resolveParamValue(
     {
       mode: 'expr',
-      expression: 'nodeOutputs.trigger1.value + ',
+      expression: 'steps.salesforceOpportunity.amount + ',
       fallback: 'expression-fallback',
     },
     context as any
   );
   assert.equal(fallbackResult, 'expression-fallback');
+
+  const schemaEvaluation = expressionEvaluator.evaluateDetailed(
+    'steps.salesforceOpportunity',
+    context as any
+  );
+  assert.equal(
+    schemaEvaluation.contextSchema?.properties?.steps?.properties?.salesforceOpportunity?.type,
+    'object'
+  );
+
+  const validationResult = expressionEvaluator.evaluateDetailed(
+    'steps.slackNotify.ts',
+    context as any,
+    { expectedResultSchema: { type: 'number' } }
+  );
+  assert.equal(validationResult.valid, false);
+  assert(validationResult.diagnostics.length > 0);
 
   console.log('Expression parameter resolution scenarios completed successfully.');
 };

--- a/shared/nodeGraphSchema.ts
+++ b/shared/nodeGraphSchema.ts
@@ -325,4 +325,7 @@ export interface ParameterContext {
   workflowId: string;
   userId?: string;
   executionId: string;
+  trigger?: any;
+  steps?: Record<string, any>;
+  variables?: Record<string, any>;
 }


### PR DESCRIPTION
## Summary
- replace the expression evaluator with a JSONata-inspired engine that supports array filtering, built-in functions, and JSON Schema inference for workflow context
- feed trigger, steps, and runtime variables into parameter resolution, logging schema diagnostics when validation fails
- expose richer metadata through the expression validation route and expand server-side tests to cover cross-step queries and fallbacks

## Testing
- `npx tsx server/core/__tests__/ParameterResolver.expr.test.ts` *(fails: npm registry 403 while attempting to execute tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e1573b9a44833188ae0794799d8520