### PR TITLE
Handle broken connection decrypt failures gracefully

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,9 @@
   - GET /api/admin/executions
   - GET /api/connections/usage
   - GET /api/schema/export
+- Connections
+  - GET /api/connections
+    - Returns `{ success, connections, problems }`. `problems` is an array of entries shaped like `{ id, provider, name, status: 'BROKEN_DECRYPT', error }` when credential decryption fails so clients can surface issues without crashing.
 - Recipes
   - docs/recipes/slack-on-stripe-payment.md
   - docs/recipes/hubspot-contact-from-typeform.md

--- a/server/routes/google-sheets.ts
+++ b/server/routes/google-sheets.ts
@@ -32,7 +32,7 @@ router.get(
     }
 
     try {
-      const connections = await connectionService.getUserConnections(userId, organizationId);
+      const { connections } = await connectionService.getUserConnections(userId, organizationId);
       const sheetsConnection = connections.find((conn) => {
         const provider = (conn.provider || "").toLowerCase();
         return provider.includes("sheet");

--- a/server/services/HealthMonitoringService.ts
+++ b/server/services/HealthMonitoringService.ts
@@ -407,7 +407,10 @@ export class HealthMonitoringService {
     
     try {
       // Test if we can create connections (this would test the service)
-      const testResult = await connectionService.getUserConnections('health-check-user', 'health-check-org');
+      const { connections: testResult } = await connectionService.getUserConnections(
+        'health-check-user',
+        'health-check-org'
+      );
       
       const responseTime = Date.now() - startTime;
       

--- a/server/services/__tests__/ConnectionService.encryption.test.ts
+++ b/server/services/__tests__/ConnectionService.encryption.test.ts
@@ -108,8 +108,12 @@ assert.equal(
   'provider lookup exposes payload IV'
 );
 
-const allConnections = await service.getUserConnections('user-123', 'org-123', 'openai');
+const {
+  connections: allConnections,
+  problems: roundTripProblems,
+} = await service.getUserConnections('user-123', 'org-123', 'openai');
 assert.equal(allConnections.length, 1, 'user should have one connection after creation');
+assert.equal(roundTripProblems.length, 0, 'round trip should not surface decrypt problems');
 assert.equal(allConnections[0].iv, storedRecords[0].iv, 'list entries expose iv');
 assert.deepEqual(allConnections[0].credentials, originalCredentials, 'list entries decrypt credentials');
 assert.equal(allConnections[0].encryptionKeyId ?? null, null, 'list entries expose encryptionKeyId');


### PR DESCRIPTION
## Summary
- add structured problem reporting to `ConnectionService.getUserConnections` and surface BROKEN_DECRYPT placeholders without aborting the response
- propagate the new `problems` metadata to API consumers and update docs so front-end clients can gracefully flag bad connections
- extend service tests to cover degraded responses alongside existing encryption round-trips

## Testing
- npx tsx server/services/__tests__/ConnectionService.test.ts *(hangs in this environment after logging completion; interrupted manually once output was verified)*
- npx tsx server/services/__tests__/ConnectionService.encryption.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68e345e7e9c08331a808af8fd782fab6