### PR TITLE
Expose sanitized metadata connectors catalog endpoint

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,7 +9,7 @@ import { workflowBuildRouter } from "./routes/workflow.build";
 import aiRouter from "./routes/ai";
 import appSchemaRoutes from "./routes/app-schemas.js";
 import googleSheetsRoutes from "./routes/google-sheets.js";
-import metadataRoutes from "./routes/metadata.js";
+import metadataRoutes, { metadataCatalogRouter } from "./routes/metadata.js";
 import aiAssistRoutes from "./routes/ai-assist.js";
 import templateRoutes from "./routes/templates.js";
 import collaborationRoutes from "./routes/collaboration.js";
@@ -342,6 +342,7 @@ export async function registerRoutes(app: Express): Promise<void> {
   }
 
   app.use('/api/google', googleSheetsRoutes);
+  app.use('/api', metadataCatalogRouter);
   app.use('/api/metadata', metadataRoutes);
   
   // P1-7: AI assist functionality routes

--- a/server/routes/__tests__/metadata-connectors.access.test.ts
+++ b/server/routes/__tests__/metadata-connectors.access.test.ts
@@ -157,20 +157,36 @@ try {
     authenticatedBody?.data?.connectors ?? authenticatedBody?.connectors ?? [];
   assert(Array.isArray(authenticatedConnectors) && authenticatedConnectors.length > 0);
 
-  const connectorWithAuthConfig = authenticatedConnectors.find(
-    (connector: any) => connector?.authentication?.config,
-  );
-  assert(connectorWithAuthConfig, 'expected full metadata to include authentication config');
-  assert(
-    'pricingTier' in connectorWithAuthConfig,
-    'full metadata should include entitlement details',
-  );
-  assert(
-    connectorWithAuthConfig.lifecycle?.raw,
-    'full metadata should include lifecycle raw metadata',
-  );
+  authenticatedConnectors.forEach((connector: any) => {
+    assert.equal(
+      connector.pricingTier ?? null,
+      null,
+      'authenticated catalog should omit entitlement tiers',
+    );
+    if (Array.isArray(connector.scopes)) {
+      assert.equal(
+        connector.scopes.length,
+        0,
+        'authenticated catalog scopes should be empty',
+      );
+    }
+    if (connector.authentication) {
+      assert.equal(
+        connector.authentication.config ?? null,
+        null,
+        'authenticated catalog should not expose authentication config',
+      );
+    }
+    if (connector.lifecycle) {
+      assert.equal(
+        'raw' in connector.lifecycle,
+        false,
+        'authenticated catalog should not expose lifecycle raw metadata',
+      );
+    }
+  });
 
-  console.log('Metadata catalog exposes sanitized anonymous access and full authenticated metadata.');
+  console.log('Metadata catalog exposes sanitized metadata for anonymous and authenticated access.');
 } catch (error) {
   exitCode = 1;
   console.error(error);


### PR DESCRIPTION
## Summary
- add a dedicated metadata catalog router that serves the public connector payload expected by the client
- mount the catalog router at `/api/metadata/v1/connectors` and update the access test to assert that both anonymous and authenticated calls receive sanitized data

## Testing
- `npx tsx server/routes/__tests__/metadata-connectors.access.test.ts` *(fails: npm registry access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d2c50e90833189c9fa1c282ee775