### PR TITLE
Handle dev connections in metadata route

### DIFF
--- a/server/routes/metadata.ts
+++ b/server/routes/metadata.ts
@@ -162,7 +162,21 @@ router.post(
     let credentials: Record<string, any> = { ...inlineCredentials };
 
     if (connectionId) {
-      const connection = await connectionService.getConnection(String(connectionId), userId, organizationId);
+      const connectionIdString = String(connectionId).trim();
+      const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(connectionIdString);
+      const isDevUserPlaceholder = connectionIdString === 'dev-user';
+
+      if (!isUuid || isDevUserPlaceholder) {
+        return res.status(200).json({
+          success: false,
+          error: 'CONNECTION_NOT_FOUND_DEV',
+          warnings: [
+            'The requested connection is unavailable in the current development environment.',
+          ],
+        });
+      }
+
+      const connection = await connectionService.getConnection(connectionIdString, userId, organizationId);
       if (!connection) {
         return res.status(404).json({ success: false, error: 'CONNECTION_NOT_FOUND' });
       }


### PR DESCRIPTION
## Summary
- short circuit metadata resolve route for non-UUID or dev-user connection identifiers
- return a development-friendly CONNECTION_NOT_FOUND_DEV response when skipping lookups
- keep existing database lookup and error handling for valid connection identifiers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e87fe524a883319bd1d9e5f9afcc64