### PR TITLE
feat: scaffold runtime defaults

### DIFF
--- a/docs/runtimes-and-fallbacks.md
+++ b/docs/runtimes-and-fallbacks.md
@@ -37,8 +37,8 @@ When adding a new connector or expanding coverage, ensure its definition include
 
 When we backfill runtime metadata across the catalog, run the automation scripts in order so the generated patches stay repeatable:
 
-1. `tsx scripts/default-actions-to-node.ts` – fills in missing `runtimes: ['node']` and `fallback: null` on every action definition.
-2. `tsx scripts/seed-trigger-fallbacks.ts` – adds conservative cursor-based defaults (`runtimes`, `fallback`, and `dedupe`) anywhere a trigger omits them.
-3. Review the highest-traffic connectors by hand to tighten the cursor paths, dedupe keys, or runtime overrides before landing the change set.
+1. `npm run scaffold:runtimes` – runs the action and trigger scaffolding scripts in sequence so the patches stay consistent. The action pass (`scripts/default-actions-to-node.ts`) fills in missing `runtimes: ['node']`, `fallback: null`, and `dedupe: null` fields. The trigger pass (`scripts/seed-trigger-fallbacks.ts`) seeds a conservative cursor-based dedupe strategy along with the same runtime and fallback defaults.
+   - Connector-specific overrides live in the `CONNECTOR_ACTION_OVERRIDES` and `CONNECTOR_TRIGGER_OVERRIDES` maps. Populate those maps when a connector or individual function needs bespoke defaults instead of editing the generated manifest by hand.【F:scripts/default-actions-to-node.ts†L41-L70】【F:scripts/seed-trigger-fallbacks.ts†L42-L71】
+2. Review the highest-traffic connectors by hand to tighten the cursor paths, dedupe keys, or runtime overrides before landing the change set.
 
 Recording the sequence keeps contributors aligned on how the defaults were produced and makes it easier to iterate on the seeded values without conflicting local edits.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "audit:bronze": "node scripts/audit-bronze.js",
     "audit:secrets": "tsx scripts/audit-secrets.ts",
     "scaffold:connector-metadata": "node scripts/scaffold-connector-metadata.js",
+    "scaffold:runtimes": "tsx scripts/default-actions-to-node.ts && tsx scripts/seed-trigger-fallbacks.ts",
     "smoke:e2e": "node scripts/e2e-smoke.js",
     "smoke:connectors": "tsx scripts/connector-smoke.ts",
     "smoke:supported": "tsx scripts/smoke-supported.ts",

--- a/scripts/seed-trigger-fallbacks.ts
+++ b/scripts/seed-trigger-fallbacks.ts
@@ -2,13 +2,55 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-const DEFAULT_RUNTIMES = Object.freeze(['node'] as const);
+type TriggerDefinition = {
+  id?: string;
+  runtimes?: unknown;
+  fallback?: unknown;
+  dedupe?: unknown;
+  [key: string]: unknown;
+};
+
+type TriggerBucket = TriggerDefinition[] | Record<string, TriggerDefinition>;
+
+type ConnectorDefinition = {
+  triggers?: TriggerBucket | null;
+};
+
+type TriggerDefaults = {
+  runtimes?: string[] | null;
+  fallback?: unknown;
+  dedupe?: unknown;
+};
+
+type ConnectorTriggerOverrides = {
+  skip?: boolean;
+  defaults?: TriggerDefaults;
+  triggers?: Record<string, TriggerDefaults>;
+};
+
 const DEFAULT_TRIGGER_DEDUPE = Object.freeze({
   strategy: 'cursor',
   cursor: {
     path: 'cursor',
   },
 });
+
+const GLOBAL_TRIGGER_DEFAULTS: Required<TriggerDefaults> = Object.freeze({
+  runtimes: ['node'],
+  fallback: null,
+  dedupe: DEFAULT_TRIGGER_DEDUPE,
+});
+
+const CONNECTOR_TRIGGER_OVERRIDES: Record<string, ConnectorTriggerOverrides> = {
+  // Add connector specific overrides here as needed.
+  // Example:
+  // 'hubspot-enhanced': {
+  //   defaults: { dedupe: { strategy: 'id', path: 'id' } },
+  //   triggers: {
+  //     contact_updated: { dedupe: { strategy: 'cursor', cursor: { path: 'occurredAt' } } },
+  //   },
+  // },
+};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -32,37 +74,111 @@ async function findDefinitionFiles(dir: string): Promise<string[]> {
   return files;
 }
 
