### PR TITLE
Add runtime fallback reference and connector authoring guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,4 +128,10 @@ When running real OAuth flows:
 
 ---
 
-For deeper docs, see `docs/local-development.md`, `docs/deployment-guide.md`, and `docs/operations`.
+For deeper docs, see:
+
+- `docs/local-development.md`
+- `docs/runtimes-and-fallbacks.md`
+- `docs/connectors/authoring.md`
+- `docs/deployment-guide.md`
+- `docs/operations`

--- a/docs/connectors/authoring.md
+++ b/docs/connectors/authoring.md
@@ -1,0 +1,38 @@
+# Connector Authoring Checklist
+
+Use this guide when shipping or updating connector definitions so runtime coverage, fallback semantics, and schema metadata remain consistent. Pair it with the runtime reference for environment details.
+
+## Declare runtime coverage (`runtimes`)
+
+Runtime support is derived from the HTTP metadata in each action or trigger. When an operation includes an `endpoint` and `method`, the runtime registry registers it for the Generic Executor. When `GENERIC_EXECUTOR_ENABLED` is true, those operations are merged into the runtime capability map returned by `/api/registry/capabilities`, which the editor uses to highlight whether a node will run inside the runtime sandbox.【F:server/runtime/registry.ts†L100-L309】【F:client/src/services/runtimeCapabilitiesService.ts†L1-L160】【F:server/runtime/__tests__/registry.capabilities.test.ts†L1-L41】 Include a `runtimes` block in your definition (or generator) that mirrors this information so reviewers and tooling can audit which actions/triggers are safe to execute at runtime.
+
+```jsonc
+{
+  "runtimes": {
+    "actions": ["send_message", "create_ticket"],
+    "triggers": ["message_posted"]
+  }
+}
+```
+
+## Document fallback behaviour (`fallback`)
+
+Bespoke handlers always run first. If they are missing or emit a "Function …" error, `IntegrationManager` falls back to the Generic Executor when the feature flag is on.【F:server/integrations/IntegrationManager.ts†L332-L459】 `WorkflowRuntime` records the executor that satisfied the call and preserves the fallback error in node metadata so operators can audit what happened.【F:server/core/WorkflowRuntime.ts†L680-L747】 Use a `fallback` section to summarise the HTTP shape (endpoint, method, error messaging) the runtime should expect. This context helps runtime reviewers understand the consequences of enabling the generic path and gives customer success teams language to use when they encounter `integrationFallbackReason` entries in metadata.
+
+## Provide output schemas and samples
+
+Every action and trigger must include an `outputSchema` with a `$schema` pointer and at least one `sample` payload. The `npm run check:connectors` lint step fails when either field is missing.【F:scripts/validate-connectors.ts†L16-L135】 Good samples make reviews faster—see the Google Calendar trigger for an example that pairs a schema with a lightweight sample.【F:connectors/google-calendar/definition.json†L824-L864】
+
+## Configure trigger deduplication (`dedupe`)
+
+Triggers also require a `dedupe` object so the platform can suppress repeats. The validator enforces that triggers provide a structured dedupe configuration, and the Google Calendar definition demonstrates the expected `strategy`/`path` pattern.【F:scripts/validate-connectors.ts†L52-L81】【F:connectors/google-calendar/definition.json†L857-L863】 Reuse existing strategies where possible so downstream persistence components can keep working without changes.
+
+## Run the connector lint suite
+
+Before opening a pull request, run the local validator:
+
+```bash
+npm run check:connectors
+```
+
+The command is also part of `npm run lint`, so catching issues locally keeps CI green.【F:package.json†L39-L59】 Add any new guidance or known exceptions to this document so future authors inherit the same guard rails.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,12 @@
   - POST /api/integrations/execute-batch
 - Architecture
   - docs/architecture/connector-modules.md
+- Runtime
+  - docs/runtimes-and-fallbacks.md
+- Connectors
+  - docs/connectors/authoring.md
+  - docs/connectors/output-schemas.md
+  - docs/connectors/parity.md
 - Telemetry
   - GET /api/roadmap
   - GET /api/roadmap/summary

