### PR TITLE
Fix runtime capability index iteration for record entries

### DIFF
--- a/client/src/services/runtimeCapabilitiesService.ts
+++ b/client/src/services/runtimeCapabilitiesService.ts
@@ -677,10 +677,10 @@ export const buildRuntimeCapabilityIndex = (
 
       ensureIndexEntry(index, normalizedAppId);
 
-      entry.actions.forEach((operationId) => {
+      Object.keys(entry.actions ?? {}).forEach((operationId) => {
         assignOperationStatus(index, capabilities, normalizedAppId, 'action', operationId);
       });
-      entry.triggers.forEach((operationId) => {
+      Object.keys(entry.triggers ?? {}).forEach((operationId) => {
         assignOperationStatus(index, capabilities, normalizedAppId, 'trigger', operationId);
       });
     });


### PR DESCRIPTION
## Summary
- iterate runtime capability action and trigger maps using Object.keys now that entries are records instead of sets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e740cda4a48331b8b853191ff63f70