### PR TITLE
Add workflow-based runtime smoke validation

### DIFF
--- a/docs/smoke-tests.md
+++ b/docs/smoke-tests.md
@@ -41,7 +41,8 @@ Prereqs: `GENERIC_EXECUTOR_ENABLED=true` in `.env`, JWT for auth.
 
 - Ensure `GENERIC_EXECUTOR_ENABLED=true` is set for the API process so the
   generic executor will accept JSON connector payloads.
-- Export an API token and organization id for the account you want to target:
+- Export an API token and organization id for the account you want to target
+  (the token needs `execution:read` to hit the dry-run endpoint):
 
   ```bash
   export SMOKE_AUTH_TOKEN="<jwt>"
@@ -49,8 +50,8 @@ Prereqs: `GENERIC_EXECUTOR_ENABLED=true` in `.env`, JWT for auth.
   export SMOKE_BASE_URL="http://127.0.0.1:3000" # override if the API is hosted elsewhere
   ```
 
-- Run `npm run smoke:supported` to fetch `/api/registry/capabilities`, build
-  synthetic request bodies from the connector definitions, and POST them through
-  `/api/integrations/execute`. The script prints an OK/SKIP/FAIL table for every
-  `app.function` and exits with a non-zero status when any executions fail so it
-  can gate CI.
+- Run `npm run smoke:supported` to fetch `/api/registry/capabilities`, generate
+  a minimal workflow for each supported action, and execute it through
+  `/api/executions/dry-run`. The summary table flags fallback runs, prints
+  OK/SKIP/FAIL totals, and exits non-zero when any action fails so CI pipelines
+  can block regressions.

--- a/scripts/ci-smoke.ts
+++ b/scripts/ci-smoke.ts
@@ -8,6 +8,7 @@ const baseEnv = {
   DISABLE_VITE: 'true',
   SKIP_WORKER_HEARTBEAT_CHECK: 'true',
   NODE_ENV: 'development',
+  GENERIC_EXECUTOR_ENABLED: process.env.GENERIC_EXECUTOR_ENABLED ?? 'true',
 };
 
 function wait(ms: number) {
@@ -33,15 +34,45 @@ async function waitForHealth(url: string, timeoutMs: number) {
   throw lastError ?? new Error('Timed out waiting for health check');
 }
 
-async function runCommand(cmd: string, args: string[]) {
+async function runCommand(cmd: string, args: string[], envOverrides: Record<string, string | undefined> = {}) {
   return new Promise<void>((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: 'inherit', env: baseEnv });
+    const child = spawn(cmd, args, { stdio: 'inherit', env: { ...baseEnv, ...envOverrides } });
     child.on('exit', (code) => {
       if (code === 0) resolve();
       else reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
     });
     child.on('error', reject);
   });
+}
+
+async function ensureSmokeCredentials(): Promise<{ token: string; orgId: string; userId: string }> {
+  const email = process.env.DEV_BOOTSTRAP_EMAIL || 'developer@local.test';
+  const password = process.env.DEV_BOOTSTRAP_PASSWORD || 'Devpassw0rd!';
+
+  const authModule = await import('../server/services/AuthService.js');
+  const authService = authModule.authService;
+
+  let auth = await authService.login({ email, password });
+  if (!auth.success) {
+    const registration = await authService.register({ email, password, name: 'Local Developer' });
+    if (!registration.success) {
+      throw new Error(`Failed to register smoke user: ${registration.error ?? 'unknown error'}`);
+    }
+    auth = await authService.login({ email, password });
+    if (!auth.success) {
+      throw new Error(`Failed to login smoke user: ${auth.error ?? 'unknown error'}`);
+    }
+  }
+
+  const token = auth.token;
+  const userId = auth.user?.id;
+  const orgId = auth.activeOrganization?.id;
+
+  if (!token || !userId || !orgId) {
+    throw new Error('Smoke user login did not return token or organization context');
+  }
+
+  return { token, orgId, userId };
 }
 
 async function main() {
@@ -56,6 +87,19 @@ async function main() {
     await runCommand('npm', ['run', 'dev:smoke']);
     await runCommand('npm', ['run', 'dev:webhook']);
     await runCommand('npm', ['run', 'dev:oauth']);
+    const { token, orgId, userId } = await ensureSmokeCredentials();
+    const smokeBaseUrl = process.env.SMOKE_BASE_URL ?? 'http://127.0.0.1:5000';
+    await runCommand(
+      'npm',
+      ['run', 'smoke:supported'],
+      {
+        SMOKE_AUTH_TOKEN: token,
+        SMOKE_ORGANIZATION_ID: orgId,
+        SMOKE_USER_ID: userId,
+        SMOKE_BASE_URL: smokeBaseUrl,
+        GENERIC_EXECUTOR_ENABLED: 'true',
+      },
+    );
   } finally {
     devProcess.kill('SIGTERM');
   }


### PR DESCRIPTION
## Summary
- update the runtime smoke harness to build preview workflows for each supported action, execute them through `/api/executions/dry-run`, and surface fallback runs in the summary output
- run the new `smoke:supported` check from the CI smoke pipeline by minting a dev token automatically before invoking the script
- document the token/permission prerequisites for the runtime smoke test and its workflow-based execution flow

## Testing
- not run (requires the API stack to be running)


------
https://chatgpt.com/codex/tasks/task_e_68e69728ad1483319afc14000912ac4b