### PR TITLE
Improve OAuth connection reconciliation in node modal

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -1964,7 +1964,26 @@ const GraphEditorContent = () => {
         const list = Array.isArray(json?.connections) ? json.connections : [];
         setConfigConnections(list);
 
-        const connection = list.find((item: any) => item?.id === connectionId) ?? null;
+        let connection = list.find((item: any) => item?.id === connectionId) ?? null;
+
+        if (!connection) {
+          try {
+            const detailResponse = await authFetch(`/api/connections/${connectionId}`);
+            const detailJson = await detailResponse.json().catch(() => ({}));
+            const detailConnection = detailJson?.connection || detailJson?.data || null;
+
+            if (detailConnection && typeof detailConnection === 'object') {
+              connection = detailConnection;
+              setConfigConnections((prev) => {
+                const map = new Map(prev.map((item: any) => [item?.id, item] as const));
+                map.set(connectionId, detailConnection);
+                return Array.from(map.values());
+              });
+            }
+          } catch {
+            // Ignore detail fetch errors – we already refreshed the list.
+          }
+        }
 
         if (configOpen) {
           setConfigNodeData((prev) =>


### PR DESCRIPTION
## Summary
- keep a local connection list in NodeConfigurationModal and merge OAuth completion payloads immediately while skipping redundant OAuth launches
- refresh `/api/connections` in ProfessionalGraphEditor when new connections are created and return the resolved record
- extend the NodeConfigurationModal OAuth tests to cover optimistic connection display and saving without reauthorization

## Testing
- npx vitest run client/src/components/workflow/__tests__/NodeConfigurationModal.oauth.test.tsx *(fails: npm 403 Forbidden fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68e52116cc8c8331a85186fe86b55cec