### PR TITLE
feat: strengthen queue orchestration and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ redis-server --daemonize yes
 npm run dev:stack
 ```
 
-`dev:stack` runs `drizzle-kit push`, verifies Redis availability, and starts:
+`dev:stack` runs `drizzle-kit push`, verifies Redis and Postgres connectivity up front, and starts:
 
 - `npm run dev:api`
 - `npm run dev:worker`
 - `npm run dev:scheduler`
+- `npm run dev:timers`
 - `npm run dev:rotation`
 
 Inline worker is disabled in this mode, so queue health maps to the dedicated worker process.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -106,6 +106,38 @@ services:
       jaeger:
         condition: service_started
 
+  timers:
+    image: node:22
+    working_dir: /app
+    command: npm run dev:timers
+    environment:
+      <<: *node-environment
+    volumes:
+      - .:/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      jaeger:
+        condition: service_started
+
+  encryption-rotation:
+    image: node:22
+    working_dir: /app
+    command: npm run dev:rotation
+    environment:
+      <<: *node-environment
+    volumes:
+      - .:/app
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      jaeger:
+        condition: service_started
+
 volumes:
   postgres-data:
   redis-data:

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -29,3 +29,33 @@
 
   - Use a process supervisor (systemd, PM2, etc.) to restart the web and worker processes and to forward `SIGTERM` for graceful shutdowns.
   - Both processes require the same environment (DATABASE_URL, API keys). Workers will drain in-flight jobs before exiting.
+
+## Platform-specific process manifests
+
+### Heroku
+
+- The root [`Procfile`](../Procfile) declares **five** dyno types: `web`, `worker`, `scheduler`, `timers`, and `encryption-rotation`. Provision one dyno for each so background jobs, timers, and key-rotation jobs continue to run during deploys.【F:Procfile†L1-L5】
+- Add a [release phase](https://devcenter.heroku.com/articles/release-phase) that runs `npm run check:queue` followed by `curl -fsS "$APP_URL/api/production/queue/heartbeat" | jq -e '.status.status == "pass"'` to fail the deploy if Redis or the worker heartbeat is unavailable.【F:scripts/ci-smoke.ts†L32-L58】【F:docs/operations/monitoring.md†L33-L58】
+- Use Heroku Redis or point `QUEUE_REDIS_*` at an external instance; the API exits on startup when Redis is unreachable.【F:scripts/dev-stack.ts†L111-L160】
+
+### Render
+
+- Mirror the Procfile by creating one Web Service (API) and four Background Services (worker, scheduler, timers, encryption-rotation). Each service shares the same environment block so Redis credentials remain consistent.【F:docker-compose.dev.yml†L4-L86】
+- Add a Render Health Check for `/api/production/queue/heartbeat` to each background service so the dashboard reports unhealthy when the queue stops draining.【F:docs/operations/monitoring.md†L33-L58】
+- Render deploy hooks should run `npm run check:queue` or the curl heartbeat guard before flipping traffic, matching the Heroku release step.
+
+### Fly.io
+
+- Run the API and workers as separate Fly apps or as distinct processes within a single machine using `[processes]` blocks for `web`, `worker`, `scheduler`, `timers`, and `encryption-rotation` mirroring the Procfile. Each machine must load identical `DATABASE_URL` and `QUEUE_REDIS_*` secrets.【F:Procfile†L1-L5】
+- Configure Fly checks on `/api/production/ready` for the web process and `/api/production/queue/heartbeat` for each worker-oriented process. Treat failures as reasons to halt a deployment.
+- Use Fly's release command (or GitHub Action) to call the heartbeat endpoint before promoting a new image.
+
+### PM2 / bare metal
+
+- Run `pm2 start ecosystem.config.js` after `npm run build`. The [`ecosystem.config.js`](../ecosystem.config.js) file already defines five apps matching the Procfile so PM2 supervises the same topology.【F:ecosystem.config.js†L1-L41】
+- Configure `pm2-runtime` or your CI/CD hooks to execute `npm run check:queue` and the heartbeat curl before marking the deployment healthy, ensuring Redis and the worker fleet are online.
+
+## Queue health validation in automation
+
+- Add the queue heartbeat probe to your deployment pipelines. The CI smoke harness already waits for `GET /api/production/queue/heartbeat` to succeed before exercising the API; reuse the same command in release automation.【F:scripts/ci-smoke.ts†L16-L61】
+- The monitoring runbook documents the exact curl invocation and expected JSON fields—use it as the canonical guardrail before routing external traffic.【F:docs/operations/monitoring.md†L33-L61】

--- a/docs/operations/local-dev.md
+++ b/docs/operations/local-dev.md
@@ -32,7 +32,7 @@ Launch the full stack with a single command:
 docker compose -f docker-compose.dev.yml up --build
 ```
 
-The compose file starts Postgres, Redis, Jaeger, and three Node.js processes bound to the local workspace:
+The compose file starts Postgres, Redis, Jaeger, and five Node.js processes bound to the local workspace:
 
 | Service    | Command                | Ports exposed | Purpose |
 | ---------- | --------------------- | ------------- | ------- |
