### PR TITLE
Refine priority connector schemas and add metadata tests

### DIFF
--- a/connectors/gmail/definition.json
+++ b/connectors/gmail/definition.json
@@ -594,85 +594,237 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique Gmail message identifier"
           },
           "threadId": {
-            "type": "string"
+            "type": "string",
+            "description": "Thread identifier for the conversation"
+          },
+          "historyId": {
+            "type": "string",
+            "description": "History record identifier for incremental sync"
           },
           "labelIds": {
             "type": "array",
+            "description": "Labels currently applied to the message",
             "items": {
               "type": "string"
             }
           },
           "subject": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Message subject extracted from headers"
+          },
+          "snippet": {
+            "type": "string",
+            "description": "First 100 characters of the message body"
           },
           "from": {
-            "type": "string"
+            "type": "string",
+            "format": "email",
+            "description": "Sender email address"
+          },
+          "fromName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name parsed from the From header"
           },
           "to": {
             "type": "array",
+            "description": "Primary recipient email addresses",
             "items": {
               "type": "string",
               "format": "email"
             }
           },
-          "snippet": {
-            "type": "string"
+          "cc": {
+            "type": "array",
+            "description": "Carbon-copy recipient email addresses",
+            "items": {
+              "type": "string",
+              "format": "email"
+            }
           },
-          "internalDate": {
-            "type": "string"
+          "bcc": {
+            "type": "array",
+            "description": "Blind carbon-copy recipient email addresses",
+            "items": {
+              "type": "string",
+              "format": "email"
+            }
+          },
+          "replyTo": {
+            "type": "array",
+            "description": "Reply-To email addresses if provided",
+            "items": {
+              "type": "string",
+              "format": "email"
+            }
+          },
+          "deliveredTo": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "email",
+            "description": "Mailbox that received the message"
+          },
+          "receivedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp the message was delivered"
+          },
+          "sizeEstimate": {
+            "type": "integer",
+            "description": "Approximate size of the entire message in bytes"
+          },
+          "bodyPlain": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Plain-text body content"
+          },
+          "bodyHtml": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "HTML body content"
           },
           "attachments": {
             "type": "array",
+            "description": "Attachment metadata included with the message",
             "items": {
               "type": "object",
               "properties": {
+                "attachmentId": {
+                  "type": "string",
+                  "description": "Identifier used to download the attachment"
+                },
                 "filename": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Attachment file name"
                 },
                 "mimeType": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Attachment MIME type"
                 },
                 "size": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "Attachment size in bytes"
                 }
               },
               "required": [
+                "attachmentId",
                 "filename",
                 "mimeType"
               ],
-              "additionalProperties": true
+              "additionalProperties": false
             }
