### PR TITLE
Handle OAuth connection completion without reloading the workflow editor

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -1822,6 +1822,28 @@ const GraphEditorContent = () => {
     }
   };
 
+  const handleConnectionCreated = useCallback(
+    async (connectionId: string) => {
+      if (!token) return;
+
+      try {
+        const response = await authFetch('/api/connections');
+        const json = await response.json().catch(() => ({}));
+        const list = Array.isArray(json?.connections) ? json.connections : [];
+        setConfigConnections(list);
+
+        if (configOpen) {
+          setConfigNodeData((prev) =>
+            prev ? { ...prev, connectionId } : prev
+          );
+        }
+      } catch (error) {
+        toast.error('Connection created, but failed to refresh the connection list.');
+      }
+    },
+    [authFetch, configOpen, token]
+  );
+
   const handleNodeConfigSave = (updated: any) => {
     // Persist selected function, connectionId, and parameters back into node data
     setNodes((nds) =>
@@ -3801,6 +3823,7 @@ const GraphEditorContent = () => {
           availableFunctions={configFunctions}
           connections={configConnections}
           oauthProviders={configOAuthProviders}
+          onConnectionCreated={handleConnectionCreated}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- listen for `oauth:connection` postMessage events in the node configuration modal so new OAuth connections select immediately, reset loading state, and emit toast feedback without a reload
- refresh the workflow editor connection list when a new connection is created so the modal preselects the new credential while staying open

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4d2c0ff68833199a37fb94f20406b