### PR TITLE
Refactor professional editor layout into grid shell

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -112,6 +112,7 @@ import { useQueueHealth } from '@/hooks/useQueueHealth';
 import { useWorkerHeartbeat, WORKER_FLEET_GUIDANCE } from '@/hooks/useWorkerHeartbeat';
 import { collectNodeConfigurationErrors } from './nodeConfigurationValidation';
 import './editor-topbar.css';
+import './professional-graph-editor.css';
 
 // Enhanced Node Template Interface
 interface NodeTemplate {
@@ -3579,17 +3580,19 @@ const GraphEditorContent = () => {
   });
 
   return (
-    <div className="flex h-screen bg-gray-100">
+    <div className="editor-shell">
       {/* Sidebar */}
-      <NodeSidebar
-        onAddNode={onAddNode}
-        catalog={catalog}
-        loading={catalogLoading || connectorDefinitionsLoading}
-        connectorDefinitions={connectorDefinitions}
-      />
-      
+      <aside className="editor-shell__left">
+        <NodeSidebar
+          onAddNode={onAddNode}
+          catalog={catalog}
+          loading={catalogLoading || connectorDefinitionsLoading}
+          connectorDefinitions={connectorDefinitions}
+        />
+      </aside>
+
       {/* Main Graph Area */}
-      <div className="flex-1 flex flex-col relative min-w-0">
+      <div className="center-pane">
         <EditorTopBar
           statusLabel={statusLabel}
           statusTone={queueStatusTone}
@@ -3635,7 +3638,7 @@ const GraphEditorContent = () => {
           onExport={exportAction}
         />
 
-        <div className="flex-1 min-h-0">
+        <div className="center-pane__canvas">
           <ValidationFixContext.Provider value={handleFixValidationError}>
             <ReactFlow
               nodes={nodes}
@@ -3669,7 +3672,7 @@ const GraphEditorContent = () => {
             }}
             fitView
             attributionPosition="bottom-left"
-            className="bg-gray-100"
+            className="center-pane__flow bg-gray-100"
           >
             <Background
               color="#e2e8f0"
@@ -3747,37 +3750,50 @@ const GraphEditorContent = () => {
           </ValidationFixContext.Provider>
         </div>
       </div>
-      
+
       {/* Node Properties Panel - Enterprise Design */}
-      {selectedNode && (
-        <div
-          data-inspector
-          className="workflow-inspector-panel w-96 bg-gradient-to-br from-slate-50 to-white border-l-2 border-slate-200 shadow-xl overflow-y-auto nopan"
-          onPointerDown={(e) => { e.stopPropagation(); }}
-          onPointerUp={(e) => { e.stopPropagation(); }}
-          onMouseDown={(e) => { e.stopPropagation(); }}
-          onMouseUp={(e) => { e.stopPropagation(); }}
-          onClick={(e) => { e.stopPropagation(); }}
-          onDoubleClick={(e) => { e.stopPropagation(); }}
-          onPointerDownCapture={(e) => { e.stopPropagation(); const ne: any = (e as any).nativeEvent; if (ne?.stopImmediatePropagation) ne.stopImmediatePropagation(); }}
-          onMouseDownCapture={(e) => { e.stopPropagation(); const ne: any = (e as any).nativeEvent; if (ne?.stopImmediatePropagation) ne.stopImmediatePropagation(); }}
-          onClickCapture={(e) => { e.stopPropagation(); const ne: any = (e as any).nativeEvent; if (ne?.stopImmediatePropagation) ne.stopImmediatePropagation(); }}
-          onKeyDownCapture={(event) => {
-            if (event.ctrlKey || event.metaKey) {
-              event.stopPropagation();
-              const nativeEvent: any = event.nativeEvent;
-              if (nativeEvent?.stopImmediatePropagation) nativeEvent.stopImmediatePropagation();
-            }
-          }}
-          onKeyUpCapture={(event) => {
-            if (event.ctrlKey || event.metaKey) {
-              event.stopPropagation();
-              const nativeEvent: any = event.nativeEvent;
-              if (nativeEvent?.stopImmediatePropagation) nativeEvent.stopImmediatePropagation();
-            }
-          }}
-          style={{ pointerEvents: 'auto' }}
-        >
+      <aside className="right-pane">
+        {selectedNode && (
+          <div
+            data-inspector
+            className="workflow-inspector-panel w-full bg-gradient-to-br from-slate-50 to-white border-l-2 border-slate-200 shadow-xl overflow-y-auto nopan"
+            onPointerDown={(e) => { e.stopPropagation(); }}
+            onPointerUp={(e) => { e.stopPropagation(); }}
+            onMouseDown={(e) => { e.stopPropagation(); }}
+            onMouseUp={(e) => { e.stopPropagation(); }}
+            onClick={(e) => { e.stopPropagation(); }}
+            onDoubleClick={(e) => { e.stopPropagation(); }}
+            onPointerDownCapture={(e) => {
+              e.stopPropagation();
+              const ne: any = (e as any).nativeEvent;
+              if (ne?.stopImmediatePropagation) ne.stopImmediatePropagation();
+            }}
+            onMouseDownCapture={(e) => {
+              e.stopPropagation();
+              const ne: any = (e as any).nativeEvent;
+              if (ne?.stopImmediatePropagation) ne.stopImmediatePropagation();
+            }}
+            onClickCapture={(e) => {
+              e.stopPropagation();
+              const ne: any = (e as any).nativeEvent;
+              if (ne?.stopImmediatePropagation) ne.stopImmediatePropagation();
+            }}
+            onKeyDownCapture={(event) => {
+              if (event.ctrlKey || event.metaKey) {
+                event.stopPropagation();
+                const nativeEvent: any = event.nativeEvent;
+                if (nativeEvent?.stopImmediatePropagation) nativeEvent.stopImmediatePropagation();
+              }
+            }}
+            onKeyUpCapture={(event) => {
+              if (event.ctrlKey || event.metaKey) {
+                event.stopPropagation();
+                const nativeEvent: any = event.nativeEvent;
+                if (nativeEvent?.stopImmediatePropagation) nativeEvent.stopImmediatePropagation();
+              }
+            }}
+            style={{ pointerEvents: 'auto' }}
+          >
           {/* Header */}
           <div className="bg-gradient-to-r from-blue-600 to-indigo-600 px-6 py-4 border-b">
             <div className="flex items-center justify-between">
@@ -4084,8 +4100,8 @@ const GraphEditorContent = () => {
               </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </aside>
       <Dialog open={promotionDialogOpen} onOpenChange={handlePromotionDialogOpenChange}>
         <DialogContent className="sm:max-w-2xl">
           <DialogHeader>

--- a/client/src/components/workflow/editor-topbar.css
+++ b/client/src/components/workflow/editor-topbar.css
@@ -1,7 +1,7 @@
 .editor-topbar {
   position: sticky;
   top: 0;
-  z-index: 20;
+  z-index: 10;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -163,5 +163,4 @@
 
 .workflow-inspector-panel {
   position: relative;
-  z-index: 40;
 }

--- a/client/src/components/workflow/professional-graph-editor.css
+++ b/client/src/components/workflow/professional-graph-editor.css
@@ -1,0 +1,56 @@
+.editor-shell {
+  display: grid;
+  grid-template-columns: 310px 1fr 380px;
+  height: 100vh;
+  background-color: #f3f4f6;
+  overflow: hidden;
+}
+
+.editor-shell__left {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  border-right: 1px solid rgba(148, 163, 184, 0.35);
+  background-color: #ffffff;
+}
+
+.editor-shell__left > * {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.center-pane {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  background: transparent;
+}
+
+.center-pane__canvas {
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.center-pane__flow {
+  width: 100%;
+  height: 100%;
+}
+
+.right-pane {
+  position: relative;
+  z-index: 20;
+  min-height: 0;
+  overflow-y: auto;
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.92), rgba(241, 245, 249, 0.85));
+  border-left: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.right-pane > * {
+  min-height: 100%;
+}


### PR DESCRIPTION
## Summary
- refactor the professional graph editor shell to use a three-column grid with dedicated left, center, and right panes
- move the top bar and canvas into a stacked center pane and add a layout stylesheet to replace the old flex-based rules
- adjust z-index layering so the smart parameters drawer stays above the toolbar while maintaining sticky behavior

## Testing
- npm run build:client *(fails: vite not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f09eb3508331a8b473fa6ee07c1f