+          },
+          "threadSnippet": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Snippet from the most recent message in the thread"
+          },
+          "_meta": {
+            "type": "object",
+            "description": "Connector metadata including the raw Gmail API payload",
+            "properties": {
+              "raw": {
+                "type": "object",
+                "description": "Raw Gmail message resource as returned by the API",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
           }
         },
         "required": [
           "id",
           "threadId",
-          "subject",
-          "from",
-          "to",
-          "snippet"
+          "labelIds",
+          "snippet",
+          "receivedAt"
         ],
-        "additionalProperties": true
+        "additionalProperties": false
       },
       "sample": {
-        "id": "188c9ab45fbc0d21",
-        "threadId": "188c9ab45fbc0d21",
+        "id": "1890f0ae5e3c1b3d",
+        "threadId": "1890f0ae5e3c1b3d",
+        "historyId": "156789",
         "labelIds": [
           "INBOX",
           "UNREAD"
         ],
-        "subject": "Weekly Metrics",
-        "from": "analytics@example.com",
+        "subject": "Quarterly metrics overview",
+        "snippet": "Hi team, sharing the Q4 KPIs summary for review...",
+        "from": "analytics-bot@example.com",
+        "fromName": "Analytics Bot",
         "to": [
-          "user@example.com"
+          "ops-lead@example.com"
         ],
-        "snippet": "Here are the latest metrics for the product launch...",
-        "internalDate": "1733779200000",
-        "attachments": []
-      }
+        "cc": [
+          "finance@example.com"
+        ],
+        "bcc": [],
+        "replyTo": [
+          "analytics-bot@example.com"
+        ],
+        "deliveredTo": "ops-lead@example.com",
+        "receivedAt": "2024-12-09T17:22:14Z",
+        "sizeEstimate": 25439,
+        "bodyPlain": "Hi team,\nPlease find the attached metrics deck.\nThanks!",
+        "bodyHtml": "<p>Hi team,</p><p>Please find the attached metrics deck.</p>",
+        "attachments": [
+          {
+            "attachmentId": "ANGjdJ8slA1",
+            "filename": "q4-metrics.xlsx",
+            "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "size": 18234
+          }
+        ],
+        "threadSnippet": "Latest reply: Looks great—publishing to the board workspace shortly.",
+        "_meta": {
+          "raw": {
+            "id": "1890f0ae5e3c1b3d",
+            "threadId": "1890f0ae5e3c1b3d",
+            "historyId": "156789",
+            "labelIds": [
+              "INBOX",
+              "UNREAD"
+            ],
+            "payload": {
+              "mimeType": "multipart/alternative",
+              "headers": [
+                {
+                  "name": "Date",
+                  "value": "Mon, 9 Dec 2024 09:22:14 -0800"
+                },
+                {
+                  "name": "Message-ID",
+                  "value": "<CAEPk12345@example.com>"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "id",
+        "cursor": "receivedAt"
+      },
+      "dedupeKey": "id"
     },
     {
       "id": "email_received_from",
@@ -700,53 +852,229 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique Gmail message identifier"
           },
           "threadId": {
-            "type": "string"
+            "type": "string",
+            "description": "Conversation thread identifier"
+          },
+          "historyId": {
+            "type": "string",
+            "description": "History record identifier"
+          },
+          "labelIds": {
+            "type": "array",
+            "description": "Labels applied to the message",
+            "items": {
+              "type": "string"
+            }
           },
           "subject": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Message subject"
+          },
+          "snippet": {
+            "type": "string",
+            "description": "First 100 characters of the body"
           },
           "from": {
-            "type": "string"
+            "type": "string",
+            "format": "email",
+            "description": "Sender email address"
+          },
+          "fromName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name parsed from the From header"
           },
           "to": {
             "type": "array",
+            "description": "Primary recipient addresses",
             "items": {
               "type": "string",
               "format": "email"
             }
           },
-          "snippet": {
-            "type": "string"
+          "cc": {
+            "type": "array",
+            "description": "Carbon-copy recipients",
+            "items": {
+              "type": "string",
+              "format": "email"
+            }
+          },
+          "bcc": {
+            "type": "array",
+            "description": "Blind carbon-copy recipients",
+            "items": {
+              "type": "string",
+              "format": "email"
+            }
+          },
+          "replyTo": {
+            "type": "array",
+            "description": "Reply-To addresses",
+            "items": {
+              "type": "string",
+              "format": "email"
+            }
+          },
+          "deliveredTo": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "email",
+            "description": "Inbox that received the message"
           },
           "receivedAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Delivery timestamp"
+          },
+          "sizeEstimate": {
+            "type": "integer",
+            "description": "Approximate message size in bytes"
+          },
+          "bodyPlain": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Plain text message body"
+          },
+          "bodyHtml": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "HTML message body"
+          },
+          "attachments": {
+            "type": "array",
+            "description": "Attachments included in the message",
+            "items": {
+              "type": "object",
+              "properties": {
+                "attachmentId": {
+                  "type": "string",
+                  "description": "Identifier to download the attachment"
+                },
+                "filename": {
+                  "type": "string",
+                  "description": "Attachment file name"
+                },
+                "mimeType": {
+                  "type": "string",
+                  "description": "Attachment MIME type"
+                },
+                "size": {
+                  "type": "integer",
+                  "description": "Attachment size in bytes"
+                }
+              },
+              "required": [
+                "attachmentId",
+                "filename",
+                "mimeType"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "_meta": {
+            "type": "object",
+            "description": "Connector metadata including the raw Gmail API payload",
+            "properties": {
+              "raw": {
+                "type": "object",
+                "description": "Raw Gmail message resource",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
           }
         },
         "required": [
           "id",
           "threadId",
-          "subject",
-          "from",
-          "to",
-          "snippet"
+          "labelIds",
+          "snippet",
+          "receivedAt"
         ],
-        "additionalProperties": true
+        "additionalProperties": false
       },
       "sample": {
-        "id": "188c9acb5a6e23f4",
-        "threadId": "188c9acb5a6e23f4",
-        "subject": "Contract Signed",
-        "from": "ceo@example.com",
-        "to": [
-          "user@example.com"
+        "id": "1890f1c52d0ab8f2",
+        "threadId": "1890f1c52d0ab8f2",
+        "historyId": "156793",
+        "labelIds": [
+          "INBOX",
+          "IMPORTANT"
         ],
-        "snippet": "We received the countersigned contract this morning.",
-        "receivedAt": "2024-12-09T15:24:05Z"
-      }
+        "subject": "Signed agreement received",
+        "snippet": "Great news—we have the countersigned agreement attached.",
+        "from": "chief.partnerships@example.com",
+        "fromName": "Chief Partnerships",
+        "to": [
+          "legal-ops@example.com"
+        ],
+        "cc": [
+          "sales-lead@example.com"
+        ],
+        "bcc": [],
+        "replyTo": [
+          "chief.partnerships@example.com"
+        ],
+        "deliveredTo": "legal-ops@example.com",
+        "receivedAt": "2024-12-09T15:24:05Z",
+        "sizeEstimate": 19872,
+        "bodyPlain": "Hi team,\nAttached is the executed agreement.\nRegards",
+        "bodyHtml": "<p>Hi team,</p><p>Attached is the executed agreement.</p>",
+        "attachments": [
+          {
+            "attachmentId": "ANGjdJ8uBy0",
+            "filename": "agreement.pdf",
+            "mimeType": "application/pdf",
+            "size": 14532
+          }
+        ],
+        "_meta": {
+          "raw": {
+            "id": "1890f1c52d0ab8f2",
+            "threadId": "1890f1c52d0ab8f2",
+            "historyId": "156793",
+            "labelIds": [
+              "INBOX",
+              "IMPORTANT"
+            ],
+            "payload": {
+              "mimeType": "multipart/mixed",
+              "headers": [
+                {
+                  "name": "Date",
+                  "value": "Mon, 9 Dec 2024 07:24:05 -0800"
+                },
+                {
+                  "name": "Message-ID",
+                  "value": "<CAD+ReceivedFrom@example.com>"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "id",
+        "cursor": "receivedAt"
+      },
+      "dedupeKey": "id"
     },
     {
       "id": "email_with_attachment",
@@ -775,77 +1103,227 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique Gmail message identifier"
           },
           "threadId": {
-            "type": "string"
+            "type": "string",
+            "description": "Conversation thread identifier"
+          },
+          "historyId": {
+            "type": "string",
+            "description": "History record identifier"
+          },
+          "labelIds": {
+            "type": "array",
+            "description": "Labels applied to the message",
+            "items": {
+              "type": "string"
+            }
           },
           "subject": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Message subject"
+          },
+          "snippet": {
+            "type": "string",
+            "description": "First 100 characters of the body"
           },
           "from": {
-            "type": "string"
+            "type": "string",
+            "format": "email",
+            "description": "Sender email address"
+          },
+          "fromName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name parsed from the From header"
           },
           "to": {
             "type": "array",
+            "description": "Primary recipient addresses",
             "items": {
               "type": "string",
               "format": "email"
             }
           },
-          "snippet": {
-            "type": "string"
+          "cc": {
+            "type": "array",
+            "description": "Carbon-copy recipients",
+            "items": {
+              "type": "string",
+              "format": "email"
+            }
+          },
+          "bcc": {
+            "type": "array",
+            "description": "Blind carbon-copy recipients",
+            "items": {
+              "type": "string",
+              "format": "email"
+            }
+          },
+          "replyTo": {
+            "type": "array",
+            "description": "Reply-To addresses",
+            "items": {
+              "type": "string",
+              "format": "email"
+            }
+          },
+          "deliveredTo": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "email",
+            "description": "Inbox that received the message"
+          },
+          "receivedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Delivery timestamp"
+          },
+          "sizeEstimate": {
+            "type": "integer",
+            "description": "Approximate message size in bytes"
+          },
+          "bodyPlain": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Plain text message body"
+          },
+          "bodyHtml": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "HTML message body"
           },
           "attachments": {
             "type": "array",
+            "description": "Attachments included in the message",
             "items": {
               "type": "object",
               "properties": {
+                "attachmentId": {
+                  "type": "string",
+                  "description": "Identifier to download the attachment"
+                },
                 "filename": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Attachment file name"
                 },
                 "mimeType": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Attachment MIME type"
                 },
                 "size": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "Attachment size in bytes"
                 }
               },
               "required": [
+                "attachmentId",
                 "filename",
                 "mimeType"
               ],
-              "additionalProperties": true
+              "additionalProperties": false
             }
