### PR TITLE
Add dedupe defaults to connector triggers

### DIFF
--- a/connectors/adobesign/definition.json
+++ b/connectors/adobesign/definition.json
@@ -312,6 +312,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -342,6 +346,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/adp/definition.json
+++ b/connectors/adp/definition.json
@@ -238,6 +238,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/adyen/definition.json
+++ b/connectors/adyen/definition.json
@@ -285,6 +285,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/airtable-enhanced/definition.json
+++ b/connectors/airtable-enhanced/definition.json
@@ -504,6 +504,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -539,6 +543,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/airtable/definition.json
+++ b/connectors/airtable/definition.json
@@ -363,6 +363,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -402,6 +406,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/ansible/definition.json
+++ b/connectors/ansible/definition.json
@@ -340,6 +340,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -374,6 +378,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/argocd/definition.json
+++ b/connectors/argocd/definition.json
@@ -299,6 +299,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -345,6 +349,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/asana-enhanced/definition.json
+++ b/connectors/asana-enhanced/definition.json
@@ -708,6 +708,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -746,6 +750,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -791,6 +799,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/aws-cloudformation/definition.json
+++ b/connectors/aws-cloudformation/definition.json
@@ -316,6 +316,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -359,6 +363,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/aws-codepipeline/definition.json
+++ b/connectors/aws-codepipeline/definition.json
@@ -273,6 +273,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -307,6 +311,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -341,6 +349,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/azure-devops/definition.json
+++ b/connectors/azure-devops/definition.json
@@ -312,6 +312,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -356,6 +360,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/bamboohr/definition.json
+++ b/connectors/bamboohr/definition.json
@@ -283,6 +283,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -310,6 +314,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/basecamp/definition.json
+++ b/connectors/basecamp/definition.json
@@ -342,6 +342,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -372,6 +376,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/bigcommerce/definition.json
+++ b/connectors/bigcommerce/definition.json
@@ -360,6 +360,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -390,6 +394,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/bigquery/definition.json
+++ b/connectors/bigquery/definition.json
@@ -410,6 +410,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/bitbucket/definition.json
+++ b/connectors/bitbucket/definition.json
@@ -435,6 +435,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -470,6 +474,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/box/definition.json
+++ b/connectors/box/definition.json
@@ -441,6 +441,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -471,6 +475,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/braze/definition.json
+++ b/connectors/braze/definition.json
@@ -405,6 +405,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -443,6 +447,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/brex/definition.json
+++ b/connectors/brex/definition.json
@@ -469,6 +469,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -499,6 +503,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/caldotcom/definition.json
+++ b/connectors/caldotcom/definition.json
@@ -478,6 +478,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -508,6 +512,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/calendly/definition.json
+++ b/connectors/calendly/definition.json
@@ -364,6 +364,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -399,6 +403,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/circleci/definition.json
+++ b/connectors/circleci/definition.json
@@ -366,6 +366,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -399,6 +403,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/clickup/definition.json
+++ b/connectors/clickup/definition.json
@@ -605,6 +605,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -635,6 +639,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/coda/definition.json
+++ b/connectors/coda/definition.json
@@ -535,6 +535,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -570,6 +574,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/concur/definition.json
+++ b/connectors/concur/definition.json
@@ -461,6 +461,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -491,6 +495,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/confluence/definition.json
+++ b/connectors/confluence/definition.json
@@ -598,6 +598,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -633,6 +637,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/coupa/definition.json
+++ b/connectors/coupa/definition.json
@@ -509,6 +509,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -542,6 +546,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/databricks/definition.json
+++ b/connectors/databricks/definition.json
@@ -596,6 +596,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -626,6 +630,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/datadog/definition.json
+++ b/connectors/datadog/definition.json
@@ -520,6 +520,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -550,6 +554,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/docker-hub/definition.json
+++ b/connectors/docker-hub/definition.json
@@ -274,6 +274,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -308,6 +312,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/docusign/definition.json
+++ b/connectors/docusign/definition.json
@@ -565,6 +565,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -595,6 +599,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -625,6 +633,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/dropbox-enhanced/definition.json
+++ b/connectors/dropbox-enhanced/definition.json
@@ -622,6 +622,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -654,6 +658,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -684,6 +692,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/dropbox/definition.json
+++ b/connectors/dropbox/definition.json
@@ -552,6 +552,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -579,6 +583,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/dynamics365/definition.json
+++ b/connectors/dynamics365/definition.json
@@ -577,6 +577,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -607,6 +611,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -637,6 +645,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/egnyte/definition.json
+++ b/connectors/egnyte/definition.json
@@ -500,6 +500,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -532,6 +536,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/excel-online/definition.json
+++ b/connectors/excel-online/definition.json
@@ -606,6 +606,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -641,6 +645,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/expensify/definition.json
+++ b/connectors/expensify/definition.json
@@ -469,6 +469,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -499,6 +503,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -532,6 +540,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/freshdesk/definition.json
+++ b/connectors/freshdesk/definition.json
@@ -573,6 +573,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -603,6 +607,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/github-enhanced/definition.json
+++ b/connectors/github-enhanced/definition.json
@@ -626,6 +626,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -670,6 +674,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -712,6 +720,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/github/definition.json
+++ b/connectors/github/definition.json
@@ -1018,6 +1018,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1074,6 +1078,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1133,6 +1141,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1179,6 +1191,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1225,6 +1241,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/gitlab/definition.json
+++ b/connectors/gitlab/definition.json
@@ -377,6 +377,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -407,6 +411,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/gmail-enhanced/definition.json
+++ b/connectors/gmail-enhanced/definition.json
@@ -644,6 +644,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -671,6 +675,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/google-admin/definition.json
+++ b/connectors/google-admin/definition.json
@@ -547,6 +547,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -577,6 +581,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/google-calendar/definition.json
+++ b/connectors/google-calendar/definition.json
@@ -856,6 +856,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -894,6 +898,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -940,6 +948,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/google-chat/definition.json
+++ b/connectors/google-chat/definition.json
@@ -609,6 +609,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -642,6 +646,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -680,6 +688,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/google-contacts/definition.json
+++ b/connectors/google-contacts/definition.json
@@ -571,6 +571,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -604,6 +608,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/google-docs/definition.json
+++ b/connectors/google-docs/definition.json
@@ -558,6 +558,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -596,6 +600,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/google-drive/definition.json
+++ b/connectors/google-drive/definition.json
@@ -1726,6 +1726,10 @@
             "emailAddress": "alex.rivera@example.com"
           }
         ]
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1800,6 +1804,10 @@
           "displayName": "Taylor Morgan",
           "emailAddress": "taylor.morgan@example.com"
         }
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1879,6 +1887,10 @@
           }
         ],
         "sharedTime": "2024-12-09T12:30:00Z"
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/google-forms/definition.json
+++ b/connectors/google-forms/definition.json
@@ -551,6 +551,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -581,6 +585,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/google-meet/definition.json
+++ b/connectors/google-meet/definition.json
@@ -462,6 +462,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -500,6 +504,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -544,6 +552,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/google-sheets-enhanced/definition.json
+++ b/connectors/google-sheets-enhanced/definition.json
@@ -1184,7 +1184,7 @@
           "B": "Enterprise",
           "C": 125000,
           "D": "Closed Won"
