### PR TITLE
Add runtime fallback reference and connector metadata guidance

### DIFF
--- a/docs/connectors/authoring.md
+++ b/docs/connectors/authoring.md
@@ -2,6 +2,10 @@
 
 Use this guide when shipping or updating connector definitions so runtime coverage, fallback semantics, and schema metadata remain consistent. Pair it with the runtime reference for environment details.
 
+## Required runtime metadata (`runtimes` and `fallback`)
+
+Every action and trigger definition must declare a `runtimes` array plus a `fallback` key so the runtime registry, Generic Executor, and debugging surfaces stay in sync. The catalog automation scripts enforce those fields when seeding defaults, but new contributions should include them up front to avoid churn in follow-up passes.【F:scripts/default-actions-to-node.ts†L35-L75】【F:scripts/seed-trigger-fallbacks.ts†L41-L80】 When you add bespoke fallback handling, document the HTTP behaviour directly in the manifest and cross-link the [Runtime Environment and Fallback Guide](../runtimes-and-fallbacks.md) for reviewers who need environment context.
+
 ## Declare runtime coverage (`runtimes`)
 
 Runtime support is derived from the HTTP metadata in each action or trigger. When an operation includes an `endpoint` and `method`, the runtime registry registers it for the Generic Executor. When `GENERIC_EXECUTOR_ENABLED` is true, those operations are merged into the runtime capability map returned by `/api/registry/capabilities`, which the editor uses to highlight whether a node will run inside the runtime sandbox.【F:server/runtime/registry.ts†L100-L309】【F:client/src/services/runtimeCapabilitiesService.ts†L1-L160】【F:server/runtime/__tests__/registry.capabilities.test.ts†L1-L41】 Include a `runtimes` block in your definition (or generator) that mirrors this information so reviewers and tooling can audit which actions/triggers are safe to execute at runtime.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@
 - Architecture
   - docs/architecture/connector-modules.md
 - Runtime
-  - docs/runtimes-and-fallbacks.md
+  - [Runtime Environment and Fallback Guide](docs/runtimes-and-fallbacks.md)
 - Connectors
   - docs/connectors/authoring.md
   - docs/connectors/output-schemas.md

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -3,6 +3,8 @@
 This guide covers the quickest path to booting the platform locally with Docker Compose.
 
 > 📘 **Need a mental model for the runtime?** Read the [Workflow Runtime Interaction Guide](./architecture/workflow-runtime-interactions.md) to understand how WorkflowRuntime, IntegrationManager, GenericExecutor, and RetryManager coordinate while you run local flows.
+>
+> 🧭 **Configuring runtimes and fallbacks?** The [Runtime Environment and Fallback Guide](./runtimes-and-fallbacks.md) maps the required environment variables, worker commands, and metadata conventions referenced below.
 
 ## 1. Prepare environment variables
 

--- a/docs/runtimes-and-fallbacks.md
+++ b/docs/runtimes-and-fallbacks.md
@@ -1,19 +1,21 @@
-# Runtime Runtimes and Fallback Reference
+# Runtime Environment and Fallback Guide
 
-This guide consolidates the environment toggles, worker processes, and fallback behaviour that govern the runtime executors. Use it alongside the connector authoring checklist when enabling new runtimes or reviewing fallback expectations.
+This guide consolidates the configuration flags, worker commands, metadata expectations, and troubleshooting workflows that govern runtime execution. Pair it with the connector authoring checklist when enabling new runtimes or reviewing fallback behaviour.
 
 ## Runtime environment variables
 
