### PR TITLE
Add provider-backed fallback handlers and integrate polling

### DIFF
--- a/server/runtime/__tests__/fallbackRegistry.test.ts
+++ b/server/runtime/__tests__/fallbackRegistry.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 
-import { getFallbackHandler } from '../fallbackRegistry.js';
+import {
+  getFallbackHandler,
+  type HttpClient,
+} from '../fallbackRegistry.js';
 import type { PollingTrigger } from '../../webhooks/types.js';
 
 const baseTrigger: PollingTrigger = {
@@ -16,10 +19,18 @@ const baseTrigger: PollingTrigger = {
   metadata: {},
 };
 
+type RunHandlerOptions = {
+  httpClient?: HttpClient;
+  credentials?: Record<string, any>;
+  parameters?: Record<string, any>;
+  additionalConfig?: Record<string, any>;
+};
+
 const runHandler = async (
   key: string,
   triggerOverrides: Partial<PollingTrigger>,
   cursor: Record<string, any> | null,
+  options: RunHandlerOptions = {},
 ) => {
   const handler = getFallbackHandler(key);
   assert.ok(handler, `Expected fallback handler for ${key}`);
@@ -39,53 +50,99 @@ const runHandler = async (
     log: (message, details) => {
       logs.push({ message, ...(details ? { details } : {}) });
     },
+    ...(options.httpClient ? { httpClient: options.httpClient } : {}),
+    ...(options.credentials ? { credentials: options.credentials } : {}),
+    ...(options.parameters ? { parameters: options.parameters } : {}),
+    ...(options.additionalConfig ? { additionalConfig: options.additionalConfig } : {}),
   });
 
   return { result: result ?? { items: [] }, logs, now };
 };
 
 {
-  const { result, logs, now } = await runHandler(
-    'gmail.polling.new_email',
-    {
-      metadata: {
-        mockResults: [
-          { id: 'msg-1', historyId: 'h-1' },
-          { id: 'msg-2', historyId: 'h-2' },
+  const requests: Array<{ url: string; init?: Record<string, any> }> = [];
+  const httpClient: HttpClient = async (url, init) => {
+    requests.push({ url, init });
+    assert.ok(url.startsWith('https://gmail.googleapis.com/gmail/v1/users/me/messages'));
+    assert.ok(init?.headers?.Authorization?.includes('test-token'));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        messages: [
+          { id: 'msg-1', threadId: 'thread-1' },
+          { id: 'msg-2', threadId: 'thread-2' },
         ],
-      },
+        nextPageToken: 'next-token',
+        historyId: 'h-2',
+      }),
+    };
+  };
+
+  const { result, logs, now } = await runHandler(
+    'gmail.messages.list',
+    {
+      metadata: { parameters: { labelIds: ['INBOX'] } },
     },
-    { historyId: 'h-0' },
+    { pageToken: 'prev-token', historyId: 'h-1' },
+    {
+      httpClient,
+      credentials: { accessToken: 'test-token' },
+      parameters: { maxResults: 2 },
+    },
   );
 
+  assert.equal(requests.length, 1, 'gmail fallback should issue a single HTTP request');
   assert.equal(result.items?.length, 2, 'gmail fallback should return provided results');
   assert.equal(result.items?.[0]?.payload.id, 'msg-1');
   assert.equal(result.items?.[1]?.dedupeToken, 'msg-2');
+  assert.equal(result.cursor?.pageToken, 'next-token', 'cursor should include next page token');
   assert.equal(result.cursor?.historyId, 'h-2', 'cursor should advance to last history id');
   assert.equal(result.cursor?.lastPolledAt, now.toISOString(), 'cursor should record last poll timestamp');
-  assert.equal(result.diagnostics?.handlerKey, 'gmail.polling.new_email');
+  assert.equal(result.diagnostics?.handlerKey, 'gmail.messages.list');
   assert.equal(result.diagnostics?.mode, 'fallback');
   assert.ok(Array.isArray(logs) && logs.length > 0, 'gmail fallback should emit logs');
+
+  assert.equal(
+    getFallbackHandler('gmail.messages.list'),
+    getFallbackHandler('gmail.polling.new_email'),
+    'gmail handler aliases should resolve to the same implementation',
+  );
 }
 
 {
-  const { result, logs, now } = await runHandler(
-    'google_drive.files.watch',
-    {
-      appId: 'google_drive',
-      triggerId: 'watch_files',
-      metadata: {
-        mockFiles: [
+  const httpClient: HttpClient = async url => {
+    assert.ok(url.startsWith('https://www.googleapis.com/drive/v3/files'));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        files: [
           { id: 'file-1', modifiedTime: '2024-02-01T01:02:03Z' },
           { id: 'file-2', modifiedTime: '2024-02-01T02:03:04Z' },
         ],
-      },
+        nextPageToken: 'drive-next-token',
+      }),
+    };
+  };
+
+  const { result, logs, now } = await runHandler(
+    'google_drive.files.watch',
+    {
+      appId: 'google_docs',
+      triggerId: 'document_updated',
     },
-    { lastSyncToken: '2023-12-31T23:59:59Z' },
+    { pageToken: 'drive-prev-token', lastSyncToken: '2024-02-01T00:00:00Z' },
+    {
+      httpClient,
+      credentials: { accessToken: 'drive-token' },
+      parameters: { folderId: 'folder-1', pageSize: 25 },
+    },
   );
 
   assert.equal(result.items?.length, 2, 'drive fallback should return mock files');
   assert.equal(result.items?.[0]?.payload.id, 'file-1');
+  assert.equal(result.cursor?.pageToken, 'drive-next-token');
   assert.equal(result.cursor?.lastSyncToken, '2024-02-01T02:03:04Z');
   assert.equal(result.cursor?.lastPolledAt, now.toISOString());
   assert.equal(result.diagnostics?.handlerKey, 'google_drive.files.watch');
@@ -94,26 +151,43 @@ const runHandler = async (
 }
 
 {
+  const httpClient: HttpClient = async url => {
+    assert.ok(url.startsWith('https://slack.com/api/conversations.history'));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        messages: [
+          { ts: '1706875200.000100', text: 'hello' },
+          { ts: '1706875300.000200', text: 'world' },
+        ],
+        response_metadata: { next_cursor: 'cursor-2' },
+      }),
+    };
+  };
+
   const { result, logs, now } = await runHandler(
-    'slack.api.poller',
+    'slack.conversations.history',
     {
       appId: 'slack',
       triggerId: 'events',
-      metadata: {
-        mockEvents: [
-          { id: 'evt-1', ts: '1706875200.000100' },
-          { id: 'evt-2', ts: '1706875300.000200' },
-        ],
-      },
+      metadata: { parameters: { channel: 'C123' } },
     },
-    { lastEventTs: '1706875100.000000' },
+    { nextCursor: 'cursor-1', lastEventTs: '1706875100.000000' },
+    {
+      httpClient,
+      credentials: { accessToken: 'slack-token' },
+      parameters: { limit: 2 },
+    },
   );
 
   assert.equal(result.items?.length, 2, 'slack fallback should return mock events');
   assert.equal(result.items?.[1]?.dedupeToken, '1706875300.000200');
