### PR TITLE
Update metadata resolve workflow client and tests

### DIFF
--- a/client/src/components/workflow/__tests__/SmartParametersPanel.ui.test.tsx
+++ b/client/src/components/workflow/__tests__/SmartParametersPanel.ui.test.tsx
@@ -1,9 +1,30 @@
 import React from "react";
-import { describe, expect, it, beforeEach, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+
+const extractUrl = (request: RequestInfo | URL): string => {
+  if (typeof request === "string") return request;
+  if (request instanceof URL) return request.toString();
+  if (typeof Request !== "undefined" && request instanceof Request) {
+    return request.url;
+  }
+  return String(request);
+};
+
+const createJsonResponse = (body: any, status = 200) =>
+  Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  } as Response);
 
 const mockNodes: any[] = [];
 const mockEdges: any[] = [];
+
+const originalFetch = global.fetch;
+let fetchMock: vi.Mock;
 
 vi.mock("reactflow", async () => {
   const actual = await vi.importActual<any>("reactflow");
@@ -33,6 +54,13 @@ describe("SmartParametersPanel metadata-driven UI", () => {
   beforeEach(() => {
     mockNodes.splice(0, mockNodes.length);
     mockEdges.splice(0, mockEdges.length);
+    fetchMock = vi.fn((input: RequestInfo | URL) => createJsonResponse({}));
+    global.fetch = fetchMock as any;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
   });
 
   it("surfaces quick picks and preview payloads from normalized metadata", async () => {
@@ -88,5 +116,101 @@ describe("SmartParametersPanel metadata-driven UI", () => {
     fireEvent.click(previewToggle);
     expect(screen.getByText(/"email": "ada@example.com"/i)).toBeInTheDocument();
     expect(screen.queryByText(/metadata .* unavailable/i)).not.toBeInTheDocument();
+  });
+
+  it("posts metadata resolution requests and applies sheet extras", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = extractUrl(input);
+      if (url === "/api/ai/models") {
+        return createJsonResponse({ providers: { available: [] } });
+      }
+      if (url.startsWith("/api/google/sheets/")) {
+        return createJsonResponse({ sheets: [] });
+      }
+      if (url === "/api/metadata/resolve") {
+        return createJsonResponse({
+          success: true,
+          connector: "google-sheets",
+          metadata: { columns: ["server-email"] },
+          extras: { tabs: ["Server Tab", "Archive"] },
+          warnings: ["Sample warning"],
+        });
+      }
+      return createJsonResponse({});
+    });
+
+    mockNodes.push({
+      id: "selected",
+      type: "action",
+      selected: true,
+      data: {
+        label: "Sheets Destination",
+        app: "google-sheets",
+        actionId: "append_row",
+        parameters: { spreadsheetId: "sheet-123", sheet: "", range: "" },
+        metadata: {
+          schema: {
+            spreadsheetId: { type: "string", title: "Spreadsheet" },
+            sheet: { type: "string", title: "Sheet" },
+            range: { type: "string", title: "Range" },
+          },
+        },
+      },
+    });
+
+    render(<SmartParametersPanel />);
+
+    await screen.findByText(/Spreadsheet/);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("automation:connection-selected", {
+          detail: {
+            nodeId: "selected",
+            params: { spreadsheetId: "sheet-123", sheet: "", range: "" },
+            reason: "test-refresh",
+          },
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      const metadataCall = fetchMock.mock.calls.find(([request]) =>
+        extractUrl(request).includes("/api/metadata/resolve"),
+      );
+      expect(metadataCall).toBeTruthy();
+    });
+
+    const metadataCall = fetchMock.mock.calls.find(([request]) =>
+      extractUrl(request).includes("/api/metadata/resolve"),
+    )!;
+    const metadataInit = metadataCall[1] as RequestInit | undefined;
+    const bodyText =
+      typeof metadataInit?.body === "string"
+        ? metadataInit.body
+        : metadataInit?.body instanceof URLSearchParams
+          ? metadataInit.body.toString()
+          : metadataInit?.body
+            ? String(metadataInit.body)
+            : "";
+    const parsedBody = bodyText ? JSON.parse(bodyText) : {};
+
+    expect(parsedBody).toMatchObject({
+      connector: "google-sheets",
+      params: expect.objectContaining({ spreadsheetId: "sheet-123" }),
+    });
+    expect(parsedBody.options).toMatchObject({
+      nodeId: "selected",
+    });
+    expect(parsedBody).not.toHaveProperty("credentials");
+
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: "Server Tab" })).toBeInTheDocument(),
+    );
+
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- point SmartParametersPanel metadata refresh at `/api/metadata/resolve` and build connector-aware request bodies that capture warnings and extras
- merge resolved metadata, warnings, and extras into local state while applying returned sheet tabs to the parameter schema
- extend the SmartParametersPanel UI test harness to cover the new API contract and verify extras render in the sheet field

## Testing
- npx vitest run client/src/components/workflow/__tests__/SmartParametersPanel.ui.test.tsx *(fails: npm registry access forbidden in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e7daf5ca108331922c299d36ad2c07