### PR TITLE
Add runtime capability refresh control and smoke test

### DIFF
--- a/client/src/components/ai/N8NStyleWorkflowBuilder.tsx
+++ b/client/src/components/ai/N8NStyleWorkflowBuilder.tsx
@@ -31,6 +31,7 @@ import {
   Brain,
   Sparkles,
   Loader2,
+  RefreshCw,
   Settings,
   Play,
   Save,
@@ -72,6 +73,12 @@ import {
   sanitizeAnalyticsOperationId,
   trackAnalyticsEvent,
 } from '@/lib/analytics';
+
+declare global {
+  interface Window {
+    __runtimeCapabilitiesRefresh?: () => Promise<void>;
+  }
+}
 
 // N8N-Style Custom Node Component (visual only; configuration handled by parent modal)
 const N8NNode: React.FC<NodeProps<any>> = ({ data }) => {
@@ -346,7 +353,23 @@ export const N8NStyleWorkflowBuilder: React.FC = () => {
     capabilities: runtimeCapabilities,
     index: runtimeCapabilityIndex,
     loading: runtimeCapabilitiesLoading,
+    refresh: refreshRuntimeCapabilities,
   } = useRuntimeCapabilityIndex();
+  const forceRefreshRuntimeCapabilities = useCallback(
+    () => refreshRuntimeCapabilities(true),
+    [refreshRuntimeCapabilities],
+  );
+  const handleRuntimeRefreshClick = useCallback(() => {
+    void forceRefreshRuntimeCapabilities();
+  }, [forceRefreshRuntimeCapabilities]);
+  useEffect(() => {
+    window.__runtimeCapabilitiesRefresh = forceRefreshRuntimeCapabilities;
+    return () => {
+      if (window.__runtimeCapabilitiesRefresh === forceRefreshRuntimeCapabilities) {
+        delete window.__runtimeCapabilitiesRefresh;
+      }
+    };
+  }, [forceRefreshRuntimeCapabilities]);
   const runtimeSelectionWasManualRef = useRef(false);
   const appsScriptDisableAnalyticsRef = useRef<string | null>(null);
   const [selectedRuntime, setSelectedRuntime] = useState<RuntimeKey>('appsScript');
@@ -609,6 +632,29 @@ export const N8NStyleWorkflowBuilder: React.FC = () => {
     </Tooltip>
   ) : (
     runtimeToggle
+  );
+  const runtimeRefreshButton = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="text-xs text-gray-300 hover:text-white"
+      onClick={handleRuntimeRefreshClick}
+      disabled={runtimeCapabilitiesLoading}
+    >
+      {runtimeCapabilitiesLoading ? (
+        <Loader2 className="w-3 h-3 mr-2 animate-spin" />
+      ) : (
+        <RefreshCw className="w-3 h-3 mr-2" />
+      )}
+      Refresh runtime support
+    </Button>
+  );
+  const runtimeControls = (
+    <div className="flex items-center gap-2">
+      {runtimeToggleControl}
+      {runtimeRefreshButton}
+    </div>
   );
 
   const queueBadgeLabel = queueDurabilityBypassed
@@ -1824,7 +1870,7 @@ export const N8NStyleWorkflowBuilder: React.FC = () => {
               </TooltipContent>
             </Tooltip>
 
-            {runtimeToggleControl}
+            {runtimeControls}
 
             {runDisableReason ? (
               <Tooltip>

--- a/client/src/components/ai/__tests__/N8NStyleWorkflowBuilder.runtimeRefresh.test.tsx
+++ b/client/src/components/ai/__tests__/N8NStyleWorkflowBuilder.runtimeRefresh.test.tsx
@@ -1,0 +1,256 @@
+import React from 'react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const authFetchMock = vi.fn<typeof fetch>();
+const logoutMock = vi.fn();
+const isDevIgnoreQueueEnabledMock = vi.fn(() => false);
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: (selector: any) => {
+    const state = {
+      token: 'token',
+      authFetch: authFetchMock,
+      logout: logoutMock,
+    };
+    return selector ? selector(state) : state;
+  },
+}));
+
+const queueHealthMock = vi.fn();
+vi.mock('@/hooks/useQueueHealth', () => ({
+  useQueueHealth: (...args: any[]) => queueHealthMock(...args),
+}));
+
+vi.mock('@/config/featureFlags', () => ({
+  isDevIgnoreQueueEnabled: (...args: any[]) => isDevIgnoreQueueEnabledMock(...args),
+}));
+
+const workerHeartbeatMock = vi.fn();
+vi.mock('@/hooks/useWorkerHeartbeat', () => ({
+  useWorkerHeartbeat: (...args: any[]) => workerHeartbeatMock(...args),
+  WORKER_FLEET_GUIDANCE: 'Start the execution worker and scheduler processes to run workflows.',
+}));
+
+vi.mock('@/components/workflow/NodeConfigurationModal', () => ({
+  NodeConfigurationModal: () => null,
+}));
+
+vi.mock('reactflow/dist/style.css', () => ({}), { virtual: true });
+
+const runtimeRefreshSpy = vi.fn<(force?: boolean) => void>();
+const runtimeState: {
+  setSnapshot?: React.Dispatch<React.SetStateAction<{ capabilities: Record<string, unknown>; index: Record<string, unknown> }>>;
+  setLoading?: React.Dispatch<React.SetStateAction<boolean>>;
+  onRefresh?: (force?: boolean) => Promise<void> | void;
+} = {};
+
+vi.mock('@/hooks/useRuntimeCapabilityIndex', () => {
+  const React = require('react');
+  return {
+    useRuntimeCapabilityIndex: () => {
+      const [snapshot, setSnapshot] = React.useState({
+        capabilities: { unsupported: true } as Record<string, unknown>,
+        index: { unsupported: true } as Record<string, unknown>,
+      });
+      const [loading, setLoading] = React.useState(false);
+
+      React.useEffect(() => {
+        runtimeState.setSnapshot = setSnapshot;
+        runtimeState.setLoading = setLoading;
+      }, [setSnapshot, setLoading]);
+
+      const refresh = React.useCallback(async (force?: boolean) => {
+        runtimeRefreshSpy(force);
+        runtimeState.setLoading?.(true);
+        if (runtimeState.onRefresh) {
+          await runtimeState.onRefresh(force);
+        }
+        runtimeState.setLoading?.(false);
+      }, []);
+
+      return {
+        capabilities: snapshot.capabilities,
+        index: snapshot.index,
+        loading,
+        error: null,
+        refresh,
+      };
+    },
+  };
+});
+
+let appsScriptSupported = false;
+const unsupportedDetection = {
+  node: { id: 'action-1' },
+  support: {
+    appId: 'test-app',
+    appLabel: 'Test App',
+    operationId: 'test-operation',
+    operationLabel: 'Test Operation',
+    kind: 'action',
+    fallbackRuntime: 'node',
+    reason: 'Apps Script is not available for this connector yet.',
+    mode: 'unavailable',
+  },
+};
+
+vi.mock('@/services/runtimeCapabilitiesService', async () => {
+  const actual = await vi.importActual<typeof import('@/services/runtimeCapabilitiesService')>(
+    '@/services/runtimeCapabilitiesService',
+  );
+  return {
+    ...actual,
+    findAppsScriptUnsupportedNode: vi.fn(() => (appsScriptSupported ? null : (unsupportedDetection as any))),
+  };
+});
+
+const jsonResponse = (body: any, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const sampleDraft = {
+  id: 'draft-1',
+  name: 'Draft Workflow',
+  nodes: [
+    {
+      id: 'trigger-1',
+      type: 'n8nNode',
+      position: { x: 0, y: 0 },
+      data: {
+        app: 'core',
+        label: 'Manual Trigger',
+        function: 'core.manual',
+        configured: true,
+      },
+    },
+    {
+      id: 'action-1',
+      type: 'n8nNode',
+      position: { x: 320, y: 0 },
+      data: {
+        app: 'gmail',
+        label: 'Send Email',
+        function: 'gmail.send',
+        connectionId: 'conn-1',
+        auth: { connectionId: 'conn-1' },
+        configured: true,
+        parameters: {},
+      },
+    },
+  ],
+  edges: [
+    { id: 'edge-1', source: 'trigger-1', target: 'action-1' },
+  ],
+};
+
+describe('N8NStyleWorkflowBuilder runtime capability refresh', () => {
+  beforeEach(() => {
+    appsScriptSupported = false;
+    runtimeRefreshSpy.mockClear();
+    runtimeState.onRefresh = undefined;
+    queueHealthMock.mockReset();
+    workerHeartbeatMock.mockReset();
+    authFetchMock.mockReset();
+    logoutMock.mockReset();
+    localStorage.clear();
+    localStorage.setItem('automation.builder.draft', JSON.stringify(sampleDraft));
+    (global as any).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    isDevIgnoreQueueEnabledMock.mockReturnValue(false);
+    queueHealthMock.mockReturnValue({
+      health: {
+        status: 'pass',
+        durable: true,
+        message: 'Queue ready',
+        latencyMs: 5,
+        checkedAt: new Date().toISOString(),
+      },
+      status: 'pass',
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+    workerHeartbeatMock.mockReturnValue({
+      workers: [],
+      environmentWarnings: [],
+      summary: {
+        totalWorkers: 1,
+        healthyWorkers: 1,
+        staleWorkers: 0,
+        totalQueueDepth: 0,
+        maxQueueDepth: 0,
+        hasExecutionWorker: true,
+        schedulerHealthy: true,
+        timerHealthy: true,
+        usesPublicHeartbeat: false,
+        queueStatus: null,
+        queueDurable: null,
+        queueMessage: null,
+      },
+      scheduler: null,
+      queue: null,
+      source: 'admin',
+      lastUpdated: new Date().toISOString(),
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+    authFetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/workflows/validate')) {
+        return Promise.resolve(
+          jsonResponse({ success: true, validation: { valid: true, errors: [], warnings: [] } }),
+        );
+      }
+      return Promise.resolve(jsonResponse({ success: true }));
+    });
+  });
+
+  afterEach(() => {
+    queueHealthMock.mockReset();
+    workerHeartbeatMock.mockReset();
+    authFetchMock.mockReset();
+    localStorage.clear();
+    isDevIgnoreQueueEnabledMock.mockReset();
+  });
+
+  it('forces a runtime capability refresh and updates the selector when capabilities change', async () => {
+    const user = userEvent.setup();
+    const { default: Builder } = await import('../N8NStyleWorkflowBuilder');
+    render(<Builder />);
+
+    const appsScriptToggle = await screen.findByRole('button', { name: /apps script/i });
+    await waitFor(() => {
+      expect(appsScriptToggle).toBeDisabled();
+    });
+
+    runtimeState.onRefresh = async () => {
+      appsScriptSupported = true;
+      runtimeState.setSnapshot?.({
+        capabilities: { supported: true } as Record<string, unknown>,
+        index: { supported: true } as Record<string, unknown>,
+      });
+    };
+
+    const refreshButton = await screen.findByRole('button', { name: /refresh runtime support/i });
+    await user.click(refreshButton);
+
+    await waitFor(() => {
+      expect(runtimeRefreshSpy).toHaveBeenCalledWith(true);
+    });
+
+    await waitFor(() => {
+      expect(appsScriptToggle).not.toBeDisabled();
+    });
+
+    expect(window.__runtimeCapabilitiesRefresh).toBeTypeOf('function');
+  });
+});

--- a/client/src/hooks/useRuntimeCapabilityIndex.ts
+++ b/client/src/hooks/useRuntimeCapabilityIndex.ts
@@ -14,7 +14,7 @@ interface UseRuntimeCapabilityIndexResult {
   index: RuntimeCapabilityIndex;
   loading: boolean;
   error: string | null;
-  refresh: () => Promise<void>;
+  refresh: (forceRefresh?: boolean) => Promise<void>;
 }
 
 export const useRuntimeCapabilityIndex = (): UseRuntimeCapabilityIndexResult => {
@@ -24,11 +24,11 @@ export const useRuntimeCapabilityIndex = (): UseRuntimeCapabilityIndexResult => 
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (forceRefresh = false) => {
     setLoading(true);
     setError(null);
     try {
-      const loaded = await getRuntimeCapabilities();
+      const loaded = await getRuntimeCapabilities(forceRefresh);
       setCapabilities(mergeWithFallbackCapabilities(loaded));
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- expose a runtime capability refresh helper on the workflow builder and add a UI control for it
- update the runtime capability hook so forced refreshes bypass the cached registry response
- add a smoke test covering the refresh flow and runtime selector update

## Testing
- npx vitest run client/src/components/ai/__tests__/N8NStyleWorkflowBuilder.runtimeRefresh.test.tsx *(fails: registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8969bb324833188822fca3d1cf045