### PR TITLE
Expose runtime capabilities and validate unsupported ops

### DIFF
--- a/scripts/diff-runtime-capabilities.js
+++ b/scripts/diff-runtime-capabilities.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function loadJson(path) {
+  try {
+    const fullPath = resolve(process.cwd(), path);
+    const content = readFileSync(fullPath, 'utf8');
+    return JSON.parse(content);
+  } catch (error) {
+    console.error(`Failed to load JSON from ${path}: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+function extractCatalogOperations(catalogJson) {
+  const nodes = [];
+  const categories = catalogJson?.catalog?.categories ?? {};
+
+  for (const category of Object.values(categories)) {
+    const items = Array.isArray(category?.nodes) ? category.nodes : [];
+    for (const node of items) {
+      const type = typeof node?.type === 'string' ? node.type : '';
+      if (!type) continue;
+
+      const match = type.match(/^(action|trigger)\.([^.]+)\.(.+)$/);
+      if (!match) continue;
+
+      const [, categoryType, app, op] = match;
+      nodes.push({
+        type: categoryType,
+        app,
+        operation: op.replace(/\./g, '_'),
+      });
+    }
+  }
+
+  return nodes;
+}
+
+function buildCapabilityMap(capabilitiesJson) {
+  const map = new Map();
+  const entries = Array.isArray(capabilitiesJson?.capabilities) ? capabilitiesJson.capabilities : [];
+
+  for (const entry of entries) {
+    const app = typeof entry?.app === 'string' ? entry.app : '';
+    if (!app) continue;
+
+    const actions = new Set(Array.isArray(entry?.actions) ? entry.actions : []);
+    const triggers = new Set(Array.isArray(entry?.triggers) ? entry.triggers : []);
+    map.set(app, { actions, triggers });
+  }
+
+  return map;
+}
+
+function main() {
+  const catalogPath = process.argv[2] ?? 'catalog_test.json';
+  const capabilitiesPath = process.argv[3] ?? 'capabilities.json';
+
+  const catalog = loadJson(catalogPath);
+  const capabilities = loadJson(capabilitiesPath);
+
+  const operations = extractCatalogOperations(catalog);
+  const capabilityMap = buildCapabilityMap(capabilities);
+
+  let missing = 0;
+
+  for (const op of operations) {
+    const appCapabilities = capabilityMap.get(op.app);
+    const set = op.type === 'trigger' ? appCapabilities?.triggers : appCapabilities?.actions;
+    const supported = Boolean(set && set.has(op.operation));
+
+    if (!supported) {
+      console.log(`MISSING ${op.app}.${op.operation} (${op.type})`);
+      missing += 1;
+    }
+  }
+
+  if (missing > 0) {
+    console.error(`\n${missing} operation(s) missing runtime support.`);
+    process.exit(2);
+  }
+
+  console.log('All catalog operations are implemented in the runtime.');
+}
+
+main();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -67,6 +67,7 @@ import usageAdminRoutes from "./routes/usage";
 import devToolsRouter from "./routes/dev-tools.js";
 import { getSchedulerLockService } from './services/SchedulerLockService.js';
 import { checkQueueHealth } from './services/QueueHealthService.js';
+import runtimeRegistryRoutes from "./routes/registry.js";
 
 const SUPPORTED_CONNECTION_PROVIDERS = [
   'openai',
@@ -368,6 +369,7 @@ export async function registerRoutes(app: Express): Promise<void> {
 
   // Expression evaluation tooling
   app.use('/api/expressions', expressionRoutes);
+  app.use(runtimeRegistryRoutes);
   
   // CRITICAL FIX: Workflow read routes for Graph Editor handoff
   app.use('/api', optionalAuth, workflowReadRoutes);

--- a/server/routes/registry.ts
+++ b/server/routes/registry.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+
+import { getRuntimeCapabilities } from '../runtime/registry.js';
+
+const router = Router();
+
+router.get('/api/registry/capabilities', (_req, res) => {
+  res.json({
+    success: true,
+    capabilities: getRuntimeCapabilities(),
+  });
+});
+
+export default router;

--- a/server/runtime/registry.ts
+++ b/server/runtime/registry.ts
@@ -1,0 +1,63 @@
+import { buildOperationKeyCandidates, getRuntimeOpHandlers } from '../workflow/compiler/op-map.js';
+
+export interface RuntimeAppOperations {
+  actions: Record<string, unknown>;
+  triggers: Record<string, unknown>;
+}
+
+export interface RuntimeCapabilitySummary {
+  app: string;
+  actions: string[];
+  triggers: string[];
+}
+
+function buildRegistry(): Record<string, RuntimeAppOperations> {
+  const handlers = getRuntimeOpHandlers();
+  const registry: Record<string, RuntimeAppOperations> = {};
+
+  for (const [key, handler] of Object.entries(handlers)) {
+    const match = key.match(/^(action|trigger)\.([^:.]+)[:.](.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    const [, category, app, operation] = match;
+    const bucket = (registry[app] ||= { actions: {}, triggers: {} });
+
+    if (category === 'trigger') {
+      bucket.triggers[operation] = handler;
+    } else {
+      bucket.actions[operation] = handler;
+    }
+  }
+
+  return registry;
+}
+
+const RUNTIME_HANDLERS = getRuntimeOpHandlers();
+const RUNTIME_HANDLER_KEYS = new Set(Object.keys(RUNTIME_HANDLERS));
+
+export const RUNTIME_REGISTRY: Record<string, RuntimeAppOperations> = buildRegistry();
+
+export function getRuntimeCapabilities(): RuntimeCapabilitySummary[] {
+  return Object.entries(RUNTIME_REGISTRY)
+    .map(([app, ops]) => ({
+      app,
+      actions: Object.keys(ops.actions).sort(),
+      triggers: Object.keys(ops.triggers).sort(),
+    }))
+    .sort((a, b) => a.app.localeCompare(b.app));
+}
+
+export function hasRuntimeImplementation(
+  type: 'action' | 'trigger',
+  app: string,
+  operation: string,
+): boolean {
+  if (!app || !operation) {
+    return false;
+  }
+
+  const candidates = buildOperationKeyCandidates(app, operation, type);
+  return candidates.some(candidate => RUNTIME_HANDLER_KEYS.has(candidate));
+}


### PR DESCRIPTION
## Summary
- add a runtime capabilities registry and expose it via `/api/registry/capabilities`
- validate graphs for unsupported action/trigger operations using the runtime registry
- add a diff script to compare catalog coverage against runtime capabilities

## Testing
- npm run check *(fails: missing Node and Vite type definitions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6573bc66c8331bca55e374736cade