### PR TITLE
Reorder Professional editor save callback ahead of dependent hooks

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -2113,6 +2113,57 @@ const GraphEditorContent = () => {
     return workflowIdentifier;
   }, [activeWorkflowId, setActiveWorkflowId]);
 
+  const onSaveWorkflow = useCallback(async (): Promise<string | null> => {
+    if (nodes.length === 0) {
+      toast.error('Add at least one node before saving');
+      return null;
+    }
+
+    if (!ensureSupportedNodes()) {
+      return null;
+    }
+
+    const workflowIdentifier = activeWorkflowId ?? fallbackWorkflowIdRef.current ?? `local-${Date.now()}`;
+    const payload = createGraphPayload(workflowIdentifier);
+
+    setSaveState('saving');
+    try {
+      const response = await authFetch('/api/flows/save', {
+        method: 'POST',
+        body: JSON.stringify({
+          id: workflowIdentifier,
+          name: payload.name,
+          graph: payload,
+          metadata: payload.metadata
+        })
+      });
+
+      const result = await response.json().catch(() => ({}));
+      if (!response.ok || !result?.success) {
+        const message = result?.error || (response.status === 401 ? 'Sign in to save workflows' : 'Failed to save workflow');
+        if (response.status === 401) {
+          await logout(true);
+        }
+        throw new Error(message);
+      }
+
+      const savedId = result.workflowId || workflowIdentifier;
+      setActiveWorkflowId(savedId);
+      try {
+        localStorage.setItem('lastWorkflowId', savedId);
+      } catch (error) {
+        console.warn('Unable to persist workflow id after save:', error);
+      }
+      toast.success('Workflow saved');
+      return savedId;
+    } catch (error: any) {
+      toast.error(error?.message || 'Failed to save workflow');
+      return null;
+    } finally {
+      setSaveState('idle');
+    }
+  }, [nodes, ensureSupportedNodes, activeWorkflowId, createGraphPayload, authFetch, logout, setActiveWorkflowId]);
+
   const prepareWorkflowForExecution = useCallback(async (): Promise<{ workflowId: string; payload: NodeGraph } | null> => {
     if (nodes.length === 0) {
       return null;
@@ -2513,57 +2564,6 @@ const GraphEditorContent = () => {
     setSelectedNodeId(String(node.id));
     setNodes((nds) => nds.map((n) => ({ ...n, selected: n.id === node.id })));
   }, [setNodes]);
-
-  const onSaveWorkflow = useCallback(async (): Promise<string | null> => {
-    if (nodes.length === 0) {
-      toast.error('Add at least one node before saving');
-      return null;
-    }
-
-    if (!ensureSupportedNodes()) {
-      return null;
-    }
-
-    const workflowIdentifier = activeWorkflowId ?? fallbackWorkflowIdRef.current ?? `local-${Date.now()}`;
-    const payload = createGraphPayload(workflowIdentifier);
-
-    setSaveState('saving');
-    try {
-      const response = await authFetch('/api/flows/save', {
-        method: 'POST',
-        body: JSON.stringify({
-          id: workflowIdentifier,
-          name: payload.name,
-          graph: payload,
-          metadata: payload.metadata
-        })
-      });
-
-      const result = await response.json().catch(() => ({}));
-      if (!response.ok || !result?.success) {
-        const message = result?.error || (response.status === 401 ? 'Sign in to save workflows' : 'Failed to save workflow');
-        if (response.status === 401) {
-          await logout(true);
-        }
-        throw new Error(message);
-      }
-
-      const savedId = result.workflowId || workflowIdentifier;
-      setActiveWorkflowId(savedId);
-      try {
-        localStorage.setItem('lastWorkflowId', savedId);
-      } catch (error) {
-        console.warn('Unable to persist workflow id after save:', error);
-      }
-      toast.success('Workflow saved');
-      return savedId;
-    } catch (error: any) {
-      toast.error(error?.message || 'Failed to save workflow');
-      return null;
-    } finally {
-      setSaveState('idle');
-    }
-  }, [nodes, ensureSupportedNodes, activeWorkflowId, createGraphPayload, authFetch, logout, setActiveWorkflowId]);
 
   const onRunWorkflow = useCallback(async () => {
     if (!queueReady) {


### PR DESCRIPTION
## Summary
- move the `onSaveWorkflow` callback ahead of other hooks that capture it in `ProfessionalGraphEditor`
- keep dependent callbacks referencing the stable `onSaveWorkflow` instance in their dependency arrays

## Testing
- npm run build:client *(fails: vite command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d2cf3b4883318c4c15981672baa2