### PR TITLE
Follow-up: Surface runtime fallback modes in workflow editor

### DIFF
--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -1638,15 +1638,17 @@ export const NodeSidebar: React.FC<NodeSidebarProps> = ({
                             'trigger',
                             runtimeId,
                           );
-                      const capabilityFallback =
-                        capabilityStatus ??
-                        checkRuntimeCapability(runtimeCapabilities, capabilityAppId, 'trigger', runtimeId);
+                      const capabilityFallback = runtimeCapabilitiesLoading
+                        ? null
+                        : capabilityStatus ??
+                          checkRuntimeCapability(runtimeCapabilities, capabilityAppId, 'trigger', runtimeId);
 
-                      const mode = capabilityStatus?.mode ?? (capabilityFallback.supported ? 'native' : 'unavailable');
+                      const resolvedMode = capabilityStatus?.mode ?? (capabilityFallback?.supported ? 'native' : 'unavailable');
+                      const mode = runtimeCapabilitiesLoading ? 'native' : resolvedMode;
                       const isUnavailable = mode === 'unavailable';
                       const isFallback = mode === 'fallback';
                       const isSupported = !isUnavailable;
-                      const issue = capabilityStatus?.issue ?? capabilityFallback.issue;
+                      const issue = runtimeCapabilitiesLoading ? null : capabilityStatus?.issue ?? capabilityFallback?.issue;
                       const fallbackRuntimeName = capabilityStatus?.fallbackRuntime
                         ? RUNTIME_DISPLAY_NAMES[capabilityStatus.fallbackRuntime] ?? capabilityStatus.fallbackRuntime
                         : RUNTIME_DISPLAY_NAMES.node;
@@ -1757,15 +1759,17 @@ export const NodeSidebar: React.FC<NodeSidebarProps> = ({
                             capabilityKind,
                             runtimeId,
                           );
-                      const capabilityFallback =
-                        capabilityStatus ??
-                        checkRuntimeCapability(runtimeCapabilities, capabilityAppId, capabilityKind, runtimeId);
+                      const capabilityFallback = runtimeCapabilitiesLoading
+                        ? null
+                        : capabilityStatus ??
+                          checkRuntimeCapability(runtimeCapabilities, capabilityAppId, capabilityKind, runtimeId);
 
-                      const mode = capabilityStatus?.mode ?? (capabilityFallback.supported ? 'native' : 'unavailable');
+                      const resolvedMode = capabilityStatus?.mode ?? (capabilityFallback?.supported ? 'native' : 'unavailable');
+                      const mode = runtimeCapabilitiesLoading ? 'native' : resolvedMode;
                       const isUnavailable = mode === 'unavailable';
                       const isFallback = mode === 'fallback';
                       const isSupported = !isUnavailable;
-                      const issue = capabilityStatus?.issue ?? capabilityFallback.issue;
+                      const issue = runtimeCapabilitiesLoading ? null : capabilityStatus?.issue ?? capabilityFallback?.issue;
                       const fallbackRuntimeName = capabilityStatus?.fallbackRuntime
                         ? RUNTIME_DISPLAY_NAMES[capabilityStatus.fallbackRuntime] ?? capabilityStatus.fallbackRuntime
                         : RUNTIME_DISPLAY_NAMES.node;


### PR DESCRIPTION
## Summary
- enrich the runtime capabilities service with explicit native, fallback, and unavailable modes so connector operations carry fallback metadata
- surface runtime mode badges in the workflow sidebar and node runtime detection, including fallback-aware inspector messaging
- expand NodeSidebar tests to cover fallback availability and runtime enablement transitions
- keep sidebar trigger and action entries interactive while runtime capabilities load so the optimistic UX matches the prior behavior

## Testing
- npx vitest run client/src/components/workflow/__tests__/NodeSidebar.connectors.test.tsx *(fails: npm registry access forbidden in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e7325a55348331b88f0b71393d1800