### PR TITLE
Document inline worker local override

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,5 @@
+# Example local overrides for single-process development.
+# Enable the inline worker only on your workstation. Keep this flag disabled in production,
+# staging, or any shared environment that runs the multi-process scripts (`npm run dev:stack`,
+# docker compose, or the pm2 ecosystem).
+ENABLE_INLINE_WORKER=true

--- a/.gitignore
+++ b/.gitignore
@@ -7,15 +7,12 @@ vite.config.ts.*
 # Security and runtime artifacts
 .env
 .env.*
+!.env.local.example
 !.env.example
 *.log
 logs/
 .temp-deployments/
+
 .data/
-.env
-
-.env
-.env.*
-
 configs/connector-smoke.config.json
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ npm run dev:stack
 - `npm run dev:timers`
 - `npm run dev:rotation`
 
-Inline worker is disabled in this mode, so queue health maps to the dedicated worker process.
+Inline worker is disabled in this mode, so queue health maps to the dedicated worker process. When you do need to collapse the
+API and execution worker into a single process for quick debugging, create `.env.local` alongside `.env.development` and set
+`ENABLE_INLINE_WORKER=true` (see `.env.local.example`). The API loads `.env.local` last so the override applies only to your
+machine. Remember to delete or flip the flag before committing changes or running the multi-process commands that shared
+environments rely on—`npm run dev:stack`, `npm run dev:worker`, and the production `pm2` scripts all expect the inline worker to
+stay disabled.
 
 ### Split-process development
 


### PR DESCRIPTION
## Summary
- Document how to enable the inline worker via `.env.local` for single-process debugging while keeping it disabled for shared environments.
- Reference the multi-process scripts that require the flag to remain off and point to the new `.env.local.example` helper snippet.
- Allow `.env.local.example` to be committed so developers can quickly copy the local override guidance.

## Testing
- Not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68e7d7bfef988331b7e8dba9552e010e