### PR TITLE
Enhance queue readiness guardrails and documentation

### DIFF
--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -20,7 +20,8 @@ During local development `npm run dev:stack` now polls this endpoint and termina
 
 ### `GET /api/production/queue/heartbeat`
 
-Use this endpoint to observe the execution worker heartbeat and queue depth in detail.
+Use this endpoint to observe the execution worker heartbeat and queue depth in detail. Production runbooks should hit this probe
+before and after each deployment to ensure the queue is draining and workers are emitting timely heartbeats.
 
 * When the dedicated worker is offline (no heartbeat observed), the probe returns HTTP 503 with `status.status: "fail"` and the message `Execution worker has not been started. Queue processing is offline.`【F:server/routes/production-health.ts†L228-L267】
 * When Redis is reachable but reports a queue failure (for example, authentication issues), the heartbeat endpoint surfaces the queue health failure message and also returns HTTP 503.【F:server/routes/production-health.ts†L236-L242】
@@ -36,7 +37,7 @@ Use this endpoint to observe the execution worker heartbeat and queue depth in d
   curl -fsS "${API_ORIGIN:-http://localhost:5000}/api/production/ready" \
     | jq '{ready: .ready, queueReady: .checks.queue, queueMessage: .checks.queueDetails.message}'
   ```
-* Inspect the worker heartbeat and backlog:
+* Inspect the worker heartbeat and backlog (recommended pre- and post-deploy runbook step):
   ```bash
   curl -fsS "${API_ORIGIN:-http://localhost:5000}/api/production/queue/heartbeat" \
     | jq '{status: .status.status, message: .status.message, latestHeartbeatAt: .worker.latestHeartbeatAt, queueDepths: .queueDepths}'

--- a/docs/operations/secret-management.md
+++ b/docs/operations/secret-management.md
@@ -19,6 +19,23 @@ Each referenced secret should resolve to a JSON object (e.g. `{"OPENAI_API_KEY":
 containing the desired key/value pairs. Non-JSON secrets fall back to a single key derived
 from the secret name.
 
+When provisioning Redis for BullMQ, store the following keys in the same secret payload so they hydrate into the runtime
+environment alongside your API credentials:
+
+```json
+{
+  "QUEUE_REDIS_HOST": "redis.production.example.com",
+  "QUEUE_REDIS_PORT": "6379",
+  "QUEUE_REDIS_DB": "0",
+  "QUEUE_REDIS_USERNAME": "queue-user",
+  "QUEUE_REDIS_PASSWORD": "super-secure-password",
+  "QUEUE_REDIS_TLS": "true"
+}
+```
+
+The loader honours per-region overrides (`QUEUE_REDIS_<REGION>_*`) if you provide multi-tenant secrets; export values for every
+region that needs a dedicated Redis endpoint.
+
 AWS credentials are resolved from the ambient environment variables
 (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`). When running on
 managed infrastructure (EKS, ECS, Lambda, etc.) assign an IAM role with `secretsmanager:GetSecretValue`

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "start:timers": "NODE_ENV=production node dist/workers/timerDispatcher.js",
     "start:rotation": "NODE_ENV=production node dist/workers/encryption-rotation.js",
     "check": "tsc",
+    "check:queue": "tsx scripts/check-queue-readiness.ts",
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
     "lint": "npm run check && tsx scripts/check-connector-parity.ts && tsx scripts/validate-connector-ops.ts && tsx scripts/validate-procfile.ts",

--- a/production/deployment-checklist.md
+++ b/production/deployment-checklist.md
@@ -105,6 +105,19 @@ GEMINI_API_KEY=your-production-gemini-key
 JWT_SECRET=your-secure-jwt-secret-32-chars-minimum
 BCRYPT_ROUNDS=12
 
+# Queue (BullMQ via Redis)
+QUEUE_REDIS_HOST=redis.production.example.com
+QUEUE_REDIS_PORT=6379
+QUEUE_REDIS_DB=0
+QUEUE_REDIS_USERNAME=queue-user
+QUEUE_REDIS_PASSWORD=super-secure-password
+QUEUE_REDIS_TLS=true
+
+# Queue validation (run before routing traffic)
+npm run check:queue
+curl -fsS "${API_ORIGIN:-https://api.yourdomain.com}/api/production/queue/heartbeat" \
+  | jq '{status: .status.status, message: .status.message, queueDepths: .queueDepths}'
+
 # Performance
 MAX_CONCURRENT_BUILDS=10
 BUILD_TIMEOUT_MS=300000

--- a/production/environment-config.ts
+++ b/production/environment-config.ts
@@ -125,8 +125,8 @@ REDIS_URL=redis://localhost:6379
 QUEUE_REDIS_HOST=redis.production.example.com
 QUEUE_REDIS_PORT=6379
 QUEUE_REDIS_DB=0
-# QUEUE_REDIS_USERNAME=your-redis-username
-# QUEUE_REDIS_PASSWORD=your-redis-password
+QUEUE_REDIS_USERNAME=queue-user
+QUEUE_REDIS_PASSWORD=super-secure-password
 QUEUE_REDIS_TLS=true
 ELASTICSEARCH_URL=http://localhost:9200
 

--- a/scripts/check-queue-readiness.ts
+++ b/scripts/check-queue-readiness.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env tsx
+import { env } from '../server/env';
+import { assertQueueIsReady, checkQueueHealth, getRedisTargetLabel } from '../server/services/QueueHealthService';
+
+async function main(): Promise<void> {
+  try {
+    await assertQueueIsReady({ context: 'CI queue readiness check' });
+    const status = await checkQueueHealth();
+    const target = getRedisTargetLabel();
+    const environment = env.NODE_ENV ?? process.env.NODE_ENV ?? 'unknown';
+    const latency = typeof status.latencyMs === 'number' ? `${status.latencyMs}ms` : 'n/a';
+    console.log(`✅ Queue readiness confirmed at ${target} (latency=${latency}, env=${environment}).`);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error.message);
+      if (error.cause instanceof Error) {
+        console.error(`Caused by: ${error.cause.message}`);
+      }
+    } else {
+      console.error('Queue readiness check failed:', error);
+    }
+    process.exit(1);
+  }
+}
+
+void main();


### PR DESCRIPTION
## Summary
- add explicit Redis queue configuration placeholders to production environment templates, deployment docs, and secret-store guidance so deployments align with server/env.ts defaults
- improve queue readiness diagnostics by surfacing Redis targets, remediation hints, and invoking the check during API startup; provide a CLI helper for CI pipelines
- update monitoring runbooks to require the /api/production/queue/heartbeat probe before and after deployments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2520eb8a483318a06b3cdefc0f8ac