### PR TITLE
feat: add reusable workflow editor top bar

### DIFF
--- a/client/src/components/workflow/EditorTopBar.tsx
+++ b/client/src/components/workflow/EditorTopBar.tsx
@@ -1,0 +1,211 @@
+import React from "react";
+import clsx from "clsx";
+import type { LucideIcon } from "lucide-react";
+import { Activity, Loader2, MoreHorizontal, Play } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+export interface EditorTopBarAction {
+  id: string;
+  label: string;
+  onSelect: () => void;
+  icon?: LucideIcon;
+  disabled?: boolean;
+  description?: string;
+}
+
+export interface EditorTopBarProps {
+  statusLabel: string;
+  statusTone?: "ready" | "warning" | "error";
+  statusTooltip?: string;
+  statusHelperText?: string | null;
+  statusPulse?: boolean;
+  onRun: () => void;
+  runDisabled?: boolean;
+  runTooltip?: string;
+  isRunLoading?: boolean;
+  runIdleText?: string;
+  runLoadingText?: string;
+  onValidate: () => void;
+  validateDisabled?: boolean;
+  validateTooltip?: string;
+  isValidateLoading?: boolean;
+  validateIdleText?: string;
+  validateLoadingText?: string;
+  banner?: React.ReactNode;
+  overflowActions?: EditorTopBarAction[];
+}
+
+const STATUS_TONE_CLASS: Record<NonNullable<EditorTopBarProps["statusTone"]>, string> = {
+  ready: "editor-topbar__status-dot--ready",
+  warning: "editor-topbar__status-dot--warning",
+  error: "editor-topbar__status-dot--error",
+};
+
+const EditorTopBar: React.FC<EditorTopBarProps> = ({
+  statusLabel,
+  statusTone = "ready",
+  statusTooltip,
+  statusHelperText,
+  statusPulse,
+  onRun,
+  runDisabled,
+  runTooltip,
+  isRunLoading,
+  runIdleText = "Run workflow",
+  runLoadingText = "Enqueuing…",
+  onValidate,
+  validateDisabled,
+  validateTooltip,
+  isValidateLoading,
+  validateIdleText = "Validate / Dry run",
+  validateLoadingText = "Validating…",
+  banner,
+  overflowActions,
+}) => {
+  const showRunTooltip = Boolean(runTooltip);
+  const showValidateTooltip = Boolean(validateTooltip);
+  const hasOverflow = Boolean(overflowActions && overflowActions.length > 0);
+
+  const runButton = (
+    <Button
+      type="button"
+      onClick={onRun}
+      disabled={runDisabled}
+      className="editor-topbar__action editor-topbar__action--primary"
+    >
+      {isRunLoading ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <Play className="h-4 w-4" />
+      )}
+      <span>{isRunLoading ? runLoadingText : runIdleText}</span>
+    </Button>
+  );
+
+  const validateButton = (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={onValidate}
+      disabled={validateDisabled}
+      className="editor-topbar__action editor-topbar__action--secondary"
+    >
+      {isValidateLoading ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <Activity className="h-4 w-4" />
+      )}
+      <span>{isValidateLoading ? validateLoadingText : validateIdleText}</span>
+    </Button>
+  );
+
+  const statusContent = (
+    <div className="editor-topbar__status">
+      <span
+        className={clsx(
+          "editor-topbar__status-dot",
+          STATUS_TONE_CLASS[statusTone],
+          statusPulse && "editor-topbar__status-dot--pulse"
+        )}
+      />
+      <div className="editor-topbar__status-text">
+        <span className="editor-topbar__status-label">{statusLabel}</span>
+        {statusHelperText ? (
+          <span className="editor-topbar__status-helper">{statusHelperText}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="editor-topbar">
+      <div className="editor-topbar__inner">
+        {statusTooltip ? (
+          <Tooltip>
+            <TooltipTrigger asChild>{statusContent}</TooltipTrigger>
+            <TooltipContent side="bottom" className="max-w-xs text-center">
+              <p>{statusTooltip}</p>
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          statusContent
+        )}
+
+        <div className="editor-topbar__controls">
+          {showRunTooltip ? (
+            <Tooltip>
+              <TooltipTrigger asChild>{runButton}</TooltipTrigger>
+              <TooltipContent side="bottom" className="max-w-xs text-center">
+                <p>{runTooltip}</p>
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            runButton
+          )}
+
+          {showValidateTooltip ? (
+            <Tooltip>
+              <TooltipTrigger asChild>{validateButton}</TooltipTrigger>
+              <TooltipContent side="bottom" className="max-w-xs text-center">
+                <p>{validateTooltip}</p>
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            validateButton
+          )}
+
+          {hasOverflow ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="editor-topbar__overflow-trigger"
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                  <span className="sr-only">More actions</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="editor-topbar__overflow-menu">
+                {overflowActions!.map((action) => {
+                  const Icon = action.icon;
+                  return (
+                    <DropdownMenuItem
+                      key={action.id}
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        if (!action.disabled) {
+                          action.onSelect();
+                        }
+                      }}
+                      disabled={action.disabled}
+                      className="editor-topbar__overflow-item"
+                    >
+                      {Icon ? <Icon className="h-4 w-4" /> : null}
+                      <span>{action.label}</span>
+                      {action.description ? (
+                        <span className="editor-topbar__overflow-description">{action.description}</span>
+                      ) : null}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+        </div>
+      </div>
+
+      {banner ? <div className="editor-topbar__banner">{banner}</div> : null}
+    </div>
+  );
+};
+
+export default EditorTopBar;

--- a/client/src/components/workflow/editor-topbar.css
+++ b/client/src/components/workflow/editor-topbar.css
@@ -1,0 +1,167 @@
+.editor-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 8px 20px -12px rgba(15, 23, 42, 0.45);
+}
+
+.editor-topbar__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.editor-topbar__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.55);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.editor-topbar__status-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.editor-topbar__status-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.editor-topbar__status-helper {
+  font-size: 0.7rem;
+  opacity: 0.8;
+}
+
+.editor-topbar__status-dot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.55);
+}
+
+.editor-topbar__status-dot--ready {
+  background: #22c55e;
+  box-shadow: 0 0 0 2px rgba(22, 101, 52, 0.45);
+}
+
+.editor-topbar__status-dot--warning {
+  background: #f97316;
+  box-shadow: 0 0 0 2px rgba(194, 65, 12, 0.45);
+}
+
+.editor-topbar__status-dot--error {
+  background: #ef4444;
+  box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.45);
+}
+
+@keyframes editor-topbar-status-pulse {
+  0% {
+    transform: scale(0.95);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.95);
+    opacity: 0.7;
+  }
+}
+
+.editor-topbar__status-dot--pulse {
+  animation: editor-topbar-status-pulse 1.4s ease-in-out infinite;
+}
+
+.editor-topbar__controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.editor-topbar__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding-inline: 1rem;
+}
+
+.editor-topbar__action--primary {
+  background: linear-gradient(135deg, #10b981, #0ea5e9);
+  color: white;
+  border: none;
+}
+
+.editor-topbar__action--primary:hover:not(:disabled) {
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+}
+
+.editor-topbar__action--secondary {
+  background: rgba(250, 204, 21, 0.12);
+  color: #fbbf24;
+  border-color: rgba(234, 179, 8, 0.35);
+}
+
+.editor-topbar__action--secondary:hover:not(:disabled) {
+  background: rgba(250, 204, 21, 0.2);
+  color: #facc15;
+}
+
+.editor-topbar__overflow-trigger {
+  color: #cbd5f5;
+  border-radius: 9999px;
+}
+
+.editor-topbar__overflow-trigger:hover {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.editor-topbar__overflow-menu {
+  min-width: 14rem;
+}
+
+.editor-topbar__overflow-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.editor-topbar__overflow-item svg {
+  color: #6366f1;
+}
+
+.editor-topbar__overflow-description {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #94a3b8;
+  margin-left: auto;
+}
+
+.editor-topbar__banner {
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.workflow-inspector-panel {
+  position: relative;
+  z-index: 40;
+}


### PR DESCRIPTION
## Summary
- add a reusable EditorTopBar component with run, validate, and overflow actions for the workflow editor
- introduce sticky toolbar styling and elevate the inspector drawer with new editor-topbar CSS
- integrate the toolbar into ProfessionalGraphEditor while restructuring the center pane layout and overflow actions

## Testing
- npm run check *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68e5d5f395748331803bf0d018a509a6