### PR TITLE
Fix: declare lodash dependency for workflow debounce import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "framer-motion": "^11.13.1",
         "input-otp": "^1.4.2",
         "jsonwebtoken": "9.0.2",
+        "lodash": "^4.17.21",
         "lucide-react": "^0.453.0",
         "memorystore": "^1.6.7",
         "nanoid": "^5.1.5",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "framer-motion": "^11.13.1",
     "input-otp": "^1.4.2",
     "jsonwebtoken": "9.0.2",
+    "lodash": "^4.17.21",
     "lucide-react": "^0.453.0",
     "memorystore": "^1.6.7",
     "nanoid": "^5.1.5",


### PR DESCRIPTION
## Summary
- add lodash as an explicit runtime dependency so the workflow editor debounce import resolves reliably

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e5dc7170d883319c48ef56155a3ac3