-        ],
+        },
         "addedAt": "2024-12-09T16:05:12Z",
         "_meta": {
           "raw": {

--- a/connectors/google-slides/definition.json
+++ b/connectors/google-slides/definition.json
@@ -666,6 +666,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -704,6 +708,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/grafana/definition.json
+++ b/connectors/grafana/definition.json
@@ -311,6 +311,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -345,6 +349,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/greenhouse/definition.json
+++ b/connectors/greenhouse/definition.json
@@ -824,6 +824,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -859,6 +863,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -889,6 +897,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/guru/definition.json
+++ b/connectors/guru/definition.json
@@ -668,6 +668,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -712,6 +716,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -753,6 +761,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/hashicorp-vault/definition.json
+++ b/connectors/hashicorp-vault/definition.json
@@ -260,6 +260,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -294,6 +298,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/hellosign/definition.json
+++ b/connectors/hellosign/definition.json
@@ -850,6 +850,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -897,6 +901,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -938,6 +946,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/helm/definition.json
+++ b/connectors/helm/definition.json
@@ -307,6 +307,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -345,6 +349,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/hubspot-enhanced/definition.json
+++ b/connectors/hubspot-enhanced/definition.json
@@ -957,6 +957,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -998,6 +1002,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1036,6 +1044,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1069,6 +1081,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/hubspot/definition.json
+++ b/connectors/hubspot/definition.json
@@ -1906,6 +1906,10 @@
           "lastmodifieddate": "2024-12-08T22:10:04.512Z"
         },
         "createdAt": "2024-12-09T14:21:17.000Z"
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -2005,6 +2009,10 @@
         "changedFields": [
           "phone"
         ]
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -2088,6 +2096,10 @@
           "lastmodifieddate": "2024-12-09T08:44:29.934Z"
         },
         "createdAt": "2024-11-30T15:05:10.000Z"
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -2145,6 +2157,10 @@
         "currentStage": "contractsent",
         "changedAt": "2024-12-09T12:01:45.000Z",
         "amount": 145000
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/intercom/definition.json
+++ b/connectors/intercom/definition.json
@@ -741,6 +741,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -780,6 +784,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -813,6 +821,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/iterable/definition.json
+++ b/connectors/iterable/definition.json
@@ -815,6 +815,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -862,6 +866,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -912,6 +920,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -951,6 +963,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/jenkins/definition.json
+++ b/connectors/jenkins/definition.json
@@ -688,6 +688,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -737,6 +741,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -783,6 +791,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/jira-service-management/definition.json
+++ b/connectors/jira-service-management/definition.json
@@ -827,6 +827,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -881,6 +885,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -935,6 +943,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -986,6 +998,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/jira/definition.json
+++ b/connectors/jira/definition.json
@@ -771,6 +771,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -819,6 +823,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -871,6 +879,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -919,6 +931,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/jotform/definition.json
+++ b/connectors/jotform/definition.json
@@ -687,6 +687,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -720,6 +724,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/klaviyo/definition.json
+++ b/connectors/klaviyo/definition.json
@@ -848,6 +848,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -883,6 +887,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -918,6 +926,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/kubernetes/definition.json
+++ b/connectors/kubernetes/definition.json
@@ -335,6 +335,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -373,6 +377,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/kustomer/definition.json
+++ b/connectors/kustomer/definition.json
@@ -835,6 +835,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -883,6 +887,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -945,6 +953,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -984,6 +996,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/lever/definition.json
+++ b/connectors/lever/definition.json
@@ -817,6 +817,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -855,6 +859,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -888,6 +896,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/linear/definition.json
+++ b/connectors/linear/definition.json
@@ -685,6 +685,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -726,6 +730,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -770,6 +778,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/llm/definition.json
+++ b/connectors/llm/definition.json
@@ -236,6 +236,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/looker/definition.json
+++ b/connectors/looker/definition.json
@@ -790,6 +790,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -834,6 +838,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/luma/definition.json
+++ b/connectors/luma/definition.json
@@ -762,6 +762,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -806,6 +810,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -847,6 +855,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -885,6 +897,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/magento/definition.json
+++ b/connectors/magento/definition.json
@@ -632,6 +632,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -682,6 +686,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/mailchimp-enhanced/definition.json
+++ b/connectors/mailchimp-enhanced/definition.json
@@ -969,6 +969,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1004,6 +1008,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1116,6 +1124,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/mailchimp/definition.json
+++ b/connectors/mailchimp/definition.json
@@ -1008,6 +1008,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1052,6 +1056,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1093,6 +1101,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1143,6 +1155,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/mailgun/definition.json
+++ b/connectors/mailgun/definition.json
@@ -765,6 +765,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -824,6 +828,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -886,6 +894,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -939,6 +951,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -983,6 +999,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1030,6 +1050,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/marketo/definition.json
+++ b/connectors/marketo/definition.json
@@ -979,6 +979,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1023,6 +1027,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1070,6 +1078,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1108,6 +1120,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1158,6 +1174,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/microsoft-teams/definition.json
+++ b/connectors/microsoft-teams/definition.json
@@ -569,6 +569,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -602,6 +606,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -640,6 +648,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/microsoft-todo/definition.json
+++ b/connectors/microsoft-todo/definition.json
@@ -496,6 +496,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -531,6 +535,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/miro/definition.json
+++ b/connectors/miro/definition.json
@@ -1117,6 +1117,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1158,6 +1162,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1212,6 +1220,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1266,6 +1278,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/mixpanel/definition.json
+++ b/connectors/mixpanel/definition.json
@@ -947,6 +947,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -985,6 +989,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1026,6 +1034,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1064,6 +1076,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/monday-enhanced/definition.json
+++ b/connectors/monday-enhanced/definition.json
@@ -687,6 +687,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -738,6 +742,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/monday/definition.json
+++ b/connectors/monday/definition.json
@@ -775,6 +775,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -823,6 +827,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -861,6 +869,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -909,6 +921,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/navan/definition.json
+++ b/connectors/navan/definition.json
@@ -380,6 +380,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/netsuite/definition.json
+++ b/connectors/netsuite/definition.json
@@ -345,6 +345,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/newrelic/definition.json
+++ b/connectors/newrelic/definition.json
@@ -399,6 +399,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/nexus/definition.json
+++ b/connectors/nexus/definition.json
@@ -309,6 +309,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -349,6 +353,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/notion-enhanced/definition.json
+++ b/connectors/notion-enhanced/definition.json
@@ -913,6 +913,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -958,6 +962,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -999,6 +1007,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1040,6 +1052,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/notion/definition.json
+++ b/connectors/notion/definition.json
@@ -604,6 +604,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -649,6 +653,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -690,6 +698,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/okta/definition.json
+++ b/connectors/okta/definition.json
@@ -953,6 +953,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -980,6 +984,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1007,6 +1015,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/onedrive/definition.json
+++ b/connectors/onedrive/definition.json
@@ -352,6 +352,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/opsgenie/definition.json
+++ b/connectors/opsgenie/definition.json
@@ -721,6 +721,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -772,6 +776,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -823,6 +831,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/outlook/definition.json
+++ b/connectors/outlook/definition.json
@@ -983,6 +983,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1137,6 +1141,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/pagerduty/definition.json
+++ b/connectors/pagerduty/definition.json
@@ -960,6 +960,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -992,6 +996,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1024,6 +1032,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/pardot/definition.json
+++ b/connectors/pardot/definition.json
@@ -489,6 +489,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/paypal/definition.json
+++ b/connectors/paypal/definition.json
@@ -607,6 +607,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -648,6 +652,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -690,6 +698,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -723,6 +735,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/pipedrive/definition.json
+++ b/connectors/pipedrive/definition.json
@@ -800,6 +800,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -844,6 +848,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/powerbi-enhanced/definition.json
+++ b/connectors/powerbi-enhanced/definition.json
@@ -1091,6 +1091,11 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "refreshId",
+        "cursor": "endTime"
       }
     },
     {
@@ -1138,6 +1143,11 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "reportId",
+        "cursor": "createdDateTime"
       }
     },
     {
@@ -1189,6 +1199,11 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "refreshId",
+        "cursor": "endTime"
       }
     }
   ],