@@ -42,6 +42,10 @@ The compose file starts Postgres, Redis, Jaeger, and three Node.js processes bou
 | api        | `npm run dev:api`      | `5000`        | HTTP + Vite frontend dev server (defaults to inline worker) |
 | worker     | `npm run dev:worker`   | _internal_    | Workflow execution worker |
 | scheduler  | `npm run dev:scheduler`| _internal_    | Polling trigger scheduler |
+| timers     | `npm run dev:timers`   | _internal_    | Dispatches delayed/timer jobs |
+| encryption-rotation | `npm run dev:rotation` | _internal_ | Rotates envelope encryption keys for stored secrets |
+
+`npm run dev:stack` orchestrates these processes, verifies Postgres and Redis connectivity up front, and exits immediately with remediation hints when either service is unavailable so you do not accidentally run the API without its dependencies.【F:scripts/dev-stack.ts†L37-L160】
 
 Jaeger’s UI is available at [http://localhost:16686](http://localhost:16686). The API listens on [http://localhost:5000](http://localhost:5000).
 
@@ -60,7 +64,7 @@ export QUEUE_REDIS_DB=0
 
 The defaults in `.env.example` mirror these values so host-based processes connect to `localhost`. When you run inside the Compose network, override `QUEUE_REDIS_HOST` to `redis` (the service name) or whichever hostname your containers should reach.
 
-With Redis enabled, start the worker (`npm run dev:worker`) and scheduler (`npm run dev:scheduler`) alongside the API so queued jobs are actually processed. In development the API now auto-enables the inline execution worker when `ENABLE_INLINE_WORKER` is not set. Export `ENABLE_INLINE_WORKER=false` (or rely on `npm run dev:stack`, which sets it for the API process) whenever you want the dedicated worker process to take over. The readiness probe at `http://localhost:5000/api/health/ready` returns `503` if Redis is unreachable or the queue is running in in-memory mode, making it easy to verify durability before exercising workflows.【F:server/routes/production-health.ts†L35-L103】 The same startup routine now also fails fast when no execution worker heartbeat is detected in development/CI so missing workers surface quickly; override with `SKIP_WORKER_HEARTBEAT_CHECK=true` only for exceptional automation or smoke-test containers.
+With Redis enabled, start the worker (`npm run dev:worker`), scheduler (`npm run dev:scheduler`), timers (`npm run dev:timers`), and encryption rotation process (`npm run dev:rotation`) alongside the API so queued jobs are actually processed and cryptographic housekeeping continues in the background. In development the API now auto-enables the inline execution worker when `ENABLE_INLINE_WORKER` is not set. Export `ENABLE_INLINE_WORKER=false` (or rely on `npm run dev:stack`, which sets it for the API process) whenever you want the dedicated worker process to take over. The readiness probe at `http://localhost:5000/api/health/ready` returns `503` if Redis is unreachable or the queue is running in in-memory mode, making it easy to verify durability before exercising workflows.【F:server/routes/production-health.ts†L35-L103】 The same startup routine now also fails fast when no execution worker heartbeat is detected in development/CI so missing workers surface quickly; override with `SKIP_WORKER_HEARTBEAT_CHECK=true` only for exceptional automation or smoke-test containers.
 
 ## Observability
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev:worker": "NODE_ENV=development tsx watch server/workers/execution.ts",
     "dev:rotation": "NODE_ENV=development tsx watch server/workers/encryption-rotation.ts",
     "dev:scheduler": "NODE_ENV=development tsx watch server/workers/scheduler.ts",
+    "dev:timers": "NODE_ENV=development tsx watch server/workers/timerDispatcher.ts",
     "dev:stack": "tsx scripts/dev-stack.ts",
     "dev:bootstrap": "tsx scripts/dev-bootstrap.ts",
     "dev:smoke": "tsx scripts/dev-smoke-run.ts",

--- a/server/index.ts
+++ b/server/index.ts
@@ -201,6 +201,8 @@ app.use((req, res, next) => {
     } else {
       console.log('🏭 Inline execution worker disabled. Expecting external worker process.');
     }
+
+    executionQueueService.enableExternalConsumerMonitor();
   } catch (error) {
     console.warn('⚠️ Failed to configure execution queue:', (error as any)?.message || error);
 


### PR DESCRIPTION
## Summary
- update the dev stack script, npm scripts, and Docker Compose to start the API, worker, scheduler, timers, and encryption rotation together after verifying Redis/Postgres
- document the required process topology and queue heartbeat checks across deployment platforms along with queue runbook updates
- surface queue consumer gaps by monitoring backlog/heartbeats on the server and rendering admin UI warnings

## Testing
- npm install --no-progress *(fails: registry returns HTTP 403 while downloading bufferutil)*

------
https://chatgpt.com/codex/tasks/task_e_68e49d33d064833185b9debb169684e7