+  assert.equal(result.cursor?.nextCursor, 'cursor-2');
   assert.equal(result.cursor?.lastEventTs, '1706875300.000200');
   assert.equal(result.cursor?.lastPolledAt, now.toISOString());
-  assert.equal(result.diagnostics?.handlerKey, 'slack.api.poller');
+  assert.equal(result.diagnostics?.handlerKey, 'slack.conversations.history');
   assert.equal(result.diagnostics?.mode, 'fallback');
   assert.ok(logs.length > 0, 'slack fallback should log activity');
 }
@@ -123,4 +197,4 @@ const runHandler = async (
   assert.equal(handler, undefined, 'unknown fallback handler should be undefined');
 }
 
-console.log('✅ fallbackRegistry handlers resolve and execute with mock contexts.');
+console.log('✅ fallbackRegistry handlers resolve and execute with mocked provider clients.');

--- a/server/runtime/fallbackRegistry.ts
+++ b/server/runtime/fallbackRegistry.ts
@@ -1,3 +1,4 @@
+import type { APICredentials } from '../integrations/BaseAPIClient.js';
 import type { PollingTrigger } from '../webhooks/types.js';
 
 export interface FallbackHandlerContext {
@@ -5,6 +6,10 @@ export interface FallbackHandlerContext {
   cursor: Record<string, any> | null;
   now: Date;
   log: (message: string, details?: Record<string, any>) => void;
+  credentials?: APICredentials | null;
+  parameters?: Record<string, any> | null;
+  additionalConfig?: Record<string, any> | null;
+  httpClient?: HttpClient | null;
 }
 
 export interface FallbackResultItem {
@@ -25,6 +30,14 @@ export interface FallbackHandlerResult {
   latencyMs?: number;
 }
 
+export type HttpResponseLike = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<any>;
+};
+
+export type HttpClient = (url: string, init?: Record<string, any>) => Promise<HttpResponseLike>;
+
 export type FallbackHandler = (
   context: FallbackHandlerContext,
 ) => Promise<FallbackHandlerResult | void | null> | FallbackHandlerResult | void | null;
@@ -40,6 +53,12 @@ const registerHandler = (key: string, handler: FallbackHandler): void => {
   registry.set(normalizeKey(key), handler);
 };
 
+const registerAliases = (keys: string[], handler: FallbackHandler): void => {
+  for (const key of keys) {
+    registerHandler(key, handler);
+  }
+};
+
 const ensureArray = <T>(value: unknown): T[] => {
   if (Array.isArray(value)) {
     return value as T[];
@@ -52,153 +71,536 @@ const buildLogEntry = (message: string, details?: Record<string, any>): Fallback
   ...(details ? { details } : {}),
 });
 
-const gmailPollingFallback: FallbackHandler = async ({ trigger, cursor, now, log }) => {
-  const metadata = trigger.metadata ?? {};
-  const mockResults = ensureArray<Record<string, any>>(metadata.mockResults);
+const safeJson = async (response: any): Promise<any> => {
+  if (!response || typeof response.json !== 'function') {
+    return {};
+  }
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+};
 
-  const items: FallbackResultItem[] = mockResults.map((entry, index) => {
+const extractAccessToken = (
+  credentials?: APICredentials | null,
+  additionalConfig?: Record<string, any> | null,
+): string | null => {
+  const candidates: Array<unknown> = [];
+  if (credentials) {
+    candidates.push(
+      credentials.accessToken,
+      (credentials as any).access_token,
+      credentials.token,
+      (credentials as any).oauthToken,
+      (credentials as any).botToken,
+      (credentials as any).bearerToken,
+    );
+  }
+  if (additionalConfig) {
+    candidates.push(
+      additionalConfig.accessToken,
+      (additionalConfig as any).botToken,
+      (additionalConfig as any).token,
+    );
+  }
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  }
+
+  return null;
+};
+
+const resolveHttpClient = (context: FallbackHandlerContext): HttpClient | null => {
+  if (typeof context.httpClient === 'function') {
+    return context.httpClient;
+  }
+  if (typeof globalThis.fetch === 'function') {
+    return (url, init) => globalThis.fetch(url, init as any) as unknown as Promise<HttpResponseLike>;
+  }
+  return null;
+};
+
+const mergeParameters = (
+  trigger: PollingTrigger,
+  parameters?: Record<string, any> | null,
+): Record<string, any> => {
+  const merged: Record<string, any> = {};
+  const triggerParams =
+    trigger.metadata && typeof trigger.metadata.parameters === 'object'
+      ? (trigger.metadata.parameters as Record<string, any>)
+      : {};
+  Object.assign(merged, triggerParams);
+  if (parameters && typeof parameters === 'object') {
+    Object.assign(merged, parameters);
+  }
+  return merged;
+};
+
+const gmailMessagesListFallback: FallbackHandler = async context => {
+  const start = Date.now();
+  const httpClient = resolveHttpClient(context);
+  const handlerKey = 'gmail.messages.list';
+
+  if (!httpClient) {
+    context.log('Gmail fallback skipped: HTTP client unavailable', { handler: handlerKey });
+    return {
+      items: [],
+      cursor: context.cursor ?? null,
+      logs: [buildLogEntry('gmail.messages.list skipped - missing HTTP client')],
+      diagnostics: { handlerKey, mode: 'fallback', reason: 'missing_http_client' },
+    };
+  }
+
+  const token = extractAccessToken(context.credentials, context.additionalConfig);
+  if (!token) {
+    context.log('Gmail fallback skipped: missing access token', { handler: handlerKey });
+    return {
+      items: [],
+      cursor: context.cursor ?? null,
+      logs: [buildLogEntry('gmail.messages.list skipped - missing credentials')],
+      diagnostics: { handlerKey, mode: 'fallback', reason: 'missing_credentials' },
+    };
+  }
+
+  const params = mergeParameters(context.trigger, context.parameters);
+  const searchParams = new URLSearchParams();
+
+  const maxResultsCandidate = params.maxResults ?? params.limit;
+  const maxResults = Number.parseInt(String(maxResultsCandidate ?? '25'), 10);
+  if (Number.isFinite(maxResults) && maxResults > 0) {
+    searchParams.set('maxResults', String(maxResults));
+  }
+
+  if (params.q) {
+    searchParams.set('q', String(params.q));
+  }
+
+  const labelIds = ensureArray<string>(params.labelIds ?? params.labels)
+    .map(value => String(value).trim())
+    .filter(value => value.length > 0);
+  for (const label of labelIds) {
+    searchParams.append('labelIds', label);
+  }
+
+  if (params.includeSpamTrash) {
+    searchParams.set('includeSpamTrash', 'true');
+  }
+
+  if (context.cursor?.pageToken) {
+    searchParams.set('pageToken', String(context.cursor.pageToken));
+  }
+
+  const url = `https://gmail.googleapis.com/gmail/v1/users/me/messages${
+    searchParams.size > 0 ? `?${searchParams.toString()}` : ''
+  }`;
+
+  const response = await httpClient(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const body = await safeJson(response);
+    context.log('Gmail fallback request failed', {
+      handler: handlerKey,
+      status: response.status,
+      body,
+    });
+    return {
+      items: [],
+      cursor: context.cursor ?? null,
+      logs: [
+        buildLogEntry('gmail.messages.list request failed', {
+          status: response.status,
+        }),
+      ],
+      diagnostics: {
+        handlerKey,
+        mode: 'fallback',
+        status: response.status,
+        error: body?.error ?? 'http_error',
+      },
+      latencyMs: Date.now() - start,
+    };
+  }
+
+  const data = await safeJson(response);
+  const messages = ensureArray<any>(data.messages);
+
+  const items: FallbackResultItem[] = messages.map((entry, index) => {
     const payload = { ...entry };
     if (!payload.id) {
-      payload.id = `${trigger.id}-msg-${index}`;
-    }
-    if (!payload.historyId) {
-      payload.historyId = payload.id;
-    }
-
-    return {
-      payload,
-      dedupeToken: typeof payload.id === 'string' ? payload.id : undefined,
-    };
-  });
-
-  const lastHistoryId =
-    items.length > 0 ? items[items.length - 1]?.payload?.historyId : cursor?.historyId;
-
-  const nextCursor = {
-    ...(cursor ?? {}),
-    historyId: lastHistoryId ?? null,
-    lastPolledAt: now.toISOString(),
-  } as Record<string, any>;
-
-  log('Processed Gmail fallback batch', {
-    mode: 'fallback',
-    handler: 'gmail.polling.new_email',
-    itemCount: items.length,
-  });
-
-  return {
-    items,
-    cursor: nextCursor,
-    logs: [buildLogEntry('gmail.polling.new_email processed items', { count: items.length })],
-    diagnostics: {
-      handlerKey: 'gmail.polling.new_email',
-      itemCount: items.length,
-      mode: 'fallback',
-    },
-  };
-};
-
-const googleDriveWatcherFallback: FallbackHandler = async ({ trigger, cursor, now, log }) => {
-  const metadata = trigger.metadata ?? {};
-  const mockFiles = ensureArray<Record<string, any>>(metadata.mockFiles ?? metadata.mockResults);
-
-  const items: FallbackResultItem[] = mockFiles.map((file, index) => {
-    const payload = { ...file };
-    if (!payload.id) {
-      payload.id = `${trigger.id}-file-${index}`;
-    }
-    if (!payload.modifiedTime) {
-      payload.modifiedTime = now.toISOString();
-    }
-
-    return {
-      payload,
-      dedupeToken: typeof payload.id === 'string' ? payload.id : undefined,
-    };
-  });
-
-  const lastSyncToken =
-    items.length > 0
-      ? items[items.length - 1]?.payload?.modifiedTime ?? cursor?.lastSyncToken
-      : cursor?.lastSyncToken;
-
-  const nextCursor = {
-    ...(cursor ?? {}),
-    lastSyncToken: lastSyncToken ?? null,
-    lastPolledAt: now.toISOString(),
-  } as Record<string, any>;
-
-  log('Processed Google Drive fallback batch', {
-    mode: 'fallback',
-    handler: 'google_drive.files.watch',
-    itemCount: items.length,
-  });
-
-  return {
-    items,
-    cursor: nextCursor,
-    logs: [buildLogEntry('google_drive.files.watch processed items', { count: items.length })],
-    diagnostics: {
-      handlerKey: 'google_drive.files.watch',
-      itemCount: items.length,
-      mode: 'fallback',
-    },
-  };
-};
-
-const slackApiPollerFallback: FallbackHandler = async ({ trigger, cursor, now, log }) => {
-  const metadata = trigger.metadata ?? {};
-  const mockEvents = ensureArray<Record<string, any>>(metadata.mockEvents ?? metadata.mockResults);
-
-  const items: FallbackResultItem[] = mockEvents.map((event, index) => {
-    const payload = { ...event };
-    if (!payload.ts) {
-      payload.ts = `${now.getTime() / 1000 + index}`;
+      payload.id = payload.threadId ?? `${context.trigger.id}-msg-${index}`;
     }
 
     return {
       payload,
       dedupeToken:
-        typeof payload.ts === 'string'
-          ? payload.ts
-          : typeof payload.id === 'string'
+        typeof payload.id === 'string'
           ? payload.id
+          : typeof payload.threadId === 'string'
+          ? payload.threadId
           : undefined,
     };
   });
 
-  const lastEventToken =
-    items.length > 0
-      ? items[items.length - 1]?.dedupeToken ?? cursor?.lastEventTs
-      : cursor?.lastEventTs;
+  const historyId =
+    typeof data.historyId === 'string'
+      ? data.historyId
+      : typeof data.historyId === 'number'
+      ? String(data.historyId)
+      : context.cursor?.historyId ?? null;
 
-  const nextCursor = {
-    ...(cursor ?? {}),
-    lastEventTs: lastEventToken ?? null,
-    lastPolledAt: now.toISOString(),
-  } as Record<string, any>;
+  const nextCursor: Record<string, any> = {
+    ...(context.cursor ?? {}),
+    pageToken: typeof data.nextPageToken === 'string' ? data.nextPageToken : null,
+    historyId,
+    lastPolledAt: context.now.toISOString(),
+  };
 
-  log('Processed Slack fallback batch', {
+  context.log('Processed Gmail fallback batch', {
     mode: 'fallback',
-    handler: 'slack.api.poller',
+    handler: handlerKey,
     itemCount: items.length,
+    pageToken: nextCursor.pageToken ?? undefined,
   });
 
   return {
     items,
     cursor: nextCursor,
-    logs: [buildLogEntry('slack.api.poller processed items', { count: items.length })],
+    logs: [buildLogEntry('gmail.messages.list fetched messages', { count: items.length })],
     diagnostics: {
-      handlerKey: 'slack.api.poller',
-      itemCount: items.length,
+      handlerKey,
       mode: 'fallback',
+      itemCount: items.length,
+      nextPageToken: nextCursor.pageToken ?? undefined,
     },
+    latencyMs: Date.now() - start,
   };
 };
 
-registerHandler('gmail.polling.new_email', gmailPollingFallback);
-registerHandler('google_drive.files.watch', googleDriveWatcherFallback);
-registerHandler('slack.api.poller', slackApiPollerFallback);
+const driveFilesPollingFallback: FallbackHandler = async context => {
+  const start = Date.now();
+  const httpClient = resolveHttpClient(context);
+  const handlerKey = 'google_drive.files.watch';
+
+  if (!httpClient) {
+    context.log('Google Drive fallback skipped: HTTP client unavailable', { handler: handlerKey });
+    return {
+      items: [],
+      cursor: context.cursor ?? null,
+      logs: [buildLogEntry('google_drive.files.watch skipped - missing HTTP client')],
+      diagnostics: { handlerKey, mode: 'fallback', reason: 'missing_http_client' },
+    };
+  }
+
+  const token = extractAccessToken(context.credentials, context.additionalConfig);
+  if (!token) {
+    context.log('Google Drive fallback skipped: missing access token', { handler: handlerKey });
+    return {
+      items: [],
+      cursor: context.cursor ?? null,
+      logs: [buildLogEntry('google_drive.files.watch skipped - missing credentials')],
+      diagnostics: { handlerKey, mode: 'fallback', reason: 'missing_credentials' },
+    };
+  }
+
+  const params = mergeParameters(context.trigger, context.parameters);
+  const searchParams = new URLSearchParams();
+
+  const pageSizeCandidate = params.pageSize ?? params.limit ?? 50;
+  const pageSize = Number.parseInt(String(pageSizeCandidate), 10);
+  searchParams.set('pageSize', Number.isFinite(pageSize) && pageSize > 0 ? String(pageSize) : '50');
+  searchParams.set(
+    'fields',
+    'files(id,name,mimeType,createdTime,modifiedTime,owners,webViewLink),nextPageToken',
+  );
+  searchParams.set('spaces', String(params.spaces ?? 'drive'));
+
+  if (context.cursor?.pageToken) {
+    searchParams.set('pageToken', String(context.cursor.pageToken));
+  }
+
+  const queryParts: string[] = ['trashed = false'];
+  if (params.folderId) {
+    queryParts.push(`'${String(params.folderId).replace(/'/g, "\\'")}' in parents`);
+  }
+  if (params.mimeType) {
+    queryParts.push(`mimeType = '${String(params.mimeType)}'`);
+  } else {
+    queryParts.push("mimeType contains 'application/vnd.google-apps.document'");
+  }
+  if (params.modifiedAfter) {
+    queryParts.push(`modifiedTime > '${String(params.modifiedAfter)}'`);
+  } else if (context.cursor?.lastSyncToken) {
+    queryParts.push(`modifiedTime > '${String(context.cursor.lastSyncToken)}'`);
+  }
+
+  if (queryParts.length > 0) {
+    searchParams.set('q', queryParts.join(' and '));
+  }
+
+  const url = `https://www.googleapis.com/drive/v3/files?${searchParams.toString()}`;
+
+  const response = await httpClient(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const body = await safeJson(response);
+    context.log('Google Drive fallback request failed', {
+      handler: handlerKey,
+      status: response.status,
+      body,
+    });
+    return {
+      items: [],
+      cursor: context.cursor ?? null,
+      logs: [buildLogEntry('google_drive.files.watch request failed', { status: response.status })],
+      diagnostics: {
+        handlerKey,
+        mode: 'fallback',
+        status: response.status,
+        error: body?.error ?? 'http_error',
+      },
+      latencyMs: Date.now() - start,
+    };
+  }
+
+  const data = await safeJson(response);
+  const files = ensureArray<any>(data.files);
+
+  const items: FallbackResultItem[] = files.map((entry, index) => {
+    const payload = { ...entry };
+    if (!payload.id) {
+      payload.id = `${context.trigger.id}-file-${index}`;
+    }
+    if (!payload.modifiedTime && payload.createdTime) {
+      payload.modifiedTime = payload.createdTime;
+    }
+
+    return {
+      payload,
+      dedupeToken: typeof payload.id === 'string' ? payload.id : undefined,
+    };
+  });
+
+  const lastModified =
+    items.length > 0
+      ? items[items.length - 1].payload?.modifiedTime ?? items[items.length - 1].payload?.createdTime ?? null
+      : context.cursor?.lastSyncToken ?? null;
+
+  const nextCursor: Record<string, any> = {
+    ...(context.cursor ?? {}),
+    pageToken: typeof data.nextPageToken === 'string' ? data.nextPageToken : null,
+    lastSyncToken: lastModified,
+    lastPolledAt: context.now.toISOString(),
+  };
+
+  context.log('Processed Google Drive fallback batch', {
+    mode: 'fallback',
+    handler: handlerKey,
+    itemCount: items.length,
+    pageToken: nextCursor.pageToken ?? undefined,
+  });
+
+  return {
+    items,
+    cursor: nextCursor,
+    logs: [buildLogEntry('google_drive.files.watch fetched files', { count: items.length })],
+    diagnostics: {
+      handlerKey,
+      mode: 'fallback',
+      itemCount: items.length,
+      nextPageToken: nextCursor.pageToken ?? undefined,
+    },
+    latencyMs: Date.now() - start,
+  };
+};
+
+const slackConversationsHistoryFallback: FallbackHandler = async context => {
+  const start = Date.now();
+  const httpClient = resolveHttpClient(context);
+  const handlerKey = 'slack.conversations.history';
+
+  if (!httpClient) {
+    context.log('Slack fallback skipped: HTTP client unavailable', { handler: handlerKey });
+    return {
+      items: [],
+      cursor: context.cursor ?? null,
+      logs: [buildLogEntry('slack.conversations.history skipped - missing HTTP client')],
+      diagnostics: { handlerKey, mode: 'fallback', reason: 'missing_http_client' },
+    };
+  }
+
+  const token = extractAccessToken(context.credentials, context.additionalConfig);
+  if (!token) {
+    context.log('Slack fallback skipped: missing access token', { handler: handlerKey });
+    return {
+      items: [],
+      cursor: context.cursor ?? null,
+      logs: [buildLogEntry('slack.conversations.history skipped - missing credentials')],
+      diagnostics: { handlerKey, mode: 'fallback', reason: 'missing_credentials' },
+    };
+  }
+
+  const params = mergeParameters(context.trigger, context.parameters);
+  const channel = typeof params.channel === 'string' ? params.channel.trim() : '';
+  if (!channel) {
+    context.log('Slack fallback skipped: missing channel parameter', { handler: handlerKey });
+    return {
+      items: [],
+      cursor: context.cursor ?? null,
+      logs: [buildLogEntry('slack.conversations.history skipped - missing channel')],
+      diagnostics: { handlerKey, mode: 'fallback', reason: 'missing_channel' },
+    };
+  }
+
+  const searchParams = new URLSearchParams();
+  searchParams.set('channel', channel);
+
+  const limitCandidate = params.limit ?? params.pageSize ?? 50;
+  const limit = Number.parseInt(String(limitCandidate), 10);
+  if (Number.isFinite(limit) && limit > 0) {
+    searchParams.set('limit', String(limit));
+  }
+
+  if (context.cursor?.nextCursor) {
+    searchParams.set('cursor', String(context.cursor.nextCursor));
+  }
+
+  if (params.inclusive) {
+    searchParams.set('inclusive', String(Boolean(params.inclusive)));
+  }
+  if (params.oldest) {
+    searchParams.set('oldest', String(params.oldest));
+  }
+  if (params.latest) {
+    searchParams.set('latest', String(params.latest));
+  }
+
+  const url = `https://slack.com/api/conversations.history?${searchParams.toString()}`;
+
+  const response = await httpClient(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const body = await safeJson(response);
+    context.log('Slack fallback request failed', {
+      handler: handlerKey,
+      status: response.status,
+      body,
+    });
+    return {
+      items: [],
+      cursor: context.cursor ?? null,
+      logs: [buildLogEntry('slack.conversations.history request failed', { status: response.status })],
+      diagnostics: {
+        handlerKey,
+        mode: 'fallback',
+        status: response.status,
+        error: body?.error ?? 'http_error',
+      },
+      latencyMs: Date.now() - start,
+    };
+  }
+
+  const data = await safeJson(response);
+  if (data && data.ok === false) {
+    context.log('Slack fallback reported API error', {
+      handler: handlerKey,
+      error: data.error ?? 'unknown_error',
+    });
+    return {
+      items: [],
+      cursor: context.cursor ?? null,
+      logs: [
+        buildLogEntry('slack.conversations.history API error', {
+          error: data.error ?? 'unknown_error',
+        }),
+      ],
+      diagnostics: {
+        handlerKey,
+        mode: 'fallback',
+        error: data.error ?? 'api_error',
+      },
+      latencyMs: Date.now() - start,
+    };
+  }
+
+  const events = ensureArray<any>(data?.messages);
+  const items: FallbackResultItem[] = events.map(entry => ({
+    payload: { ...entry },
+    dedupeToken:
+      typeof entry.ts === 'string'
+        ? entry.ts
+        : typeof entry.event_ts === 'string'
+        ? entry.event_ts
+        : undefined,
+  }));
+
+  const nextCursorValue = data?.response_metadata?.next_cursor;
+  const nextCursor: Record<string, any> = {
+    ...(context.cursor ?? {}),
+    nextCursor: typeof nextCursorValue === 'string' && nextCursorValue.length > 0 ? nextCursorValue : null,
+    lastEventTs:
+      items.length > 0
+        ? items[items.length - 1].dedupeToken ?? context.cursor?.lastEventTs ?? null
+        : context.cursor?.lastEventTs ?? null,
+    lastPolledAt: context.now.toISOString(),
+  };
+
+  context.log('Processed Slack fallback batch', {
+    mode: 'fallback',
+    handler: handlerKey,
+    itemCount: items.length,
+    nextCursor: nextCursor.nextCursor ?? undefined,
+  });
+
+  return {
+    items,
+    cursor: nextCursor,
+    logs: [buildLogEntry('slack.conversations.history fetched events', { count: items.length })],
+    diagnostics: {
+      handlerKey,
+      mode: 'fallback',
+      itemCount: items.length,
+      nextCursor: nextCursor.nextCursor ?? undefined,
+    },
+    latencyMs: Date.now() - start,
+  };
+};
+
+registerAliases(['gmail.messages.list', 'gmail.polling.new_email'], gmailMessagesListFallback);
+registerAliases(
+  [
+    'google_drive.files.watch',
+    'google_docs.drive.polling',
+    'google_docs.documents.watch',
+    'google_docs.document_updated',
+  ],
+  driveFilesPollingFallback,
+);
+registerAliases(['slack.conversations.history', 'slack.api.poller'], slackConversationsHistoryFallback);
 
 export function getFallbackHandler(key: string | null | undefined): FallbackHandler | undefined {
   if (typeof key !== 'string' || !key.trim()) {
@@ -206,4 +608,3 @@ export function getFallbackHandler(key: string | null | undefined): FallbackHand
   }
   return registry.get(normalizeKey(key));
 }
-

--- a/server/webhooks/WebhookManager.ts
+++ b/server/webhooks/WebhookManager.ts
@@ -1330,6 +1330,9 @@ export class WebhookManager {
                 log: (message, details) => {
                   fallbackLogs.push({ message, ...(details ? { details } : {}) });
                 },
+                credentials: context.credentials,
+                parameters: context.parameters,
+                additionalConfig: context.additionalConfig,
               })) as FallbackHandlerResult | void | null) ?? { items: [] };
 
             const items = this.normalizeFallbackItems(result.items);


### PR DESCRIPTION
## Summary
- implement HTTP-backed fallback handlers for Gmail, Google Drive, and Slack with shared registry aliases
- pass credentials and polling parameters into fallback execution to support provider-backed calls
- refresh fallback registry tests to validate handler behaviour with mocked HTTP clients

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e7406dbd7083319c1f70ddf11eb037