### PR TITLE
Add generic connector capabilities to runtime registry

### DIFF
--- a/server/runtime/__tests__/registry.capabilities.test.ts
+++ b/server/runtime/__tests__/registry.capabilities.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 
-import { getRuntimeCapabilities, hasRuntimeImplementation } from '../registry.js';
+process.env.GENERIC_EXECUTOR_ENABLED = 'false';
+
+const { getRuntimeCapabilities, hasRuntimeImplementation } = await import('../registry.js');
 
 {
   const capabilities = getRuntimeCapabilities();
@@ -13,3 +15,27 @@ import { getRuntimeCapabilities, hasRuntimeImplementation } from '../registry.js
   );
   assert.equal(hasRuntimeImplementation('action', 'http', 'request'), true);
 }
+
+{
+  const capabilities = getRuntimeCapabilities();
+  const slackCapabilities = capabilities.find(entry => entry.app === 'slack');
+
+  assert.ok(!slackCapabilities || !slackCapabilities.actions.includes('send_message'));
+  assert.equal(hasRuntimeImplementation('action', 'slack', 'send_message'), false);
+}
+
+process.env.GENERIC_EXECUTOR_ENABLED = 'true';
+
+{
+  const capabilities = getRuntimeCapabilities();
+  const slackCapabilities = capabilities.find(entry => entry.app === 'slack');
+
+  assert.ok(slackCapabilities, 'slack capabilities should be available when generic executor is enabled');
+  assert.ok(
+    slackCapabilities.actions.includes('send_message'),
+    'slack send_message action should be exposed via runtime registry when generic executor is enabled',
+  );
+  assert.equal(hasRuntimeImplementation('action', 'slack', 'send_message'), true);
+}
+
+process.env.GENERIC_EXECUTOR_ENABLED = 'false';

