### PR TITLE
Guard queue health hook updates after unmount

### DIFF
--- a/client/src/components/ai/__tests__/N8NStyleWorkflowBuilder.toolbar.test.tsx
+++ b/client/src/components/ai/__tests__/N8NStyleWorkflowBuilder.toolbar.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const authFetchMock = vi.fn<typeof fetch>();
+const logoutMock = vi.fn();
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: (selector: any) => {
+    const state = {
+      token: 'token',
+      authFetch: authFetchMock,
+      logout: logoutMock,
+    };
+    return selector ? selector(state) : state;
+  },
+}));
+
+const queueHealthMock = vi.fn();
+vi.mock('@/hooks/useQueueHealth', () => ({
+  useQueueHealth: (...args: any[]) => queueHealthMock(...args),
+}));
+
+vi.mock('@/components/workflow/NodeConfigurationModal', () => ({
+  NodeConfigurationModal: () => null,
+}));
+
+vi.mock('reactflow/dist/style.css', () => ({}), { virtual: true });
+
+const jsonResponse = (body: any, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const sampleDraft = {
+  id: 'draft-1',
+  name: 'Draft Workflow',
+  nodes: [
+    {
+      id: 'trigger-1',
+      type: 'n8nNode',
+      position: { x: 0, y: 0 },
+      data: {
+        app: 'core',
+        label: 'Manual Trigger',
+        function: 'core.manual',
+        configured: true,
+      },
+    },
+    {
+      id: 'action-1',
+      type: 'n8nNode',
+      position: { x: 320, y: 0 },
+      data: {
+        app: 'gmail',
+        label: 'Send Email',
+        function: 'gmail.send',
+        connectionId: 'conn-1',
+        auth: { connectionId: 'conn-1' },
+        configured: true,
+        parameters: {},
+      },
+    },
+  ],
+  edges: [
+    { id: 'edge-1', source: 'trigger-1', target: 'action-1' },
+  ],
+};
+
+describe('N8NStyleWorkflowBuilder toolbar gating', () => {
+  beforeEach(() => {
+    queueHealthMock.mockReset();
+    authFetchMock.mockReset();
+    logoutMock.mockReset();
+    localStorage.clear();
+    localStorage.setItem('automation.builder.draft', JSON.stringify(sampleDraft));
+    (global as any).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    queueHealthMock.mockReturnValue({
+      health: {
+        status: 'pass',
+        durable: true,
+        message: 'Queue ready',
+        latencyMs: 5,
+        checkedAt: new Date().toISOString(),
+      },
+      status: 'pass',
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+    authFetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/workflows/validate')) {
+        return Promise.resolve(
+          jsonResponse({ success: true, validation: { valid: true, errors: [], warnings: [] } })
+        );
+      }
+      return Promise.resolve(jsonResponse({ success: true }));
+    });
+  });
+
+  afterEach(() => {
+    queueHealthMock.mockReset();
+    authFetchMock.mockReset();
+    localStorage.clear();
+  });
+
+  it('disables the run button when queue health is failing', async () => {
+    queueHealthMock.mockReturnValue({
+      health: {
+        status: 'fail',
+        durable: true,
+        message: 'Redis unavailable',
+        latencyMs: 15,
+        checkedAt: new Date().toISOString(),
+      },
+      status: 'fail',
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+
+    const { default: Builder } = await import('../N8NStyleWorkflowBuilder');
+    render(<Builder />);
+
+    await waitFor(() => {
+      expect(authFetchMock).toHaveBeenCalled();
+    });
+
+    const runButton = await screen.findByRole('button', { name: /run workflow/i });
+    await waitFor(() => {
+      expect(runButton).toBeDisabled();
+    });
+  });
+
+  it('keeps the run button disabled when nodes require configuration', async () => {
+    const draft = JSON.parse(localStorage.getItem('automation.builder.draft') || 'null');
+    if (draft?.nodes?.[1]) {
+      delete draft.nodes[1].data.function;
+      localStorage.setItem('automation.builder.draft', JSON.stringify(draft));
+    }
+
+    const { default: Builder } = await import('../N8NStyleWorkflowBuilder');
+    render(<Builder />);
+
+    await waitFor(() => {
+      expect(authFetchMock).toHaveBeenCalled();
+    });
+
+    const runButton = await screen.findByRole('button', { name: /run workflow/i });
+    await waitFor(() => {
+      expect(runButton).toBeDisabled();
+    });
+  });
+});
+

--- a/client/src/components/workflow/nodeConfigurationValidation.ts
+++ b/client/src/components/workflow/nodeConfigurationValidation.ts
@@ -1,0 +1,133 @@
+import type { ValidationError } from '@shared/nodeGraphSchema';
+
+type NodeLike = {
+  id: string | number;
+  type?: string | null;
+  data?: Record<string, any> | null;
+};
+
+type Options = {
+  nodeRequiresConnection?: (node: NodeLike) => boolean;
+};
+
+const normalizeType = (node: NodeLike): string => {
+  const data = node.data || {};
+  const candidates: Array<unknown> = [
+    node.type,
+    data.nodeType,
+    data.type,
+    data.role,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.toLowerCase();
+    }
+  }
+  return '';
+};
+
+const isTriggerNode = (node: NodeLike): boolean => {
+  const type = normalizeType(node);
+  return type.includes('trigger');
+};
+
+const isTransformNode = (node: NodeLike): boolean => {
+  const type = normalizeType(node);
+  return type.includes('transform') || type.includes('condition');
+};
+
+const collectFirstString = (candidates: Array<unknown>): string | undefined => {
+  for (const value of candidates) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+};
+
+export const collectNodeConfigurationErrors = (
+  nodes: NodeLike[],
+  options: Options = {}
+): ValidationError[] => {
+  const results: ValidationError[] = [];
+  const requiresConnection = options.nodeRequiresConnection;
+
+  nodes.forEach((node) => {
+    const data = node.data || {};
+    const nodeId = String(node.id);
+    const isTrigger = isTriggerNode(node);
+    const isTransform = isTransformNode(node);
+
+    const connector = collectFirstString([
+      data.app,
+      data.application,
+      data.appId,
+      data.appName,
+      data.connector,
+      data.connectorId,
+      data.integrationId,
+      data.provider,
+      data.service,
+    ]);
+
+    const functionId = collectFirstString([
+      data.function,
+      data.operation,
+      data.selectedFunction,
+      data.workflowFunctionId,
+      data.actionId,
+      data.triggerId,
+    ]);
+
+    const hasInlineCredentials = Boolean(data.credentials);
+    const hasConnectionId = Boolean(
+      data.connectionId ||
+      data.auth?.connectionId ||
+      data.params?.connectionId ||
+      data.parameters?.connectionId
+    );
+
+    const nodeLabel = collectFirstString([
+      data.label,
+      data.name,
+      connector,
+      node.type,
+      nodeId,
+    ]) ?? nodeId;
+
+    if (!isTrigger && !isTransform && !connector) {
+      results.push({
+        nodeId,
+        path: `/nodes/${nodeId}/metadata/connector`,
+        message: `Select a connector for "${nodeLabel}" before running.`,
+        severity: 'error',
+      });
+    }
+
+    if (!isTrigger && !functionId) {
+      results.push({
+        nodeId,
+        path: `/nodes/${nodeId}/metadata/function`,
+        message: `Choose an action for "${nodeLabel}" before running.`,
+        severity: 'error',
+      });
+    }
+
+    if (
+      typeof requiresConnection === 'function'
+        ? requiresConnection(node)
+        : !isTrigger && !isTransform && !hasInlineCredentials && !hasConnectionId
+    ) {
+      results.push({
+        nodeId,
+        path: `/nodes/${nodeId}/metadata/connection`,
+        message: `Connect an account for "${nodeLabel}" before running.`,
+        severity: 'error',
+      });
+    }
+  });
+
+  return results;
+};
+

--- a/client/src/hooks/useQueueHealth.ts
+++ b/client/src/hooks/useQueueHealth.ts
@@ -1,0 +1,123 @@
+import { useAuthStore } from '@/store/authStore';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export type QueueHealthStatus = {
+  status: 'pass' | 'fail';
+  durable: boolean;
+  message: string;
+  latencyMs: number | null;
+  checkedAt: string;
+  error?: string;
+};
+
+export type UseQueueHealthOptions = {
+  /** Poll for updates (default: true). */
+  poll?: boolean;
+  /** Interval in milliseconds between polls (default: 30s). */
+  intervalMs?: number;
+};
+
+export type UseQueueHealthResult = {
+  health: QueueHealthStatus | null;
+  status: QueueHealthStatus['status'];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+};
+
+const DEFAULT_INTERVAL_MS = 30000;
+
+export function useQueueHealth(options: UseQueueHealthOptions = {}): UseQueueHealthResult {
+  const authFetch = useAuthStore((state) => state.authFetch);
+  const [health, setHealth] = useState<QueueHealthStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const poll = options.poll ?? true;
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const abortRef = useRef<AbortController | null>(null);
+  const hasFetchedRef = useRef(false);
+  const isMountedRef = useRef(true);
+
+  const fetchHealth = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    setIsLoading((previous) => (hasFetchedRef.current ? previous : true));
+    setError(null);
+
+    try {
+      const response = await authFetch('/api/health/queue', { signal: controller.signal });
+      const payload = (await response.json().catch(() => ({}))) as Record<string, any>;
+      if (!response.ok) {
+        throw new Error(payload?.error || `Queue health request failed with status ${response.status}`);
+      }
+
+      const status: QueueHealthStatus | null = payload && typeof payload === 'object'
+        ? (payload.health as QueueHealthStatus | undefined) ?? (payload as QueueHealthStatus)
+        : null;
+
+      if (status && typeof status.status === 'string') {
+        if (isMountedRef.current) {
+          setHealth(status);
+          hasFetchedRef.current = true;
+        }
+      } else {
+        throw new Error('Received unexpected payload from /api/health/queue');
+      }
+    } catch (err: any) {
+      if (err?.name === 'AbortError') {
+        return;
+      }
+      if (isMountedRef.current) {
+        setError(err?.message || 'Unable to determine queue health');
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [authFetch]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    void fetchHealth();
+
+    if (!poll) {
+      return () => {
+        abortRef.current?.abort();
+        isMountedRef.current = false;
+      };
+    }
+
+    const interval = window.setInterval(() => {
+      if (!isMountedRef.current) {
+        return;
+      }
+      void fetchHealth();
+    }, intervalMs);
+
+    return () => {
+      isMountedRef.current = false;
+      abortRef.current?.abort();
+      window.clearInterval(interval);
+    };
+  }, [fetchHealth, poll, intervalMs]);
+
+  const status = health?.status ?? 'fail';
+
+  const result = useMemo<UseQueueHealthResult>(() => ({
+    health,
+    status,
+    isLoading,
+    error,
+    refresh: fetchHealth,
+  }), [health, status, isLoading, error, fetchHealth]);
+
+  return result;
+}
+

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1254,6 +1254,15 @@ export async function registerRoutes(app: Express): Promise<void> {
     }
   });
 
