### PR TITLE
Fix inspector panel markup

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -4269,6 +4269,7 @@ const GraphEditorContent = () => {
               </div>
             </div>
           </div>
+        </div>
         )}
       </aside>
       <Dialog open={promotionDialogOpen} onOpenChange={handlePromotionDialogOpenChange}>


### PR DESCRIPTION
## Summary
- close the right-pane inspector container div in the professional graph editor so the smart parameters panel is wrapped correctly

## Testing
- npm run build:client *(fails: 403 Forbidden when downloading dependencies from the npm registry in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f8d64d48833193db1e7e44fe6380