### PR TITLE
Ensure auth headers ignore invalid tokens

### DIFF
--- a/client/src/services/__tests__/authHeaders.regression.test.ts
+++ b/client/src/services/__tests__/authHeaders.regression.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+
+import { authStore } from '@/store/authStore';
+import {
+  getConnectorDefinitions,
+  invalidateConnectorDefinitionsCache,
+} from '../connectorDefinitionsService';
+import { functionLibraryService } from '../functionLibraryService';
+
+const originalFetch = globalThis.fetch;
+const { token: originalToken, activeOrganizationId: originalOrgId } = authStore.getState();
+
+const setAuthStateForTest = () => {
+  authStore.setState({ token: 'undefined', activeOrganizationId: 'org-dev' });
+};
+
+const createMockResponse = <T>(status: number, ok: boolean, payload: T): Response =>
+  ({
+    ok,
+    status,
+    json: async () => payload,
+  } as unknown as Response);
+
+try {
+  await (async () => {
+    invalidateConnectorDefinitionsCache();
+    const recordedAuthHeaders: Array<string | null> = [];
+    const recordedOrgHeaders: Array<string | null> = [];
+    let callCount = 0;
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers as HeadersInit | undefined);
+      recordedAuthHeaders.push(headers.get('Authorization'));
+      recordedOrgHeaders.push(headers.get('X-Organization-Id'));
+      callCount += 1;
+
+      if (typeof input === 'string' && input.startsWith('/api/metadata/v1/connectors')) {
+        return createMockResponse(500, false, {});
+      }
+
+      if (typeof input === 'string' && input.startsWith('/api/registry/catalog')) {
+        return createMockResponse(200, true, {
+          success: true,
+          catalog: {
+            connectors: {
+              demo: { id: 'demo', name: 'Demo Connector', hasImplementation: true },
+            },
+          },
+        });
+      }
+
+      throw new Error(`Unexpected fetch input: ${String(input)}`);
+    }) as typeof fetch;
+
+    try {
+      setAuthStateForTest();
+      const definitions = await getConnectorDefinitions(true);
+      assert.equal(callCount, 2, 'should attempt metadata fetch and fallback catalog fetch');
+      assert.deepEqual(
+        recordedAuthHeaders,
+        [null, null],
+        'Authorization header should be omitted when stored token string equals "undefined"',
+      );
+      assert.deepEqual(
+        recordedOrgHeaders,
+        ['org-dev', 'org-dev'],
+        'Organization header should still be forwarded for fallback requests',
+      );
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(definitions, 'demo'),
+        'fallback connector response should be normalized',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      invalidateConnectorDefinitionsCache();
+    }
+  })();
+
+  await (async () => {
+    const recordedAuthHeaders: Array<string | null> = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers as HeadersInit | undefined);
+      recordedAuthHeaders.push(headers.get('Authorization'));
+
+      if (typeof input === 'string' && input.startsWith('/api/registry/functions/')) {
+        return createMockResponse(200, true, {
+          success: true,
+          functions: { actions: [], triggers: [] },
+        });
+      }
+
+      throw new Error(`Unexpected fetch input: ${String(input)}`);
+    }) as typeof fetch;
+
+    try {
+      setAuthStateForTest();
+      (functionLibraryService as any).cache?.clear?.();
+      (functionLibraryService as any).cacheExpiry?.clear?.();
+      const functions = await functionLibraryService.getAppFunctions('demo', true);
+      assert.deepEqual(
+        recordedAuthHeaders,
+        [null],
+        'Function library requests should omit Authorization when token string equals "undefined"',
+      );
+      assert.deepEqual(functions, [], 'empty mock payload should map to an empty function list');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  })();
+} finally {
+  globalThis.fetch = originalFetch;
+  authStore.setState({ token: originalToken, activeOrganizationId: originalOrgId });
+  invalidateConnectorDefinitionsCache();
+  (functionLibraryService as any).cache?.clear?.();
+  (functionLibraryService as any).cacheExpiry?.clear?.();
+}

--- a/client/src/services/functionLibraryService.ts
+++ b/client/src/services/functionLibraryService.ts
@@ -27,20 +27,6 @@ class FunctionLibraryService {
   private readonly CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 
   /**
-   * Get authentication headers
-   */
-  private getAuthHeaders(): Record<string, string> {
-    const token = authStore.getState().token;
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json'
-    };
-    if (token && token !== 'null' && token !== 'undefined') {
-      headers['Authorization'] = `Bearer ${token}`;
-    }
-    return headers;
-  }
-
-  /**
    * Check if cache is valid for an app
    */
   private isCacheValid(appName: string): boolean {
@@ -61,9 +47,7 @@ class FunctionLibraryService {
    */
   async getSupportedApplications(): Promise<string[]> {
     try {
-      const response = await fetch('/api/registry/catalog?implemented=true', {
-        headers: this.getAuthHeaders()
-      });
+      const response = await authStore.getState().authFetch('/api/registry/catalog?implemented=true');
 
       const result = await response.json();
 
@@ -92,9 +76,9 @@ class FunctionLibraryService {
     }
 
     try {
-      const response = await fetch(`/api/registry/functions/${encodeURIComponent(appName)}`, {
-        headers: this.getAuthHeaders()
-      });
+      const response = await authStore.getState().authFetch(
+        `/api/registry/functions/${encodeURIComponent(appName)}`
+      );
 
       if (!response.ok) {
         if (response.status === 404) {


### PR DESCRIPTION
## Summary
- sanitize stored auth tokens so shared helpers never emit Bearer headers for `undefined`/`null` strings
- switch connector and function library services to rely on the shared `authFetch` helper for authenticated requests
- add regression coverage that asserts Authorization is omitted when a persisted token equals the string `"undefined"`

## Testing
- npx tsx client/src/services/__tests__/authHeaders.regression.test.ts *(fails: npm registry access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4fe61c2648331943a2c75d41fcfd3