### PR TITLE
Add runtime handlers for Gmail/Slack and Google workspace polling

### DIFF
--- a/server/integrations/GoogleDocsAPIClient.ts
+++ b/server/integrations/GoogleDocsAPIClient.ts
@@ -32,4 +32,129 @@ export class GoogleDocsAPIClient extends BaseAPIClient {
     this.validateRequiredParams(params as any, ['documentId']);
     return this.get(`/documents/${params.documentId}`, this.getAuthHeaders());
   }
+
+  public async pollDocumentCreated(params: { folderId?: string; since?: string } = {}): Promise<any[]> {
+    try {
+      const queryParts = [
+        `mimeType = '${this.escapeDriveQueryValue('application/vnd.google-apps.document')}'`,
+        'trashed = false',
+      ];
+
+      if (params.folderId) {
+        queryParts.push(`'${this.escapeDriveQueryValue(params.folderId)}' in parents`);
+      }
+
+      if (params.since) {
+        queryParts.push(`createdTime > '${this.escapeDriveQueryValue(params.since)}'`);
+      }
+
+      return await this.fetchDriveFiles({
+        queryParts,
+        orderBy: 'createdTime desc',
+      });
+    } catch (error) {
+      console.error('[GoogleDocsAPIClient] pollDocumentCreated failed:', error);
+      return [];
+    }
+  }
+
+  public async pollDocumentUpdated(params: { documentId?: string; since?: string } = {}): Promise<any[]> {
+    try {
+      if (params.documentId) {
+        const document = await this.fetchDriveFile(params.documentId);
+        if (!document) {
+          return [];
+        }
+
+        if (params.since && document.modifiedTime) {
+          const modifiedAt = new Date(document.modifiedTime).getTime();
+          const since = new Date(params.since).getTime();
+          if (!(Number.isFinite(modifiedAt) && modifiedAt > since)) {
+            return [];
+          }
+        }
+
+        return [document];
+      }
+
+      const queryParts = [
+        `mimeType = '${this.escapeDriveQueryValue('application/vnd.google-apps.document')}'`,
+        'trashed = false',
+      ];
+
+      if (params.since) {
+        queryParts.push(`modifiedTime > '${this.escapeDriveQueryValue(params.since)}'`);
+      }
+
+      return await this.fetchDriveFiles({
+        queryParts,
+        orderBy: 'modifiedTime desc',
+      });
+    } catch (error) {
+      console.error('[GoogleDocsAPIClient] pollDocumentUpdated failed:', error);
+      return [];
+    }
+  }
+
+  private async fetchDriveFiles(options: {
+    queryParts: string[];
+    orderBy?: string;
+    pageSize?: number;
+    fields?: string;
+  }): Promise<any[]> {
+    const params = new URLSearchParams();
+    params.set('pageSize', String(options.pageSize ?? 50));
+    params.set(
+      'fields',
+      options.fields
+        ?? 'files(id,name,mimeType,createdTime,modifiedTime,owners,lastModifyingUser,webViewLink)'
+    );
+
+    if (options.orderBy) {
+      params.set('orderBy', options.orderBy);
+    }
+
+    const query = options.queryParts.filter(part => typeof part === 'string' && part.trim().length > 0);
+    if (query.length > 0) {
+      params.set('q', query.join(' and '));
+    }
+
+    const response = await fetch(`https://www.googleapis.com/drive/v3/files?${params.toString()}`, {
+      method: 'GET',
+      headers: this.getAuthHeaders(),
+    });
+
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(data?.error?.message ?? `HTTP ${response.status}`);
+    }
+
+    return Array.isArray(data.files) ? data.files : [];
+  }
+
+  private async fetchDriveFile(fileId: string): Promise<any | null> {
+    const params = new URLSearchParams({
+      fields: 'id,name,mimeType,createdTime,modifiedTime,owners,lastModifyingUser,webViewLink',
+    });
+
+    const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}?${params.toString()}`, {
+      method: 'GET',
+      headers: this.getAuthHeaders(),
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(data?.error?.message ?? `HTTP ${response.status}`);
+    }
+
+    return data;
+  }
+
+  private escapeDriveQueryValue(value: string): string {
+    return value.replace(/'/g, "\\'");
+  }
 }

--- a/server/integrations/GoogleDriveAPIClient.ts
+++ b/server/integrations/GoogleDriveAPIClient.ts
@@ -87,4 +87,147 @@ export class GoogleDriveAPIClient extends BaseAPIClient {
     this.validateRequiredParams(params as any, ['fileId']);
     return this.get(`/files/${params.fileId}?fields=id,name,mimeType,modifiedTime,owners`, this.getAuthHeaders());
   }
+
+  public async pollFileCreated(params: { folderId?: string; mimeType?: string; since?: string } = {}): Promise<any[]> {
+    try {
+      const queryParts = ['trashed = false'];
+      if (params.mimeType) {
+        queryParts.push(`mimeType = '${this.escapeQueryValue(params.mimeType)}'`);
+      }
+      if (params.folderId) {
+        queryParts.push(`'${this.escapeQueryValue(params.folderId)}' in parents`);
+      }
+      if (params.since) {
+        queryParts.push(`createdTime > '${this.escapeQueryValue(params.since)}'`);
+      }
+
+      return await this.fetchFiles({
+        queryParts,
+        orderBy: 'createdTime desc',
+      });
+    } catch (error) {
+      console.error('[GoogleDriveAPIClient] pollFileCreated failed:', error);
+      return [];
+    }
+  }
+
+  public async pollFileUpdated(params: { folderId?: string; fileId?: string; since?: string } = {}): Promise<any[]> {
+    try {
+      if (params.fileId) {
+        const file = await this.fetchFile(params.fileId);
+        if (!file) {
+          return [];
+        }
+
+        if (params.since && file.modifiedTime) {
+          const modifiedAt = new Date(file.modifiedTime).getTime();
+          const since = new Date(params.since).getTime();
+          if (!(Number.isFinite(modifiedAt) && modifiedAt > since)) {
+            return [];
+          }
+        }
+
+        return [file];
+      }
+
+      const queryParts = ['trashed = false'];
+      if (params.folderId) {
+        queryParts.push(`'${this.escapeQueryValue(params.folderId)}' in parents`);
+      }
+      if (params.since) {
+        queryParts.push(`modifiedTime > '${this.escapeQueryValue(params.since)}'`);
+      }
+
+      return await this.fetchFiles({
+        queryParts,
+        orderBy: 'modifiedTime desc',
+      });
+    } catch (error) {
+      console.error('[GoogleDriveAPIClient] pollFileUpdated failed:', error);
+      return [];
+    }
+  }
+
+  public async pollFileShared(params: { folderId?: string; since?: string } = {}): Promise<any[]> {
+    try {
+      const queryParts = ['sharedWithMe', 'trashed = false'];
+      if (params.folderId) {
+        queryParts.push(`'${this.escapeQueryValue(params.folderId)}' in parents`);
+      }
+      if (params.since) {
+        queryParts.push(`modifiedTime > '${this.escapeQueryValue(params.since)}'`);
+      }
+
+      return await this.fetchFiles({
+        queryParts,
+        orderBy: 'modifiedTime desc',
+        fields: 'files(id,name,mimeType,modifiedTime,createdTime,owners,permissions,webViewLink,shared)',
+      });
+    } catch (error) {
+      console.error('[GoogleDriveAPIClient] pollFileShared failed:', error);
+      return [];
+    }
+  }
+
+  private async fetchFiles(options: {
+    queryParts: string[];
+    orderBy?: string;
+    pageSize?: number;
+    fields?: string;
+  }): Promise<any[]> {
+    const params = new URLSearchParams();
+    params.set('pageSize', String(options.pageSize ?? 50));
+    params.set(
+      'fields',
+      options.fields
+        ?? 'files(id,name,mimeType,createdTime,modifiedTime,owners,webViewLink,shared)'
+    );
+
+    if (options.orderBy) {
+      params.set('orderBy', options.orderBy);
+    }
+
+    const query = options.queryParts.filter(part => typeof part === 'string' && part.trim().length > 0);
+    if (query.length > 0) {
+      params.set('q', query.join(' and '));
+    }
+
+    const response = await fetch(`https://www.googleapis.com/drive/v3/files?${params.toString()}`, {
+      method: 'GET',
+      headers: this.getAuthHeaders(),
+    });
+
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(data?.error?.message ?? `HTTP ${response.status}`);
+    }
+
+    return Array.isArray(data.files) ? data.files : [];
+  }
+
+  private async fetchFile(fileId: string): Promise<any | null> {
+    const params = new URLSearchParams({
+      fields: 'id,name,mimeType,createdTime,modifiedTime,owners,permissions,webViewLink,shared',
+    });
+
+    const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}?${params.toString()}`, {
+      method: 'GET',
+      headers: this.getAuthHeaders(),
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(data?.error?.message ?? `HTTP ${response.status}`);
+    }
+
+    return data;
+  }
+
+  private escapeQueryValue(value: string): string {
+    return value.replace(/'/g, "\\'");
+  }
 }

--- a/server/integrations/__tests__/CommunicationAPIClients.test.ts
+++ b/server/integrations/__tests__/CommunicationAPIClients.test.ts
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+
+import { GmailAPIClient } from '../GmailAPIClient.js';
+import { SlackAPIClient } from '../SlackAPIClient.js';
+import { GoogleDocsAPIClient } from '../GoogleDocsAPIClient.js';
+import { GoogleDriveAPIClient } from '../GoogleDriveAPIClient.js';
+import { getRuntimeOpHandler } from '../../workflow/compiler/op-map.js';
+import { replyWithJson, replyWithText, replyWithHtml } from '../../webhooks/replyHelpers.js';
+
+interface MockResponse {
+  body?: any;
+  status?: number;
+  headers?: Record<string, string>;
+}
+
+interface FetchCall {
+  url: string;
+  init?: any;
+}
+
+async function withMockedFetch<T>(
+  responses: MockResponse[],
+  fn: (calls: FetchCall[]) => Promise<T>
+): Promise<T> {
+  const queue = responses.length > 0 ? responses : [{ body: {} }];
+  const calls: FetchCall[] = [];
+  const originalFetch = globalThis.fetch;
+  let index = 0;
+
+  (globalThis as any).fetch = async (input: any, init?: any) => {
+    const current = queue[Math.min(index, queue.length - 1)] ?? { body: {} };
+    index += 1;
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : String(input);
+    calls.push({ url, init });
+    const body = current.body ?? {};
+    const responseInit = {
+      status: current.status ?? 200,
+      headers: current.headers ?? { 'Content-Type': 'application/json' },
+    };
+    const payload = typeof body === 'string' ? body : JSON.stringify(body);
+    return new Response(payload, responseInit);
+  };
+
+  try {
+    return await fn(calls);
+  } finally {
+    (globalThis as any).fetch = originalFetch;
+  }
+}
+
+async function testGmailHandlers(): Promise<void> {
+  await withMockedFetch(
+    [
+      { body: { id: 'abc123' } },
+      { body: { id: 'runtime-456' } },
+    ],
+    async calls => {
+      const client = new GmailAPIClient({ accessToken: 'token' });
+      const result = await client.sendEmail({ to: 'user@example.com', subject: 'Hello', body: 'Greetings' });
+      assert.equal(result.success, true, 'Gmail sendEmail should succeed');
+      assert.equal(calls.length, 1, 'Expected one fetch call for direct client invocation');
+      assert.ok(calls[0].url.includes('/users/me/messages/send'), 'Gmail request should target send endpoint');
+      const payload = calls[0].init?.body ? JSON.parse(String(calls[0].init?.body)) : {};
+      assert.ok(typeof payload.raw === 'string' && payload.raw.length > 0, 'Gmail payload should include raw message');
+
+      const handler = getRuntimeOpHandler('action.gmail:send_email');
+      assert.ok(handler, 'Runtime handler for Gmail send_email should be registered');
+      const runtimeResult = await handler!(client, {
+        to: 'runtime@example.com',
+        subject: 'Runtime',
+        body: 'From runtime',
+      });
+      assert.equal(runtimeResult.success, true, 'Runtime Gmail handler should succeed');
+      assert.equal(calls.length, 2, 'Runtime handler should trigger additional fetch');
+    }
+  );
+}
+
+async function testSlackHandlers(): Promise<void> {
+  await withMockedFetch(
+    [
+      { body: { ok: true, channel: 'C123', ts: '1.2' } },
+      { body: { ok: true, channel: 'C123', ts: '3.4' } },
+    ],
+    async calls => {
+      const client = new SlackAPIClient({ accessToken: 'xoxb-token' });
+      const result = await client.sendMessage({ channel: 'C123', text: 'hello world' });
+      assert.equal(result.success, true, 'Slack sendMessage should succeed');
+      assert.equal(calls.length, 1, 'Expected single fetch call for Slack client');
+      assert.ok(calls[0].url.endsWith('/chat.postMessage'), 'Slack request should target chat.postMessage');
+      const payload = calls[0].init?.body ? JSON.parse(String(calls[0].init?.body)) : {};
+      assert.equal(payload.channel, 'C123');
+      assert.equal(payload.text, 'hello world');
+
+      const handler = getRuntimeOpHandler('action.slack:send_message');
+      assert.ok(handler, 'Runtime handler for Slack send_message should exist');
+      const runtimeResult = await handler!(client, { channel: 'C123', text: 'runtime text' });
+      assert.equal(runtimeResult.success, true, 'Runtime Slack handler should succeed');
+      assert.equal(calls.length, 2, 'Runtime Slack handler should produce another request');
+    }
+  );
+}
+
+async function testGoogleDocsTriggers(): Promise<void> {
+  await withMockedFetch(
+    [
+      { body: { files: [{ id: 'doc1', name: 'Doc', createdTime: '2024-01-02T00:00:00Z' }] } },
+      { body: { files: [{ id: 'doc2', name: 'Doc2', modifiedTime: '2024-01-03T00:00:00Z' }] } },
+    ],
+    async calls => {
+      const client = new GoogleDocsAPIClient({ accessToken: 'token' });
+      const documents = await client.pollDocumentCreated({ since: '2024-01-01T00:00:00Z' });
+      assert.equal(Array.isArray(documents), true, 'pollDocumentCreated should return array');
+      assert.equal(documents.length, 1, 'Expected one created document');
+      assert.ok(calls[0].url.includes('drive/v3/files'), 'Google Docs polling should call Drive files endpoint');
+      assert.ok(
+        decodeURIComponent(calls[0].url).includes("createdTime > '2024-01-01T00:00:00Z'"),
+        'Created query should include since filter'
+      );
+
+      const handler = getRuntimeOpHandler('trigger.google-docs:document_created');
+      assert.ok(handler, 'Runtime handler for google-docs document_created should exist');
+      const runtimeResult = await handler!(client, { since: '2024-01-02T00:00:00Z' });
+      assert.equal(runtimeResult.success, true, 'Runtime docs trigger should succeed');
+      assert.equal(Array.isArray(runtimeResult.data), true, 'Runtime docs trigger should return data array');
+    }
+  );
+}
+
+async function testGoogleDriveTriggers(): Promise<void> {
+  await withMockedFetch(
+    [
+      { body: { files: [{ id: 'file1', name: 'Quarterly Report', createdTime: '2024-01-04T00:00:00Z' }] } },
+      { body: { files: [{ id: 'file2', name: 'Shared File', shared: true, modifiedTime: '2024-01-05T00:00:00Z' }] } },
+      { body: { files: [{ id: 'file3', name: 'Runtime File', modifiedTime: '2024-01-06T00:00:00Z' }] } },
+    ],
+    async calls => {
+      const client = new GoogleDriveAPIClient({ accessToken: 'token' });
+      const created = await client.pollFileCreated({ folderId: 'root', since: '2024-01-01T00:00:00Z' });
+      assert.equal(created.length, 1, 'pollFileCreated should return new files');
+      assert.ok(calls[0].url.includes('drive/v3/files'), 'Drive polling should call files endpoint');
+      assert.ok(
+        decodeURIComponent(calls[0].url).includes("'root' in parents"),
+        'File created query should include folder filter'
+      );
+
+      const shared = await client.pollFileShared({ since: '2024-01-01T00:00:00Z' });
+      assert.equal(shared.length, 1, 'pollFileShared should return shared files');
+      assert.ok(decodeURIComponent(calls[1].url).includes('sharedWithMe'), 'Shared query should include sharedWithMe');
+
+      const handler = getRuntimeOpHandler('trigger.google-drive:file_updated');
+      assert.ok(handler, 'Runtime handler for google-drive file_updated should exist');
+      const runtimeResult = await handler!(client, { since: '2024-01-05T00:00:00Z' });
+      assert.equal(runtimeResult.success, true, 'Runtime drive trigger should succeed');
+      assert.equal(Array.isArray(runtimeResult.data), true, 'Runtime drive trigger should return array data');
+    }
+  );
+}
+
+async function testWebhookReplyHelpers(): Promise<void> {
+  const json = await replyWithJson({ body: { ok: true }, statusCode: 201 });
+  assert.equal(json.success, true, 'replyWithJson should succeed');
+  assert.equal(json.data?.statusCode, 201);
+  assert.equal(json.data?.headers['content-type'], 'application/json; charset=utf-8');
+
+  const runtimeJson = getRuntimeOpHandler('action.webhook:reply_json');
+  assert.ok(runtimeJson, 'Runtime webhook reply_json handler should exist');
+  const runtimeResponse = await runtimeJson!(null as any, { body: { ack: true }, statusCode: 202 });
+  assert.equal(runtimeResponse.success, true);
+  assert.equal(runtimeResponse.data?.statusCode, 202);
+
+  const text = await replyWithText({ body: 'pong', statusCode: 200 });
+  assert.equal(text.data?.format, 'text');
+  const html = await replyWithHtml({ body: '<strong>ok</strong>', headers: { 'x-extra': '1' } });
+  assert.equal(html.data?.headers['x-extra'], '1');
+}
+
+await testGmailHandlers();
+await testSlackHandlers();
+await testGoogleDocsTriggers();
+await testGoogleDriveTriggers();
+await testWebhookReplyHelpers();
+
+console.log('Communication API client runtime tests passed.');

--- a/server/webhooks/WebhookManager.ts
+++ b/server/webhooks/WebhookManager.ts
@@ -1667,3 +1667,71 @@ export class WebhookManager {
 
 // Export singleton instance
 export const webhookManager = WebhookManager.getInstance();
+
+function nowPlusSeconds(seconds: number): Date {
+  return new Date(Date.now() + Math.max(0, seconds) * 1000);
+}
+
+function sanitizeIntervalSeconds(intervalSeconds?: number): number {
+  const numeric = Number(intervalSeconds);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 300;
+  }
+  return Math.max(60, Math.floor(numeric));
+}
+
+export function buildGoogleDocsPollingTrigger(options: {
+  workflowId: string;
+  triggerId: 'document_created' | 'document_updated';
+  organizationId?: string;
+  userId?: string;
+  region?: OrganizationRegion;
+  intervalSeconds?: number;
+  metadata?: Record<string, any>;
+}): PollingTrigger {
+  const interval = sanitizeIntervalSeconds(options.intervalSeconds);
+  const next = nowPlusSeconds(interval);
+
+  return {
+    id: `${options.workflowId}:google-docs:${options.triggerId}`,
+    appId: 'google-docs',
+    triggerId: options.triggerId,
+    workflowId: options.workflowId,
+    interval,
+    nextPoll: next,
+    nextPollAt: next,
+    isActive: true,
+    metadata: options.metadata ?? {},
+    organizationId: options.organizationId,
+    userId: options.userId,
+    region: options.region,
+  };
+}
+
+export function buildGoogleDrivePollingTrigger(options: {
+  workflowId: string;
+  triggerId: 'file_created' | 'file_updated' | 'file_shared';
+  organizationId?: string;
+  userId?: string;
+  region?: OrganizationRegion;
+  intervalSeconds?: number;
+  metadata?: Record<string, any>;
+}): PollingTrigger {
+  const interval = sanitizeIntervalSeconds(options.intervalSeconds);
+  const next = nowPlusSeconds(interval);
+
+  return {
+    id: `${options.workflowId}:google-drive:${options.triggerId}`,
+    appId: 'google-drive',
+    triggerId: options.triggerId,
+    workflowId: options.workflowId,
+    interval,
+    nextPoll: next,
+    nextPollAt: next,
+    isActive: true,
+    metadata: options.metadata ?? {},
+    organizationId: options.organizationId,
+    userId: options.userId,
+    region: options.region,
+  };
+}

--- a/server/webhooks/replyHelpers.ts
+++ b/server/webhooks/replyHelpers.ts
@@ -1,0 +1,96 @@
+import type { APIResponse } from '../integrations/BaseAPIClient.js';
+
+export type WebhookReplyFormat = 'json' | 'text' | 'html';
+
+export interface WebhookReplyPayload {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: unknown;
+  format: WebhookReplyFormat;
+}
+
+interface ReplyOptions {
+  statusCode?: number;
+  headers?: Record<string, string> | null;
+}
+
+function normalizeStatusCode(statusCode?: number): number {
+  if (typeof statusCode !== 'number' || !Number.isFinite(statusCode)) {
+    return 200;
+  }
+
+  const clamped = Math.floor(statusCode);
+  if (clamped < 100) return 200;
+  if (clamped > 599) return 599;
+  return clamped;
+}
+
+function normalizeHeaders(
+  base: Record<string, string>,
+  overrides?: Record<string, string> | null
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(base)) {
+    if (typeof value === 'string' && value.length > 0) {
+      headers[key.toLowerCase()] = value;
+    }
+  }
+
+  if (!overrides) {
+    return headers;
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (typeof key !== 'string') continue;
+    if (value === undefined || value === null) continue;
+    const normalizedKey = key.toLowerCase();
+    headers[normalizedKey] = String(value);
+  }
+
+  return headers;
+}
+
+function buildWebhookReply(
+  format: WebhookReplyFormat,
+  body: unknown,
+  options: ReplyOptions,
+  defaultHeaders: Record<string, string>
+): APIResponse<WebhookReplyPayload> {
+  const statusCode = normalizeStatusCode(options.statusCode);
+  const headers = normalizeHeaders(defaultHeaders, options.headers);
+
+  return {
+    success: true,
+    data: {
+      statusCode,
+      headers,
+      body,
+      format,
+    },
+  };
+}
+
+export async function replyWithJson(
+  params: { body: unknown } & ReplyOptions
+): Promise<APIResponse<WebhookReplyPayload>> {
+  return buildWebhookReply('json', params.body, params, {
+    'content-type': 'application/json; charset=utf-8',
+  });
+}
+
+export async function replyWithText(
+  params: { body: string } & ReplyOptions
+): Promise<APIResponse<WebhookReplyPayload>> {
+  return buildWebhookReply('text', params.body, params, {
+    'content-type': 'text/plain; charset=utf-8',
+  });
+}
+
+export async function replyWithHtml(
+  params: { body: string } & ReplyOptions
+): Promise<APIResponse<WebhookReplyPayload>> {
+  return buildWebhookReply('html', params.body, params, {
+    'content-type': 'text/html; charset=utf-8',
+  });
+}

--- a/server/workflow/compiler/op-map.ts
+++ b/server/workflow/compiler/op-map.ts
@@ -31,6 +31,15 @@ import { BigCommerceAPIClient } from '../../integrations/BigCommerceAPIClient.js
 import { MagentoAPIClient } from '../../integrations/MagentoAPIClient.js';
 import { WooCommerceAPIClient } from '../../integrations/WooCommerceAPIClient.js';
 import { SquareAPIClient } from '../../integrations/SquareAPIClient.js';
+import { GmailAPIClient } from '../../integrations/GmailAPIClient.js';
+import { SlackAPIClient } from '../../integrations/SlackAPIClient.js';
+import { GoogleDocsAPIClient } from '../../integrations/GoogleDocsAPIClient.js';
+import { GoogleDriveAPIClient } from '../../integrations/GoogleDriveAPIClient.js';
+import {
+  replyWithHtml,
+  replyWithJson,
+  replyWithText,
+} from '../../webhooks/replyHelpers.js';
 
 /**
  * Get the compiler operation map
@@ -288,6 +297,39 @@ const RUNTIME_OPS: Record<string, RuntimeHandler> = {
   'action.grafana:get_dashboard': (client, params = {}) =>
     assertClientInstance(client, GrafanaAPIClient).getDashboard(params),
 
+  'action.gmail:test_connection': client =>
+    assertClientInstance(client, GmailAPIClient).testConnection(),
+  'action.gmail:send_email': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).sendEmail(params),
+  'action.gmail:send_reply': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).replyToEmail(params),
+  'action.gmail:reply_to_email': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).replyToEmail(params),
+  'action.gmail:forward_email': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).forwardEmail(params),
+  'action.gmail:search_emails': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).searchEmails(params),
+  'action.gmail:get_email': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).getEmail(params),
+  'action.gmail:get_emails_by_label': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).getEmailsByLabel(params),
+  'action.gmail:get_unread_emails': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).getUnreadEmails(params),
+  'action.gmail:add_label': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).addLabel(params),
+  'action.gmail:remove_label': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).removeLabel(params),
+  'action.gmail:create_label': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).createLabel(params),
+  'action.gmail:mark_as_read': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).markAsRead(params),
+  'action.gmail:mark_as_unread': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).markAsUnread(params),
+  'action.gmail:archive_email': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).archiveEmail(params),
+  'action.gmail:delete_email': (client, params = {}) =>
+    assertClientInstance(client, GmailAPIClient).deleteEmail(params),
+
   'action.prometheus:test_connection': client => assertClientInstance(client, PrometheusAPIClient).testConnection(),
   'action.prometheus:query_metrics': (client, params = {}) =>
     assertClientInstance(client, PrometheusAPIClient).queryMetrics(params),
@@ -336,6 +378,32 @@ const RUNTIME_OPS: Record<string, RuntimeHandler> = {
     assertClientInstance(client, PowerbiAPIClient).addRows(params),
   'trigger.powerbi:dataset_refresh_completed': (client, params = {}) =>
     assertClientInstance(client, PowerbiAPIClient).pollDatasetRefreshCompleted(params),
+
+  'trigger.google-docs:document_created': async (client, params = {}) => {
+    const docsClient = assertClientInstance(client, GoogleDocsAPIClient);
+    const documents = await docsClient.pollDocumentCreated(params);
+    return { success: true, data: documents };
+  },
+  'trigger.google-docs:document_updated': async (client, params = {}) => {
+    const docsClient = assertClientInstance(client, GoogleDocsAPIClient);
+    const documents = await docsClient.pollDocumentUpdated(params);
+    return { success: true, data: documents };
+  },
+  'trigger.google-drive:file_created': async (client, params = {}) => {
+    const driveClient = assertClientInstance(client, GoogleDriveAPIClient);
+    const files = await driveClient.pollFileCreated(params);
+    return { success: true, data: files };
+  },
+  'trigger.google-drive:file_updated': async (client, params = {}) => {
+    const driveClient = assertClientInstance(client, GoogleDriveAPIClient);
+    const files = await driveClient.pollFileUpdated(params);
+    return { success: true, data: files };
+  },
+  'trigger.google-drive:file_shared': async (client, params = {}) => {
+    const driveClient = assertClientInstance(client, GoogleDriveAPIClient);
+    const files = await driveClient.pollFileShared(params);
+    return { success: true, data: files };
+  },
 
   'action.sentry:test_connection': client => assertClientInstance(client, SentryAPIClient).testConnection(),
   'action.sentry:get_organizations': (client, params = {}) =>
@@ -437,6 +505,31 @@ const RUNTIME_OPS: Record<string, RuntimeHandler> = {
   'action.square:create_order': (client, params = {}) =>
     assertClientInstance(client, SquareAPIClient).createOrder(params),
 
+  'action.slack:test_connection': client =>
+    assertClientInstance(client, SlackAPIClient).testConnection(),
+  'action.slack:send_message': (client, params = {}) =>
+    assertClientInstance(client, SlackAPIClient).sendMessage(params),
+  'action.slack:create_channel': (client, params = {}) =>
+    assertClientInstance(client, SlackAPIClient).createChannel(params),
+  'action.slack:invite_to_channel': (client, params = {}) =>
+    assertClientInstance(client, SlackAPIClient).inviteToChannel(params),
+  'action.slack:upload_file': (client, params = {}) =>
+    assertClientInstance(client, SlackAPIClient).uploadFile(params),
+  'action.slack:get_channel_info': (client, params = {}) =>
+    assertClientInstance(client, SlackAPIClient).getChannelInfo(params),
+  'action.slack:list_channels': (client, params = {}) =>
+    assertClientInstance(client, SlackAPIClient).listChannels(params),
+  'action.slack:get_user_info': (client, params = {}) =>
+    assertClientInstance(client, SlackAPIClient).getUserInfo(params),
+  'action.slack:list_users': (client, params = {}) =>
+    assertClientInstance(client, SlackAPIClient).listUsers(params),
+  'action.slack:add_reaction': (client, params = {}) =>
+    assertClientInstance(client, SlackAPIClient).addReaction(params),
+  'action.slack:remove_reaction': (client, params = {}) =>
+    assertClientInstance(client, SlackAPIClient).removeReaction(params),
+  'action.slack:schedule_message': (client, params = {}) =>
+    assertClientInstance(client, SlackAPIClient).scheduleMessage(params),
+
   'action.kubernetes:test_connection': client => assertClientInstance(client, KubernetesAPIClient).testConnection(),
   'action.kubernetes:create_deployment': (client, params = {}) =>
     assertClientInstance(client, KubernetesAPIClient).createDeployment(params),
@@ -502,6 +595,10 @@ const RUNTIME_OPS: Record<string, RuntimeHandler> = {
     assertClientInstance(client, AnsibleAPIClient).listJobTemplates(),
   'action.ansible:delete_job_template': (client, params = {}) =>
     assertClientInstance(client, AnsibleAPIClient).deleteJobTemplate(params),
+
+  'action.webhook:reply_json': (_, params = {}) => replyWithJson(params),
+  'action.webhook:reply_text': (_, params = {}) => replyWithText(params),
+  'action.webhook:reply_html': (_, params = {}) => replyWithHtml(params),
 
   'action.jenkins:test_connection': client => assertClientInstance(client, JenkinsAPIClient).testConnection(),
   'action.jenkins:trigger_build': (client, params = {}) =>


### PR DESCRIPTION
## Summary
- add runtime operation mappings for Gmail actions, Slack actions, Google Docs/Drive triggers, and webhook replies
- implement Google Docs and Google Drive polling helpers plus webhook reply utilities used by the runtime
- expand Gmail label handling and add communication runtime tests covering the new handlers

## Testing
- ⚠️ `npx tsx server/integrations/__tests__/CommunicationAPIClients.test.ts` *(failed: npm registry access denied in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e661a5a1348331ab5c73cc547d3a3c