### PR TITLE
Add keyboard shortcuts and overflow menu handling to workflow editor

### DIFF
--- a/client/src/components/workflow/EditorTopBar.tsx
+++ b/client/src/components/workflow/EditorTopBar.tsx
@@ -42,6 +42,9 @@ export interface EditorTopBarProps {
   validateIdleText?: string;
   validateLoadingText?: string;
   banner?: React.ReactNode;
+  onSave?: EditorTopBarAction;
+  onPromote?: EditorTopBarAction;
+  onExport?: EditorTopBarAction;
   overflowActions?: EditorTopBarAction[];
 }
 
@@ -58,6 +61,7 @@ const EditorTopBar: React.FC<EditorTopBarProps> = ({
   statusHelperText,
   statusPulse,
   onRun,
+  canRun,
   runDisabled,
   runTooltip,
   isRunLoading,
@@ -71,11 +75,36 @@ const EditorTopBar: React.FC<EditorTopBarProps> = ({
   validateIdleText = "Validate / Dry run",
   validateLoadingText = "Validating…",
   banner,
+  onSave,
+  onPromote,
+  onExport,
   overflowActions,
 }) => {
   const showRunTooltip = Boolean(runTooltip);
   const showValidateTooltip = Boolean(validateTooltip);
-  const hasOverflow = Boolean(overflowActions && overflowActions.length > 0);
+  const derivedOverflowActions = React.useMemo(() => {
+    const actions: EditorTopBarAction[] = [];
+
+    if (onSave) {
+      actions.push(onSave);
+    }
+
+    if (onPromote) {
+      actions.push(onPromote);
+    }
+
+    if (onExport) {
+      actions.push(onExport);
+    }
+
+    if (overflowActions && overflowActions.length > 0) {
+      actions.push(...overflowActions);
+    }
+
+    return actions;
+  }, [onSave, onPromote, onExport, overflowActions]);
+
+  const hasOverflow = derivedOverflowActions.length > 0;
 
   const runButtonDisabled = Boolean(runDisabled ?? false) || (typeof canRun === "boolean" ? !canRun : false);
   const validateButtonDisabled =
@@ -182,7 +211,7 @@ const EditorTopBar: React.FC<EditorTopBarProps> = ({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="editor-topbar__overflow-menu">
-                {overflowActions!.map((action) => {
+                {derivedOverflowActions.map((action) => {
                   const Icon = action.icon;
                   return (
                     <DropdownMenuItem

--- a/client/src/components/workflow/__tests__/EditorKeyboardShortcuts.test.tsx
+++ b/client/src/components/workflow/__tests__/EditorKeyboardShortcuts.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import "@testing-library/jest-dom/vitest";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  useEditorKeyboardShortcuts,
+  type EditorKeyboardShortcutOptions,
+} from "../ProfessionalGraphEditor";
+
+const ShortcutHarness: React.FC<EditorKeyboardShortcutOptions> = (props) => {
+  useEditorKeyboardShortcuts(props);
+  return <div data-testid="shortcut-harness">Harness</div>;
+};
+
+describe("useEditorKeyboardShortcuts", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("invokes run handlers for meta+enter and ctrl+enter when enabled", () => {
+    const onRun = vi.fn();
+    const onValidate = vi.fn();
+
+    render(
+      <ShortcutHarness
+        onRun={onRun}
+        canRun
+        runDisabled={false}
+        onValidate={onValidate}
+        canValidate
+        validateDisabled={false}
+      />,
+    );
+
+    fireEvent.keyDown(document.body, { key: "Enter", metaKey: true });
+    fireEvent.keyDown(document.body, { key: "Enter", ctrlKey: true });
+
+    expect(onRun).toHaveBeenCalledTimes(2);
+    expect(onValidate).not.toHaveBeenCalled();
+  });
+
+  it("invokes validate handler for shift+enter and ignores disallowed contexts", () => {
+    const onRun = vi.fn();
+    const onValidate = vi.fn();
+
+    const { rerender } = render(
+      <ShortcutHarness
+        onRun={onRun}
+        canRun
+        runDisabled={false}
+        onValidate={onValidate}
+        canValidate
+        validateDisabled={false}
+      />,
+    );
+
+    fireEvent.keyDown(document.body, { key: "Enter", shiftKey: true });
+    expect(onValidate).toHaveBeenCalledTimes(1);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+    expect(onRun).not.toHaveBeenCalled();
+    input.remove();
+
+    onRun.mockClear();
+    onValidate.mockClear();
+
+    rerender(
+      <ShortcutHarness
+        onRun={onRun}
+        canRun={false}
+        runDisabled
+        onValidate={onValidate}
+        canValidate={false}
+        validateDisabled
+      />,
+    );
+
+    fireEvent.keyDown(document.body, { key: "Enter", metaKey: true });
+    fireEvent.keyDown(document.body, { key: "Enter", shiftKey: true });
+
+    expect(onRun).not.toHaveBeenCalled();
+    expect(onValidate).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/workflow/__tests__/EditorTopBar.overflow.test.tsx
+++ b/client/src/components/workflow/__tests__/EditorTopBar.overflow.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import EditorTopBar from "../EditorTopBar";
+
+const baseProps = {
+  statusLabel: "Ready",
+  statusTone: "ready" as const,
+  statusHelperText: "All systems go",
+  onRun: vi.fn(),
+  canRun: true,
+  runDisabled: false,
+  onValidate: vi.fn(),
+  canValidate: true,
+  validateDisabled: false,
+};
+
+describe("EditorTopBar overflow actions", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("hides the overflow trigger when no actions are provided", () => {
+    render(<EditorTopBar {...baseProps} />);
+    expect(screen.queryByRole("button", { name: /more actions/i })).toBeNull();
+  });
+
+  it("invokes provided overflow handlers", async () => {
+    const onSave = vi.fn();
+    const onPromote = vi.fn();
+    const onExport = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <EditorTopBar
+        {...baseProps}
+        onSave={{ id: "save", label: "Save draft", onSelect: onSave }}
+        onPromote={{ id: "promote", label: "Promote", onSelect: onPromote }}
+        onExport={{ id: "export", label: "Export workflow JSON", onSelect: onExport }}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /more actions/i });
+
+    await user.click(trigger);
+    const saveItem = await screen.findByRole("menuitem", { name: /save draft/i });
+    await user.click(saveItem);
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    await user.click(trigger);
+    const promoteItem = await screen.findByRole("menuitem", { name: /promote/i });
+    await user.click(promoteItem);
+    expect(onPromote).toHaveBeenCalledTimes(1);
+
+    await user.click(trigger);
+    const exportItem = await screen.findByRole("menuitem", { name: /export workflow json/i });
+    await user.click(exportItem);
+    expect(onExport).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable keyboard shortcut hook and wire ProfessionalGraphEditor to trigger run/validate on ⌘/Ctrl+Enter and ⇧+Enter
- gate save/promote/export availability, add an export workflow flow, and pass the actions to EditorTopBar only when ready
- update EditorTopBar to build its overflow menu from discrete actions and add tests covering shortcuts and menu behavior

## Testing
- `npx vitest run client/src/components/workflow/__tests__/EditorKeyboardShortcuts.test.tsx client/src/components/workflow/__tests__/EditorTopBar.overflow.test.tsx` *(fails: npm 403 when attempting to resolve vitest in the restricted environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5dc46be84833186bb3eb874f7fde7