### PR TITLE
feat(client): centralize workflow execution enqueueing

### DIFF
--- a/client/src/services/__tests__/executions.test.ts
+++ b/client/src/services/__tests__/executions.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+
+import { authStore } from '@/store/authStore';
+import { enqueueExecution, ExecutionEnqueueError } from '../executions';
+
+const originalAuthFetch = authStore.getState().authFetch;
+
+const resetAuthFetch = () => {
+  authStore.setState({ authFetch: originalAuthFetch } as any);
+};
+
+try {
+  await (async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    authStore.setState({
+      authFetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({ input, init });
+        return new Response(
+          JSON.stringify({ success: true, executionId: 'exec-123' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      },
+    } as any);
+
+    const result = await enqueueExecution({
+      workflowId: 'wf-1',
+      triggerType: 'manual',
+      initialData: { payload: true },
+    });
+
+    assert.equal(result.executionId, 'exec-123');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.input, '/api/executions');
+    const body = calls[0]?.init?.body as string | undefined;
+    assert.ok(body, 'request body should be defined');
+    const parsed = JSON.parse(body ?? '{}');
+    assert.deepEqual(parsed, {
+      workflowId: 'wf-1',
+      triggerType: 'manual',
+      initialData: { payload: true },
+    });
+  })();
+
+  await (async () => {
+    authStore.setState({
+      authFetch: async () =>
+        new Response(
+          JSON.stringify({
+            success: false,
+            error: 'EXECUTION_QUOTA_EXCEEDED',
+            message: 'Quota reached',
+            details: { quotaType: 'TASKS' },
+          }),
+          { status: 429, headers: { 'Content-Type': 'application/json' } },
+        ),
+    } as any);
+
+    await assert.rejects(
+      () =>
+        enqueueExecution({
+          workflowId: 'wf-2',
+          triggerType: 'manual',
+          initialData: null,
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof ExecutionEnqueueError, 'error should be ExecutionEnqueueError');
+        const enqueueError = error as ExecutionEnqueueError;
+        assert.equal(enqueueError.status, 429);
+        assert.equal(enqueueError.code, 'EXECUTION_QUOTA_EXCEEDED');
+        assert.equal(enqueueError.message, 'Quota reached');
+        assert.deepEqual(enqueueError.details, { quotaType: 'TASKS' });
+        return true;
+      },
+    );
+  })();
+} finally {
+  resetAuthFetch();
+}
+

--- a/client/src/services/executions.ts
+++ b/client/src/services/executions.ts
@@ -1,0 +1,80 @@
+import { authStore } from '@/store/authStore';
+
+export type ExecutionTriggerType = string;
+
+export type EnqueueExecutionParams = {
+  workflowId: string;
+  triggerType: ExecutionTriggerType;
+  initialData: unknown;
+};
+
+export type EnqueueExecutionResult = {
+  executionId: string;
+};
+
+export type ExecutionEnqueueErrorDetails = Record<string, any> | undefined;
+
+export class ExecutionEnqueueError extends Error {
+  status: number;
+  code?: string;
+  details?: ExecutionEnqueueErrorDetails;
+
+  constructor(
+    status: number,
+    message: string,
+    code?: string,
+    details?: ExecutionEnqueueErrorDetails,
+  ) {
+    super(message);
+    this.name = 'ExecutionEnqueueError';
+    this.status = status;
+    this.code = code;
+    this.details = details;
+    Object.setPrototypeOf(this, ExecutionEnqueueError.prototype);
+  }
+}
+
+const extractExecutionId = (payload: Record<string, any>): string | undefined => {
+  if (typeof payload?.executionId === 'string') {
+    return payload.executionId;
+  }
+
+  if (typeof payload?.data?.executionId === 'string') {
+    return payload.data.executionId;
+  }
+
+  return undefined;
+};
+
+export const enqueueExecution = async ({
+  workflowId,
+  triggerType,
+  initialData,
+}: EnqueueExecutionParams): Promise<EnqueueExecutionResult> => {
+  const { authFetch } = authStore.getState();
+
+  const response = await authFetch('/api/executions', {
+    method: 'POST',
+    body: JSON.stringify({ workflowId, triggerType, initialData }),
+  });
+
+  const result = (await response.json().catch(() => ({}))) as Record<string, any>;
+  const executionId = extractExecutionId(result);
+
+  if (!response.ok || result?.success === false || !executionId) {
+    const message =
+      typeof result?.message === 'string'
+        ? result.message
+        : typeof result?.error === 'string'
+          ? result.error
+          : `Failed to enqueue workflow execution (status ${response.status}).`;
+
+    const code = typeof result?.error === 'string' ? result.error : undefined;
+    const details = result?.details as ExecutionEnqueueErrorDetails;
+
+    throw new ExecutionEnqueueError(response.status, message, code, details);
+  }
+
+  return { executionId };
+};
+


### PR DESCRIPTION
## Summary
- add a shared enqueueExecution service that wraps authFetch and normalizes execution responses
- refactor manual run entry points to use the helper while preserving quota and queue error messaging
- cover the helper with tests that assert success and surfaced error propagation

## Testing
- not run (missing local npm dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e5f09c554c83319e92d5e3e7c019d5