-- **`GENERIC_EXECUTOR_ENABLED`** – enables the Generic Executor so connector calls can fall back to the HTTP runtime when bespoke handlers are missing or fail. The flag is exposed both through `env.GENERIC_EXECUTOR_ENABLED` and the exported `FLAGS` helper so other services can gate behaviour consistently.【F:server/env.ts†L141-L190】
-- **`SANDBOX_EXECUTOR`** – forces the sandbox implementation. Set to `worker` (worker threads) or `process` (child processes) to pin a strategy; otherwise the runtime auto-selects based on the `WORKER_SANDBOX_ENABLED` flag.【F:server/runtime/NodeSandbox.ts†L170-L186】
-- **`WORKER_SANDBOX_ENABLED`** – when `true`, the runtime prefers the worker-thread executor. Leave unset to run sandboxes in isolated Node processes (safer for debugging or when worker threads are unstable).【F:server/runtime/NodeSandbox.ts†L170-L186】
-- **Resource guard rails** – use `SANDBOX_MAX_CPU_MS`, `SANDBOX_CPU_QUOTA_MS`, `SANDBOX_MAX_MEMORY_MB`, `SANDBOX_CGROUP_ROOT`, `SANDBOX_HEARTBEAT_INTERVAL_MS`, and `SANDBOX_HEARTBEAT_TIMEOUT_MS` to bound sandbox executions and avoid noisy neighbours. The Node sandbox reads these values on boot before running user code.【F:server/runtime/NodeSandbox.ts†L43-L99】
+| Variable | Purpose |
+| --- | --- |
+| `GENERIC_EXECUTOR_ENABLED` | Enables the Generic Executor so connector calls can fall back to the HTTP runtime when bespoke handlers are missing or fail. The flag is exposed via `env.GENERIC_EXECUTOR_ENABLED` and the exported `FLAGS` helper so other services can gate behaviour consistently.【F:server/env.ts†L141-L190】 |
+| `SANDBOX_EXECUTOR` | Forces the sandbox implementation. Set to `worker` (worker threads) or `process` (child processes); otherwise the runtime auto-selects based on `WORKER_SANDBOX_ENABLED`.【F:server/runtime/NodeSandbox.ts†L170-L186】 |
+| `WORKER_SANDBOX_ENABLED` | When `true`, the runtime prefers the worker-thread executor. Leave unset to run sandboxes in isolated Node processes (safer for debugging or when worker threads are unstable).【F:server/runtime/NodeSandbox.ts†L170-L186】 |
+| Resource guard rails | Use `SANDBOX_MAX_CPU_MS`, `SANDBOX_CPU_QUOTA_MS`, `SANDBOX_MAX_MEMORY_MB`, `SANDBOX_CGROUP_ROOT`, `SANDBOX_HEARTBEAT_INTERVAL_MS`, and `SANDBOX_HEARTBEAT_TIMEOUT_MS` to bound sandbox executions and avoid noisy neighbours. The Node sandbox reads these values on boot before running user code.【F:server/runtime/NodeSandbox.ts†L43-L99】 |
 
-Adjust these knobs per environment. For example, CI can keep short timeouts while production raises the limits but pins the executor mode.
+Adjust these knobs per environment—CI typically keeps short timeouts while production raises the limits but pins the executor mode.
 
-## Worker command matrix
+## Worker lifecycle commands
 
-The fastest path to booting the stack locally relies on the packaged scripts. The local-development guide summarises the core commands you should know when switching runtime modes or verifying workers are healthy.【F:docs/local-development.md†L63-L118】
+The quickest way to boot the stack relies on the packaged scripts. Use these during local work or when verifying worker health:
 
 | Command | Purpose |
 | --- | --- |
@@ -22,23 +24,58 @@ The fastest path to booting the stack locally relies on the packaged scripts. Th
 | `npm run dev:scheduler` | Boots the polling scheduler that enqueues trigger-based jobs. |
 | `npm run dev:stack` | Supervises the API, worker, scheduler, timers, and encryption rotation processes together, enforcing queue consistency before declaring readiness. |
 
