### PR TITLE
Replace Neon database client with node-postgres pools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ SERVER_PUBLIC_URL=http://localhost:5000
 # Database connection (PostgreSQL URL)
 # Format: postgres://USER:PASSWORD@HOST:PORT/DATABASE
 DATABASE_URL=postgres://postgres:postgres@postgres:5432/automation
+# Enable SSL when connecting to managed/cloud PostgreSQL providers
+# Set to "true" for providers that require TLS (Neon, Render, etc.). Leave unset/false for localhost.
+DATABASE_SSL=false
 
 # Authentication & encryption secrets (generate per developer)
 # Use a unique 32-byte base64 string, e.g. `openssl rand -base64 32`

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -19,6 +19,7 @@ This guide covers the quickest path to booting the platform locally with Docker 
    This script backfills strong random values for `ENCRYPTION_MASTER_KEY` and `JWT_SECRET`, matching the minimum length enforced by `EncryptionService`.
 3. Edit `.env.development` to match your local setup. Fill in any provider API keys you plan to exercise (OpenAI, Anthropic, Claude, Google, Gemini). Leave them blank to disable those integrations locally.
    The runtime now records whether a key came from AWS Secrets Manager, a local `.env` file, or the deterministic development fallback—check the admin-only `GET /api/health/credentials` endpoint when you need to confirm which secrets are active.
+   The database layer now uses the standard [`node-postgres`](https://node-postgres.com/) driver via Drizzle ORM—set `DATABASE_SSL=true` when pointing at a managed cloud database that enforces TLS and leave it `false` (the default) for localhost or Docker Compose.
 
 4. When you need single-process execution for quick debugging, create `.env.local` (ignored by git) next to `.env.development` and add `ENABLE_INLINE_WORKER=true`. The API resolves `.env.local` last, so the override remains local to your machine. A ready-to-copy snippet lives in `.env.local.example`. Remove the flag or set it back to `false` before pushing changes or running shared scripts such as `npm run dev:stack`, `npm run dev:worker`, or the production `pm2` ecosystem—those flows rely on the dedicated worker process.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@google/generative-ai": "0.24.1",
         "@hookform/resolvers": "^3.10.0",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "@neondatabase/serverless": "^0.10.4",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.52.0",
         "@opentelemetry/exporter-jaeger": "2.0.1",
@@ -3223,16 +3222,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@neondatabase/serverless": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.10.4.tgz",
-      "integrity": "sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/pg": "8.11.6"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@google/generative-ai": "0.24.1",
     "@hookform/resolvers": "^3.10.0",
     "@jridgewell/trace-mapping": "^0.3.25",
-    "@neondatabase/serverless": "^0.10.4",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.52.0",
     "@opentelemetry/exporter-jaeger": "2.0.1",

--- a/replit.md
+++ b/replit.md
@@ -25,7 +25,7 @@ Preferred communication style: Simple, everyday language.
 - **Storage Interface**: Abstract storage layer with in-memory implementation (ready for database expansion)
 
 ### Data Storage Solutions
-- **PostgreSQL with Drizzle ORM**: Configured for production database with Neon serverless driver
+- **PostgreSQL with Drizzle ORM**: Configured for production database using the Node Postgres driver
 - **Schema Definition**: Shared schema files using Drizzle with Zod validation
 - **Database Migrations**: Drizzle Kit for schema management and migrations
 - **Development Fallback**: In-memory storage implementation for development/testing
@@ -60,10 +60,9 @@ Preferred communication style: Simple, everyday language.
 - **Lucide React** for consistent iconography
 - **Class Variance Authority** for component variant management
 
-#### Backend and Database
 - **Express.js** for server framework
 - **Drizzle ORM** with PostgreSQL dialect
-- **@neondatabase/serverless** for PostgreSQL connection
+- **pg** (`node-postgres`) for PostgreSQL connection pooling
 - **Drizzle Kit** for database schema management
 - **Drizzle Zod** for runtime validation
 

--- a/server/routes/__tests__/executions-local-id.test.ts
+++ b/server/routes/__tests__/executions-local-id.test.ts
@@ -22,8 +22,9 @@ const originalEnqueue = executionQueueService.enqueue;
 
 (WorkflowRepository as any).saveWorkflowGraph = async (input: any) => {
   if (input.id && !uuidRegex.test(input.id)) {
-    const error = new Error('invalid input syntax for type uuid');
-    (error as any).name = 'NeonDbError';
+    const error = new Error(`invalid input syntax for type uuid: "${input.id}"`);
+    (error as any).name = 'error';
+    (error as any).code = '22P02';
     throw error;
   }
 


### PR DESCRIPTION
## Summary
- replace the drizzle Neon HTTP client with a pooled node-postgres client that respects a DATABASE_SSL toggle
- remove the Neon package, update fixtures/docs to describe the node-postgres driver, and adjust the execution route test error shape

## Testing
- npm install --omit=optional --no-fund --no-audit --progress=false *(fails: container terminates installation due to resource/time limits)*

------
https://chatgpt.com/codex/tasks/task_e_68e8c156303883318579b412131d45cf