### PR TITLE
Ensure Apps Script runtime flag propagates to deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ CONNECTOR_SIMULATOR_ENABLED=false
 ALLOW_PLAINTEXT_TOKENS_IN_DEV=false
 CONNECTOR_SIMULATOR_FIXTURES_DIR=server/testing/fixtures
 
+# Runtime feature toggles
+RUNTIME_APPS_SCRIPT_ENABLED=true
+
 # Queue / Redis configuration
 # Defaults align with `server/env.ts`. Override if running Redis in Docker using
 # the compose file (e.g. set to `redis`) or a remote instance.

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
-web: node dist/index.js
-worker: node dist/workers/execution.js
-scheduler: node dist/workers/scheduler.js
-timers: node dist/workers/timerDispatcher.js
-encryption-rotation: node dist/workers/encryption-rotation.js
+web: RUNTIME_APPS_SCRIPT_ENABLED=true node dist/index.js
+worker: RUNTIME_APPS_SCRIPT_ENABLED=true node dist/workers/execution.js
+scheduler: RUNTIME_APPS_SCRIPT_ENABLED=true node dist/workers/scheduler.js
+timers: RUNTIME_APPS_SCRIPT_ENABLED=true node dist/workers/timerDispatcher.js
+encryption-rotation: RUNTIME_APPS_SCRIPT_ENABLED=true node dist/workers/encryption-rotation.js

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -6,6 +6,7 @@
   - Configure OAuth client IDs/secrets in deployment environment; never commit .env.
   - Prefer managed secrets: set `SECRET_MANAGER_PROVIDER=aws` and populate AWS Secrets Manager as described in [operations/secret-management](./operations/secret-management.md).
   - Ensure DATABASE_URL is set for persistence.
+  - Set `RUNTIME_APPS_SCRIPT_ENABLED` (defaults to `true`) so API and workers advertise the Apps Script runtime. Override to `false` if the environment should hide Apps Script capabilities.
 - Rate limits
   - See GET /api/status/rate-limits for derived vendor limits; adjust reverse proxy if needed.
 - Health checks

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -4,6 +4,7 @@ const sharedQueueEnv = (() => {
     QUEUE_REDIS_HOST: process.env.QUEUE_REDIS_HOST ?? '127.0.0.1',
     QUEUE_REDIS_PORT: process.env.QUEUE_REDIS_PORT ?? '6379',
     QUEUE_REDIS_DB: process.env.QUEUE_REDIS_DB ?? '0',
+    RUNTIME_APPS_SCRIPT_ENABLED: process.env.RUNTIME_APPS_SCRIPT_ENABLED ?? 'true',
   };
 
   if (process.env.QUEUE_REDIS_USERNAME) {


### PR DESCRIPTION
## Summary
- default RUNTIME_APPS_SCRIPT_ENABLED to true in the shared PM2 environment block
- propagate the runtime flag to Procfile processes and document the requirement for operators
- surface the variable in .env.example so deployers configure the Apps Script capability explicitly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8969427cc83319890e360380d3b65