--- a/connectors/powerbi/definition.json
+++ b/connectors/powerbi/definition.json
@@ -503,6 +503,11 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "refreshId",
+        "cursor": "endTime"
       }
     }
   ],

--- a/connectors/prometheus/definition.json
+++ b/connectors/prometheus/definition.json
@@ -276,6 +276,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -314,6 +318,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/qualtrics/definition.json
+++ b/connectors/qualtrics/definition.json
@@ -523,6 +523,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/quickbooks/definition.json
+++ b/connectors/quickbooks/definition.json
@@ -1246,6 +1246,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1301,6 +1305,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1348,6 +1356,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/ramp/definition.json
+++ b/connectors/ramp/definition.json
@@ -276,6 +276,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/razorpay/definition.json
+++ b/connectors/razorpay/definition.json
@@ -328,6 +328,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -367,6 +371,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/ringcentral/definition.json
+++ b/connectors/ringcentral/definition.json
@@ -651,6 +651,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -689,6 +693,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/sageintacct/definition.json
+++ b/connectors/sageintacct/definition.json
@@ -569,6 +569,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/salesforce-enhanced/definition.json
+++ b/connectors/salesforce-enhanced/definition.json
@@ -389,6 +389,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -424,6 +428,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/salesforce/definition.json
+++ b/connectors/salesforce/definition.json
@@ -239,6 +239,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/sap-ariba/definition.json
+++ b/connectors/sap-ariba/definition.json
@@ -962,6 +962,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1016,6 +1020,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1073,6 +1081,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/sendgrid/definition.json
+++ b/connectors/sendgrid/definition.json
@@ -754,6 +754,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "sg_event_id"
       }
     },
     {
@@ -804,6 +808,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "sg_event_id"
       }
     },
     {
@@ -857,6 +865,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "sg_event_id"
       }
     }
   ],

