### PR TITLE
Add scripts to backfill connector runtime defaults

### DIFF
--- a/docs/runtimes-and-fallbacks.md
+++ b/docs/runtimes-and-fallbacks.md
@@ -32,3 +32,13 @@ Use the `start:*` variants in production (`npm run start:worker`, etc.) when run
 4. **Client capability checks** – the frontend caches the capabilities map, providing fallback entries for built-in runtimes and warning users when an operation lacks runtime coverage.【F:client/src/services/runtimeCapabilitiesService.ts†L1-L160】 Runtime unit tests confirm that connectors such as Slack only appear when the generic executor flag is enabled, preventing accidental exposure when bespoke coverage is required.【F:server/runtime/__tests__/registry.capabilities.test.ts†L1-L41】
 
 When adding a new connector or expanding coverage, ensure its definition includes the HTTP metadata needed for the registry to derive fallback routes. Combined with the environment flags above, this keeps runtime behaviour predictable across development, staging, and production.
+
+## Backfilling connector defaults
+
+When we backfill runtime metadata across the catalog, run the automation scripts in order so the generated patches stay repeatable:
+
+1. `tsx scripts/default-actions-to-node.ts` – fills in missing `runtimes: ['node']` and `fallback: null` on every action definition.
+2. `tsx scripts/seed-trigger-fallbacks.ts` – adds conservative cursor-based defaults (`runtimes`, `fallback`, and `dedupe`) anywhere a trigger omits them.
+3. Review the highest-traffic connectors by hand to tighten the cursor paths, dedupe keys, or runtime overrides before landing the change set.
+
+Recording the sequence keeps contributors aligned on how the defaults were produced and makes it easier to iterate on the seeded values without conflicting local edits.

