### PR TITLE
Refine workflow editor top bar

### DIFF
--- a/client/src/components/workflow/__tests__/EditorTopBar.overflow.test.tsx
+++ b/client/src/components/workflow/__tests__/EditorTopBar.overflow.test.tsx
@@ -7,15 +7,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import EditorTopBar from "../EditorTopBar";
 
 const baseProps = {
-  statusLabel: "Ready",
-  statusTone: "ready" as const,
-  statusHelperText: "All systems go",
   onRun: vi.fn(),
-  canRun: true,
-  runDisabled: false,
   onValidate: vi.fn(),
+  canRun: true,
   canValidate: true,
-  validateDisabled: false,
+  isRunning: false,
+  isValidating: false,
+  workersOnline: 1,
 };
 
 describe("EditorTopBar overflow actions", () => {
@@ -25,7 +23,7 @@ describe("EditorTopBar overflow actions", () => {
 
   it("hides the overflow trigger when no actions are provided", () => {
     render(<EditorTopBar {...baseProps} />);
-    expect(screen.queryByRole("button", { name: /more actions/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /workflow actions/i })).toBeNull();
   });
 
   it("invokes provided overflow handlers", async () => {
@@ -37,13 +35,15 @@ describe("EditorTopBar overflow actions", () => {
     render(
       <EditorTopBar
         {...baseProps}
-        onSave={{ id: "save", label: "Save draft", onSelect: onSave }}
-        onPromote={{ id: "promote", label: "Promote", onSelect: onPromote }}
-        onExport={{ id: "export", label: "Export workflow JSON", onSelect: onExport }}
+        overflowActions={[
+          { id: "save", label: "Save draft", onSelect: onSave },
+          { id: "promote", label: "Promote", onSelect: onPromote },
+          { id: "export", label: "Export workflow JSON", onSelect: onExport },
+        ]}
       />,
     );
 
-    const trigger = screen.getByRole("button", { name: /more actions/i });
+    const trigger = screen.getByRole("button", { name: /workflow actions/i });
 
     await user.click(trigger);
     const saveItem = await screen.findByRole("menuitem", { name: /save draft/i });

--- a/client/src/components/workflow/editor-topbar.css
+++ b/client/src/components/workflow/editor-topbar.css
@@ -1,92 +1,59 @@
 .editor-topbar {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 20;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  background: rgba(15, 23, 42, 0.9);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
-  box-shadow: 0 8px 20px -12px rgba(15, 23, 42, 0.45);
+  padding: 0.5rem 0.75rem;
+  background: rgba(15, 23, 42, 0.88);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 12px 28px -18px rgba(15, 23, 42, 0.6);
 }
 
 .editor-topbar__inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.75rem;
+  min-height: 2.75rem;
 }
 
-.editor-topbar__status {
+.editor-topbar__status-pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.35rem 0.75rem;
+  gap: 0.5rem;
+  padding: 0.3rem 0.7rem;
   border-radius: 9999px;
-  background: rgba(15, 23, 42, 0.55);
-  color: #e2e8f0;
+  background: rgba(15, 23, 42, 0.65);
   border: 1px solid rgba(148, 163, 184, 0.25);
-}
-
-.editor-topbar__status-text {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.1;
-}
-
-.editor-topbar__status-label {
+  color: #e2e8f0;
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.02em;
   text-transform: uppercase;
 }
 
-.editor-topbar__status-helper {
-  font-size: 0.7rem;
-  opacity: 0.8;
+.editor-topbar__worker-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 9999px;
+  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.65);
 }
 
-.editor-topbar__status-dot {
-  width: 0.65rem;
-  height: 0.65rem;
-  border-radius: 50%;
-  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.55);
-}
-
-.editor-topbar__status-dot--ready {
+.editor-topbar__worker-dot--online {
   background: #22c55e;
-  box-shadow: 0 0 0 2px rgba(22, 101, 52, 0.45);
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.25);
 }
 
-.editor-topbar__status-dot--warning {
-  background: #f97316;
-  box-shadow: 0 0 0 2px rgba(194, 65, 12, 0.45);
-}
-
-.editor-topbar__status-dot--error {
+.editor-topbar__worker-dot--offline {
   background: #ef4444;
-  box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.45);
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.25);
 }
 
-@keyframes editor-topbar-status-pulse {
-  0% {
-    transform: scale(0.95);
-    opacity: 0.7;
-  }
-  50% {
-    transform: scale(1.1);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(0.95);
-    opacity: 0.7;
-  }
-}
-
-.editor-topbar__status-dot--pulse {
-  animation: editor-topbar-status-pulse 1.4s ease-in-out infinite;
+.editor-topbar__worker-label {
+  line-height: 1;
 }
 
 .editor-topbar__controls {
@@ -95,7 +62,7 @@
   gap: 0.5rem;
 }
 
-.editor-topbar__action {
+.editor-topbar__primary-action {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -104,63 +71,124 @@
   padding-inline: 1rem;
 }
 
-.editor-topbar__action--primary {
-  background: linear-gradient(135deg, #10b981, #0ea5e9);
-  color: white;
-  border: none;
+.editor-topbar__primary-action svg {
+  width: 1rem;
+  height: 1rem;
 }
 
-.editor-topbar__action--primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, #0ea5e9, #6366f1);
-}
-
-.editor-topbar__action--secondary {
-  background: rgba(250, 204, 21, 0.12);
-  color: #fbbf24;
-  border-color: rgba(234, 179, 8, 0.35);
-}
-
-.editor-topbar__action--secondary:hover:not(:disabled) {
-  background: rgba(250, 204, 21, 0.2);
-  color: #facc15;
+.editor-topbar__overflow {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
 .editor-topbar__overflow-trigger {
-  color: #cbd5f5;
-  border-radius: 9999px;
-}
-
-.editor-topbar__overflow-trigger:hover {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
   background: rgba(148, 163, 184, 0.12);
+  color: #cbd5f5;
+  border: none;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.15s ease;
 }
 
-.editor-topbar__overflow-menu {
-  min-width: 14rem;
+.editor-topbar__overflow-trigger:hover,
+.editor-topbar__overflow-trigger:focus-visible {
+  background: rgba(148, 163, 184, 0.2);
+  color: #f8fafc;
+  transform: translateY(-1px);
+}
+
+.editor-topbar__overflow-sheet {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  min-width: 15rem;
+  padding: 0.75rem;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.96);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 20px 48px -18px rgba(15, 23, 42, 0.75);
+  opacity: 0;
+  transform: translateY(6px) scale(0.98);
+  pointer-events: none;
+  transition: opacity 120ms ease, transform 140ms ease;
+}
+
+.editor-topbar__overflow--open .editor-topbar__overflow-sheet {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+}
+
+.editor-topbar__overflow-title {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.editor-topbar__overflow-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .editor-topbar__overflow-item {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
+  align-items: flex-start;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.55rem 0.6rem;
+  border-radius: 0.65rem;
+  background: transparent;
+  border: none;
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  text-align: left;
+  transition: background 0.15s ease, transform 0.15s ease;
 }
 
 .editor-topbar__overflow-item svg {
+  width: 0.95rem;
+  height: 0.95rem;
   color: #6366f1;
 }
 
+.editor-topbar__overflow-item:hover:not(:disabled),
+.editor-topbar__overflow-item:focus-visible:not(:disabled) {
+  background: rgba(148, 163, 184, 0.18);
+  transform: translateX(2px);
+}
+
+.editor-topbar__overflow-item:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.editor-topbar__overflow-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.editor-topbar__overflow-label {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
 .editor-topbar__overflow-description {
-  font-size: 0.75rem;
-  font-weight: 500;
+  font-size: 0.7rem;
   color: #94a3b8;
-  margin-left: auto;
 }
 
 .editor-topbar__banner {
   border-radius: 0.75rem;
   overflow: hidden;
-}
-
-.workflow-inspector-panel {
-  position: relative;
 }


### PR DESCRIPTION
## Summary
- streamline the workflow EditorTopBar to expose a single contextual run/validate control with worker status and hover overflow actions
- update the professional graph editor to pass the simplified state and collapse auxiliary commands into the overflow list
- refresh the sticky toolbar styling and align the overflow interaction test with the new API

## Testing
- npx vitest run client/src/components/workflow/__tests__/EditorTopBar.overflow.test.tsx *(fails: npm registry access is blocked in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f279deb08331abdb9e136871da1e