### PR TITLE
Allow inactive dev org workflow validation

### DIFF
--- a/server/utils/organizationContext.ts
+++ b/server/utils/organizationContext.ts
@@ -45,6 +45,14 @@ export const resolveOrganizationContext = (
   }
 
   if (existingOrganizationStatus && existingOrganizationStatus !== 'active') {
+    if (process.env.NODE_ENV !== 'production') {
+      return {
+        organizationId: existingOrganizationId ?? DEFAULT_DEV_ORGANIZATION_ID,
+        organizationStatus: 'active',
+        injectedFallback: true,
+      };
+    }
+
     res.status(403).json({ success: false, error: 'Organization is not active' });
     return {
       organizationId: null,


### PR DESCRIPTION
## Summary
- update the organization context resolver to coerce inactive statuses to active in non-production and mark the fallback so requests are patched
- extend the workflow dev fallback test app to accept organization headers and cover the inactive status validation path

## Testing
- npx tsx server/routes/__tests__/workflow-dev-fallback.test.ts *(fails: npm registry access forbidden in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4fe5df298833191b62ebe19c26fb2