### PR TITLE
Add @shared alias mapping

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"],
+      "@shared": ["../shared/index.ts"],
       "@shared/*": ["../shared/*"],
       "@assets/*": ["../attached_assets/*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
     "types": ["node", "vite/client"],
     "paths": {
       "@/*": ["./client/src/*"],
+      "@shared": ["./shared/index.ts"],
       "@shared/*": ["./shared/*"]
     }
   }


### PR DESCRIPTION
## Summary
- add a direct `@shared` path mapping in both the client and root TypeScript configs so bare imports resolve correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7750fffdc83318216278248d8685a