### PR TITLE
Fix runtime status memo initialization order

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -1831,13 +1831,6 @@ const GraphEditorContent = () => {
   }, [nodes, selectedNodeId]);
   const showInspector = Boolean(selectedNode);
   const lastExecution = selectedNode?.data?.lastExecution;
-  const selectedNodeRuntimeStatus = useMemo<SelectedNodeRuntimeSupport | null>(() => {
-    if (!selectedNode || runtimeCapabilitiesLoading) {
-      return null;
-    }
-    const status = getNodeRuntimeSupport(selectedNode);
-    return status.supported ? null : status;
-  }, [getNodeRuntimeSupport, runtimeCapabilitiesLoading, selectedNode]);
   const [labelValue, setLabelValue] = useState<string>('');
   const [descValue, setDescValue] = useState<string>('');
   const [credentialsDraft, setCredentialsDraft] = useState<string>('');
@@ -2324,6 +2317,14 @@ const GraphEditorContent = () => {
     },
     [normalizeAppName, runtimeCapabilities, runtimeCapabilitiesLoading],
   );
+
+  const selectedNodeRuntimeStatus = useMemo<SelectedNodeRuntimeSupport | null>(() => {
+    if (!selectedNode || runtimeCapabilitiesLoading) {
+      return null;
+    }
+    const status = getNodeRuntimeSupport(selectedNode);
+    return status.supported ? null : status;
+  }, [getNodeRuntimeSupport, runtimeCapabilitiesLoading, selectedNode]);
 
   const findUnsupportedNode = useCallback(() => {
     if (runtimeCapabilitiesLoading) {


### PR DESCRIPTION
## Summary
- relocate the `selectedNodeRuntimeStatus` memo below the `getNodeRuntimeSupport` callback so the helper is defined before use
- preserve the memo dependency list so runtime capability updates still recompute the status

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67110313483319c50292865677e44