### PR TITLE
Simplify workflow editor top bar UI

### DIFF
--- a/client/src/components/workflow/EditorTopBar.tsx
+++ b/client/src/components/workflow/EditorTopBar.tsx
@@ -4,13 +4,6 @@ import type { LucideIcon } from "lucide-react";
 import { Activity, Loader2, MoreHorizontal, Play } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export interface EditorTopBarAction {
   id: string;
@@ -22,224 +15,115 @@ export interface EditorTopBarAction {
 }
 
 export interface EditorTopBarProps {
-  statusLabel: string;
-  statusTone?: "ready" | "warning" | "error";
-  statusTooltip?: string;
-  statusHelperText?: string | null;
-  statusPulse?: boolean;
+  canRun: boolean;
+  canValidate: boolean;
+  isRunning: boolean;
+  isValidating: boolean;
+  workersOnline: number;
   onRun: () => void;
-  canRun?: boolean;
-  runDisabled?: boolean;
-  runTooltip?: string;
-  isRunLoading?: boolean;
-  runIdleText?: string;
-  runLoadingText?: string;
   onValidate: () => void;
-  canValidate?: boolean;
-  validateDisabled?: boolean;
-  validateTooltip?: string;
-  isValidateLoading?: boolean;
-  validateIdleText?: string;
-  validateLoadingText?: string;
-  banner?: React.ReactNode;
-  onSave?: EditorTopBarAction;
-  onPromote?: EditorTopBarAction;
-  onExport?: EditorTopBarAction;
   overflowActions?: EditorTopBarAction[];
 }
 
-const STATUS_TONE_CLASS: Record<NonNullable<EditorTopBarProps["statusTone"]>, string> = {
-  ready: "editor-topbar__status-dot--ready",
-  warning: "editor-topbar__status-dot--warning",
-  error: "editor-topbar__status-dot--error",
-};
-
 const EditorTopBar: React.FC<EditorTopBarProps> = ({
-  statusLabel,
-  statusTone = "ready",
-  statusTooltip,
-  statusHelperText,
-  statusPulse,
-  onRun,
   canRun,
-  runDisabled,
-  runTooltip,
-  isRunLoading,
-  runIdleText = "Run workflow",
-  runLoadingText = "Enqueuing…",
-  onValidate,
   canValidate,
-  validateDisabled,
-  validateTooltip,
-  isValidateLoading,
-  validateIdleText = "Validate / Dry run",
-  validateLoadingText = "Validating…",
-  banner,
-  onSave,
-  onPromote,
-  onExport,
-  overflowActions,
+  isRunning,
+  isValidating,
+  workersOnline,
+  onRun,
+  onValidate,
+  overflowActions = [],
 }) => {
-  const showRunTooltip = Boolean(runTooltip);
-  const showValidateTooltip = Boolean(validateTooltip);
-  const derivedOverflowActions = React.useMemo(() => {
-    const actions: EditorTopBarAction[] = [];
+  const hasWorkersOnline = workersOnline > 0;
+  const workerLabel = hasWorkersOnline
+    ? `${workersOnline} worker${workersOnline === 1 ? "" : "s"} online`
+    : "No workers online";
 
-    if (onSave) {
-      actions.push(onSave);
+  const primaryAction = React.useMemo(() => {
+    if (isRunning || (canRun && !isValidating)) {
+      return {
+        label: isRunning ? "Running…" : "Run workflow",
+        Icon: Play,
+        onClick: onRun,
+        disabled: !canRun || isRunning,
+        isLoading: isRunning,
+      } as const;
     }
 
-    if (onPromote) {
-      actions.push(onPromote);
-    }
-
-    if (onExport) {
-      actions.push(onExport);
-    }
-
-    if (overflowActions && overflowActions.length > 0) {
-      actions.push(...overflowActions);
-    }
-
-    return actions;
-  }, [onSave, onPromote, onExport, overflowActions]);
-
-  const hasOverflow = derivedOverflowActions.length > 0;
-
-  const runButtonDisabled = Boolean(runDisabled ?? false) || (typeof canRun === "boolean" ? !canRun : false);
-  const validateButtonDisabled =
-    Boolean(validateDisabled ?? false) || (typeof canValidate === "boolean" ? !canValidate : false);
-
-  const runButton = (
-    <Button
-      type="button"
-      onClick={onRun}
-      disabled={runButtonDisabled}
-      className="editor-topbar__action editor-topbar__action--primary"
-    >
-      {isRunLoading ? (
-        <Loader2 className="h-4 w-4 animate-spin" />
-      ) : (
-        <Play className="h-4 w-4" />
-      )}
-      <span>{isRunLoading ? runLoadingText : runIdleText}</span>
-    </Button>
-  );
-
-  const validateButton = (
-    <Button
-      type="button"
-      variant="outline"
-      onClick={onValidate}
-      disabled={validateButtonDisabled}
-      className="editor-topbar__action editor-topbar__action--secondary"
-    >
-      {isValidateLoading ? (
-        <Loader2 className="h-4 w-4 animate-spin" />
-      ) : (
-        <Activity className="h-4 w-4" />
-      )}
-      <span>{isValidateLoading ? validateLoadingText : validateIdleText}</span>
-    </Button>
-  );
-
-  const statusContent = (
-    <div className="editor-topbar__status">
-      <span
-        className={clsx(
-          "editor-topbar__status-dot",
-          STATUS_TONE_CLASS[statusTone],
-          statusPulse && "editor-topbar__status-dot--pulse"
-        )}
-      />
-      <div className="editor-topbar__status-text">
-        <span className="editor-topbar__status-label">{statusLabel}</span>
-        {statusHelperText ? (
-          <span className="editor-topbar__status-helper">{statusHelperText}</span>
-        ) : null}
-      </div>
-    </div>
-  );
+    return {
+      label: isValidating ? "Validating…" : "Validate workflow",
+      Icon: Activity,
+      onClick: onValidate,
+      disabled: !canValidate || isValidating,
+      isLoading: isValidating,
+    } as const;
+  }, [canRun, canValidate, isRunning, isValidating, onRun, onValidate]);
 
   return (
     <div className="editor-topbar">
-      <div className="editor-topbar__inner">
-        {statusTooltip ? (
-          <Tooltip>
-            <TooltipTrigger asChild>{statusContent}</TooltipTrigger>
-            <TooltipContent side="bottom" className="max-w-xs text-center">
-              <p>{statusTooltip}</p>
-            </TooltipContent>
-          </Tooltip>
-        ) : (
-          statusContent
-        )}
-
-        <div className="editor-topbar__controls">
-          {showRunTooltip ? (
-            <Tooltip>
-              <TooltipTrigger asChild>{runButton}</TooltipTrigger>
-              <TooltipContent side="bottom" className="max-w-xs text-center">
-                <p>{runTooltip}</p>
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            runButton
+      <div className="editor-topbar__status" role="status" aria-live="polite">
+        <span
+          aria-hidden="true"
+          className={clsx(
+            "editor-topbar__status-indicator",
+            hasWorkersOnline
+              ? "editor-topbar__status-indicator--online"
+              : "editor-topbar__status-indicator--offline",
           )}
-
-          {showValidateTooltip ? (
-            <Tooltip>
-              <TooltipTrigger asChild>{validateButton}</TooltipTrigger>
-              <TooltipContent side="bottom" className="max-w-xs text-center">
-                <p>{validateTooltip}</p>
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            validateButton
-          )}
-
-          {hasOverflow ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="editor-topbar__overflow-trigger"
-                >
-                  <MoreHorizontal className="h-4 w-4" />
-                  <span className="sr-only">More actions</span>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="editor-topbar__overflow-menu">
-                {derivedOverflowActions.map((action) => {
-                  const Icon = action.icon;
-                  return (
-                    <DropdownMenuItem
-                      key={action.id}
-                      onSelect={(event) => {
-                        event.preventDefault();
-                        if (!action.disabled) {
-                          action.onSelect();
-                        }
-                      }}
-                      disabled={action.disabled}
-                      className="editor-topbar__overflow-item"
-                    >
-                      {Icon ? <Icon className="h-4 w-4" /> : null}
-                      <span>{action.label}</span>
-                      {action.description ? (
-                        <span className="editor-topbar__overflow-description">{action.description}</span>
-                      ) : null}
-                    </DropdownMenuItem>
-                  );
-                })}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : null}
-        </div>
+        />
+        <span className="editor-topbar__status-label">{workerLabel}</span>
       </div>
 
-      {banner ? <div className="editor-topbar__banner">{banner}</div> : null}
+      <div className="editor-topbar__controls">
+        <Button
+          type="button"
+          onClick={primaryAction.onClick}
+          disabled={primaryAction.disabled}
+          className="editor-topbar__primary"
+        >
+          {primaryAction.isLoading ? (
+            <Loader2 className="editor-topbar__primary-spinner" />
+          ) : (
+            <primaryAction.Icon className="editor-topbar__primary-icon" />
+          )}
+          <span>{primaryAction.label}</span>
+        </Button>
+
+        {overflowActions.length > 0 ? (
+          <div className="editor-topbar__overflow">
+            <button
+              type="button"
+              className="editor-topbar__overflow-trigger"
+              aria-haspopup="menu"
+              aria-label="More actions"
+            >
+              <MoreHorizontal className="editor-topbar__overflow-icon" />
+            </button>
+            <div className="editor-topbar__overflow-sheet" role="menu">
+              {overflowActions.map((action) => {
+                const Icon = action.icon;
+                return (
+                  <button
+                    key={action.id}
+                    type="button"
+                    role="menuitem"
+                    className="editor-topbar__overflow-item"
+                    onClick={action.onSelect}
+                    disabled={action.disabled}
+                  >
+                    {Icon ? <Icon className="editor-topbar__overflow-item-icon" /> : null}
+                    <span className="editor-topbar__overflow-item-label">{action.label}</span>
+                    {action.description ? (
+                      <span className="editor-topbar__overflow-item-description">{action.description}</span>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 };

--- a/client/src/components/workflow/__tests__/EditorTopBar.overflow.test.tsx
+++ b/client/src/components/workflow/__tests__/EditorTopBar.overflow.test.tsx
@@ -7,15 +7,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import EditorTopBar from "../EditorTopBar";
 
 const baseProps = {
-  statusLabel: "Ready",
-  statusTone: "ready" as const,
-  statusHelperText: "All systems go",
   onRun: vi.fn(),
-  canRun: true,
-  runDisabled: false,
   onValidate: vi.fn(),
+  canRun: true,
   canValidate: true,
-  validateDisabled: false,
+  isRunning: false,
+  isValidating: false,
+  workersOnline: 3,
 };
 
 describe("EditorTopBar overflow actions", () => {
@@ -37,25 +35,27 @@ describe("EditorTopBar overflow actions", () => {
     render(
       <EditorTopBar
         {...baseProps}
-        onSave={{ id: "save", label: "Save draft", onSelect: onSave }}
-        onPromote={{ id: "promote", label: "Promote", onSelect: onPromote }}
-        onExport={{ id: "export", label: "Export workflow JSON", onSelect: onExport }}
+        overflowActions={[
+          { id: "save", label: "Save draft", onSelect: onSave },
+          { id: "promote", label: "Promote", onSelect: onPromote },
+          { id: "export", label: "Export workflow JSON", onSelect: onExport },
+        ]}
       />,
     );
 
     const trigger = screen.getByRole("button", { name: /more actions/i });
 
-    await user.click(trigger);
+    await user.hover(trigger);
     const saveItem = await screen.findByRole("menuitem", { name: /save draft/i });
     await user.click(saveItem);
     expect(onSave).toHaveBeenCalledTimes(1);
 
-    await user.click(trigger);
+    await user.hover(trigger);
     const promoteItem = await screen.findByRole("menuitem", { name: /promote/i });
     await user.click(promoteItem);
     expect(onPromote).toHaveBeenCalledTimes(1);
 
-    await user.click(trigger);
+    await user.hover(trigger);
     const exportItem = await screen.findByRole("menuitem", { name: /export workflow json/i });
     await user.click(exportItem);
     expect(onExport).toHaveBeenCalledTimes(1);

--- a/client/src/components/workflow/editor-topbar.css
+++ b/client/src/components/workflow/editor-topbar.css
@@ -1,92 +1,46 @@
 .editor-topbar {
   position: sticky;
   top: 0;
-  z-index: 20;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  background: rgba(15, 23, 42, 0.9);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
-  box-shadow: 0 8px 20px -12px rgba(15, 23, 42, 0.45);
-}
-
-.editor-topbar__inner {
+  z-index: 30;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background-color: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .editor-topbar__status {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.35rem 0.75rem;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
   border-radius: 9999px;
-  background: rgba(15, 23, 42, 0.55);
-  color: #e2e8f0;
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: #cbd5f5;
+  font-size: 0.85rem;
+  line-height: 1.2;
 }
 
-.editor-topbar__status-text {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.1;
+.editor-topbar__status-indicator {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.2);
+  transition: background-color 150ms ease, box-shadow 150ms ease;
 }
 
-.editor-topbar__status-label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
+.editor-topbar__status-indicator--online {
+  background-color: #34d399;
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.25);
 }
 
-.editor-topbar__status-helper {
-  font-size: 0.7rem;
-  opacity: 0.8;
-}
-
-.editor-topbar__status-dot {
-  width: 0.65rem;
-  height: 0.65rem;
-  border-radius: 50%;
-  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.55);
-}
-
-.editor-topbar__status-dot--ready {
-  background: #22c55e;
-  box-shadow: 0 0 0 2px rgba(22, 101, 52, 0.45);
-}
-
-.editor-topbar__status-dot--warning {
-  background: #f97316;
-  box-shadow: 0 0 0 2px rgba(194, 65, 12, 0.45);
-}
-
-.editor-topbar__status-dot--error {
-  background: #ef4444;
-  box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.45);
-}
-
-@keyframes editor-topbar-status-pulse {
-  0% {
-    transform: scale(0.95);
-    opacity: 0.7;
-  }
-  50% {
-    transform: scale(1.1);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(0.95);
-    opacity: 0.7;
-  }
-}
-
-.editor-topbar__status-dot--pulse {
-  animation: editor-topbar-status-pulse 1.4s ease-in-out infinite;
+.editor-topbar__status-indicator--offline {
+  background-color: #f87171;
+  box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.25);
 }
 
 .editor-topbar__controls {
@@ -95,70 +49,137 @@
   gap: 0.5rem;
 }
 
-.editor-topbar__action {
+.editor-topbar__primary {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  color: #0f172a;
   font-weight: 600;
+  font-size: 0.85rem;
   letter-spacing: 0.01em;
-  padding-inline: 1rem;
 }
 
-.editor-topbar__action--primary {
-  background: linear-gradient(135deg, #10b981, #0ea5e9);
-  color: white;
-  border: none;
+.editor-topbar__primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
-.editor-topbar__action--primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+.editor-topbar__primary-icon,
+.editor-topbar__primary-spinner {
+  width: 1rem;
+  height: 1rem;
 }
 
-.editor-topbar__action--secondary {
-  background: rgba(250, 204, 21, 0.12);
-  color: #fbbf24;
-  border-color: rgba(234, 179, 8, 0.35);
+.editor-topbar__primary-spinner {
+  animation: editor-topbar__spin 0.9s linear infinite;
 }
 
-.editor-topbar__action--secondary:hover:not(:disabled) {
-  background: rgba(250, 204, 21, 0.2);
-  color: #facc15;
+@keyframes editor-topbar__spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.editor-topbar__overflow {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
 .editor-topbar__overflow-trigger {
-  color: #cbd5f5;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
   border-radius: 9999px;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.16);
+  color: #e2e8f0;
+  transition: background-color 150ms ease, color 150ms ease;
 }
 
-.editor-topbar__overflow-trigger:hover {
-  background: rgba(148, 163, 184, 0.12);
+.editor-topbar__overflow-trigger:hover,
+.editor-topbar__overflow-trigger:focus-visible {
+  background: rgba(148, 163, 184, 0.25);
+  color: #f8fafc;
+  outline: none;
 }
 
-.editor-topbar__overflow-menu {
-  min-width: 14rem;
+.editor-topbar__overflow-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.editor-topbar__overflow-sheet {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 13rem;
+  padding: 0.5rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.35);
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+  transition: opacity 150ms ease, transform 150ms ease;
+}
+
+.editor-topbar__overflow:hover .editor-topbar__overflow-sheet,
+.editor-topbar__overflow:focus-within .editor-topbar__overflow-sheet {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 
 .editor-topbar__overflow-item {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.875rem;
+  width: 100%;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.5rem;
+  background: transparent;
+  border: none;
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  text-align: left;
+  transition: background-color 150ms ease, color 150ms ease;
 }
 
-.editor-topbar__overflow-item svg {
-  color: #6366f1;
+.editor-topbar__overflow-item:hover:not(:disabled),
+.editor-topbar__overflow-item:focus-visible:not(:disabled) {
+  background: rgba(99, 102, 241, 0.2);
+  color: #f8fafc;
+  outline: none;
 }
 
-.editor-topbar__overflow-description {
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: #94a3b8;
+.editor-topbar__overflow-item:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.editor-topbar__overflow-item-icon {
+  width: 1rem;
+  height: 1rem;
+  color: #22d3ee;
+}
+
+.editor-topbar__overflow-item-description {
   margin-left: auto;
-}
-
-.editor-topbar__banner {
-  border-radius: 0.75rem;
-  overflow: hidden;
+  font-size: 0.75rem;
+  color: #94a3b8;
 }
 
 .workflow-inspector-panel {


### PR DESCRIPTION
## Summary
- replace the workflow editor top bar component with a streamlined single-action variant that chooses between run and validate states and shows worker availability
- restyle the editor toolbar to be compact, sticky, and reveal the overflow action sheet on hover
- update the workflow editor integration and tests to use the new props and overflow action array

## Testing
- npx vitest run client/src/components/workflow/__tests__/EditorTopBar.overflow.test.tsx *(fails: registry access forbidden in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f09962a083318bc3683d9bd7a565