### PR TITLE
Fix shared runtime imports in workflow UI components

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -88,7 +88,7 @@ import * as LucideIcons from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { NodeGraph, GraphNode, VisualNode } from '../../../shared/nodeGraphSchema';
 import type { ValidationError } from '../../../shared/nodeGraphSchema';
-import { DEFAULT_RUNTIME, RUNTIME_DISPLAY_NAMES } from '../../../shared';
+import { DEFAULT_RUNTIME, RUNTIME_DISPLAY_NAMES } from '../../../../shared';
 import clsx from 'clsx';
 import debounce from 'lodash/debounce';
 import type { DebouncedFunc } from 'lodash';

--- a/client/src/components/workflow/RightInspectorPanel.tsx
+++ b/client/src/components/workflow/RightInspectorPanel.tsx
@@ -11,7 +11,7 @@ import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 import SmartParametersPanel from "./SmartParametersPanel";
 import type { ConnectorDefinitionMap } from "@/services/connectorDefinitionsService";
 import type { RuntimeCapabilityIssue } from "@/services/runtimeCapabilitiesService";
-import { type RuntimeKey, RUNTIME_DISPLAY_NAMES } from "../../../shared";
+import { type RuntimeKey, RUNTIME_DISPLAY_NAMES } from "../../../../shared";
 
 export interface SelectedNodeRuntimeSupport {
   supported: boolean;


### PR DESCRIPTION
## Summary
- correct the shared runtime import path in `ProfessionalGraphEditor`
- align the inspector panel to import shared runtime helpers from the top-level shared module

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e726aa79388331882ed33fed32663a