### PR TITLE
Add shared organization resolver with dev fallback

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -439,7 +439,7 @@ export async function registerRoutes(app: Express): Promise<void> {
   app.use('/api', productionHealthRoutes);
   
   // ChatGPT Fix: Flow storage routes for AI Builder → Graph Editor handoff
-  app.use('/api/flows', flowRoutes);
+  app.use('/api/flows', optionalAuth, flowRoutes);
 
   // Organization role management APIs
   app.use('/api/organizations', organizationRoleRoutes);

--- a/server/routes/__tests__/workflow-dev-fallback.test.ts
+++ b/server/routes/__tests__/workflow-dev-fallback.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import express from 'express';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalDatabaseUrl = process.env.DATABASE_URL;
+const originalEncryptionKey = process.env.ENCRYPTION_MASTER_KEY;
+const originalJwtSecret = process.env.JWT_SECRET;
+
+process.env.NODE_ENV = 'development';
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ?? 'postgresql://user:password@localhost:5432/testdb';
+process.env.ENCRYPTION_MASTER_KEY =
+  process.env.ENCRYPTION_MASTER_KEY ?? '0123456789abcdef0123456789abcdef';
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-jwt-secret';
+
+const { registerRoutes } = await import('../../routes.ts');
+const workflowRepositoryModule = await import('../../workflow/WorkflowRepository.js');
+
+const originalSaveWorkflowGraph = workflowRepositoryModule.WorkflowRepository.saveWorkflowGraph;
+
+let capturedSavePayload: any = null;
+
+(workflowRepositoryModule.WorkflowRepository as any).saveWorkflowGraph = async (
+  payload: any,
+) => {
+  capturedSavePayload = payload;
+  return {
+    id: payload?.id ?? 'saved-workflow',
+    organizationId: payload?.organizationId,
+    graph: payload?.graph ?? {},
+  };
+};
+
+const app = express();
+app.use(express.json());
+
+let server: Server | null = null;
+let exitCode = 0;
+
+try {
+  await registerRoutes(app);
+  server = createServer(app);
+
+  await new Promise<void>((resolve, reject) =>
+    server!.listen(0, (err?: Error) => (err ? reject(err) : resolve())),
+  );
+
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  const flowResponse = await fetch(`${baseUrl}/api/flows/save`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      graph: {
+        id: 'test-flow',
+        name: 'Dev Flow',
+        nodes: [],
+        edges: [],
+      },
+    }),
+  });
+
+  assert.equal(flowResponse.status, 200, 'flows save should succeed without auth in development');
+  const flowBody = await flowResponse.json();
+  assert.equal(flowBody.success, true, 'flows save should return success');
+  assert.equal(
+    capturedSavePayload?.organizationId,
+    'dev-org',
+    'dev fallback should inject the development organization id for flow saves',
+  );
+
+  const validateResponse = await fetch(`${baseUrl}/api/workflows/validate`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      graph: {
+        id: 'validate-flow',
+        name: 'Validate Flow',
+        nodes: [
+          {
+            id: 'node-1',
+            type: 'trigger',
+            data: { label: 'Start' },
+            position: { x: 0, y: 0 },
+          },
+        ],
+        edges: [],
+      },
+    }),
+  });
+
+  assert.equal(
+    validateResponse.status,
+    200,
+    'workflow validation should succeed without auth in development',
+  );
+  const validateBody = await validateResponse.json();
+  assert.equal(validateBody.success, true, 'workflow validation should return success payload');
+
+  console.log(
+    'Development organization fallback allows unauthenticated flow saves and workflow validation.',
+  );
+} catch (error) {
+  exitCode = 1;
+  console.error(error);
+} finally {
+  if (server) {
+    await new Promise<void>((resolve, reject) =>
+      server!.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+
+  (workflowRepositoryModule.WorkflowRepository as any).saveWorkflowGraph = originalSaveWorkflowGraph;
+
+  const restore = (
+    key: 'NODE_ENV' | 'DATABASE_URL' | 'ENCRYPTION_MASTER_KEY' | 'JWT_SECRET',
+    value: string | undefined,
+  ) => {
+    if (value) {
+      process.env[key] = value;
+    } else {
+      delete process.env[key];
+    }
+  };
+
+  restore('NODE_ENV', originalNodeEnv);
+  restore('DATABASE_URL', originalDatabaseUrl);
+  restore('ENCRYPTION_MASTER_KEY', originalEncryptionKey);
+  restore('JWT_SECRET', originalJwtSecret);
+
+  process.exit(exitCode);
+}

--- a/server/utils/organizationContext.ts
+++ b/server/utils/organizationContext.ts
@@ -1,0 +1,79 @@
+import type { Request, Response } from 'express';
+
+export interface ResolvedOrganizationContext {
+  organizationId: string | null;
+  organizationStatus: string | null;
+  injectedFallback: boolean;
+}
+
+const DEFAULT_DEV_ORGANIZATION_ID = 'dev-org';
+
+/**
+ * Resolves the active organization context for a request.
+ *
+ * In development environments (NODE_ENV !== 'production'), a default organization is
+ * returned when none is attached to the request so that local workflows can execute
+ * without explicit authentication.
+ */
+export const resolveOrganizationContext = (
+  req: Request,
+  res: Response,
+): ResolvedOrganizationContext => {
+  const requestWithOrg = req as Partial<Request> & {
+    organizationId?: string;
+    organizationStatus?: string;
+  };
+
+  const existingOrganizationId = requestWithOrg.organizationId ?? null;
+  const existingOrganizationStatus = requestWithOrg.organizationStatus ?? null;
+
+  if (!existingOrganizationId) {
+    if (process.env.NODE_ENV !== 'production') {
+      return {
+        organizationId: DEFAULT_DEV_ORGANIZATION_ID,
+        organizationStatus: 'active',
+        injectedFallback: true,
+      };
+    }
+
+    res.status(403).json({ success: false, error: 'Organization context is required' });
+    return {
+      organizationId: null,
+      organizationStatus: null,
+      injectedFallback: false,
+    };
+  }
+
+  if (existingOrganizationStatus && existingOrganizationStatus !== 'active') {
+    res.status(403).json({ success: false, error: 'Organization is not active' });
+    return {
+      organizationId: null,
+      organizationStatus: existingOrganizationStatus,
+      injectedFallback: false,
+    };
+  }
+
+  return {
+    organizationId: existingOrganizationId,
+    organizationStatus: existingOrganizationStatus,
+    injectedFallback: false,
+  };
+};
+
+export const applyResolvedOrganizationToRequest = (
+  req: Request,
+  context: ResolvedOrganizationContext,
+): void => {
+  if (!context.injectedFallback || !context.organizationId) {
+    return;
+  }
+
+  const requestWithOrg = req as Partial<Request> & {
+    organizationId?: string;
+    organizationStatus?: string;
+  };
+
+  requestWithOrg.organizationId = context.organizationId;
+  requestWithOrg.organizationStatus = context.organizationStatus ?? 'active';
+};
+


### PR DESCRIPTION
## Summary
- add a shared resolveOrganizationContext utility that falls back to the dev organization in non-production environments
- update flow and workflow routes to use the shared helper and ensure optional auth runs before flow routes
- add a regression test covering unauthenticated development requests for flow saves and workflow validation

## Testing
- not run (blocked by missing local tsx binary)


------
https://chatgpt.com/codex/tasks/task_e_68e4ea2856f08331b436dc49f53307e9