--- a/connectors/sentry/definition.json
+++ b/connectors/sentry/definition.json
@@ -942,6 +942,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -993,6 +997,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1060,6 +1068,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1114,6 +1126,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/servicenow/definition.json
+++ b/connectors/servicenow/definition.json
@@ -503,6 +503,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -553,6 +557,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/sharepoint/definition.json
+++ b/connectors/sharepoint/definition.json
@@ -806,6 +806,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -858,6 +862,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -909,6 +917,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -954,6 +966,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/shopify-enhanced/definition.json
+++ b/connectors/shopify-enhanced/definition.json
@@ -1403,6 +1403,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1483,6 +1487,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1579,6 +1587,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/shopify/definition.json
+++ b/connectors/shopify/definition.json
@@ -1003,6 +1003,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1054,6 +1058,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1097,6 +1105,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1152,6 +1164,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1198,6 +1214,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/slab/definition.json
+++ b/connectors/slab/definition.json
@@ -401,6 +401,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -445,6 +449,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/slack-enhanced/definition.json
+++ b/connectors/slack-enhanced/definition.json
@@ -992,6 +992,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "ts"
       }
     },
     {
@@ -1114,6 +1118,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "channel.id"
       }
     },
     {
@@ -1263,6 +1271,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "file_id"
       }
     },
     {
@@ -1331,6 +1343,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "primaryKey",
+        "primaryKey": "event_ts"
       }
     }
   ],

