### PR TITLE
Add queue readiness gating to workflow run actions

### DIFF
--- a/client/src/hooks/useQueueHealth.ts
+++ b/client/src/hooks/useQueueHealth.ts
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useAuthStore } from '@/store/authStore';
+
+export type QueueHealthStatus = {
+  status: 'pass' | 'fail';
+  durable: boolean;
+  message: string;
+  latencyMs: number | null;
+  checkedAt: string;
+  error?: string;
+};
+
+export type QueueHealthState = {
+  queueHealth: QueueHealthStatus | null;
+  isQueueReady: boolean;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+};
+
+const POLL_INTERVAL_MS = 30000;
+
+const normalizeQueueHealth = (raw: any): QueueHealthStatus => {
+  const status = raw?.status === 'pass' ? 'pass' : 'fail';
+  const durable = Boolean(raw?.durable);
+  const message =
+    typeof raw?.message === 'string' && raw.message.trim().length > 0
+      ? raw.message
+      : 'Start worker & scheduler processes to run workflows';
+  const latency = typeof raw?.latencyMs === 'number' && Number.isFinite(raw.latencyMs)
+    ? raw.latencyMs
+    : null;
+  const checkedAt = typeof raw?.checkedAt === 'string' && raw.checkedAt
+    ? raw.checkedAt
+    : new Date().toISOString();
+  const error = typeof raw?.error === 'string' ? raw.error : undefined;
+
+  return {
+    status,
+    durable,
+    message,
+    latencyMs: latency,
+    checkedAt,
+    error,
+  };
+};
+
+export function useQueueHealth(options: { poll?: boolean; intervalMs?: number } = {}): QueueHealthState {
+  const { poll = true, intervalMs = POLL_INTERVAL_MS } = options;
+  const authFetch = useAuthStore((state) => state.authFetch);
+  const [queueHealth, setQueueHealth] = useState<QueueHealthStatus | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const fetchHealth = useCallback(async () => {
+    setIsLoading((prev) => (queueHealth ? prev : true));
+    try {
+      const response = await authFetch('/api/health/queue');
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      const payload = (await response.json().catch(() => ({}))) as any;
+      const data = payload?.data ?? payload?.queue ?? payload;
+      const normalized = normalizeQueueHealth(data ?? {});
+
+      if (!mountedRef.current) {
+        return;
+      }
+
+      setQueueHealth(normalized);
+      setError(null);
+    } catch (caught: any) {
+      if (!mountedRef.current) {
+        return;
+      }
+      const message = caught?.message || 'Unable to load queue health';
+      setError(message);
+      setQueueHealth((prev) => prev);
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [authFetch, queueHealth]);
+
+  useEffect(() => {
+    void fetchHealth();
+    if (!poll) {
+      return undefined;
+    }
+
+    const interval = window.setInterval(() => {
+      void fetchHealth();
+    }, intervalMs);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [fetchHealth, poll, intervalMs]);
+
+  const isQueueReady = useMemo(() => {
+    return Boolean(queueHealth && queueHealth.status === 'pass' && queueHealth.durable);
+  }, [queueHealth]);
+
+  return {
+    queueHealth,
+    isQueueReady,
+    isLoading,
+    error,
+    refresh: fetchHealth,
+  };
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1254,6 +1254,15 @@ export async function registerRoutes(app: Express): Promise<void> {
     }
   });
 
+  app.get('/api/health/queue', async (_req, res) => {
+    try {
+      const status = await checkQueueHealth();
+      res.json({ success: true, data: status });
+    } catch (error) {
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  });
+
   // Export connector schemas (all or by appId)
   app.get('/api/schema/export', async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- expose a GET /api/health/queue endpoint for clients that need live queue readiness
- add a reusable useQueueHealth hook and wire the professional and n8n-style builders to poll queue health, disable their run actions, and surface worker tooltips
- run lightweight graph validation ahead of execution to flag missing connections/functions inline and extend the validation test suite for queue failures

## Testing
- npx vitest run client/src/components/workflow/__tests__/ProfessionalGraphEditor.validation.test.tsx *(fails: registry access forbidden in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e49daa4128833199ca6ed23a7dbbbc