### PR TITLE
Switch Drizzle client to pg pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ SERVER_PUBLIC_URL=http://localhost:5000
 # Database connection (PostgreSQL URL)
 # Format: postgres://USER:PASSWORD@HOST:PORT/DATABASE
 DATABASE_URL=postgres://postgres:postgres@postgres:5432/automation
+# Enable TLS when connecting to managed Postgres providers (e.g. Neon, RDS)
+# Accepts true/on/yes/1 (case-insensitive). Defaults to disabled for local stacks.
+DATABASE_SSL=false
 
 # Authentication & encryption secrets (generate per developer)
 # Use a unique 32-byte base64 string, e.g. `openssl rand -base64 32`

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Processes:
 - `timers`: `dist/workers/timerDispatcher.js`
 - `encryption-rotation`: `dist/workers/encryption-rotation.js`
 
-Ensure `DATABASE_URL`, `QUEUE_REDIS_*`, and secrets exist in the environment before starting.
+Ensure `DATABASE_URL`, `QUEUE_REDIS_*`, and secrets exist in the environment before starting. Set `DATABASE_SSL=true` (or `on`/`yes`/`1`) if your managed Postgres provider requires TLS.
 
 ## Webhooks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@google/generative-ai": "0.24.1",
         "@hookform/resolvers": "^3.10.0",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "@neondatabase/serverless": "^0.10.4",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.52.0",
         "@opentelemetry/exporter-jaeger": "2.0.1",
@@ -3223,16 +3222,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@neondatabase/serverless": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.10.4.tgz",
-      "integrity": "sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/pg": "8.11.6"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -10408,7 +10397,6 @@
         "@electric-sql/pglite": ">=0.2.0",
         "@libsql/client": ">=0.10.0",
         "@libsql/client-wasm": ">=0.10.0",
-        "@neondatabase/serverless": ">=0.10.0",
         "@op-engineering/op-sqlite": ">=2",
         "@opentelemetry/api": "^1.4.1",
         "@planetscale/database": ">=1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@google/generative-ai": "0.24.1",
     "@hookform/resolvers": "^3.10.0",
     "@jridgewell/trace-mapping": "^0.3.25",
-    "@neondatabase/serverless": "^0.10.4",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.52.0",
     "@opentelemetry/exporter-jaeger": "2.0.1",

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -1,5 +1,5 @@
-import { drizzle } from 'drizzle-orm/neon-http';
-import { neon } from '@neondatabase/serverless';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
 import {
   pgTable,
   text,
@@ -1612,8 +1612,16 @@ const schemaRegistry = {
 export type DatabaseSchema = typeof schemaRegistry;
 
 function createDrizzleClient(connectionString: string) {
-  const sql = neon(connectionString);
-  return drizzle(sql, { schema: schemaRegistry });
+  const sslEnabled =
+    typeof process.env.DATABASE_SSL === 'string' &&
+    ['1', 'true', 'yes', 'on'].includes(process.env.DATABASE_SSL.toLowerCase());
+
+  const pool = new Pool({
+    connectionString,
+    ssl: sslEnabled ? { rejectUnauthorized: false } : undefined,
+  });
+
+  return drizzle(pool, { schema: schemaRegistry });
 }
 
 // Database connection


### PR DESCRIPTION
## Summary
- switch the Drizzle client to use a pg Pool with an optional DATABASE_SSL toggle so connections can opt into TLS
- drop the @neondatabase/serverless dependency and document the TLS flag in the environment template and README

## Testing
- npm install --package-lock-only --loglevel error --progress false *(fails: registry responded 403 for @tailwindcss/oxide-wasm32-wasi)*
- npm run db:push *(fails: drizzle-kit binary not available because dependencies are not installed in this environment)*
- npm run dev *(fails: dependency health check reports missing packages because npm install could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68e8c15716a483319e3ea035fd40d47b