--- a/connectors/smartsheet/definition.json
+++ b/connectors/smartsheet/definition.json
@@ -954,6 +954,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1008,6 +1012,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1056,6 +1064,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/snowflake/definition.json
+++ b/connectors/snowflake/definition.json
@@ -825,6 +825,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -973,6 +977,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/sonarqube/definition.json
+++ b/connectors/sonarqube/definition.json
@@ -307,6 +307,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -341,6 +345,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/square/definition.json
+++ b/connectors/square/definition.json
@@ -487,6 +487,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -531,6 +535,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/stripe-enhanced/definition.json
+++ b/connectors/stripe-enhanced/definition.json
@@ -282,6 +282,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -323,6 +327,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/stripe/definition.json
+++ b/connectors/stripe/definition.json
@@ -1615,6 +1615,10 @@
             }
           }
         }
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1754,6 +1758,10 @@
             }
           }
         }
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1946,6 +1954,10 @@
             "collection_method": "charge_automatically"
           }
         }
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -2081,6 +2093,10 @@
             }
           }
         }
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/successfactors/definition.json
+++ b/connectors/successfactors/definition.json
@@ -309,6 +309,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -344,6 +348,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/surveymonkey/definition.json
+++ b/connectors/surveymonkey/definition.json
@@ -984,6 +984,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1062,6 +1066,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1148,6 +1156,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/tableau/definition.json
+++ b/connectors/tableau/definition.json
@@ -884,6 +884,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -932,6 +936,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/talkdesk/definition.json
+++ b/connectors/talkdesk/definition.json
@@ -856,6 +856,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -925,6 +929,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -998,6 +1006,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/teamwork/definition.json
+++ b/connectors/teamwork/definition.json
@@ -983,6 +983,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1061,6 +1065,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1124,6 +1132,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1194,6 +1206,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/terraform-cloud/definition.json
+++ b/connectors/terraform-cloud/definition.json
@@ -295,6 +295,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -324,6 +328,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/toggl/definition.json
+++ b/connectors/toggl/definition.json
@@ -995,6 +995,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1065,6 +1069,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1111,6 +1119,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1189,6 +1201,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/trello-enhanced/definition.json
+++ b/connectors/trello-enhanced/definition.json
@@ -634,6 +634,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -666,6 +670,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -698,6 +706,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/trello/definition.json
+++ b/connectors/trello/definition.json
@@ -1613,6 +1613,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1679,6 +1683,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1725,6 +1733,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1769,6 +1781,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/twilio/definition.json
+++ b/connectors/twilio/definition.json
@@ -1136,6 +1136,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "MessageSid"
       }
     },
     {
@@ -1232,6 +1236,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "CallSid"
       }
     },
     {
@@ -1333,6 +1341,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "CallSid"
       }
     },
     {
@@ -1436,6 +1448,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "MessageSid"
       }
     }
   ],

