### PR TITLE
Add runtime selection for builder runs

### DIFF
--- a/client/src/components/ai/__tests__/N8NStyleWorkflowBuilder.toolbar.test.tsx
+++ b/client/src/components/ai/__tests__/N8NStyleWorkflowBuilder.toolbar.test.tsx
@@ -33,6 +33,16 @@ vi.mock('@/hooks/useWorkerHeartbeat', () => ({
   WORKER_FLEET_GUIDANCE: 'Start the execution worker and scheduler processes to run workflows.',
 }));
 
+vi.mock('@/hooks/useRuntimeCapabilityIndex', () => ({
+  useRuntimeCapabilityIndex: () => ({
+    capabilities: {},
+    index: {},
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
 vi.mock('@/components/workflow/NodeConfigurationModal', () => ({
   NodeConfigurationModal: () => null,
 }));
@@ -173,7 +183,7 @@ describe('N8NStyleWorkflowBuilder toolbar gating', () => {
       expect(authFetchMock).toHaveBeenCalled();
     });
 
-    const runButton = await screen.findByRole('button', { name: /run workflow/i });
+    const runButton = await screen.findByRole('button', { name: /run in/i });
     await waitFor(() => {
       expect(runButton).toBeDisabled();
     });
@@ -226,7 +236,7 @@ describe('N8NStyleWorkflowBuilder toolbar gating', () => {
     const { default: Builder } = await import('../N8NStyleWorkflowBuilder');
     render(<Builder />);
 
-    const runButton = await screen.findByRole('button', { name: /run workflow/i });
+    const runButton = await screen.findByRole('button', { name: /run in/i });
     await waitFor(() => {
       expect(runButton).not.toBeDisabled();
     });
@@ -251,7 +261,7 @@ describe('N8NStyleWorkflowBuilder toolbar gating', () => {
     const { default: Builder } = await import('../N8NStyleWorkflowBuilder');
     render(<Builder />);
 
-    const runButton = await screen.findByRole('button', { name: /run workflow/i });
+    const runButton = await screen.findByRole('button', { name: /run in/i });
     await waitFor(() => {
       expect(runButton).not.toBeDisabled();
     });
@@ -301,7 +311,7 @@ describe('N8NStyleWorkflowBuilder toolbar gating', () => {
     const { default: Builder } = await import('../N8NStyleWorkflowBuilder');
     render(<Builder />);
 
-    const runButton = await screen.findByRole('button', { name: /run workflow/i });
+    const runButton = await screen.findByRole('button', { name: /run in/i });
     await waitFor(() => {
       expect(runButton).not.toBeDisabled();
     });
@@ -337,7 +347,7 @@ describe('N8NStyleWorkflowBuilder toolbar gating', () => {
     const { default: Builder } = await import('../N8NStyleWorkflowBuilder');
     render(<Builder />);
 
-    const runButton = await screen.findByRole('button', { name: /run workflow/i });
+    const runButton = await screen.findByRole('button', { name: /run in/i });
     await waitFor(() => {
       expect(runButton).toBeDisabled();
     });
@@ -362,7 +372,7 @@ describe('N8NStyleWorkflowBuilder toolbar gating', () => {
       expect(authFetchMock).toHaveBeenCalled();
     });
 
-    const runButton = await screen.findByRole('button', { name: /run workflow/i });
+    const runButton = await screen.findByRole('button', { name: /run in/i });
     await waitFor(() => {
       expect(runButton).toBeDisabled();
     });

--- a/client/src/hooks/useRuntimeCapabilityIndex.ts
+++ b/client/src/hooks/useRuntimeCapabilityIndex.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  buildRuntimeCapabilityIndex,
+  createFallbackRuntimeCapabilities,
+  getRuntimeCapabilities,
+  mergeWithFallbackCapabilities,
+  type RuntimeCapabilityIndex,
+  type RuntimeCapabilityMap,
+} from '@/services/runtimeCapabilitiesService';
+import { useConnectorDefinitions } from './useConnectorDefinitions';
+
+interface UseRuntimeCapabilityIndexResult {
+  capabilities: RuntimeCapabilityMap;
+  index: RuntimeCapabilityIndex;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export const useRuntimeCapabilityIndex = (): UseRuntimeCapabilityIndexResult => {
+  const { data: connectorDefinitions, loading: connectorDefinitionsLoading, error: connectorDefinitionsError } =
+    useConnectorDefinitions();
+  const [capabilities, setCapabilities] = useState<RuntimeCapabilityMap>(() => createFallbackRuntimeCapabilities());
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const loaded = await getRuntimeCapabilities();
+      setCapabilities(mergeWithFallbackCapabilities(loaded));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setCapabilities(createFallbackRuntimeCapabilities());
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const index = useMemo(
+    () => buildRuntimeCapabilityIndex(capabilities, connectorDefinitions ?? null),
+    [capabilities, connectorDefinitions],
+  );
+
+  const combinedLoading = loading || connectorDefinitionsLoading;
+  const combinedError = error ?? (connectorDefinitionsError ? connectorDefinitionsError.message : null);
+
+  return {
+    capabilities,
+    index,
+    loading: combinedLoading,
+    error: combinedError,
+    refresh,
+  };
+};

--- a/client/src/services/executions.ts
+++ b/client/src/services/executions.ts
@@ -1,4 +1,5 @@
 import { authStore } from '@/store/authStore';
+import type { RuntimeKey } from '@shared/runtimes';
 
 export type ExecutionTriggerType = string;
 
@@ -6,6 +7,7 @@ export type EnqueueExecutionParams = {
   workflowId: string;
   triggerType: ExecutionTriggerType;
   initialData: unknown;
+  runtime?: RuntimeKey;
 };
 
 export type EnqueueExecutionResult = {
@@ -50,12 +52,18 @@ export const enqueueExecution = async ({
   workflowId,
   triggerType,
   initialData,
+  runtime,
 }: EnqueueExecutionParams): Promise<EnqueueExecutionResult> => {
   const { authFetch } = authStore.getState();
 
+  const payload: Record<string, any> = { workflowId, triggerType, initialData };
+  if (runtime) {
+    payload.runtime = runtime;
+  }
+
   const response = await authFetch('/api/executions', {
     method: 'POST',
-    body: JSON.stringify({ workflowId, triggerType, initialData }),
+    body: JSON.stringify(payload),
   });
 
   const result = (await response.json().catch(() => ({}))) as Record<string, any>;


### PR DESCRIPTION
## Summary
- add a reusable hook that loads the runtime capability index with connector fallbacks
- detect Apps Script-incompatible nodes in the N8N builder, surface a runtime toggle, and send the chosen runtime when enqueueing runs
- extend the execution service/tests to accept an optional runtime field on manual runs

## Testing
- `npx vitest run client/src/services/__tests__/executions.test.ts` *(fails: npm registry access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e87feb19d48331ba88a8c03a5fcdaa