### PR TITLE
Fix ensureWorkflowId ordering in ProfessionalGraphEditor

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -1544,6 +1544,102 @@ const GraphEditorContent = () => {
   }, [workerStatusMessage, queueStatusMessage]);
   const isRunHealthLoading = isQueueHealthLoading || isWorkerStatusLoading;
   const runReady = queueReady && workerFleetReady;
+  const ensureWorkflowId = useCallback(
+    async (
+      payload?: NodeGraph,
+    ): Promise<{ workflowId: string; payload?: NodeGraph } | null> => {
+      const updateResolvedId = (resolvedId: string) => {
+        fallbackWorkflowIdRef.current = resolvedId;
+        setActiveWorkflowId((prev) => (prev === resolvedId ? prev : resolvedId));
+        try {
+          localStorage.setItem('lastWorkflowId', resolvedId);
+        } catch (error) {
+          console.warn('Unable to persist workflow id:', error);
+        }
+      };
+
+      const getStoredIdentifier = (): string | undefined => {
+        let stored: string | undefined;
+        try {
+          stored = localStorage.getItem('lastWorkflowId') ?? undefined;
+        } catch (error) {
+          console.warn('Unable to read workflow id from storage:', error);
+        }
+        return stored;
+      };
+
+      const payloadIdentifier = typeof payload?.id === 'string' ? payload.id : undefined;
+
+      let workflowIdentifier =
+        (isUuid(payloadIdentifier) ? payloadIdentifier : undefined) ??
+        activeWorkflowId ??
+        fallbackWorkflowIdRef.current ??
+        getStoredIdentifier() ??
+        `local-${Date.now()}`;
+
+      if (isUuid(workflowIdentifier)) {
+        updateResolvedId(workflowIdentifier);
+        const ensuredPayload = payload
+          ? { ...payload, id: workflowIdentifier }
+          : undefined;
+        return { workflowId: workflowIdentifier, payload: ensuredPayload };
+      }
+
+      const requestedIdentifier = workflowIdentifier;
+
+      const body: Record<string, any> = {
+        name: payload?.name ?? 'Untitled Workflow',
+        requestedId: requestedIdentifier,
+      };
+
+      if (payload) {
+        const graphForCreation: any = { ...payload };
+        delete graphForCreation.id;
+        body.graph = graphForCreation;
+        if (payload.metadata !== undefined) {
+          body.metadata = payload.metadata;
+        }
+      }
+
+      let response: Response | null = null;
+      try {
+        response = await authFetch('/api/flows/save', {
+          method: 'POST',
+          body: JSON.stringify(body),
+        });
+      } catch (error: any) {
+        throw new Error(error?.message || 'Failed to initialize workflow identifier');
+      }
+
+      const result = (await response
+        .json()
+        .catch(() => ({}))) as Record<string, any>;
+
+      if (!response.ok || !result?.success || typeof result.workflowId !== 'string') {
+        const message =
+          result?.error ||
+          (response.status === 401
+            ? 'Sign in to manage workflows before continuing.'
+            : 'Failed to initialize workflow identifier');
+
+        if (response.status === 401) {
+          await logout(true);
+        }
+
+        throw new Error(message);
+      }
+
+      const resolvedId = result.workflowId;
+      updateResolvedId(resolvedId);
+
+      const ensuredPayload = payload
+        ? { ...payload, id: resolvedId }
+        : undefined;
+
+      return { workflowId: resolvedId, payload: ensuredPayload };
+    },
+    [activeWorkflowId, authFetch, logout, setActiveWorkflowId],
+  );
   const [catalog, setCatalog] = useState<any | null>(null);
   const [catalogLoading, setCatalogLoading] = useState(true);
   const [refreshConnectorsFlag, setRefreshConnectorsFlag] = useState(false);
@@ -2096,103 +2192,6 @@ const GraphEditorContent = () => {
       metadata,
     });
   }, [nodes, edges, spec]);
-
-  const ensureWorkflowId = useCallback(
-    async (
-      payload?: NodeGraph,
-    ): Promise<{ workflowId: string; payload?: NodeGraph } | null> => {
-      const updateResolvedId = (resolvedId: string) => {
-        fallbackWorkflowIdRef.current = resolvedId;
-        setActiveWorkflowId((prev) => (prev === resolvedId ? prev : resolvedId));
-        try {
-          localStorage.setItem('lastWorkflowId', resolvedId);
-        } catch (error) {
-          console.warn('Unable to persist workflow id:', error);
-        }
-      };
-
-      const getStoredIdentifier = (): string | undefined => {
-        let stored: string | undefined;
-        try {
-          stored = localStorage.getItem('lastWorkflowId') ?? undefined;
-        } catch (error) {
-          console.warn('Unable to read workflow id from storage:', error);
-        }
-        return stored;
-      };
-
-      const payloadIdentifier = typeof payload?.id === 'string' ? payload.id : undefined;
-
-      let workflowIdentifier =
-        (isUuid(payloadIdentifier) ? payloadIdentifier : undefined) ??
-        activeWorkflowId ??
-        fallbackWorkflowIdRef.current ??
-        getStoredIdentifier() ??
-        `local-${Date.now()}`;
-
-      if (isUuid(workflowIdentifier)) {
-        updateResolvedId(workflowIdentifier);
-        const ensuredPayload = payload
-          ? { ...payload, id: workflowIdentifier }
-          : undefined;
-        return { workflowId: workflowIdentifier, payload: ensuredPayload };
-      }
-
-      const requestedIdentifier = workflowIdentifier;
-
-      const body: Record<string, any> = {
-        name: payload?.name ?? 'Untitled Workflow',
-        requestedId: requestedIdentifier,
-      };
-
-      if (payload) {
-        const graphForCreation: any = { ...payload };
-        delete graphForCreation.id;
-        body.graph = graphForCreation;
-        if (payload.metadata !== undefined) {
-          body.metadata = payload.metadata;
-        }
-      }
-
-      let response: Response | null = null;
-      try {
-        response = await authFetch('/api/flows/save', {
-          method: 'POST',
-          body: JSON.stringify(body),
-        });
-      } catch (error: any) {
-        throw new Error(error?.message || 'Failed to initialize workflow identifier');
-      }
-
-      const result = (await response
-        .json()
-        .catch(() => ({}))) as Record<string, any>;
-
-      if (!response.ok || !result?.success || typeof result.workflowId !== 'string') {
-        const message =
-          result?.error ||
-          (response.status === 401
-            ? 'Sign in to manage workflows before continuing.'
-            : 'Failed to initialize workflow identifier');
-
-        if (response.status === 401) {
-          await logout(true);
-        }
-
-        throw new Error(message);
-      }
-
-      const resolvedId = result.workflowId;
-      updateResolvedId(resolvedId);
-
-      const ensuredPayload = payload
-        ? { ...payload, id: resolvedId }
-        : undefined;
-
-      return { workflowId: resolvedId, payload: ensuredPayload };
-    },
-    [activeWorkflowId, authFetch, logout, setActiveWorkflowId],
-  );
 
   const combinedValidationErrors = useMemo(() => {
     const seen = new Set<string>();


### PR DESCRIPTION
## Summary
- move the ensureWorkflowId callback earlier in ProfessionalGraphEditor so hooks depending on it access a defined reference
- keep existing dependency arrays referencing the hoisted callback without lint regressions

## Testing
- npm run build:client *(fails: `vite: not found` in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e554d86d948331a4af1fa0862941b6