--- a/docs/runtimes-and-fallbacks.md
+++ b/docs/runtimes-and-fallbacks.md
@@ -1,0 +1,34 @@
+# Runtime Runtimes and Fallback Reference
+
+This guide consolidates the environment toggles, worker processes, and fallback behaviour that govern the runtime executors. Use it alongside the connector authoring checklist when enabling new runtimes or reviewing fallback expectations.
+
+## Runtime environment variables
+
+- **`GENERIC_EXECUTOR_ENABLED`** – enables the Generic Executor so connector calls can fall back to the HTTP runtime when bespoke handlers are missing or fail. The flag is exposed both through `env.GENERIC_EXECUTOR_ENABLED` and the exported `FLAGS` helper so other services can gate behaviour consistently.【F:server/env.ts†L141-L190】
+- **`SANDBOX_EXECUTOR`** – forces the sandbox implementation. Set to `worker` (worker threads) or `process` (child processes) to pin a strategy; otherwise the runtime auto-selects based on the `WORKER_SANDBOX_ENABLED` flag.【F:server/runtime/NodeSandbox.ts†L170-L186】
+- **`WORKER_SANDBOX_ENABLED`** – when `true`, the runtime prefers the worker-thread executor. Leave unset to run sandboxes in isolated Node processes (safer for debugging or when worker threads are unstable).【F:server/runtime/NodeSandbox.ts†L170-L186】
+- **Resource guard rails** – use `SANDBOX_MAX_CPU_MS`, `SANDBOX_CPU_QUOTA_MS`, `SANDBOX_MAX_MEMORY_MB`, `SANDBOX_CGROUP_ROOT`, `SANDBOX_HEARTBEAT_INTERVAL_MS`, and `SANDBOX_HEARTBEAT_TIMEOUT_MS` to bound sandbox executions and avoid noisy neighbours. The Node sandbox reads these values on boot before running user code.【F:server/runtime/NodeSandbox.ts†L43-L99】
+
+Adjust these knobs per environment. For example, CI can keep short timeouts while production raises the limits but pins the executor mode.
+
+## Worker command matrix
+
+The fastest path to booting the stack locally relies on the packaged scripts. The local-development guide summarises the core commands you should know when switching runtime modes or verifying workers are healthy.【F:docs/local-development.md†L63-L118】
+
+| Command | Purpose |
+| --- | --- |
+| `npm run dev:api` | Starts the API (and inline worker when `ENABLE_INLINE_WORKER` resolves to `true`). |
+| `npm run dev:worker` | Launches the dedicated execution worker that pulls jobs off BullMQ. |
+| `npm run dev:scheduler` | Boots the polling scheduler that enqueues trigger-based jobs. |
+| `npm run dev:stack` | Supervises the API, worker, scheduler, timers, and encryption rotation processes together, enforcing queue consistency before declaring readiness. |
+
+Use the `start:*` variants in production (`npm run start:worker`, etc.) when running the compiled `dist/` bundle.【F:package.json†L30-L34】
+
+## Fallback resolution flow
+
+1. **Runtime dispatch** – `WorkflowRuntime` resolves connector metadata, executes bespoke handlers through `IntegrationManager`, and records timing/credential context. When the bespoke path fails and the generic executor is enabled, it falls back to `GenericExecutor` and captures the failure reason in node metadata so observers know why a fallback occurred.【F:server/core/WorkflowRuntime.ts†L680-L747】
+2. **Integration Manager guardrails** – the manager normalises app identifiers, builds connector modules, and routes requests to bespoke handlers. It tries the generic executor automatically when a connector is unsupported or when a bespoke handler throws a "Function …" error under the feature flag.【F:server/integrations/IntegrationManager.ts†L235-L458】
+3. **Runtime registry** – the registry exposes built-in operations and augments them with connector HTTP metadata (`endpoint`/`method`) when `GENERIC_EXECUTOR_ENABLED` is on. The merged registry powers `/api/registry/capabilities`, which lists runtime-ready actions and triggers per app.【F:server/runtime/registry.ts†L100-L309】
+4. **Client capability checks** – the frontend caches the capabilities map, providing fallback entries for built-in runtimes and warning users when an operation lacks runtime coverage.【F:client/src/services/runtimeCapabilitiesService.ts†L1-L160】 Runtime unit tests confirm that connectors such as Slack only appear when the generic executor flag is enabled, preventing accidental exposure when bespoke coverage is required.【F:server/runtime/__tests__/registry.capabilities.test.ts†L1-L41】
+
+When adding a new connector or expanding coverage, ensure its definition includes the HTTP metadata needed for the registry to derive fallback routes. Combined with the environment flags above, this keeps runtime behaviour predictable across development, staging, and production.


### PR DESCRIPTION
## Summary
- add a runtime runtimes-and-fallbacks reference covering environment flags, worker commands, and the Generic Executor flow
- document connector authoring expectations for runtimes, fallback metadata, output schemas, samples, and dedupe configs
- link the new guidance from the README and docs index for easier discovery

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e6972204588331bb3d1204226da321