### PR TITLE
Add preview flag to workflow validation requests

### DIFF
--- a/client/src/components/ai/N8NStyleWorkflowBuilder.tsx
+++ b/client/src/components/ai/N8NStyleWorkflowBuilder.tsx
@@ -600,7 +600,10 @@ export const N8NStyleWorkflowBuilder: React.FC = () => {
 
     const identifier = workflowId ?? `builder-${Date.now()}`;
     const payload = buildGraphPayload(identifier);
-    const body = JSON.stringify({ graph: payload });
+    const body = JSON.stringify({
+      graph: payload,
+      options: { preview: true },
+    });
     const controller = new AbortController();
 
     const triggerValidation = async () => {

--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -1642,7 +1642,10 @@ const GraphEditorContent = () => {
       try {
         const response = await authFetch('/api/workflows/validate', {
           method: 'POST',
-          body: JSON.stringify({ graph: graphPayload }),
+          body: JSON.stringify({
+            graph: graphPayload,
+            options: { preview: true },
+          }),
           signal,
         });
 

--- a/server/routes/__tests__/workflow-dev-fallback.test.ts
+++ b/server/routes/__tests__/workflow-dev-fallback.test.ts
@@ -195,6 +195,63 @@ try {
     'dry-run validation should not report missing trigger errors for action-only drafts',
   );
 
+  const optionsPreviewResponse = await fetch(`${baseUrl}/api/workflows/validate`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      options: { preview: true },
+      graph: {
+        id: 'options-preview-action-only',
+        name: 'Options Preview Action Only',
+        nodes: [
+          {
+            id: 'action-options-1',
+            type: 'action.gmail.send',
+            params: {
+              recipient: 'options-preview@example.com',
+            },
+            data: {
+              label: 'Send Gmail',
+              app: 'gmail',
+              nodeType: 'action.gmail.send',
+              type: 'action.gmail.send',
+              parameters: {
+                recipient: 'options-preview@example.com',
+              },
+            },
+            position: { x: 0, y: 0 },
+          },
+        ],
+        edges: [],
+      },
+    }),
+  });
+
+  assert.equal(
+    optionsPreviewResponse.status,
+    200,
+    'options preview validation should respond with 200',
+  );
+  const optionsPreviewBody = await optionsPreviewResponse.json();
+  assert.equal(
+    optionsPreviewBody.success,
+    true,
+    'options preview validation should return success payload',
+  );
+  const optionsPreviewErrors = Array.isArray(optionsPreviewBody?.validation?.errors)
+    ? optionsPreviewBody.validation.errors
+    : [];
+  const optionsTriggerErrors = optionsPreviewErrors.filter((error: any) =>
+    typeof error?.message === 'string' && error.message.toLowerCase().includes('trigger'),
+  );
+  assert.equal(
+    optionsTriggerErrors.length,
+    0,
+    'options preview validation should not report missing trigger errors for action-only drafts',
+  );
+
   const manualPreviewResponse = await fetch(`${baseUrl}/api/workflows/validate`, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
## Summary
- include a preview hint when the graph editor validates workflows so action-only drafts pass server checks
- ensure the AI builder uses the same preview mode flag when validating graphs
- add regression coverage confirming validation succeeds for action-only graphs when preview options are supplied

## Testing
- not run (network access to install tsx is restricted)


------
https://chatgpt.com/codex/tasks/task_e_68e5550278888331a37e5b40279fec05