### PR TITLE
Enforce worker heartbeat during dev startup

### DIFF
--- a/docs/operations/queue.md
+++ b/docs/operations/queue.md
@@ -66,10 +66,10 @@ backlog grows. The [`/api/health/queue/heartbeat`](../../server/routes/productio
 confirms that the worker heartbeat is current and the queue depth is draining.
 
 If you prefer to co-locate everything inside the API process for a lightweight environment, export
-`ENABLE_INLINE_WORKER=true` (or `INLINE_EXECUTION_WORKER=true`) before starting the server. The API
-boot sequence will start `executionQueueService` inline and expose the same health endpoints without
-requiring the dedicated worker container. Unset the flag to return to the recommended multi-process
-deployment.
+`ENABLE_INLINE_WORKER=true` (or `INLINE_EXECUTION_WORKER=true`) before starting the server. In
+development this flag now defaults to `true` when unset so local API boots automatically start the
+execution worker inline. Set `ENABLE_INLINE_WORKER=false` (or
+`DISABLE_INLINE_WORKER_AUTOSTART=true`) to return to the recommended multi-process deployment.
 
 ## Local development with Docker Compose
 

--- a/scripts/dev-stack.ts
+++ b/scripts/dev-stack.ts
@@ -65,9 +65,17 @@ async function main() {
 
   const exitPromises = scriptsToRun.map((script) => {
     return new Promise<void>((resolve) => {
+      const childEnv = { ...process.env };
+      if (script === 'dev:api') {
+        if (!('ENABLE_INLINE_WORKER' in childEnv)) {
+          childEnv.ENABLE_INLINE_WORKER = 'false';
+        }
+        childEnv.DISABLE_INLINE_WORKER_AUTOSTART = 'true';
+      }
+
       const child = spawn(npmCommand, ['run', script], {
         stdio: 'inherit',
-        env: { ...process.env },
+        env: childEnv,
       });
 
       const managed: ManagedProcess = { script, child };


### PR DESCRIPTION
## Summary
- default the API to start the execution worker inline in development unless explicitly disabled
- publish execution-worker heartbeats to Redis and fail development/CI startup when no worker heartbeat is detected
- document the new workflow expectations and ensure the dev stack script disables the inline auto-start when dedicated workers run

## Testing
- npm run check *(fails: existing type errors in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e22eedc870833185cffe3f716340ff