### PR TITLE
Add workflow execution step logs and diagnostics support

### DIFF
--- a/client/src/components/workflow/__tests__/RunViewer.diagnostics.test.tsx
+++ b/client/src/components/workflow/__tests__/RunViewer.diagnostics.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor, within, fireEvent, cleanup } from '@testing-library/react';
+import React from 'react';
+
+import { RunViewer } from '../RunViewer';
+
+const sampleExecution = {
+  executionId: 'exec-1',
+  workflowId: 'wf-1',
+  workflowName: 'Test Workflow',
+  organizationId: 'org-1',
+  userId: 'user-1',
+  status: 'succeeded' as const,
+  startTime: new Date().toISOString(),
+  endTime: new Date().toISOString(),
+  duration: 1234,
+  triggerType: 'manual',
+  triggerData: null,
+  totalNodes: 1,
+  completedNodes: 1,
+  failedNodes: 0,
+  nodeExecutions: [
+    {
+      nodeId: 'node-1',
+      nodeType: 'action',
+      nodeLabel: 'Test Node',
+      status: 'succeeded' as const,
+      startTime: new Date().toISOString(),
+      endTime: new Date().toISOString(),
+      duration: 250,
+      attempt: 1,
+      maxAttempts: 3,
+      input: { foo: 'bar' },
+      output: { result: 'ok' },
+      error: undefined,
+      correlationId: 'corr-1',
+      retryHistory: [] as any[],
+      metadata: {} as Record<string, any>,
+      timeline: [] as Array<Record<string, any>>,
+    },
+  ],
+  finalOutput: null,
+  error: null,
+  correlationId: 'corr-1',
+  tags: [] as string[],
+  timeline: [] as Array<Record<string, any>>,
+  metadata: {
+    retryCount: 0,
+    totalCostUSD: 0,
+    totalTokensUsed: 0,
+    cacheHitRate: 0,
+    averageNodeDuration: 0,
+    openCircuitBreakers: [] as any[],
+  },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function mockFetch(detailResponse: any, detailStatus = 200) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+    if (url.startsWith('/api/executions?')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, executions: [sampleExecution] }),
+      } as unknown as Response);
+    }
+
+    if (url === '/api/executions/exec-1') {
+      return Promise.resolve({
+        ok: detailStatus >= 200 && detailStatus < 300,
+        status: detailStatus,
+        json: async () => detailResponse,
+      } as unknown as Response);
+    }
+
+    if (url.startsWith('/api/workflows/')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, events: [] }),
+      } as unknown as Response);
+    }
+
+    if (url.startsWith('/api/admin/executions')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, entries: [] }),
+      } as unknown as Response);
+    }
+
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true }),
+    } as unknown as Response);
+  });
+}
+
+describe('RunViewer execution diagnostics', () => {
+  it('renders logs, stdout, and diagnostics when execution details load', async () => {
+    mockFetch({
+      success: true,
+      execution: {
+        nodeResults: {
+          'node-1': {
+            output: { value: 42, stdout: 'hello world' },
+            logs: ['line one', 'line two'],
+            diagnostics: { branch: 'success' },
+          },
+        },
+      },
+    });
+
+    render(<RunViewer />);
+
+    const nodeLabels = await screen.findAllByText('Test Node');
+    const nodeHeader = nodeLabels[0].parentElement?.parentElement?.parentElement as HTMLElement | null;
+    expect(nodeHeader).not.toBeNull();
+    expect(nodeHeader?.className).toContain('cursor-pointer');
+    fireEvent.click(nodeHeader!);
+
+    const nodeCard = nodeHeader!.parentElement as HTMLElement;
+    await within(nodeCard).findByRole('button', { name: /copy output/i });
+    const inspectButton = await within(nodeCard).findByRole('button', { name: /inspect/i });
+    fireEvent.click(inspectButton);
+
+    await waitFor(() => expect(within(nodeCard).getByText('line one')).toBeInTheDocument());
+    expect(within(nodeCard).getByText('line two')).toBeInTheDocument();
+    expect(within(nodeCard).getByText('Stdout', { selector: 'div' })).toBeInTheDocument();
+    expect(within(nodeCard).getByText('hello world')).toBeInTheDocument();
+    expect(within(nodeCard).getByText(/branch/i)).toBeInTheDocument();
+  });
+
+  it('shows an error message when execution details cannot be loaded', async () => {
+    mockFetch({ success: false, error: 'details unavailable' });
+
+    render(<RunViewer />);
+
+    const nodeLabels = await screen.findAllByText('Test Node');
+    const nodeHeader = nodeLabels[0].parentElement?.parentElement?.parentElement as HTMLElement | null;
+    expect(nodeHeader).not.toBeNull();
+    expect(nodeHeader?.className).toContain('cursor-pointer');
+    fireEvent.click(nodeHeader!);
+
+    const nodeCard = nodeHeader!.parentElement as HTMLElement;
+    await within(nodeCard).findByRole('button', { name: /copy output/i });
+    const inspectButton = await within(nodeCard).findByRole('button', { name: /inspect/i });
+    fireEvent.click(inspectButton);
+
+    await waitFor(() => expect(screen.getByText('details unavailable')).toBeInTheDocument());
+  });
+});

