### PR TITLE
Add resume token persistence and provider callback handling

### DIFF
--- a/migrations/0018_execution_resume_tokens.ts
+++ b/migrations/0018_execution_resume_tokens.ts
@@ -1,0 +1,47 @@
+import { sql } from 'drizzle-orm';
+
+type MigrationClient = { execute: (query: any) => Promise<unknown> };
+
+export async function up(db: MigrationClient): Promise<void> {
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "execution_resume_tokens" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "execution_id" uuid NOT NULL REFERENCES "workflow_executions"("id") ON DELETE CASCADE,
+      "workflow_id" uuid NOT NULL REFERENCES "workflows"("id") ON DELETE CASCADE,
+      "organization_id" uuid NOT NULL,
+      "node_id" text NOT NULL,
+      "user_id" uuid,
+      "token_hash" text NOT NULL UNIQUE,
+      "resume_state" jsonb NOT NULL,
+      "initial_data" jsonb,
+      "trigger_type" text NOT NULL DEFAULT 'callback',
+      "wait_until" timestamptz,
+      "metadata" jsonb,
+      "expires_at" timestamptz NOT NULL,
+      "consumed_at" timestamptz,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "updated_at" timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "execution_resume_tokens_execution_idx"
+    ON "execution_resume_tokens" ("execution_id")
+  `);
+
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "execution_resume_tokens_node_idx"
+    ON "execution_resume_tokens" ("node_id")
+  `);
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "execution_resume_tokens_expires_idx"
+    ON "execution_resume_tokens" ("expires_at")
+  `);
+}
+
+export async function down(db: MigrationClient): Promise<void> {
+  await db.execute(sql`DROP INDEX IF EXISTS "execution_resume_tokens_expires_idx"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "execution_resume_tokens_node_idx"`);
+  await db.execute(sql`DROP INDEX IF EXISTS "execution_resume_tokens_execution_idx"`);
+  await db.execute(sql`DROP TABLE IF EXISTS "execution_resume_tokens"`);
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1760000000000,
       "tag": "0017_connections_payload_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1760000001000,
+      "tag": "0018_execution_resume_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/server/core/WorkflowRuntime.ts
+++ b/server/core/WorkflowRuntime.ts
@@ -84,6 +84,12 @@ export interface ExecutionResult {
     idempotency?: Record<string, string>;
     request?: Record<string, string>;
   };
+  resumeState?: WorkflowResumeState | null;
+  waitingNode?: {
+    id: string;
+    label?: string;
+    type?: string;
+  } | null;
 }
 
 interface ConnectorCredentialResolution {
@@ -250,6 +256,16 @@ export class WorkflowRuntime {
                   scheduleResult.resumeAt
                 );
                 const executionTime = Date.now() - startTime.getTime();
+                const resumeState: WorkflowResumeState = {
+                  nodeOutputs: { ...context.outputs },
+                  prevOutput: context.prevOutput,
+                  remainingNodeIds: [...remainingNodeIds],
+                  nextNodeId: remainingNodeIds[0] ?? null,
+                  startedAt: context.startTime.toISOString(),
+                  idempotencyKeys: { ...context.idempotencyKeys },
+                  requestHashes: { ...context.requestHashes },
+                };
+
                 return {
                   success: true,
                   status: 'waiting',
@@ -261,6 +277,12 @@ export class WorkflowRuntime {
                   deterministicKeys: {
                     idempotency: { ...context.idempotencyKeys },
                     request: { ...context.requestHashes },
+                  },
+                  resumeState,
+                  waitingNode: {
+                    id: node.id,
+                    label: node.label,
+                    type: node.type,
                   },
                 };
               }

--- a/server/services/ExecutionResumeTokenService.ts
+++ b/server/services/ExecutionResumeTokenService.ts
@@ -1,0 +1,317 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+import { env } from '../env.js';
+import { db, executionResumeTokens } from '../database/schema.js';
+import { getErrorMessage } from '../types/common.js';
+import { and, eq, sql } from 'drizzle-orm';
+import type { WorkflowResumeState } from '../types/workflowTimers.js';
+
+type ResumeTokenRecord = {
+  id: string;
+  executionId: string;
+  workflowId: string;
+  organizationId: string;
+  nodeId: string;
+  userId?: string | null;
+  resumeState: WorkflowResumeState;
+  initialData: any;
+  triggerType?: string | null;
+  waitUntil?: Date | null;
+  metadata?: Record<string, any> | null;
+  expiresAt: Date;
+};
+
+type IssueTokenParams = {
+  executionId: string;
+  workflowId: string;
+  organizationId: string;
+  nodeId: string;
+  userId?: string | null;
+  resumeState: WorkflowResumeState;
+  initialData: any;
+  triggerType?: string | null;
+  waitUntil?: Date | null;
+  metadata?: Record<string, any> | null;
+  ttlMs?: number;
+};
+
+type ConsumeTokenParams = {
+  token: string;
+  signature?: string | null;
+  executionId?: string;
+  nodeId?: string;
+  organizationId?: string;
+};
+
+type ConsumedTokenResult = ResumeTokenRecord & {
+  tokenId: string;
+};
+
+const DEFAULT_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+class ExecutionResumeTokenService {
+  private static instance: ExecutionResumeTokenService;
+  private readonly memoryStore = new Map<string, ResumeTokenRecord>();
+  private readonly memoryIndex = new Map<string, string>();
+
+  private constructor() {}
+
+  public static getInstance(): ExecutionResumeTokenService {
+    if (!ExecutionResumeTokenService.instance) {
+      ExecutionResumeTokenService.instance = new ExecutionResumeTokenService();
+    }
+    return ExecutionResumeTokenService.instance;
+  }
+
+  private getBaseUrl(): string {
+    return env.SERVER_PUBLIC_URL || process.env.BASE_URL || 'http://localhost:5000';
+  }
+
+  private createToken(): string {
+    return randomBytes(32).toString('base64url');
+  }
+
+  private hashToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  private signToken(token: string): string {
+    const secret = env.JWT_SECRET || 'resume-token-secret';
+    return createHmac('sha256', secret).update(token).digest('hex');
+  }
+
+  private verifySignature(token: string, provided: string | undefined | null): boolean {
+    if (!provided) {
+      return false;
+    }
+    const expected = this.signToken(token);
+    try {
+      return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(provided, 'hex'));
+    } catch {
+      return false;
+    }
+  }
+
+  private buildCallbackUrl(executionId: string, nodeId: string, token: string, signature: string): string {
+    const base = this.getBaseUrl().replace(/\/$/, '');
+    const search = new URLSearchParams({ token, signature });
+    return `${base}/api/runs/${encodeURIComponent(executionId)}/nodes/${encodeURIComponent(nodeId)}/resume?${search.toString()}`;
+  }
+
+  private useMemoryStore(): boolean {
+    return !db;
+  }
+
+  private storeInMemory(record: ResumeTokenRecord & { token: string }): void {
+    this.memoryStore.set(record.id, record);
+    this.memoryIndex.set(this.hashToken(record.token), record.id);
+  }
+
+  private consumeFromMemory(params: ConsumeTokenParams): ConsumedTokenResult | null {
+    const now = Date.now();
+    const tokenHash = this.hashToken(params.token);
+    const recordId = this.memoryIndex.get(tokenHash);
+    if (!recordId) {
+      return null;
+    }
+    const stored = this.memoryStore.get(recordId);
+    if (!stored) {
+      this.memoryIndex.delete(tokenHash);
+      return null;
+    }
+    if (stored.expiresAt.getTime() <= now) {
+      this.memoryStore.delete(recordId);
+      this.memoryIndex.delete(tokenHash);
+      return null;
+    }
+    if (params.executionId && params.executionId !== stored.executionId) {
+      return null;
+    }
+    if (params.nodeId && params.nodeId !== stored.nodeId) {
+      return null;
+    }
+    if (params.organizationId && params.organizationId !== stored.organizationId) {
+      return null;
+    }
+    this.memoryStore.delete(recordId);
+    this.memoryIndex.delete(tokenHash);
+    return { ...stored, tokenId: recordId };
+  }
+
+  public async issueToken(
+    params: IssueTokenParams,
+  ): Promise<
+    | {
+        tokenId: string;
+        token: string;
+        signature: string;
+        callbackUrl: string;
+        expiresAt: Date;
+      }
+    | null
+  > {
+    const token = this.createToken();
+    const signature = this.signToken(token);
+    const tokenHash = this.hashToken(token);
+    const now = new Date();
+    const expiresAt = new Date(
+      now.getTime() + Math.max(60_000, params.ttlMs ?? DEFAULT_TOKEN_TTL_MS),
+    );
+
+    if (this.useMemoryStore()) {
+      const id = randomBytes(16).toString('hex');
+      this.storeInMemory({
+        id,
+        token,
+        executionId: params.executionId,
+        workflowId: params.workflowId,
+        organizationId: params.organizationId,
+        nodeId: params.nodeId,
+        userId: params.userId,
+        resumeState: params.resumeState,
+        initialData: params.initialData,
+        triggerType: params.triggerType ?? 'callback',
+        waitUntil: params.waitUntil ?? null,
+        metadata: params.metadata ?? null,
+        expiresAt,
+      });
+
+      return {
+        tokenId: id,
+        token,
+        signature,
+        callbackUrl: this.buildCallbackUrl(params.executionId, params.nodeId, token, signature),
+        expiresAt,
+      };
+    }
+
+    try {
+      const cleanupConditions = and(
+        eq(executionResumeTokens.executionId, params.executionId),
+        eq(executionResumeTokens.nodeId, params.nodeId),
+        sql`${executionResumeTokens.consumedAt} IS NULL`,
+      );
+
+      await db
+        .update(executionResumeTokens)
+        .set({
+          consumedAt: now,
+          updatedAt: now,
+        })
+        .where(cleanupConditions);
+
+      const [created] = await db
+        .insert(executionResumeTokens)
+        .values({
+          executionId: params.executionId,
+          workflowId: params.workflowId,
+          organizationId: params.organizationId,
+          nodeId: params.nodeId,
+          userId: params.userId ?? null,
+          tokenHash,
+          resumeState: params.resumeState,
+          initialData: params.initialData,
+          triggerType: params.triggerType ?? 'callback',
+          waitUntil: params.waitUntil ?? null,
+          metadata: params.metadata ?? null,
+          expiresAt,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning({ id: executionResumeTokens.id });
+
+      const tokenId = created?.id ?? randomBytes(16).toString('hex');
+
+      return {
+        tokenId,
+        token,
+        signature,
+        callbackUrl: this.buildCallbackUrl(params.executionId, params.nodeId, token, signature),
+        expiresAt,
+      };
+    } catch (error) {
+      console.error('Failed to persist execution resume token:', getErrorMessage(error));
+      return null;
+    }
+  }
+
+  public async consumeToken(params: ConsumeTokenParams): Promise<ConsumedTokenResult | null> {
+    if (!params.token) {
+      return null;
+    }
+    if (!this.verifySignature(params.token, params.signature ?? null)) {
+      return null;
+    }
+
+    if (this.useMemoryStore()) {
+      return this.consumeFromMemory(params);
+    }
+
+    try {
+      const tokenHash = this.hashToken(params.token);
+      const now = new Date();
+      const conditions = [
+        eq(executionResumeTokens.tokenHash, tokenHash),
+        sql`${executionResumeTokens.consumedAt} IS NULL`,
+        sql`${executionResumeTokens.expiresAt} > ${now}`,
+      ];
+      if (params.executionId) {
+        conditions.push(eq(executionResumeTokens.executionId, params.executionId));
+      }
+      if (params.nodeId) {
+        conditions.push(eq(executionResumeTokens.nodeId, params.nodeId));
+      }
+      if (params.organizationId) {
+        conditions.push(eq(executionResumeTokens.organizationId, params.organizationId));
+      }
+
+      const [updated] = await db
+        .update(executionResumeTokens)
+        .set({
+          consumedAt: now,
+          updatedAt: now,
+        })
+        .where(and(...conditions))
+        .returning({
+          id: executionResumeTokens.id,
+          executionId: executionResumeTokens.executionId,
+          workflowId: executionResumeTokens.workflowId,
+          organizationId: executionResumeTokens.organizationId,
+          nodeId: executionResumeTokens.nodeId,
+          userId: executionResumeTokens.userId,
+          resumeState: executionResumeTokens.resumeState,
+          initialData: executionResumeTokens.initialData,
+          triggerType: executionResumeTokens.triggerType,
+          waitUntil: executionResumeTokens.waitUntil,
+          metadata: executionResumeTokens.metadata,
+          expiresAt: executionResumeTokens.expiresAt,
+        });
+
+      if (!updated) {
+        return null;
+      }
+
+      return {
+        tokenId: updated.id,
+        executionId: updated.executionId,
+        workflowId: updated.workflowId,
+        organizationId: updated.organizationId,
+        nodeId: updated.nodeId,
+        userId: updated.userId ?? null,
+        resumeState: updated.resumeState as WorkflowResumeState,
+        initialData: updated.initialData,
+        triggerType: updated.triggerType,
+        waitUntil: updated.waitUntil ?? null,
+        metadata: (updated.metadata ?? {}) as Record<string, any>,
+        expiresAt: updated.expiresAt,
+      };
+    } catch (error) {
+      console.error('Failed to consume execution resume token:', getErrorMessage(error));
+      return null;
+    }
+  }
+}
+
+export const executionResumeTokenService = ExecutionResumeTokenService.getInstance();
+
+export type ExecutionResumeTokenServiceInstance = ExecutionResumeTokenService;

--- a/server/services/__tests__/ExecutionResumeTokenService.test.ts
+++ b/server/services/__tests__/ExecutionResumeTokenService.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/test';
+process.env.ENCRYPTION_MASTER_KEY = process.env.ENCRYPTION_MASTER_KEY || 'test-master-key';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret';
+process.env.NODE_ENV = 'test';
+
+const schemaModule = await import('../../database/schema.js');
+const { setDatabaseClientForTests, db } = schemaModule as { setDatabaseClientForTests: (client: any) => void; db: any };
+const originalDb = db;
+
+const { executionResumeTokenService } = await import('../ExecutionResumeTokenService.js');
+
+function createResumeState() {
+  return {
+    nodeOutputs: {},
+    prevOutput: null,
+    remainingNodeIds: [],
+    nextNodeId: null,
+    startedAt: new Date().toISOString(),
+    idempotencyKeys: {},
+    requestHashes: {},
+  };
+}
+
+setDatabaseClientForTests(null);
+
+try {
+  const issued = await executionResumeTokenService.issueToken({
+    executionId: 'exec-1',
+    workflowId: 'workflow-1',
+    organizationId: 'org-1',
+    nodeId: 'node-1',
+    userId: 'user-1',
+    resumeState: createResumeState(),
+    initialData: { foo: 'bar' },
+    triggerType: 'callback',
+    ttlMs: 10_000,
+  });
+
+  assert.ok(issued, 'token should be issued');
+  assert.ok(issued?.token.length, 'token should be non-empty');
+  assert.ok(issued?.signature.length, 'signature should be non-empty');
+  assert.ok(issued?.callbackUrl.includes('exec-1'), 'callback URL should include execution id');
+
+  const consumed = await executionResumeTokenService.consumeToken({
+    token: issued!.token,
+    signature: issued!.signature,
+    executionId: 'exec-1',
+    nodeId: 'node-1',
+  });
+
+  assert.ok(consumed, 'token should be consumable');
+  assert.equal(consumed?.executionId, 'exec-1');
+  assert.equal(consumed?.workflowId, 'workflow-1');
+  assert.equal(consumed?.nodeId, 'node-1');
+
+  const replay = await executionResumeTokenService.consumeToken({
+    token: issued!.token,
+    signature: issued!.signature,
+    executionId: 'exec-1',
+    nodeId: 'node-1',
+  });
+
+  assert.equal(replay, null, 'consumed token should not be reusable');
+  console.log('ExecutionResumeTokenService fallback test passed.');
+} finally {
+  setDatabaseClientForTests(originalDb);
+}

--- a/server/webhooks/__tests__/WebhookManager.persistence.test.ts
+++ b/server/webhooks/__tests__/WebhookManager.persistence.test.ts
@@ -297,7 +297,10 @@ WebhookManager.setQueueServiceForTests({
   enqueue: async (req: any) => {
     queueCalls.push(req);
     return { executionId: 'exec-123' };
-  }
+  },
+  enqueueResume: async () => {
+    throw new Error('resume should not be invoked in this test');
+  },
 });
 
 const handled = await managerAfterRestart.handleWebhook(webhookId, { hello: 'world' }, { 'x-test': '1' });

--- a/server/webhooks/__tests__/WebhookManager.verification.test.ts
+++ b/server/webhooks/__tests__/WebhookManager.verification.test.ts
@@ -178,6 +178,9 @@ async function createManager(options: { allowQueue?: boolean } = {}): Promise<Te
       }
       return { executionId: `exec-${queueCalls.length}` };
     },
+    enqueueResume: async () => {
+      throw new Error('resume should not be invoked during this test');
+    },
   });
 
   const manager = WebhookManager.getInstance();


### PR DESCRIPTION
## Summary
- add an `execution_resume_tokens` table and service to issue/consume signed resume tokens for waiting executions
- update the queue worker, API routes, and webhook manager to persist tokens, expose callback metadata, and resume runs from provider callbacks
- cover the resume token flow with a targeted service test and supporting migrations

## Testing
- npx tsx server/services/__tests__/ExecutionResumeTokenService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e15e71c53c8331b4a6920c990c041c