### PR TITLE
Capture raw webhook bodies for signature verification

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -37,8 +37,26 @@ app.use((req, res, next) => {
   runWithRequestContext({ requestId: reqId }, () => next());
 });
 
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
+const jsonParser = express.json();
+const urlencodedParser = express.urlencoded({ extended: false });
+
+const shouldBypassStandardBodyParsers = (req: Request): boolean => {
+  return req.path.startsWith('/api/webhooks');
+};
+
+app.use((req, res, next) => {
+  if (shouldBypassStandardBodyParsers(req)) {
+    return next();
+  }
+  return jsonParser(req, res, next);
+});
+
+app.use((req, res, next) => {
+  if (shouldBypassStandardBodyParsers(req)) {
+    return next();
+  }
+  return urlencodedParser(req, res, next);
+});
 
 app.use((req, res, next) => {
   const routeSnapshot = req.path;

--- a/server/webhooks/WebhookManager.ts
+++ b/server/webhooks/WebhookManager.ts
@@ -529,7 +529,7 @@ export class WebhookManager {
     webhook: WebhookTrigger,
     event: TriggerEvent,
     headers: Record<string, string>,
-    rawBody: string | undefined,
+    rawBody: string | Buffer | undefined,
     config: SignatureEnforcementConfig | null
   ): Promise<boolean> {
     const secret = webhook.secret ?? '';
@@ -756,7 +756,12 @@ export class WebhookManager {
   /**
    * Handle incoming webhook request
    */
-  async handleWebhook(webhookId: string, payload: any, headers: Record<string, string>, rawBody?: string): Promise<boolean> {
+  async handleWebhook(
+    webhookId: string,
+    payload: any,
+    headers: Record<string, string>,
+    rawBody?: string | Buffer,
+  ): Promise<boolean> {
     try {
       await this.ready;
 


### PR DESCRIPTION
## Summary
- bypass the default body parsers for /api/webhooks requests so the raw payload buffer is preserved before JSON parsing
- pass buffered webhook payloads through to the webhook manager and extend signature verification to accept Buffer inputs
- cover Stripe and Slack webhook flows with signed payload tests to confirm raw body capture and verification success

## Testing
- npx tsx server/routes/__tests__/webhooks.signature-handlers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e24b8fb9648331822f929fb7592cce