--- a/connectors/typeform/definition.json
+++ b/connectors/typeform/definition.json
@@ -54,6 +54,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -84,6 +88,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/victorops/definition.json
+++ b/connectors/victorops/definition.json
@@ -570,6 +570,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -611,6 +615,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -652,6 +660,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/webex/definition.json
+++ b/connectors/webex/definition.json
@@ -724,6 +724,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -766,6 +770,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -814,6 +822,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/webflow/definition.json
+++ b/connectors/webflow/definition.json
@@ -631,6 +631,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -688,6 +692,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -745,6 +753,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -780,6 +792,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/woocommerce/definition.json
+++ b/connectors/woocommerce/definition.json
@@ -962,6 +962,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1174,6 +1178,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/workday/definition.json
+++ b/connectors/workday/definition.json
@@ -948,6 +948,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -999,6 +1003,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1053,6 +1061,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1104,6 +1116,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/workfront/definition.json
+++ b/connectors/workfront/definition.json
@@ -954,6 +954,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1008,6 +1012,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1059,6 +1067,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/xero/definition.json
+++ b/connectors/xero/definition.json
@@ -1079,6 +1079,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1130,6 +1134,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1181,6 +1189,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/zendesk/definition.json
+++ b/connectors/zendesk/definition.json
@@ -1455,6 +1455,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1513,6 +1517,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1551,6 +1559,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/zoho-books/definition.json
+++ b/connectors/zoho-books/definition.json
@@ -980,6 +980,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1031,6 +1035,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1082,6 +1090,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/zoho-crm/definition.json
+++ b/connectors/zoho-crm/definition.json
@@ -813,6 +813,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -877,6 +881,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -910,6 +918,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/connectors/zoom-enhanced/definition.json
+++ b/connectors/zoom-enhanced/definition.json
@@ -1037,6 +1037,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1069,6 +1073,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     },
     {
@@ -1101,6 +1109,10 @@
       },
       "sample": {
         "success": true
+      },
+      "dedupe": {
+        "strategy": "id",
+        "path": "id"
       }
     }
   ],