+          },
+          "_meta": {
+            "type": "object",
+            "description": "Connector metadata including the raw Gmail API payload",
+            "properties": {
+              "raw": {
+                "type": "object",
+                "description": "Raw Gmail message resource",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
           }
         },
         "required": [
           "id",
           "threadId",
-          "subject",
-          "from",
-          "to",
+          "labelIds",
+          "receivedAt",
           "attachments"
         ],
-        "additionalProperties": true
+        "additionalProperties": false
       },
       "sample": {
-        "id": "188c9ae1bf2a6810",
-        "threadId": "188c9ae1bf2a6810",
-        "subject": "Signed Agreement",
-        "from": "legal@example.com",
-        "to": [
-          "user@example.com"
+        "id": "1890f230fa8de4c1",
+        "threadId": "1890f230fa8de4c1",
+        "historyId": "156812",
+        "labelIds": [
+          "INBOX"
         ],
-        "snippet": "Please find the signed agreement attached.",
+        "subject": "Project kickoff brief",
+        "snippet": "Attached is the design brief for the upcoming sprint.",
+        "from": "design-team@example.com",
+        "fromName": "Design Team",
+        "to": [
+          "product@example.com"
+        ],
+        "cc": [
+          "engineering@example.com"
+        ],
+        "bcc": [],
+        "replyTo": [
+          "design-team@example.com"
+        ],
+        "deliveredTo": "product@example.com",
+        "receivedAt": "2024-12-09T13:02:48Z",
+        "sizeEstimate": 31240,
+        "bodyPlain": "Team,\nSharing the kickoff brief for review.\n",
+        "bodyHtml": "<p>Team,</p><p>Sharing the kickoff brief for review.</p>",
         "attachments": [
           {
-            "filename": "agreement.pdf",
+            "attachmentId": "ANGjdJ8yBrief",
+            "filename": "design-brief.pdf",
             "mimeType": "application/pdf",
-            "size": 582341
+            "size": 24567
           }
-        ]
-      }
+        ],
+        "_meta": {
+          "raw": {
+            "id": "1890f230fa8de4c1",
+            "threadId": "1890f230fa8de4c1",
+            "historyId": "156812",
+            "labelIds": [
+              "INBOX"
+            ],
+            "payload": {
+              "mimeType": "multipart/mixed",
+              "headers": [
+                {
+                  "name": "Date",
+                  "value": "Mon, 9 Dec 2024 05:02:48 -0800"
+                },
+                {
+                  "name": "Message-ID",
+                  "value": "<CAD+Attachment@example.com>"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "id",
+        "cursor": "receivedAt"
+      },
+      "dedupeKey": "id"
     }
   ],
   "release": {

--- a/connectors/google-sheets-enhanced/definition.json
+++ b/connectors/google-sheets-enhanced/definition.json
@@ -1091,40 +1091,87 @@
         "type": "object",
         "properties": {
           "spreadsheetId": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique identifier for the spreadsheet"
+          },
+          "spreadsheetUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Link to open the spreadsheet in Google Sheets"
           },
           "sheetId": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Numeric sheet identifier"
+          },
+          "sheetTitle": {
+            "type": "string",
+            "description": "Visible name of the sheet"
+          },
+          "rowId": {
+            "type": "string",
+            "description": "Stable identifier for the inserted row"
           },
           "rowIndex": {
-            "type": "integer"
+            "type": "integer",
+            "description": "1-based row index"
           },
           "values": {
             "type": "array",
+            "description": "Row values in column order",
             "items": {
               "type": [
                 "string",
                 "number",
-                "boolean"
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "valuesByColumn": {
+            "type": "object",
+            "description": "Row values keyed by column letter",
+            "additionalProperties": {
+              "type": [
+                "string",
+                "number",
+                "boolean",
+                "null"
               ]
             }
           },
           "addedAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when the row was added"
+          },
+          "_meta": {
+            "type": "object",
+            "description": "Connector metadata including the raw Google Sheets change payload",
+            "properties": {
+              "raw": {
+                "type": "object",
+                "description": "Raw Sheets API response",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
           }
         },
         "required": [
           "spreadsheetId",
           "sheetId",
+          "rowId",
           "rowIndex",
           "values"
         ],
-        "additionalProperties": true
+        "additionalProperties": false
       },
       "sample": {
         "spreadsheetId": "1vD2xQ9pUoJlMnOpQrStUvWxYz",
+        "spreadsheetUrl": "https://docs.google.com/spreadsheets/d/1vD2xQ9pUoJlMnOpQrStUvWxYz/edit",
         "sheetId": 123456789,
+        "sheetTitle": "Pipeline",
+        "rowId": "123456789!257",
         "rowIndex": 257,
         "values": [
           "2024-12-09",
@@ -1132,8 +1179,37 @@
           125000,
           "Closed Won"
         ],
-        "addedAt": "2024-12-09T16:05:12Z"
-      }
+        "valuesByColumn": {
+          "A": "2024-12-09",
+          "B": "Enterprise",
+          "C": 125000,
+          "D": "Closed Won"
+        ],
+        "addedAt": "2024-12-09T16:05:12Z",
+        "_meta": {
+          "raw": {
+            "spreadsheetId": "1vD2xQ9pUoJlMnOpQrStUvWxYz",
+            "sheetId": 123456789,
+            "row": {
+              "range": "Pipeline!A257:D257",
+              "values": [
+                [
+                  "2024-12-09",
+                  "Enterprise",
+                  "125000",
+                  "Closed Won"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "rowId",
+        "cursor": "addedAt"
+      },
+      "dedupeKey": "rowId"
     },
     {
       "id": "cell_updated",
@@ -1162,13 +1238,24 @@
         "type": "object",
         "properties": {
           "spreadsheetId": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique identifier for the spreadsheet"
           },
           "sheetId": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Numeric sheet identifier"
+          },
+          "sheetTitle": {
+            "type": "string",
+            "description": "Visible name of the sheet"
           },
           "range": {
-            "type": "string"
+            "type": "string",
+            "description": "A1 notation for the updated cell"
+          },
+          "changeId": {
+            "type": "string",
+            "description": "Stable identifier for the cell update event"
           },
           "oldValue": {
             "type": [
@@ -1176,7 +1263,8 @@
               "number",
               "boolean",
               "null"
-            ]
+            ],
+            "description": "Value before the update"
           },
           "newValue": {
             "type": [
@@ -1184,33 +1272,69 @@
               "number",
               "boolean",
               "null"
-            ]
+            ],
+            "description": "Value after the update"
+          },
+          "updatedBy": {
+            "type": "string",
+            "format": "email",
+            "description": "Email address of the editor"
           },
           "updatedAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when the cell was updated"
           },
-          "updatedBy": {
-            "type": "string"
+          "_meta": {
+            "type": "object",
+            "description": "Connector metadata including the raw Google Sheets change payload",
+            "properties": {
+              "raw": {
+                "type": "object",
+                "description": "Raw Sheets API response",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
           }
         },
         "required": [
           "spreadsheetId",
           "sheetId",
           "range",
+          "changeId",
           "newValue"
         ],
-        "additionalProperties": true
+        "additionalProperties": false
       },
       "sample": {
         "spreadsheetId": "1vD2xQ9pUoJlMnOpQrStUvWxYz",
-        "sheetId": 0,
+        "sheetId": 123456789,
+        "sheetTitle": "Summary",
         "range": "Summary!D3",
+        "changeId": "123456789!D3@2024-12-09T15:42:30Z",
         "oldValue": "Negotiation",
         "newValue": "Closed Won",
+        "updatedBy": "owner@example.com",
         "updatedAt": "2024-12-09T15:42:30Z",
-        "updatedBy": "alex.rivera@example.com"
-      }
+        "_meta": {
+          "raw": {
+            "spreadsheetId": "1vD2xQ9pUoJlMnOpQrStUvWxYz",
+            "sheetId": 123456789,
+            "range": "Summary!D3",
+            "user": "owner@example.com",
+            "timestamp": "2024-12-09T15:42:30Z",
+            "oldValue": "Negotiation",
+            "newValue": "Closed Won"
+          }
+        }
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "changeId",
+        "cursor": "updatedAt"
+      },
+      "dedupeKey": "changeId"
     }
   ],
   "testConnection": {

--- a/connectors/slack/definition.json
+++ b/connectors/slack/definition.json
@@ -1390,35 +1390,65 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
+          "event_id": {
+            "type": "string",
+            "description": "Unique identifier for the Slack event"
+          },
+          "event_ts": {
+            "type": "string",
+            "description": "Slack-provided timestamp used for deduplication"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Workspace identifier"
+          },
+          "api_app_id": {
+            "type": "string",
+            "description": "Slack application identifier"
+          },
+          "type": {
+            "type": "string",
+            "description": "Event envelope type",
+            "const": "event_callback"
+          },
           "event": {
             "type": "object",
+            "description": "Normalized Slack event payload",
             "properties": {
               "type": {
-                "type": "string"
+                "type": "string",
+                "description": "Event subtype"
               },
               "channel": {
-                "type": "string"
+                "type": "string",
+                "description": "Channel identifier"
               },
               "channel_type": {
-                "type": "string"
+                "type": "string",
+                "description": "Channel classification (channel, group, im, mpim)"
               },
               "user": {
-                "type": "string"
+                "type": "string",
+                "description": "User identifier for the actor"
               },
               "text": {
-                "type": "string"
+                "type": "string",
+                "description": "Message body rendered as plain text"
               },
               "ts": {
-                "type": "string"
-              },
-              "team": {
-                "type": "string"
-              },
-              "event_ts": {
-                "type": "string"
+                "type": "string",
+                "description": "Message timestamp in Slack format"
               },
               "thread_ts": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Parent thread timestamp when applicable"
+              },
+              "team": {
+                "type": "string",
+                "description": "Team identifier associated with the message"
               }
             },
             "required": [
@@ -1429,14 +1459,47 @@
               "ts"
             ],
             "additionalProperties": true
+          },
+          "authorizations": {
+            "type": "array",
+            "description": "Authorized installations for the event",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Event timestamp converted to ISO 8601"
+          },
+          "_meta": {
+            "type": "object",
+            "description": "Connector metadata including the raw Slack payload",
+            "properties": {
+              "raw": {
+                "type": "object",
+                "description": "Original Slack Events API payload",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
           }
         },
         "required": [
+          "event_id",
+          "event_ts",
+          "team_id",
           "event"
         ],
         "additionalProperties": true
       },
       "sample": {
+        "event_id": "Ev04ABCDEF",
+        "event_ts": "1733757001.000400",
+        "team_id": "T12345678",
+        "api_app_id": "A0ABCDE12",
+        "type": "event_callback",
         "event": {
           "type": "message",
           "channel": "C08S3A1Q2",
@@ -1445,10 +1508,42 @@
           "text": "Reminder: customer demo at 2pm",
           "ts": "1733757001.000400",
           "thread_ts": "1733756457.000200",
-          "team": "T12345678",
-          "event_ts": "1733757001.000400"
+          "team": "T12345678"
+        },
+        "authorizations": [
+          {
+            "enterprise_id": null,
+            "team_id": "T12345678",
+            "user_id": "U0DemoBot",
+            "is_bot": true
+          }
+        ],
+        "eventTime": "2024-12-09T18:30:01Z",
+        "_meta": {
+          "raw": {
+            "token": "verification-token",
+            "team_id": "T12345678",
+            "api_app_id": "A0ABCDE12",
+            "event": {
+              "type": "message",
+              "channel": "C08S3A1Q2",
+              "user": "U061F7AUR",
+              "text": "Reminder: customer demo at 2pm",
+              "ts": "1733757001.000400",
+              "channel_type": "channel",
+              "event_ts": "1733757001.000400"
+            },
+            "type": "event_callback",
+            "event_id": "Ev04ABCDEF",
+            "event_time": 1733757001
+          }
         }
-      }
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "event_ts"
+      },
+      "dedupeKey": "event_ts"
     },
     {
       "id": "reaction_added",
@@ -1490,29 +1585,58 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
+          "event_id": {
+            "type": "string",
+            "description": "Unique identifier for the Slack event"
+          },
+          "event_ts": {
+            "type": "string",
+            "description": "Slack event timestamp used for deduplication"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Workspace identifier"
+          },
+          "api_app_id": {
+            "type": "string",
+            "description": "Slack application identifier"
+          },
+          "type": {
+            "type": "string",
+            "const": "event_callback",
+            "description": "Event envelope type"
+          },
           "event": {
             "type": "object",
+            "description": "Normalized Slack reaction payload",
             "properties": {
               "type": {
-                "type": "string"
+                "type": "string",
+                "description": "Event subtype"
               },
               "user": {
-                "type": "string"
+                "type": "string",
+                "description": "User who added the reaction"
               },
               "reaction": {
-                "type": "string"
+                "type": "string",
+                "description": "Name of the emoji reaction"
               },
               "item": {
                 "type": "object",
+                "description": "Item the reaction was added to",
                 "properties": {
                   "type": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Type of item (e.g., message)"
                   },
                   "channel": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Channel identifier containing the item"
                   },
                   "ts": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Timestamp for the target item"
                   }
                 },
                 "required": [
@@ -1523,10 +1647,8 @@
                 "additionalProperties": true
               },
               "item_user": {
-                "type": "string"
-              },
-              "event_ts": {
-                "type": "string"
+                "type": "string",
+                "description": "Owner of the item that received the reaction"
               }
             },
             "required": [
@@ -1536,14 +1658,39 @@
               "item"
             ],
             "additionalProperties": true
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Event timestamp converted to ISO 8601"
+          },
+          "_meta": {
+            "type": "object",
+            "description": "Connector metadata including the raw Slack payload",
+            "properties": {
+              "raw": {
+                "type": "object",
+                "description": "Original Slack Events API payload",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
           }
         },
         "required": [
+          "event_id",
+          "event_ts",
+          "team_id",
           "event"
         ],
         "additionalProperties": true
       },
       "sample": {
+        "event_id": "Ev04GHJKLM",
+        "event_ts": "1733757040.000500",
+        "team_id": "T12345678",
+        "api_app_id": "A0ABCDE12",
+        "type": "event_callback",
         "event": {
           "type": "reaction_added",
           "user": "U024BE7LH",
@@ -1553,10 +1700,36 @@
             "channel": "C024BE7LT",
             "ts": "1733756030.000200"
           },
-          "item_user": "U061F7AUR",
-          "event_ts": "1733757040.000500"
+          "item_user": "U061F7AUR"
+        },
+        "eventTime": "2024-12-09T18:30:40Z",
+        "_meta": {
+          "raw": {
+            "team_id": "T12345678",
+            "api_app_id": "A0ABCDE12",
+            "event": {
+              "type": "reaction_added",
+              "user": "U024BE7LH",
+              "reaction": "white_check_mark",
+              "item": {
+                "type": "message",
+                "channel": "C024BE7LT",
+                "ts": "1733756030.000200"
+              },
+              "item_user": "U061F7AUR",
+              "event_ts": "1733757040.000500"
+            },
+            "type": "event_callback",
+            "event_id": "Ev04GHJKLM",
+            "event_time": 1733757040
+          }
         }
