### PR TITLE
Align runtime capability reporting with manifest runtimes

### DIFF
--- a/server/routes/registry.ts
+++ b/server/routes/registry.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 
 import { ConnectorRegistry } from '../ConnectorRegistry';
 import { getRuntimeCapabilities } from '../runtime/registry.js';
-import { enabledRuntimes } from '../runtime/capabilities.js';
+import { enabledRuntimes, getRuntimeFlagSummaries } from '../runtime/capabilities.js';
 import { getErrorMessage } from '../types/common';
 
 const router = Router();
@@ -12,6 +12,7 @@ router.get('/api/registry/capabilities', (_req, res) => {
     success: true,
     capabilities: getRuntimeCapabilities(),
     runtimes: enabledRuntimes(),
+    runtimeFlags: getRuntimeFlagSummaries(),
   });
 });
 

--- a/server/runtime/__tests__/registry.capabilities.test.ts
+++ b/server/runtime/__tests__/registry.capabilities.test.ts
@@ -37,13 +37,17 @@ process.env.GENERIC_EXECUTOR_ENABLED = 'true';
     slackCapabilities.actions.includes('send_message'),
     'slack send_message action should be exposed via runtime registry when generic executor is enabled',
   );
-  const slackResolutionWithFallback = resolveRuntime({
+  const slackResolution = resolveRuntime({
     kind: 'action',
     appId: 'slack',
     operationId: 'send_message',
   });
-  assert.equal(slackResolutionWithFallback.availability, 'fallback');
-  assert.equal(slackResolutionWithFallback.runtime, 'node');
+  assert.equal(slackResolution.availability, 'native');
+  assert.equal(slackResolution.runtime, 'node');
+  assert.ok(
+    slackResolution.enabledNativeRuntimes.includes('node'),
+    'native runtimes should include node when generic executor is enabled',
+  );
 }
 
 process.env.GENERIC_EXECUTOR_ENABLED = 'false';

--- a/server/runtime/capabilities.ts
+++ b/server/runtime/capabilities.ts
@@ -1,9 +1,15 @@
-export type RuntimeIdentifier = 'node' | 'apps_script' | 'cloud_worker';
+import { ALL_RUNTIMES, type RuntimeKey } from '@shared/runtimes';
 
-export interface EnabledRuntimeSet {
-  node: boolean;
-  appsScript: boolean;
-  cloudWorker: boolean;
+export type RuntimeIdentifier = RuntimeKey;
+
+export type EnabledRuntimeSet = Record<RuntimeKey, boolean>;
+
+export interface RuntimeFlagSummary {
+  runtime: RuntimeKey;
+  enabled: boolean;
+  defaultEnabled: boolean;
+  source: 'default' | 'env';
+  rawValue?: string;
 }
 
 const RUNTIME_FLAG_DEFAULTS: EnabledRuntimeSet = {
@@ -12,36 +18,88 @@ const RUNTIME_FLAG_DEFAULTS: EnabledRuntimeSet = {
   cloudWorker: false,
 };
 
+const RUNTIME_ENV_MAP: Record<RuntimeKey, string> = {
+  node: 'RUNTIME_NODE_ENABLED',
+  appsScript: 'RUNTIME_APPS_SCRIPT_ENABLED',
+  cloudWorker: 'RUNTIME_CLOUD_WORKER_ENABLED',
+};
+
 const normalizeRuntimeFlag = (value: string | undefined, fallback: boolean): boolean => {
   if (value === undefined || value === null) {
     return fallback;
   }
 
   const normalized = value.trim().toLowerCase();
-  if (normalized === 'true' || normalized === '1' || normalized === 'yes') {
+  if (['true', '1', 'yes', 'y', 'on', 'enabled'].includes(normalized)) {
     return true;
   }
-  if (normalized === 'false' || normalized === '0' || normalized === 'no') {
+  if (['false', '0', 'no', 'n', 'off', 'disabled'].includes(normalized)) {
     return false;
   }
 
   return fallback;
 };
 
-export const enabledRuntimes = (): EnabledRuntimeSet => {
-  return {
-    node: normalizeRuntimeFlag(process.env.RUNTIME_NODE_ENABLED, RUNTIME_FLAG_DEFAULTS.node),
-    appsScript: normalizeRuntimeFlag(
-      process.env.RUNTIME_APPS_SCRIPT_ENABLED,
-      RUNTIME_FLAG_DEFAULTS.appsScript,
-    ),
-    cloudWorker: normalizeRuntimeFlag(
-      process.env.RUNTIME_CLOUD_WORKER_ENABLED,
-      RUNTIME_FLAG_DEFAULTS.cloudWorker,
-    ),
+const readEnabledRuntimeSet = (): EnabledRuntimeSet => {
+  const flags: EnabledRuntimeSet = {
+    node: RUNTIME_FLAG_DEFAULTS.node,
+    appsScript: RUNTIME_FLAG_DEFAULTS.appsScript,
+    cloudWorker: RUNTIME_FLAG_DEFAULTS.cloudWorker,
   };
+
+  for (const runtime of ALL_RUNTIMES) {
+    const envKey = RUNTIME_ENV_MAP[runtime];
+    const rawValue = process.env[envKey];
+    if (rawValue !== undefined) {
+      flags[runtime] = normalizeRuntimeFlag(rawValue, RUNTIME_FLAG_DEFAULTS[runtime]);
+    }
+  }
+
+  return flags;
 };
+
+export const enabledRuntimes = (): EnabledRuntimeSet => readEnabledRuntimeSet();
 
 export const enabledRuntimeSet = enabledRuntimes;
 
 export const DEFAULT_RUNTIME_ENV = RUNTIME_FLAG_DEFAULTS;
+
+export const getRuntimeFlagSummaries = (): Record<RuntimeKey, RuntimeFlagSummary> => {
+  const defaults = RUNTIME_FLAG_DEFAULTS;
+  const result: Record<RuntimeKey, RuntimeFlagSummary> = {
+    node: {
+      runtime: 'node',
+      enabled: defaults.node,
+      defaultEnabled: defaults.node,
+      source: 'default',
+    },
+    appsScript: {
+      runtime: 'appsScript',
+      enabled: defaults.appsScript,
+      defaultEnabled: defaults.appsScript,
+      source: 'default',
+    },
+    cloudWorker: {
+      runtime: 'cloudWorker',
+      enabled: defaults.cloudWorker,
+      defaultEnabled: defaults.cloudWorker,
+      source: 'default',
+    },
+  };
+
+  for (const runtime of ALL_RUNTIMES) {
+    const envKey = RUNTIME_ENV_MAP[runtime];
+    const rawValue = process.env[envKey];
+    if (rawValue !== undefined) {
+      result[runtime] = {
+        runtime,
+        enabled: normalizeRuntimeFlag(rawValue, defaults[runtime]),
+        defaultEnabled: defaults[runtime],
+        source: 'env',
+        rawValue,
+      };
+    }
+  }
+
+  return result;
+};


### PR DESCRIPTION
## Summary
- align runtime capability helpers with the shared runtime keys and expose environment flag summaries
- derive native and fallback runtime registrations from connector manifests when populating the runtime registry and capabilities API
- refactor the client runtime capability service to consume detailed operation summaries and updated capability responses
- adjust the runtime capability test expectations for native Slack support under the generic executor

## Testing
- npm test -- server/runtime/__tests__/registry.capabilities.test.ts *(fails: tsx not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e736c2863883318ac03678932ce28b