--- a/scripts/fix-add-dedupe.ts
+++ b/scripts/fix-add-dedupe.ts
@@ -1,0 +1,100 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const DEFAULT_DEDUPE = Object.freeze({
+  strategy: 'id',
+  path: 'id',
+});
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const connectorsDir = path.join(repoRoot, 'connectors');
+
+async function findDefinitionFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await findDefinitionFiles(fullPath)));
+    } else if (entry.isFile() && entry.name === 'definition.json') {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function ensureDedupe(trigger) {
+  if (!trigger || typeof trigger !== 'object') {
+    return false;
+  }
+
+  if (trigger.dedupe && typeof trigger.dedupe === 'object') {
+    return false;
+  }
+
+  trigger.dedupe = { ...DEFAULT_DEDUPE };
+  return true;
+}
+
+async function processDefinitionFile(file) {
+  const raw = await fs.readFile(file, 'utf8');
+  let definition;
+
+  try {
+    definition = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse ${file}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const triggers = definition?.triggers;
+  let changed = false;
+
+  if (!triggers || typeof triggers !== 'object') {
+    return false;
+  }
+
+  for (const trigger of Object.values(triggers)) {
+    if (ensureDedupe(trigger)) {
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    const formatted = `${JSON.stringify(definition, null, 2)}\n`;
+    await fs.writeFile(file, formatted, 'utf8');
+  }
+
+  return changed;
+}
+
+async function main() {
+  try {
+    await fs.access(connectorsDir);
+  } catch {
+    console.error('connectors directory not found');
+    process.exit(1);
+  }
+
+  const definitionFiles = await findDefinitionFiles(connectorsDir);
+  let updatedCount = 0;
+
+  for (const file of definitionFiles) {
+    if (await processDefinitionFile(file)) {
+      updatedCount += 1;
+      console.log(`Updated ${path.relative(repoRoot, file)}`);
+    }
+  }
+
+  if (updatedCount === 0) {
+    console.log('No connector definitions required updates.');
+  } else {
+    console.log(`Updated ${updatedCount} connector definition${updatedCount === 1 ? '' : 's'}.`);
+  }
+}
+
+await main();

--- a/scripts/validate-connectors.ts
+++ b/scripts/validate-connectors.ts
@@ -20,6 +20,7 @@ type ConnectorOperation = {
     [key: string]: unknown;
   } | null;
   sample?: unknown;
+  dedupe?: unknown;
   [key: string]: unknown;
 };
 
@@ -70,6 +71,13 @@ function checkOperation(
 
   if (operation.sample === undefined) {
     errors.push(`${identifier} is missing a sample`);
+  }
+
+  if (
+    type === 'trigger' &&
+    (!operation.dedupe || typeof operation.dedupe !== 'object')
+  ) {
+    errors.push(`${identifier} is missing a dedupe configuration`);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a maintenance script that assigns a conservative dedupe block to any trigger missing one and fixes a malformed Google Sheets manifest entry
- run the script to populate dedupe defaults across connector manifests and hand-tune outliers such as Power BI, Slack Enhanced, SendGrid, and Twilio triggers
- extend connector validation to fail when triggers do not define a dedupe configuration

## Testing
- node --loader ./scripts/ts-loader.mjs scripts/fix-add-dedupe.ts

------
https://chatgpt.com/codex/tasks/task_e_68e6878e419883319adb5504ab876b79