### PR TITLE
Add inline worker startup and heartbeat health probe

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -48,6 +48,27 @@ The default configuration in `.env.example` assumes PostgreSQL and Redis are run
   processing components (scheduler + execution worker) online alongside the API.
 - Consult `docs/operations/queue.md` if you need advanced Redis/BullMQ tuning.
 
+### Multi-process vs. inline worker flows
+
+Local developers can now choose between a dedicated worker topology or a single-process "inline"
+mode when booting the stack:
+
+1. **Multi-process (recommended for parity with production)**
+   - Start the API: `npm run dev:api`
+   - In a second terminal, start the scheduler: `npm run dev:scheduler`
+   - In a third terminal, run the execution worker: `npm run dev:worker`
+   - Optional: `npm run dev:rotation` or `npm run dev:stack` to supervise all of the above in one
+     shell.
+   This mirrors the production Procfile entries so you can observe queue depth and worker logs
+   independently.
+
+2. **Inline worker (single terminal)**
+   - Export `ENABLE_INLINE_WORKER=true` (or set it in `.env.development`).
+   - Run `npm run dev:api`.
+   When the flag is present, the API boot sequence automatically starts the execution worker inside
+   the same Node process. This is convenient for quick smoke tests when you do not need separate
+   worker logs. Turn the flag off to return to the dedicated worker model.
+
 Shut the stack down with:
 
 ```bash

--- a/docs/operations/queue.md
+++ b/docs/operations/queue.md
@@ -52,6 +52,25 @@ docker run --env WORKER_SCRIPT=start:timers my-org/automation-worker
 This tri-process topology keeps queue responsibilities isolated across dedicated containers while
 sharing the same build artifacts.
 
+### Launch sequencing
+
+For predictable queue behaviour, launch production processes in the following order:
+
+1. `npm run start:api` (or the API container/Procfile entry)
+2. `npm run start:scheduler`
+3. `npm run start:worker`
+4. `npm run start:timers`
+
+Starting the scheduler before the worker is acceptable, but the worker must be online before queue
+backlog grows. The [`/api/health/queue/heartbeat`](../../server/routes/production-health.ts) probe
+confirms that the worker heartbeat is current and the queue depth is draining.
+
+If you prefer to co-locate everything inside the API process for a lightweight environment, export
+`ENABLE_INLINE_WORKER=true` (or `INLINE_EXECUTION_WORKER=true`) before starting the server. The API
+boot sequence will start `executionQueueService` inline and expose the same health endpoints without
+requiring the dedicated worker container. Unset the flag to return to the recommended multi-process
+deployment.
+
 ## Local development with Docker Compose
 
 A minimal Redis instance suitable for local queue development can be started with Docker Compose:


### PR DESCRIPTION
## Summary
- start the execution queue inline when ENABLE_INLINE_WORKER (or INLINE_EXECUTION_WORKER) is set while keeping external workers supported
- expose a /api/health/queue/heartbeat probe that reports worker heartbeat freshness, queue depth, and inline mode status
- document multi-process launch ordering and the new inline option in the local development and operations guides

## Testing
- `npm run check` *(fails: existing TypeScript errors throughout client/server codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68e1fab25f248331b4f9c0a38493f1c2