-      }
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "event_ts"
+      },
+      "dedupeKey": "event_ts"
     },
     {
       "id": "user_joined_channel",
@@ -1596,29 +1769,57 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
+          "event_id": {
+            "type": "string",
+            "description": "Unique identifier for the Slack event"
+          },
+          "event_ts": {
+            "type": "string",
+            "description": "Slack event timestamp used for deduplication"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Workspace identifier"
+          },
+          "api_app_id": {
+            "type": "string",
+            "description": "Slack application identifier"
+          },
+          "type": {
+            "type": "string",
+            "const": "event_callback",
+            "description": "Event envelope type"
+          },
           "event": {
             "type": "object",
+            "description": "Normalized channel membership payload",
             "properties": {
               "type": {
-                "type": "string"
+                "type": "string",
+                "description": "Event subtype"
               },
               "user": {
-                "type": "string"
+                "type": "string",
+                "description": "User who joined the channel"
               },
               "channel": {
-                "type": "string"
+                "type": "string",
+                "description": "Channel identifier"
               },
               "channel_type": {
-                "type": "string"
+                "type": "string",
+                "description": "Channel classification"
               },
               "team": {
-                "type": "string"
+                "type": "string",
+                "description": "Workspace identifier"
               },
               "inviter": {
-                "type": "string"
-              },
-              "event_ts": {
-                "type": "string"
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "User who invited the member"
               }
             },
             "required": [
@@ -1627,24 +1828,72 @@
               "channel"
             ],
             "additionalProperties": true
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Event timestamp converted to ISO 8601"
+          },
+          "_meta": {
+            "type": "object",
+            "description": "Connector metadata including the raw Slack payload",
+            "properties": {
+              "raw": {
+                "type": "object",
+                "description": "Original Slack Events API payload",
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
           }
         },
         "required": [
+          "event_id",
+          "event_ts",
+          "team_id",
           "event"
         ],
         "additionalProperties": true
       },
       "sample": {
+        "event_id": "Ev04MEMJOIN",
+        "event_ts": "1733757205.000600",
+        "team_id": "T12345678",
+        "api_app_id": "A0ABCDE12",
+        "type": "event_callback",
         "event": {
           "type": "member_joined_channel",
           "user": "U0G9QF9C6",
           "channel": "C08S3A1Q2",
           "channel_type": "C",
           "team": "T12345678",
-          "inviter": "U024BE7LH",
-          "event_ts": "1733757205.000600"
+          "inviter": "U024BE7LH"
+        },
+        "eventTime": "2024-12-09T18:33:25Z",
+        "_meta": {
+          "raw": {
+            "team_id": "T12345678",
+            "api_app_id": "A0ABCDE12",
+            "event": {
+              "type": "member_joined_channel",
+              "user": "U0G9QF9C6",
+              "channel": "C08S3A1Q2",
+              "channel_type": "C",
+              "team": "T12345678",
+              "inviter": "U024BE7LH",
+              "event_ts": "1733757205.000600"
+            },
+            "type": "event_callback",
+            "event_id": "Ev04MEMJOIN",
+            "event_time": 1733757205
+          }
         }
-      }
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "event_ts"
+      },
+      "dedupeKey": "event_ts"
     }
   ],
   "testConnection": {

--- a/server/registry/__tests__/priorityConnectorsMetadata.test.ts
+++ b/server/registry/__tests__/priorityConnectorsMetadata.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+interface ConnectorDefinition {
+  triggers?: Array<Record<string, any>>;
+}
+
+const loadConnectorDefinition = (connectorId: string): ConnectorDefinition => {
+  const filePath = resolve(process.cwd(), 'connectors', connectorId, 'definition.json');
+  const raw = readFileSync(filePath, 'utf-8');
+  return JSON.parse(raw) as ConnectorDefinition;
+};
+
+const findTrigger = (definition: ConnectorDefinition, triggerId: string) => {
+  return definition.triggers?.find((trigger) => trigger.id === triggerId);
+};
+
+try {
+  const gmail = loadConnectorDefinition('gmail');
+  const gmailTrigger = findTrigger(gmail, 'new_email_received');
+  assert(gmailTrigger, 'gmail.new_email_received trigger should be defined');
+  assert.equal(gmailTrigger?.dedupeKey, 'id', 'Gmail trigger should dedupe on message id');
+  assert.equal(gmailTrigger?.dedupe?.primaryKey, 'id', 'Gmail trigger dedupe primary key should be id');
+  assert.equal(
+    gmailTrigger?.outputSchema?.properties?.receivedAt?.format,
+    'date-time',
+    'Gmail schema should mark receivedAt as date-time'
+  );
+  assert.equal(
+    gmailTrigger?.outputSchema?.properties?.from?.format,
+    'email',
+    'Gmail schema should mark from as email'
+  );
+  assert(gmailTrigger?.sample?._meta?.raw, 'Gmail sample should include raw metadata payload');
+  const gmailSampleSize = Buffer.byteLength(JSON.stringify(gmailTrigger?.sample), 'utf-8');
+  assert(gmailSampleSize < 2_048, 'Gmail sample should remain concise (<2KB)');
+
+  const slack = loadConnectorDefinition('slack');
+  const slackMessageTrigger = findTrigger(slack, 'message_received');
+  assert(slackMessageTrigger, 'slack.message_received trigger should be defined');
+  assert.equal(slackMessageTrigger?.dedupeKey, 'event_ts', 'Slack trigger should dedupe on event_ts');
+  assert.equal(slackMessageTrigger?.dedupe?.primaryKey, 'event_ts', 'Slack dedupe primary key should be event_ts');
+  assert.equal(
+    slackMessageTrigger?.outputSchema?.properties?.eventTime?.format,
+    'date-time',
+    'Slack schema should expose ISO eventTime hint'
+  );
+  assert(slackMessageTrigger?.sample?._meta?.raw, 'Slack sample should include raw payload metadata');
+
+  const sheets = loadConnectorDefinition('google-sheets-enhanced');
+  const sheetsRowTrigger = findTrigger(sheets, 'row_added');
+  assert(sheetsRowTrigger, 'sheets.row_added trigger should be defined');
+  assert.equal(sheetsRowTrigger?.dedupeKey, 'rowId', 'Sheets row trigger should dedupe on rowId');
+  assert.equal(
+    sheetsRowTrigger?.outputSchema?.properties?.spreadsheetUrl?.format,
+    'uri',
+    'Sheets row schema should include spreadsheetUrl uri hint'
+  );
+  assert(sheetsRowTrigger?.sample?._meta?.raw, 'Sheets row sample should embed raw metadata');
+
+  const sheetsCellTrigger = findTrigger(sheets, 'cell_updated');
+  assert(sheetsCellTrigger, 'sheets.cell_updated trigger should be defined');
+  assert.equal(sheetsCellTrigger?.dedupeKey, 'changeId', 'Sheets cell trigger should dedupe on changeId');
+  assert.equal(
+    sheetsCellTrigger?.outputSchema?.properties?.updatedBy?.format,
+    'email',
+    'Sheets cell schema should mark updatedBy as email'
+  );
+  assert(sheetsCellTrigger?.sample?._meta?.raw, 'Sheets cell sample should embed raw metadata');
+
+  console.log('Priority connector metadata includes curated dedupe, schema hints, and raw payload samples.');
+  process.exit(0);
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- enrich Gmail trigger payloads with detailed metadata, samples, and explicit dedupe configuration keyed by message id
- update Slack event triggers to expose event identifiers, ISO timestamps, and raw payload snapshots for reliable deduplication
- enhance Google Sheets triggers with stable row/change identifiers, URL hints, and curated raw metadata wrappers
- add a registry test that asserts the curated fields remain present for the Gmail, Slack, and Google Sheets triggers

## Testing
- `npx tsx server/registry/__tests__/priorityConnectorsMetadata.test.ts` *(fails: npm registry returned 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e6842fbb6c833195f92b25378c61ef