### PR TITLE
Include built-in runtime operations in registry

### DIFF
--- a/server/runtime/__tests__/registry.capabilities.test.ts
+++ b/server/runtime/__tests__/registry.capabilities.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+
+import { getRuntimeCapabilities, hasRuntimeImplementation } from '../registry.js';
+
+{
+  const capabilities = getRuntimeCapabilities();
+  const httpCapabilities = capabilities.find(entry => entry.app === 'http');
+
+  assert.ok(httpCapabilities, 'http capabilities should be registered');
+  assert.ok(
+    httpCapabilities.actions.includes('request'),
+    'http capabilities should include the request action',
+  );
+  assert.equal(hasRuntimeImplementation('action', 'http', 'request'), true);
+}

--- a/server/runtime/registry.ts
+++ b/server/runtime/registry.ts
@@ -11,6 +11,21 @@ export interface RuntimeCapabilitySummary {
   triggers: string[];
 }
 
+const BUILTIN_RUNTIME_OPERATIONS: Array<{
+  type: 'action' | 'trigger';
+  app: string;
+  operation: string;
+}> = [
+  { type: 'action', app: 'http', operation: 'request' },
+  { type: 'action', app: 'llm', operation: 'generate' },
+  { type: 'action', app: 'llm', operation: 'extract' },
+  { type: 'action', app: 'llm', operation: 'classify' },
+  { type: 'action', app: 'llm', operation: 'tool_call' },
+  { type: 'trigger', app: 'webhook', operation: 'inbound' },
+  { type: 'trigger', app: 'time', operation: 'cron' },
+  { type: 'trigger', app: 'time', operation: 'manual' },
+];
+
 function buildRegistry(): Record<string, RuntimeAppOperations> {
   const handlers = getRuntimeOpHandlers();
   const registry: Record<string, RuntimeAppOperations> = {};
@@ -37,7 +52,29 @@ function buildRegistry(): Record<string, RuntimeAppOperations> {
 const RUNTIME_HANDLERS = getRuntimeOpHandlers();
 const RUNTIME_HANDLER_KEYS = new Set(Object.keys(RUNTIME_HANDLERS));
 
-export const RUNTIME_REGISTRY: Record<string, RuntimeAppOperations> = buildRegistry();
+function injectBuiltinRuntimeEntries(
+  registry: Record<string, RuntimeAppOperations>,
+  handlerKeySet: Set<string>,
+): void {
+  for (const builtin of BUILTIN_RUNTIME_OPERATIONS) {
+    const bucket = (registry[builtin.app] ||= { actions: {}, triggers: {} });
+    if (builtin.type === 'action') {
+      bucket.actions[builtin.operation] = true;
+    } else {
+      bucket.triggers[builtin.operation] = true;
+    }
+
+    const candidates = buildOperationKeyCandidates(builtin.app, builtin.operation, builtin.type);
+    for (const candidate of candidates) {
+      handlerKeySet.add(candidate);
+    }
+  }
+}
+
+const runtimeRegistry = buildRegistry();
+injectBuiltinRuntimeEntries(runtimeRegistry, RUNTIME_HANDLER_KEYS);
+
+export const RUNTIME_REGISTRY: Record<string, RuntimeAppOperations> = runtimeRegistry;
 
 export function getRuntimeCapabilities(): RuntimeCapabilitySummary[] {
   return Object.entries(RUNTIME_REGISTRY)


### PR DESCRIPTION
## Summary
- add built-in runtime capabilities for HTTP, LLM, time, and webhook operations to the runtime registry
- ensure hasRuntimeImplementation recognizes built-in operations by seeding candidate keys
- expose the additional capabilities via getRuntimeCapabilities and add a regression test covering action.http.request

## Testing
- npx tsx server/runtime/__tests__/registry.capabilities.test.ts *(fails: npm registry access is restricted in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e661a05be08331b47f5a90e4f3bf48