+  app.get('/api/health/queue', async (_req, res) => {
+    try {
+      const health = await checkQueueHealth();
+      res.json({ success: true, health });
+    } catch (error) {
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  });
+
   // Export connector schemas (all or by appId)
   app.get('/api/schema/export', async (req, res) => {
     try {


### PR DESCRIPTION
**Summary**
* Introduced a reusable queue health polling hook and lightweight API endpoint so both builders can gate workflow execution on `/api/health/queue`.
* Added shared node configuration validation utilities and integrated proactive validation/tooltip gating in `ProfessionalGraphEditor`, including queue badges, validation polling, and stricter run-button disabling.
* Updated `N8NStyleWorkflowBuilder` to reuse queue health, configuration validation, and run-button tooltips with new toolbar tests covering queue failure and missing metadata.
* Extended existing professional editor tests to cover new disabled states under queue failure and missing configuration.
* Hardened the queue health polling hook to avoid state updates after a component unmounts.

**Outstanding Work / TODOs**
* ✅ None pending in code; however, `npx vitest run ...` failed due to npm registry access (403). Tests could not be executed in this environment. (See testing note below.)
* ⚠️ Consider additional integration tests exercising successful queue-ready runs and validation error focus behavior (no specific file TODO added).

**Testing**
* ⚠️ `npx vitest run client/src/components/workflow/__tests__/ProfessionalGraphEditor.validation.test.tsx client/src/components/ai/__tests__/N8NStyleWorkflowBuilder.toolbar.test.tsx` (blocked: npm registry access returned 403, so tests were not executed).


------
https://chatgpt.com/codex/tasks/task_e_68e4a3d5cc748331a49cfece9fc654be