### PR TITLE
Add shared module alias support for client imports

### DIFF
--- a/client/src/catalog/index.ts
+++ b/client/src/catalog/index.ts
@@ -1,7 +1,7 @@
-export { GoogleSheetsAppendRowContract } from '../../shared/catalog/google_sheets.append_row';
+export { GoogleSheetsAppendRowContract } from '@shared/catalog/google_sheets.append_row';
 
 // Central CONTRACTS registry (extend as you add more contracts)
-import { GoogleSheetsAppendRowContract as SheetsAppend } from '../../shared/catalog/google_sheets.append_row';
+import { GoogleSheetsAppendRowContract as SheetsAppend } from '@shared/catalog/google_sheets.append_row';
 
 export const CONTRACTS: Record<string, any> = {
   'sheets.append_row': SheetsAppend

--- a/client/src/components/ai/EnhancedConversationalWorkflowBuilder.tsx
+++ b/client/src/components/ai/EnhancedConversationalWorkflowBuilder.tsx
@@ -36,7 +36,7 @@ import {
   Filter,
   Globe
 } from 'lucide-react';
-import { NodeGraph, Question, ValidationError } from '../../../shared/nodeGraphSchema';
+import { NodeGraph, Question, ValidationError } from '@shared/nodeGraphSchema';
 import { AutomationSpec as AutomationSpecZ } from '../../core/spec';
 import { useSpecStore } from '../../state/specStore';
 

--- a/client/src/components/workflow/ProfessionalGraphEditor.tsx
+++ b/client/src/components/workflow/ProfessionalGraphEditor.tsx
@@ -86,9 +86,9 @@ import {
 } from 'lucide-react';
 import * as LucideIcons from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { NodeGraph, GraphNode, VisualNode } from '../../../shared/nodeGraphSchema';
-import type { ValidationError } from '../../../shared/nodeGraphSchema';
-import { DEFAULT_RUNTIME, RUNTIME_DISPLAY_NAMES } from '../../../shared';
+import { NodeGraph, GraphNode, VisualNode } from '@shared/nodeGraphSchema';
+import type { ValidationError } from '@shared/nodeGraphSchema';
+import { DEFAULT_RUNTIME, RUNTIME_DISPLAY_NAMES } from '@shared';
 import clsx from 'clsx';
 import debounce from 'lodash/debounce';
 import type { DebouncedFunc } from 'lodash';

--- a/client/src/components/workflow/RightInspectorPanel.tsx
+++ b/client/src/components/workflow/RightInspectorPanel.tsx
@@ -14,7 +14,7 @@ import type {
   RuntimeCapabilityIssue,
   RuntimeCapabilityMode,
 } from "@/services/runtimeCapabilitiesService";
-import { type RuntimeKey, RUNTIME_DISPLAY_NAMES } from "../../../shared";
+import { type RuntimeKey, RUNTIME_DISPLAY_NAMES } from "@shared";
 
 export interface SelectedNodeRuntimeSupport {
   supported: boolean;

--- a/client/src/components/workflow/SmartParametersPanel.tsx
+++ b/client/src/components/workflow/SmartParametersPanel.tsx
@@ -17,7 +17,8 @@ import { Textarea } from "../ui/textarea";
 import { Button } from "../ui/button";
 import { RefreshCw } from "lucide-react";
 import { buildMetadataFromNode } from "./metadata";
-import type { EvaluatedValue } from "../../../../shared/nodeGraphSchema";
+import type { EvaluatedValue } from "@shared/nodeGraphSchema";
+import type { NodeIOMetadata } from "@shared/metadata";
 import type { ConnectorDefinitionMap } from "@/services/connectorDefinitionsService";
 import { normalizeConnectorId } from "@/services/connectorDefinitionsService";
 
@@ -54,6 +55,7 @@ export type UpstreamNodeSummary = {
     app?: string;
     metadata?: NodeMetadataSummary;
     outputMetadata?: NodeMetadataSummary;
+    io?: NodeIOMetadata;
     [key: string]: any;
   };
 };
@@ -336,6 +338,7 @@ const gatherMetadata = (node: UpstreamNodeSummary): NodeMetadataSummary => {
     extractOutputMetadataSummary(data.connectorMetadata) ??
     extractOutputMetadataSummary(data.metadata) ??
     extractOutputMetadataSummary(data.outputMetadata) ??
+    extractOutputMetadataSummary(data.io as NodeIOMetadata | undefined) ??
     extractOutputMetadataSummary((data as any).ioMetadata);
   const directMeta = cloneMetadataSummary(data.metadata);
   const outputMeta = cloneMetadataSummary(data.outputMetadata);

--- a/client/src/components/workflow/__tests__/NodeValidationIndicators.test.tsx
+++ b/client/src/components/workflow/__tests__/NodeValidationIndicators.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ActionNode, TransformNode } from "../ProfessionalGraphEditor";
-import type { ValidationError } from "../../../../shared/nodeGraphSchema";
+import type { ValidationError } from "@shared/nodeGraphSchema";
 
 describe("Graph node validation indicators", () => {
   it("highlights action nodes with validation errors", () => {

--- a/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
+++ b/client/src/components/workflow/__tests__/SmartParametersPanel.test.ts
@@ -4,7 +4,7 @@ import { answersToGraph } from "../../../../../server/workflow/answers-to-graph"
 import { enrichWorkflowNode } from "../../../../../server/workflow/node-metadata";
 import { resolveAllParams } from "../../../../../server/core/ParameterResolver";
 import type { WorkflowNode } from "../../../../../common/workflow-types";
-import type { ParameterContext } from "../../../../../shared/nodeGraphSchema";
+import type { ParameterContext } from "@shared/nodeGraphSchema";
 
 import {
   computeMetadataSuggestions,

--- a/client/src/core/spec.ts
+++ b/client/src/core/spec.ts
@@ -1,5 +1,5 @@
 // Re-export from shared so client and server stay in sync
-export { PortRef, NodeSpec, EdgeSpec, AutomationSpec } from '../../../shared/core/spec';
-export type { AutomationSpec as AutomationSpec } from '../../../shared/core/spec';
+export { PortRef, NodeSpec, EdgeSpec, AutomationSpec } from '@shared/core/spec';
+export type { AutomationSpec as AutomationSpec } from '@shared/core/spec';
 
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["../shared/*"],
+      "@assets/*": ["../attached_assets/*"]
+    }
+  },
+  "include": ["./src"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,7 @@
         "tsx": "^4.19.1",
         "typescript": "5.6.3",
         "vite": "^5.4.14",
+        "vite-tsconfig-paths": "file:tools/vite-tsconfig-paths",
         "vitest": "3.2.4"
       },
       "engines": {
@@ -141,6 +142,11 @@
       "optionalDependencies": {
         "bufferutil": "^4.0.8"
       }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "0.0.0-local",
+      "resolved": "file:tools/vite-tsconfig-paths",
+      "dev": true
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
     "vite": "^5.4.14",
+    "vite-tsconfig-paths": "file:tools/vite-tsconfig-paths",
     "vitest": "3.2.4"
   },
   "optionalDependencies": {

--- a/tools/vite-tsconfig-paths/index.js
+++ b/tools/vite-tsconfig-paths/index.js
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const normalizePattern = (pattern) => pattern.replace(/\/\*$/, "");
+
+const resolveTarget = (projectDir, baseUrl, target) => {
+  const withoutGlob = target.replace(/\/\*$/, "");
+  const resolvedBase = baseUrl ? path.resolve(projectDir, baseUrl) : projectDir;
+  return path.resolve(resolvedBase, withoutGlob);
+};
+
+export default function tsconfigPaths(options = {}) {
+  const projects = Array.isArray(options.projects) ? options.projects : [];
+  return {
+    name: "local-tsconfig-paths",
+    config() {
+      const alias = {};
+
+      for (const projectEntry of projects) {
+        if (!projectEntry) continue;
+        const tsconfigPath = path.resolve(projectEntry);
+        if (!fs.existsSync(tsconfigPath)) continue;
+
+        const projectDir = path.dirname(tsconfigPath);
+        let content;
+        try {
+          content = JSON.parse(fs.readFileSync(tsconfigPath, "utf8"));
+        } catch (error) {
+          continue;
+        }
+
+        const compilerOptions = content?.compilerOptions ?? {};
+        const baseUrl = compilerOptions.baseUrl ?? "";
+        const paths = compilerOptions.paths ?? {};
+
+        for (const [pattern, mappings] of Object.entries(paths)) {
+          if (!Array.isArray(mappings) || mappings.length === 0) continue;
+          const target = mappings[0];
+          if (typeof target !== "string" || target.length === 0) continue;
+
+          const key = normalizePattern(pattern);
+          const resolved = resolveTarget(projectDir, baseUrl, target);
+          alias[key] = resolved;
+        }
+      }
+
+      return { resolve: { alias } };
+    },
+  };
+}

--- a/tools/vite-tsconfig-paths/package.json
+++ b/tools/vite-tsconfig-paths/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "vite-tsconfig-paths",
+  "version": "0.0.0-local",
+  "type": "module",
+  "main": "index.js"
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,11 +2,15 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [
     react(),
     runtimeErrorOverlay(),
+    tsconfigPaths({
+      projects: [path.resolve(import.meta.dirname, "client", "tsconfig.json")],
+    }),
     ...(process.env.NODE_ENV !== "production" &&
     process.env.REPL_ID !== undefined
       ? [


### PR DESCRIPTION
## Summary
- add a client tsconfig with shared path aliases for the frontend
- wire up a local vite-tsconfig-paths plugin and enable it in the Vite config
- update client code and tests to consume @shared imports and NodeIOMetadata

## Testing
- npm run build:client *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e75abe38708331af2ec7e4e2976ba2