### PR TITLE
Enhance connector metadata validation checks

### DIFF
--- a/.github/workflows/connector-validation.yml
+++ b/.github/workflows/connector-validation.yml
@@ -1,4 +1,4 @@
-name: Connector Validation
+name: Connector Metadata
 
 on:
   push:
@@ -6,6 +6,8 @@ on:
     paths:
       - 'connectors/**'
       - 'scripts/validate-connectors.ts'
+      - 'scripts/validate-connector-ops.ts'
+      - 'shared/runtimes.ts'
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/connector-validation.yml'
@@ -15,6 +17,8 @@ on:
     paths:
       - 'connectors/**'
       - 'scripts/validate-connectors.ts'
+      - 'scripts/validate-connector-ops.ts'
+      - 'shared/runtimes.ts'
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/connector-validation.yml'

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "check:queue": "tsx scripts/check-queue-readiness.ts",
     "check:deps": "node scripts/check-deps.js",
     "fix:deps": "rm -rf node_modules package-lock.json && npm cache clean --force && npm install",
-    "lint": "npm run check && tsx scripts/check-connector-parity.ts && tsx scripts/validate-connector-ops.ts && tsx scripts/validate-procfile.ts && npm run check:connectors",
+    "lint": "npm run check && tsx scripts/check-connector-parity.ts && npm run check:connectors && tsx scripts/validate-procfile.ts",
     "db:push": "drizzle-kit push",
     "db:fix-execution-logs": "tsx scripts/fix-execution-logs-pk-fk.ts",
     "test": "tsx server/services/__tests__/ConnectionService.encryption.test.ts && tsx server/services/__tests__/EncryptionService.rotation.integration.test.ts && tsx server/services/__tests__/AnswerNormalizerService.test.ts && tsx server/routes/__tests__/workflow-deploy.test.ts && tsx server/routes/__tests__/workflow-read-auth.test.ts && tsx server/routes/__tests__/registry-debug.test.ts && tsx server/routes/__tests__/workflow-execute.test.ts && tsx server/routes/__tests__/workflow-dry-run.test.ts && tsx server/routes/__tests__/webhook-verification-failures.test.ts && tsx client/src/components/workflow/__tests__/SmartParametersPanel.test.ts && tsx client/src/components/workflow/__tests__/VerificationFailurePanel.test.tsx && tsx client/src/components/workflow/__tests__/NodeConfigurationModal.regression.test.ts && tsx client/src/components/workflow/__tests__/NodeSidebar.lifecycle.test.tsx && tsx client/src/components/workflow/__tests__/NodeSidebar.connectors.test.tsx && tsx client/src/graph/__tests__/transform.test.ts && tsx server/integrations/__tests__/IntegrationManager.test.ts && tsx server/integrations/__tests__/BaseAPIClient.helpers.test.ts && tsx server/integrations/__tests__/AwsClients.test.ts && tsx server/integrations/__tests__/MarketingAPIClients.test.ts && tsx server/workflow/__tests__/WorkflowRuntimeService.test.ts && tsx server/workflow/__tests__/WorkflowRuntime.gmail.integration.test.ts && tsx server/core/__tests__/ParameterResolver.llm.test.ts && tsx server/runtime/__tests__/WorkflowRuntime.sandbox.test.ts && tsx server/workflow/__tests__/WorkflowRepository.test.ts && tsx server/workflow/__tests__/WorkflowRepository.fallback.test.ts && tsx server/services/__tests__/TriggerPersistenceService.fallback.test.ts && tsx server/webhooks/__tests__/WebhookManager.persistence.test.ts && tsx server/workers/__tests__/ExecutionWorker.failure.test.ts && tsx server/workers/__tests__/SchedulerWorker.lock.test.ts && tsx server/services/__tests__/ExecutionQueueService.quota.test.ts && npm run check:connectors",
@@ -56,7 +56,7 @@
     "ci:smoke": "tsx scripts/connector-smoke.ts --use-simulator",
     "seed:encryption-key": "tsx scripts/seed-encryption-key.ts",
     "observability:check": "tsx scripts/observability-check.ts",
-    "check:connectors": "tsx scripts/validate-connectors.ts"
+    "check:connectors": "tsx scripts/validate-connectors.ts && tsx scripts/validate-connector-ops.ts"
   },
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.676.0",


### PR DESCRIPTION
## Summary
- extend the connector metadata validator to require runtimes arrays and known runtime keys alongside existing schema, sample, and dedupe checks
- update the npm script so connector checks run both metadata and compiler coverage validators together
- retitle the connector workflow and ensure it runs when runtime definitions or coverage validation scripts change

## Testing
- npm run check:connectors *(fails: `tsx` binary unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e72e970b8c8331ab550c9a9430b86f