-type TriggerDefinition = Record<string, any>;
+function mergeDefaults(base: TriggerDefaults, source?: TriggerDefaults): TriggerDefaults {
+  if (!source) {
+    return base;
+  }
 
-type ConnectorDefinition = {
-  triggers?: unknown;
-};
+  const merged: TriggerDefaults = { ...base };
 
-function ensureTriggerDefaults(trigger: TriggerDefinition): boolean {
+  for (const [key, value] of Object.entries(source)) {
+    if (value !== undefined) {
+      (merged as Record<string, unknown>)[key] = value as unknown;
+    }
+  }
+
+  return merged;
+}
+
+function buildTriggerDefaults(connectorId: string, triggerId?: string): TriggerDefaults {
+  const connectorConfig = CONNECTOR_TRIGGER_OVERRIDES[connectorId];
+  const base = mergeDefaults(GLOBAL_TRIGGER_DEFAULTS, connectorConfig?.defaults);
+
+  if (!triggerId || !connectorConfig?.triggers) {
+    return base;
+  }
+
+  const triggerOverride = connectorConfig.triggers[triggerId];
+  if (!triggerOverride) {
+    return base;
+  }
+
+  return mergeDefaults(base, triggerOverride);
+}
+
+function cloneValue<T>(value: T): T {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function resolveTriggerId(trigger: TriggerDefinition, fallbackId?: string): string | undefined {
+  if (typeof trigger.id === 'string' && trigger.id.length > 0) {
+    return trigger.id;
+  }
+  if (fallbackId) {
+    return fallbackId;
+  }
+  return undefined;
+}
+
+function ensureTriggerDefaults(
+  trigger: TriggerDefinition,
+  connectorId: string,
+  fallbackId?: string,
+): boolean {
+  const connectorConfig = CONNECTOR_TRIGGER_OVERRIDES[connectorId];
+  if (connectorConfig?.skip) {
+    return false;
+  }
+
+  const triggerId = resolveTriggerId(trigger, fallbackId);
+  const defaults = buildTriggerDefaults(connectorId, triggerId);
+
   let changed = false;
 
-  if (!Array.isArray(trigger.runtimes) || trigger.runtimes.length === 0) {
-    trigger.runtimes = [...DEFAULT_RUNTIMES];
-    changed = true;
+  if (defaults.runtimes !== undefined) {
+    const runtimes = trigger.runtimes;
+    if (!Array.isArray(runtimes) || runtimes.length === 0 || !runtimes.every(item => typeof item === 'string')) {
+      trigger.runtimes = defaults.runtimes === null ? null : cloneValue(defaults.runtimes);
+      changed = true;
+    }
   }
 
-  if (!Object.prototype.hasOwnProperty.call(trigger, 'fallback') || trigger.fallback === undefined) {
-    trigger.fallback = null;
-    changed = true;
+  if (defaults.fallback !== undefined) {
+    if (!Object.prototype.hasOwnProperty.call(trigger, 'fallback') || trigger.fallback === undefined) {
+      trigger.fallback = cloneValue(defaults.fallback);
+      changed = true;
+    }
   }
 
-  if (!trigger.dedupe || typeof trigger.dedupe !== 'object') {
-    trigger.dedupe = JSON.parse(JSON.stringify(DEFAULT_TRIGGER_DEDUPE));
-    changed = true;
+  if (defaults.dedupe !== undefined) {
+    const dedupe = trigger.dedupe;
+    if (
+      !Object.prototype.hasOwnProperty.call(trigger, 'dedupe') ||
+      dedupe === undefined ||
+      dedupe === null ||
+      typeof dedupe !== 'object' ||
+      Array.isArray(dedupe)
+    ) {
+      trigger.dedupe = cloneValue(defaults.dedupe);
+      changed = true;
+    }
   }
 
   return changed;
 }
 
-function applyDefaults(definition: ConnectorDefinition): boolean {
+function applyDefaults(definition: ConnectorDefinition, connectorId: string): boolean {
   const triggers = definition.triggers;
 
   if (!triggers) {
+    return false;
+  }
+
+  const connectorConfig = CONNECTOR_TRIGGER_OVERRIDES[connectorId];
+  if (connectorConfig?.skip) {
     return false;
   }
 
@@ -70,7 +186,7 @@ function applyDefaults(definition: ConnectorDefinition): boolean {
 
   if (Array.isArray(triggers)) {
     for (const trigger of triggers) {
-      if (trigger && typeof trigger === 'object' && ensureTriggerDefaults(trigger)) {
+      if (trigger && typeof trigger === 'object' && ensureTriggerDefaults(trigger, connectorId)) {
         changed = true;
       }
     }
@@ -78,8 +194,8 @@ function applyDefaults(definition: ConnectorDefinition): boolean {
   }
 
   if (typeof triggers === 'object') {
-    for (const trigger of Object.values(triggers as Record<string, unknown>)) {
-      if (trigger && typeof trigger === 'object' && ensureTriggerDefaults(trigger as TriggerDefinition)) {
+    for (const [key, trigger] of Object.entries(triggers)) {
+      if (trigger && typeof trigger === 'object' && ensureTriggerDefaults(trigger, connectorId, key)) {
         changed = true;
       }
     }
@@ -88,17 +204,25 @@ function applyDefaults(definition: ConnectorDefinition): boolean {
   return changed;
 }
 
+function getConnectorId(definitionPath: string): string {
+  const relative = path.relative(connectorsDir, definitionPath);
+  const [connectorId] = relative.split(path.sep);
+  return connectorId;
+}
+
 async function processDefinition(file: string): Promise<boolean> {
   const raw = await fs.readFile(file, 'utf8');
   let definition: ConnectorDefinition;
 
   try {
-    definition = JSON.parse(raw);
+    definition = JSON.parse(raw) as ConnectorDefinition;
   } catch (error) {
     throw new Error(`Failed to parse ${file}: ${error instanceof Error ? error.message : String(error)}`);
   }
 
-  if (!applyDefaults(definition)) {
+  const connectorId = getConnectorId(file);
+
+  if (!applyDefaults(definition, connectorId)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- allow the runtime scaffolding scripts to hydrate missing runtimes, fallback values, and dedupe metadata while exposing connector-level override maps
- add an npm helper to run both scaffolding passes together and document the workflow for backfilling manifests

## Testing
- not run (utility scripts only)

------
https://chatgpt.com/codex/tasks/task_e_68e736c8e6088331a8c5af004f02e30e