--- a/scripts/default-actions-to-node.ts
+++ b/scripts/default-actions-to-node.ts
@@ -1,0 +1,125 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const DEFAULT_RUNTIMES = Object.freeze(['node'] as const);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const connectorsDir = path.join(repoRoot, 'connectors');
+
+async function findDefinitionFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await findDefinitionFiles(fullPath)));
+    } else if (entry.isFile() && entry.name === 'definition.json') {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+type ActionDefinition = Record<string, any>;
+
+type ConnectorDefinition = {
+  actions?: unknown;
+};
+
+function ensureActionDefaults(action: ActionDefinition): boolean {
+  let changed = false;
+
+  if (!Array.isArray(action.runtimes) || action.runtimes.length === 0) {
+    action.runtimes = [...DEFAULT_RUNTIMES];
+    changed = true;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(action, 'fallback') || action.fallback === undefined) {
+    action.fallback = null;
+    changed = true;
+  }
+
+  return changed;
+}
+
+function applyDefaults(definition: ConnectorDefinition): boolean {
+  const actions = definition.actions;
+
+  if (!actions) {
+    return false;
+  }
+
+  let changed = false;
+
+  if (Array.isArray(actions)) {
+    for (const action of actions) {
+      if (action && typeof action === 'object' && ensureActionDefaults(action)) {
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  if (typeof actions === 'object') {
+    for (const action of Object.values(actions as Record<string, unknown>)) {
+      if (action && typeof action === 'object' && ensureActionDefaults(action as ActionDefinition)) {
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+async function processDefinition(file: string): Promise<boolean> {
+  const raw = await fs.readFile(file, 'utf8');
+  let definition: ConnectorDefinition;
+
+  try {
+    definition = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse ${file}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (!applyDefaults(definition)) {
+    return false;
+  }
+
+  const formatted = `${JSON.stringify(definition, null, 2)}\n`;
+  await fs.writeFile(file, formatted, 'utf8');
+  return true;
+}
+
+async function main(): Promise<void> {
+  try {
+    await fs.access(connectorsDir);
+  } catch {
+    console.error('connectors directory not found');
+    process.exit(1);
+    return;
+  }
+
+  const files = await findDefinitionFiles(connectorsDir);
+  let updated = 0;
+
+  for (const file of files) {
+    if (await processDefinition(file)) {
+      updated += 1;
+      console.log(`Updated ${path.relative(repoRoot, file)}`);
+    }
+  }
+
+  if (updated === 0) {
+    console.log('No connector action defaults required changes.');
+  } else {
+    console.log(`Updated ${updated} connector definition${updated === 1 ? '' : 's'} with action defaults.`);
+  }
+}
+
+await main();

--- a/scripts/seed-trigger-fallbacks.ts
+++ b/scripts/seed-trigger-fallbacks.ts
@@ -1,0 +1,136 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const DEFAULT_RUNTIMES = Object.freeze(['node'] as const);
+const DEFAULT_TRIGGER_DEDUPE = Object.freeze({
+  strategy: 'cursor',
+  cursor: {
+    path: 'cursor',
+  },
+});
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const connectorsDir = path.join(repoRoot, 'connectors');
+
+async function findDefinitionFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await findDefinitionFiles(fullPath)));
+    } else if (entry.isFile() && entry.name === 'definition.json') {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+type TriggerDefinition = Record<string, any>;
+
+type ConnectorDefinition = {
+  triggers?: unknown;
+};
+
+function ensureTriggerDefaults(trigger: TriggerDefinition): boolean {
+  let changed = false;
+
+  if (!Array.isArray(trigger.runtimes) || trigger.runtimes.length === 0) {
+    trigger.runtimes = [...DEFAULT_RUNTIMES];
+    changed = true;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(trigger, 'fallback') || trigger.fallback === undefined) {
+    trigger.fallback = null;
+    changed = true;
+  }
+
+  if (!trigger.dedupe || typeof trigger.dedupe !== 'object') {
+    trigger.dedupe = JSON.parse(JSON.stringify(DEFAULT_TRIGGER_DEDUPE));
+    changed = true;
+  }
+
+  return changed;
+}
+
+function applyDefaults(definition: ConnectorDefinition): boolean {
+  const triggers = definition.triggers;
+
+  if (!triggers) {
+    return false;
+  }
+
+  let changed = false;
+
+  if (Array.isArray(triggers)) {
+    for (const trigger of triggers) {
+      if (trigger && typeof trigger === 'object' && ensureTriggerDefaults(trigger)) {
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  if (typeof triggers === 'object') {
+    for (const trigger of Object.values(triggers as Record<string, unknown>)) {
+      if (trigger && typeof trigger === 'object' && ensureTriggerDefaults(trigger as TriggerDefinition)) {
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+async function processDefinition(file: string): Promise<boolean> {
+  const raw = await fs.readFile(file, 'utf8');
+  let definition: ConnectorDefinition;
+
+  try {
+    definition = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse ${file}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (!applyDefaults(definition)) {
+    return false;
+  }
+
+  const formatted = `${JSON.stringify(definition, null, 2)}\n`;
+  await fs.writeFile(file, formatted, 'utf8');
+  return true;
+}
+
+async function main(): Promise<void> {
+  try {
+    await fs.access(connectorsDir);
+  } catch {
+    console.error('connectors directory not found');
+    process.exit(1);
+    return;
+  }
+
+  const files = await findDefinitionFiles(connectorsDir);
+  let updated = 0;
+
+  for (const file of files) {
+    if (await processDefinition(file)) {
+      updated += 1;
+      console.log(`Updated ${path.relative(repoRoot, file)}`);
+    }
+  }
+
+  if (updated === 0) {
+    console.log('No connector trigger defaults required changes.');
+  } else {
+    console.log(`Updated ${updated} connector definition${updated === 1 ? '' : 's'} with trigger defaults.`);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add a script that backfills missing action runtimes and fallbacks with the Node runtime
- add a script that seeds default trigger runtimes, fallbacks, and cursor-based dedupe blocks
- document the run order for the new scripts so contributors can reproduce the backfill

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e72e9c6004833196a85c7f9f567eaf