--- a/migrations/0021_workflow_execution_step_logs.ts
+++ b/migrations/0021_workflow_execution_step_logs.ts
@@ -1,0 +1,19 @@
+import { sql } from 'drizzle-orm';
+
+type MigrationClient = { execute: (query: any) => Promise<unknown> };
+
+export async function up(db: MigrationClient): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "workflow_execution_steps"
+    ADD COLUMN IF NOT EXISTS "logs" jsonb,
+    ADD COLUMN IF NOT EXISTS "diagnostics" jsonb
+  `);
+}
+
+export async function down(db: MigrationClient): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "workflow_execution_steps"
+    DROP COLUMN IF EXISTS "logs",
+    DROP COLUMN IF EXISTS "diagnostics"
+  `);
+}

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -758,6 +758,8 @@ export const workflowExecutionSteps = pgTable(
     resumeState: jsonb('resume_state').$type<WorkflowResumeState | null>().default(null),
     waitUntil: timestamp('wait_until'),
     metadata: jsonb('metadata').$type<Record<string, any> | null>().default(null),
+    logs: jsonb('logs').$type<any | null>().default(null),
+    diagnostics: jsonb('diagnostics').$type<Record<string, any> | null>().default(null),
   },
   (table) => ({
     executionNodeIdx: uniqueIndex('workflow_execution_steps_execution_node_idx').on(

--- a/server/services/ExecutionQueueService.ts
+++ b/server/services/ExecutionQueueService.ts
@@ -1422,9 +1422,15 @@ class ExecutionQueueService {
       }
 
       const stepOutput = result.nodeOutputs?.[nodeId] ?? null;
+      const outputObject =
+        stepOutput && typeof stepOutput === 'object' && !Array.isArray(stepOutput)
+          ? (stepOutput as Record<string, any>)
+          : null;
       await WorkflowExecutionStepRepository.markCompleted({
         stepId,
         output: stepOutput,
+        logs: outputObject?.logs ?? null,
+        diagnostics: (outputObject?.diagnostics as Record<string, any> | null | undefined) ?? null,
         deterministicKeys: result.deterministicKeys ?? null,
         metadata: {
           executionTime: result.executionTime,
@@ -1512,6 +1518,8 @@ class ExecutionQueueService {
         error: { error: errorMessage },
         metadata: { attempt: attemptNumber },
         finalFailure,
+        logs: null,
+        diagnostics: null,
       });
 
       if (finalFailure) {

--- a/server/workflow/WorkflowExecutionStepRepository.ts
+++ b/server/workflow/WorkflowExecutionStepRepository.ts
@@ -43,6 +43,8 @@ interface MarkStepCompletedParams {
   output: any;
   deterministicKeys?: Record<string, any> | null;
   metadata?: Record<string, any> | null;
+  logs?: any | null;
+  diagnostics?: Record<string, any> | null;
 }
 
 interface MarkStepFailedParams {
@@ -50,6 +52,8 @@ interface MarkStepFailedParams {
   error: Record<string, any> | null;
   metadata?: Record<string, any> | null;
   finalFailure?: boolean;
+  logs?: any | null;
+  diagnostics?: Record<string, any> | null;
 }
 
 interface MarkStepWaitingParams {
@@ -87,6 +91,8 @@ export class WorkflowExecutionStepRepository {
         input: null,
         output: null,
         error: null,
+        logs: null,
+        diagnostics: null,
         deterministicKeys: null,
         resumeState: null,
         waitUntil: null,
@@ -241,6 +247,8 @@ export class WorkflowExecutionStepRepository {
         output: params.output ?? null,
         deterministicKeys: params.deterministicKeys ?? null,
         metadata: params.metadata ?? null,
+        logs: params.logs ?? null,
+        diagnostics: params.diagnostics ?? null,
         error: null,
         waitUntil: null,
         resumeState: null,
@@ -260,6 +268,8 @@ export class WorkflowExecutionStepRepository {
         updatedAt: new Date(),
         error: params.error ?? null,
         metadata: params.metadata ?? null,
+        logs: params.logs ?? null,
+        diagnostics: params.diagnostics ?? null,
         waitUntil: null,
         resumeState: null,
       })


### PR DESCRIPTION
## Summary
- add a migration and schema updates for workflow execution step logs and diagnostics fields
- capture logs and diagnostics when marking steps completed or failed and expose them via getExecutionById
- surface execution logs, stdout, and diagnostics in the RunViewer UI with new tests covering success and error states

## Testing
- `npx vitest run client/src/components/workflow/__tests__/RunViewer.diagnostics.test.tsx --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68e1fa34bcfc8331bcf6290d12e3aaa1