--- a/server/runtime/registry.ts
+++ b/server/runtime/registry.ts
@@ -1,4 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { buildOperationKeyCandidates, getRuntimeOpHandlers } from '../workflow/compiler/op-map.js';
+import { env } from '../env.js';
+
+interface GenericConnectorOperation {
+  type: 'action' | 'trigger';
+  app: string;
+  operation: string;
+  endpoint: string;
+  method: string;
+}
 
 export interface RuntimeAppOperations {
   actions: Record<string, unknown>;
@@ -52,6 +64,8 @@ function buildRegistry(): Record<string, RuntimeAppOperations> {
 const RUNTIME_HANDLERS = getRuntimeOpHandlers();
 const RUNTIME_HANDLER_KEYS = new Set(Object.keys(RUNTIME_HANDLERS));
 
+const GENERIC_RUNTIME_HANDLER_KEYS = new Set<string>();
+
 function injectBuiltinRuntimeEntries(
   registry: Record<string, RuntimeAppOperations>,
   handlerKeySet: Set<string>,
@@ -74,10 +88,199 @@ function injectBuiltinRuntimeEntries(
 const runtimeRegistry = buildRegistry();
 injectBuiltinRuntimeEntries(runtimeRegistry, RUNTIME_HANDLER_KEYS);
 
-export const RUNTIME_REGISTRY: Record<string, RuntimeAppOperations> = runtimeRegistry;
+let genericRuntimeRegistryCache: Record<string, RuntimeAppOperations> | null = null;
+let mergedRuntimeRegistryCache: Record<string, RuntimeAppOperations> | null = null;
+
+function loadConnectorDefinitionOperations(): GenericConnectorOperation[] {
+  const operations: GenericConnectorOperation[] = [];
+
+  try {
+    const manifestPath = resolve(process.cwd(), 'server', 'connector-manifest.json');
+    const manifestRaw = readFileSync(manifestPath, 'utf-8');
+    const manifest = JSON.parse(manifestRaw) as {
+      connectors?: Array<{ id?: string; normalizedId?: string; definitionPath?: string }>;
+    };
+
+    if (!Array.isArray(manifest.connectors)) {
+      return operations;
+    }
+
+    for (const entry of manifest.connectors) {
+      const connectorId = typeof entry?.normalizedId === 'string' && entry.normalizedId.trim() !== ''
+        ? entry.normalizedId.trim()
+        : typeof entry?.id === 'string'
+          ? entry.id.trim()
+          : '';
+
+      const definitionPath = typeof entry?.definitionPath === 'string' ? entry.definitionPath : '';
+      if (!connectorId || !definitionPath) {
+        continue;
+      }
+
+      try {
+        const resolved = resolve(process.cwd(), definitionPath);
+        const rawDefinition = readFileSync(resolved, 'utf-8');
+        const parsed = JSON.parse(rawDefinition) as {
+          actions?: Array<{ id?: string | null; endpoint?: unknown; method?: unknown }>;
+          triggers?: Array<{ id?: string | null; endpoint?: unknown; method?: unknown }>;
+        };
+
+        const actions = Array.isArray(parsed.actions) ? parsed.actions : [];
+        const triggers = Array.isArray(parsed.triggers) ? parsed.triggers : [];
+
+        for (const action of actions) {
+          const operationId = typeof action?.id === 'string' ? action.id.trim() : '';
+          const endpoint = typeof action?.endpoint === 'string' ? action.endpoint.trim() : '';
+          const method = typeof action?.method === 'string' ? action.method.trim() : '';
+          if (!operationId || !endpoint || !method) {
+            continue;
+          }
+          operations.push({
+            type: 'action',
+            app: connectorId,
+            operation: operationId,
+            endpoint,
+            method,
+          });
+        }
+
+        for (const trigger of triggers) {
+          const operationId = typeof trigger?.id === 'string' ? trigger.id.trim() : '';
+          const endpoint = typeof trigger?.endpoint === 'string' ? trigger.endpoint.trim() : '';
+          const method = typeof trigger?.method === 'string' ? trigger.method.trim() : '';
+          if (!operationId || !endpoint || !method) {
+            continue;
+          }
+          operations.push({
+            type: 'trigger',
+            app: connectorId,
+            operation: operationId,
+            endpoint,
+            method,
+          });
+        }
+      } catch (error) {
+        console.warn(
+          `[RuntimeRegistry] Failed to load connector definition for ${connectorId}: ${error instanceof Error ? error.message : error}`,
+        );
+      }
+    }
+  } catch (error) {
+    console.warn(
+      `[RuntimeRegistry] Failed to load connector manifest: ${error instanceof Error ? error.message : error}`,
+    );
+  }
+
+  return operations;
+}
+
+function buildGenericRuntimeRegistry(): Record<string, RuntimeAppOperations> {
+  const registry: Record<string, RuntimeAppOperations> = {};
+  const seen = new Set<string>();
+
+  for (const operation of loadConnectorDefinitionOperations()) {
+    const key = `${operation.type}.${operation.app}:${operation.operation}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+
+    const bucket = (registry[operation.app] ||= { actions: {}, triggers: {} });
+    const target = operation.type === 'trigger' ? bucket.triggers : bucket.actions;
+
+    if (target[operation.operation]) {
+      continue;
+    }
+
+    target[operation.operation] = {
+      endpoint: operation.endpoint,
+      method: operation.method,
+    };
+
+    const candidates = buildOperationKeyCandidates(operation.app, operation.operation, operation.type);
+    for (const candidate of candidates) {
+      GENERIC_RUNTIME_HANDLER_KEYS.add(candidate);
+    }
+  }
+
+  return registry;
+}
+
+function ensureGenericRuntimeRegistry(): Record<string, RuntimeAppOperations> {
+  if (!genericRuntimeRegistryCache) {
+    genericRuntimeRegistryCache = buildGenericRuntimeRegistry();
+  }
+  return genericRuntimeRegistryCache;
+}
+
+function cloneRegistry(source: Record<string, RuntimeAppOperations>): Record<string, RuntimeAppOperations> {
+  const clone: Record<string, RuntimeAppOperations> = {};
+  for (const [app, ops] of Object.entries(source)) {
+    clone[app] = {
+      actions: { ...ops.actions },
+      triggers: { ...ops.triggers },
+    };
+  }
+  return clone;
+}
+
+function mergeRegistries(
+  base: Record<string, RuntimeAppOperations>,
+  addition: Record<string, RuntimeAppOperations>,
+): Record<string, RuntimeAppOperations> {
+  const merged = cloneRegistry(base);
+
+  for (const [app, ops] of Object.entries(addition)) {
+    const bucket = (merged[app] ||= { actions: {}, triggers: {} });
+
+    for (const [operation, handler] of Object.entries(ops.actions)) {
+      if (!(operation in bucket.actions)) {
+        bucket.actions[operation] = handler;
+      }
+    }
+
+    for (const [operation, handler] of Object.entries(ops.triggers)) {
+      if (!(operation in bucket.triggers)) {
+        bucket.triggers[operation] = handler;
+      }
+    }
+  }
+
+  return merged;
+}
+
+function isGenericExecutorEnabled(): boolean {
+  if (process.env.GENERIC_EXECUTOR_ENABLED === 'true') {
+    return true;
+  }
+  if (process.env.GENERIC_EXECUTOR_ENABLED === 'false') {
+    return false;
+  }
+  return env.GENERIC_EXECUTOR_ENABLED;
+}
+
+function getRuntimeRegistryInternal(): Record<string, RuntimeAppOperations> {
+  if (!isGenericExecutorEnabled()) {
+    return runtimeRegistry;
+  }
+
+  if (!mergedRuntimeRegistryCache) {
+    const genericRegistry = ensureGenericRuntimeRegistry();
+    mergedRuntimeRegistryCache = mergeRegistries(runtimeRegistry, genericRegistry);
+  }
+
+  return mergedRuntimeRegistryCache;
+}
+
+export function getRuntimeRegistry(): Record<string, RuntimeAppOperations> {
+  return getRuntimeRegistryInternal();
+}
+
+export const RUNTIME_REGISTRY: Record<string, RuntimeAppOperations> = getRuntimeRegistryInternal();
 
 export function getRuntimeCapabilities(): RuntimeCapabilitySummary[] {
-  return Object.entries(RUNTIME_REGISTRY)
+  const registry = getRuntimeRegistryInternal();
+  return Object.entries(registry)
     .map(([app, ops]) => ({
       app,
       actions: Object.keys(ops.actions).sort(),
@@ -96,5 +299,16 @@ export function hasRuntimeImplementation(
   }
 
   const candidates = buildOperationKeyCandidates(app, operation, type);
-  return candidates.some(candidate => RUNTIME_HANDLER_KEYS.has(candidate));
+  if (candidates.some(candidate => RUNTIME_HANDLER_KEYS.has(candidate))) {
+    return true;
+  }
+
+  if (isGenericExecutorEnabled()) {
+    ensureGenericRuntimeRegistry();
+    if (candidates.some(candidate => GENERIC_RUNTIME_HANDLER_KEYS.has(candidate))) {
+      return true;
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Summary
- load generic connector HTTP operations from the manifest and merge them into the runtime registry when the generic executor flag is enabled
- extend runtime implementation checks to honor the generic capability set
- exercise the new behaviour by toggling the feature flag in the registry capabilities test and asserting Slack actions appear

## Testing
- npm run --silent tsx server/runtime/__tests__/registry.capabilities.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e665b0cc288331b48cb3fcc27bd5ed