### PR TITLE
Allow fallback worker heartbeat to satisfy run gating

### DIFF
--- a/client/src/components/workflow/__tests__/ProfessionalGraphEditor.layout.test.tsx
+++ b/client/src/components/workflow/__tests__/ProfessionalGraphEditor.layout.test.tsx
@@ -65,9 +65,29 @@ vi.mock("@/hooks/useQueueHealth", () => ({
 
 vi.mock("@/hooks/useWorkerHeartbeat", () => ({
   useWorkerHeartbeat: () => ({
+    workers: [],
     environmentWarnings: [],
-    summary: { hasExecutionWorker: true, schedulerHealthy: true, timerHealthy: true },
+    summary: {
+      totalWorkers: 1,
+      healthyWorkers: 1,
+      staleWorkers: 0,
+      totalQueueDepth: 0,
+      maxQueueDepth: 0,
+      hasExecutionWorker: true,
+      schedulerHealthy: true,
+      timerHealthy: true,
+      usesPublicHeartbeat: false,
+      queueStatus: null,
+      queueDurable: null,
+      queueMessage: null,
+    },
+    scheduler: null,
+    queue: null,
+    source: 'admin',
+    lastUpdated: new Date().toISOString(),
     isLoading: false,
+    error: null,
+    refresh: vi.fn(),
   }),
   WORKER_FLEET_GUIDANCE: "Start the worker fleet to enable executions.",
 }));

--- a/client/src/components/workflow/__tests__/ProfessionalGraphEditor.validation.test.tsx
+++ b/client/src/components/workflow/__tests__/ProfessionalGraphEditor.validation.test.tsx
@@ -191,9 +191,14 @@ beforeEach(() => {
       hasExecutionWorker: true,
       schedulerHealthy: true,
       timerHealthy: true,
+      usesPublicHeartbeat: false,
+      queueStatus: null,
+      queueDurable: null,
+      queueMessage: null,
     },
     scheduler: null,
     queue: null,
+    source: 'admin',
     lastUpdated: new Date().toISOString(),
     isLoading: false,
     error: null,
@@ -867,26 +872,31 @@ describe("ProfessionalGraphEditor validation gating", () => {
   });
 
   it('disables the run button when worker telemetry reports no active workers', async () => {
-    workerHeartbeatMock.mockReturnValue({
-      workers: [],
-      environmentWarnings: [],
-      summary: {
-        totalWorkers: 0,
-        healthyWorkers: 0,
-        staleWorkers: 0,
-        totalQueueDepth: 0,
-        maxQueueDepth: 0,
-        hasExecutionWorker: false,
-        schedulerHealthy: false,
-        timerHealthy: false,
-      },
-      scheduler: null,
-      queue: null,
-      lastUpdated: new Date().toISOString(),
-      isLoading: false,
-      error: null,
-      refresh: vi.fn(),
-    });
+  workerHeartbeatMock.mockReturnValue({
+    workers: [],
+    environmentWarnings: [],
+    summary: {
+      totalWorkers: 0,
+      healthyWorkers: 0,
+      staleWorkers: 0,
+      totalQueueDepth: 0,
+      maxQueueDepth: 0,
+      hasExecutionWorker: false,
+      schedulerHealthy: false,
+      timerHealthy: false,
+      usesPublicHeartbeat: false,
+      queueStatus: null,
+      queueDurable: null,
+      queueMessage: null,
+    },
+    scheduler: null,
+    queue: null,
+    source: 'admin',
+    lastUpdated: new Date().toISOString(),
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+  });
 
     const { default: ProfessionalGraphEditor } = await loadEditor();
     render(<ProfessionalGraphEditor />);

--- a/client/src/hooks/__tests__/useWorkerHeartbeat.test.ts
+++ b/client/src/hooks/__tests__/useWorkerHeartbeat.test.ts
@@ -56,6 +56,9 @@ describe('useWorkerHeartbeat fallback handling', () => {
     expect(result.current.environmentWarnings).toHaveLength(1);
     expect(result.current.environmentWarnings[0].message).toBe('Detected stale heartbeat');
     expect(result.current.summary.staleWorkers).toBe(1);
+    expect(result.current.summary.usesPublicHeartbeat).toBe(true);
+    expect(result.current.summary.queueStatus).toBe('warn');
+    expect(result.current.summary.queueDurable).toBeNull();
   });
 
   it('adds a stale heartbeat warning when the fallback reports a pass status', async () => {
@@ -67,6 +70,7 @@ describe('useWorkerHeartbeat fallback handling', () => {
         jsonResponse({
           status: { status: 'pass', message: 'Execution worker healthy' },
           worker: { id: 'exec-2', latestHeartbeatAt: staleHeartbeat },
+          durable: true,
           queueDepths: {
             default: { waiting: 0, delayed: 0, active: 0, paused: 0 },
           },
@@ -91,5 +95,8 @@ describe('useWorkerHeartbeat fallback handling', () => {
       'Execution worker heartbeat is stale; check that the worker process is running.',
     );
     expect(result.current.summary.staleWorkers).toBe(1);
+    expect(result.current.summary.queueStatus).toBe('pass');
+    expect(result.current.summary.queueDurable).toBe(true);
+    expect(result.current.summary.queueMessage).toBe('Execution worker healthy');
   });
 });


### PR DESCRIPTION
## Summary
- extend the worker heartbeat hook with queue health metadata, source tracking, and fallback-aware summary fields
- relax run button gating in the AI and professional graph builders to rely on healthy heartbeats plus queue status while surfacing scheduler notices non-blockingly
- refresh hook and UI tests to cover admin versus public heartbeat scenarios and durability overrides

## Testing
- ⚠️ `npx vitest run client/src/hooks/__tests__/useWorkerHeartbeat.test.ts` *(fails: npm registry access returns 403 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e7db6000b08331b55f2db6d2381c38