-Use the `start:*` variants in production (`npm run start:worker`, etc.) when running the compiled `dist/` bundle.【F:package.json†L30-L34】
+Use the `start:*` variants in production (`npm run start:worker`, etc.) when running the compiled `dist/` bundle.【F:package.json†L30-L34】 For setup steps and environment prerequisites, see the [Local Development guide](./local-development.md#4-next-steps).【F:docs/local-development.md†L61-L108】
 
-## Fallback resolution flow
+## Planning runtime metadata
 
-1. **Runtime dispatch** – `WorkflowRuntime` resolves connector metadata, executes bespoke handlers through `IntegrationManager`, and records timing/credential context. When the bespoke path fails and the generic executor is enabled, it falls back to `GenericExecutor` and captures the failure reason in node metadata so observers know why a fallback occurred.【F:server/core/WorkflowRuntime.ts†L680-L747】
-2. **Integration Manager guardrails** – the manager normalises app identifiers, builds connector modules, and routes requests to bespoke handlers. It tries the generic executor automatically when a connector is unsupported or when a bespoke handler throws a "Function …" error under the feature flag.【F:server/integrations/IntegrationManager.ts†L235-L458】
-3. **Runtime registry** – the registry exposes built-in operations and augments them with connector HTTP metadata (`endpoint`/`method`) when `GENERIC_EXECUTOR_ENABLED` is on. The merged registry powers `/api/registry/capabilities`, which lists runtime-ready actions and triggers per app.【F:server/runtime/registry.ts†L100-L309】
-4. **Client capability checks** – the frontend caches the capabilities map, providing fallback entries for built-in runtimes and warning users when an operation lacks runtime coverage.【F:client/src/services/runtimeCapabilitiesService.ts†L1-L160】 Runtime unit tests confirm that connectors such as Slack only appear when the generic executor flag is enabled, preventing accidental exposure when bespoke coverage is required.【F:server/runtime/__tests__/registry.capabilities.test.ts†L1-L41】
+Runtime coverage comes from the connector manifest. `IntegrationManager` first routes calls to bespoke handlers and falls back to the Generic Executor only when the feature flag is enabled and the bespoke path errors.【F:server/integrations/IntegrationManager.ts†L332-L459】 `WorkflowRuntime` records which executor actually satisfied the node and preserves the fallback error in metadata so operators can audit the reason later.【F:server/core/WorkflowRuntime.ts†L680-L747】 The runtime registry exposes the merged capabilities map so the client can highlight supported operations in the editor.【F:server/runtime/registry.ts†L100-L309】【F:client/src/services/runtimeCapabilitiesService.ts†L1-L416】
 
-When adding a new connector or expanding coverage, ensure its definition includes the HTTP metadata needed for the registry to derive fallback routes. Combined with the environment flags above, this keeps runtime behaviour predictable across development, staging, and production.
+To keep that surface area predictable:
 
-## Backfilling connector defaults
+1. **List every runtime-capable operation.** Include a `runtimes` array for each action and trigger so reviewers and tooling can audit which operations are safe to execute. The Slack connector demonstrates the pattern by enumerating supported runtimes alongside the HTTP metadata.【F:connectors/slack/definition.json†L92-L104】
+2. **Describe the fallback shape.** Even when you do not have a bespoke fallback implementation yet, explicitly set `fallback` to `null`. Automation scripts enforce this on actions and triggers so manifests cannot omit the key entirely.【F:scripts/default-actions-to-node.ts†L35-L49】【F:scripts/seed-trigger-fallbacks.ts†L41-L59】 When you do define an HTTP fallback plan, summarise the endpoint, method, and error contract inside the `fallback` object so runtime reviewers understand the risk envelope.
+3. **Seed defaults consistently.** Run the backfill utilities (`tsx scripts/default-actions-to-node.ts`, `tsx scripts/seed-trigger-fallbacks.ts`) in order when bulk-updating the catalog to avoid churn across pull requests.【F:scripts/default-actions-to-node.ts†L35-L75】【F:scripts/seed-trigger-fallbacks.ts†L41-L80】
 
-When we backfill runtime metadata across the catalog, run the automation scripts in order so the generated patches stay repeatable:
+## Example manifest snippets
 
-1. `tsx scripts/default-actions-to-node.ts` – fills in missing `runtimes: ['node']` and `fallback: null` on every action definition.
-2. `tsx scripts/seed-trigger-fallbacks.ts` – adds conservative cursor-based defaults (`runtimes`, `fallback`, and `dedupe`) anywhere a trigger omits them.
-3. Review the highest-traffic connectors by hand to tighten the cursor paths, dedupe keys, or runtime overrides before landing the change set.
+### Action with explicit runtime coverage
 
-Recording the sequence keeps contributors aligned on how the defaults were produced and makes it easier to iterate on the seeded values without conflicting local edits.
+```jsonc
+{
+  "id": "send_message",
+  "endpoint": "/chat.postMessage",
+  "method": "POST",
+  "runtimes": ["node", "appsScript"],
+  "fallback": null
+}
+```
+
+The Slack connector publishes this shape so the registry can mark `send_message` as runtime-ready in both Node.js and Apps Script sandboxes.【F:connectors/slack/definition.json†L92-L104】
+
+### Trigger fallback outline
+
+```jsonc
+{
+  "id": "ticket_created",
+  "endpoint": "/v2/tickets",
+  "method": "GET",
+  "runtimes": ["node"],
+  "fallback": {
+    "cursor": "next_page_token",
+    "dedupe": {
+      "strategy": "cursor",
+      "cursor": { "path": "id" }
+    },
+    "notes": "Polling fallback until webhook is available."
+  }
+}
+```
+
+When introducing a fallback object, match the fields to what the runtime needs for pagination and deduplication so operators can translate the plan directly into Generic Executor behaviour. Use the defaults from the seeding scripts as a baseline and expand them with connector-specific context.【F:scripts/seed-trigger-fallbacks.ts†L1-L66】
+
+## Troubleshooting runtime availability
+
+- **Understanding UI badges.** The workflow editor tags each operation with a badge that reflects the merged runtime capabilities index. A green “Runtime ready” badge indicates native coverage, amber “Fallback” badges show the runtime that will execute via the Generic Executor, and red “Unavailable” badges block dragging altogether.【F:client/src/components/workflow/ProfessionalGraphEditor.tsx†L1680-L1736】 The right-hand inspector surfaces the same status and explains whether the limitation is a fallback or a gap in runtime support.【F:client/src/components/workflow/RightInspectorPanel.tsx†L188-L226】
+- **Interpreting fallback logs.** When an execution falls back, `WorkflowRuntime` logs the failure reason and stamps `metadata.integrationFallbackReason` on the node so the inspector and run history show why the fallback path triggered.【F:server/core/WorkflowRuntime.ts†L680-L747】 Pair that with the connector manifest’s `fallback` notes to confirm the runtime behaved as planned.
+
+Armed with these signals, you can validate runtime coverage before rollout, triage unexpected fallbacks quickly, and coordinate manifest updates with environment flag changes.


### PR DESCRIPTION
## Summary
- expand the runtime environment guide with configuration details, fallback planning guidance, examples, and troubleshooting tips
- link the new runtime guide from the docs index and local development guide
- update the connector authoring checklist with required runtimes/fallback metadata instructions

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e736c7010c8331b4322df668b4bf27