### PR TITLE
Improve static client dist resolution

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -4,6 +4,16 @@ import path from "path";
 import { type Server } from "http";
 import { nanoid } from "nanoid";
 
+function resolveClientDistPath(): string | undefined {
+  const candidates = [
+    path.resolve(import.meta.dirname, "public"),
+    path.resolve(import.meta.dirname, "../dist/public"),
+    path.resolve(process.cwd(), "dist/public"),
+  ];
+
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
 function extractMissingModuleName(error: unknown): string | undefined {
   if (error && typeof error === "object" && "message" in error) {
     const message = String((error as Error).message);
@@ -124,11 +134,17 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const distPath = resolveClientDistPath();
 
-  if (!fs.existsSync(distPath)) {
+  if (!distPath) {
+    const expectedPaths = [
+      path.resolve(import.meta.dirname, "public"),
+      path.resolve(import.meta.dirname, "../dist/public"),
+      path.resolve(process.cwd(), "dist/public"),
+    ];
+
     throw new Error(
-      `Could not find the build directory: ${distPath}, make sure to build the client first`,
+      `Could not find the build directory. Checked: ${expectedPaths.join(", ")}. Make sure to build the client first.`,
     );
   }
 


### PR DESCRIPTION
## Summary
- add a helper in `server/vite.ts` to resolve the static client distribution directory by checking multiple candidate locations
- use the helper when configuring static serving and emit a clearer error if none of the candidates exist

## Testing
- `npm run build:client` *(fails: vite binary unavailable because npm install cannot complete in this environment)*
- `DISABLE_VITE=true npm run dev` *(blocked by the failed client build)*

------
https://chatgpt.com/codex/tasks/task_e_68e7bc79772483319ab7085504e3130c