### PR TITLE
Fix runtime override imports for seeding scripts

### DIFF
--- a/scripts/default-actions-to-node.ts
+++ b/scripts/default-actions-to-node.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { CONNECTOR_RUNTIME_OVERRIDES, type ActionRuntimeOverride } from './runtime-defaults.config.js';
+import { CONNECTOR_RUNTIME_OVERRIDES, type ActionRuntimeOverride } from './runtime-defaults.config.ts';
 
 const DEFAULT_ACTION_RUNTIMES = Object.freeze(['node'] as const);
 const DEFAULT_FALLBACK: null = null;

--- a/scripts/seed-trigger-fallbacks.ts
+++ b/scripts/seed-trigger-fallbacks.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { CONNECTOR_RUNTIME_OVERRIDES, type TriggerRuntimeOverride } from './runtime-defaults.config.js';
+import { CONNECTOR_RUNTIME_OVERRIDES, type TriggerRuntimeOverride } from './runtime-defaults.config.ts';
 
 const DEFAULT_TRIGGER_RUNTIMES = Object.freeze(['node'] as const);
 const DEFAULT_TRIGGER_FALLBACK: null = null;


### PR DESCRIPTION
## Summary
- point the default action seeding script at the TypeScript runtime override module
- update trigger fallback seeding script to import the shared override definition

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e740d078c08331bc2a6edda8c191cc