### PR TITLE
Document Apps Script runtime toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ ALLOW_PLAINTEXT_TOKENS_IN_DEV=false
 CONNECTOR_SIMULATOR_FIXTURES_DIR=server/testing/fixtures
 
 # Runtime feature toggles
+# Enable Apps Script execution globally so the UI exposes the runtime selectors and run buttons.
+# Override to "false" only in environments that must hide Apps Script support.
 RUNTIME_APPS_SCRIPT_ENABLED=true
 
 # Queue / Redis configuration

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Processes:
 - `timers`: `dist/workers/timerDispatcher.js`
 - `encryption-rotation`: `dist/workers/encryption-rotation.js`
 
-Ensure `DATABASE_URL`, `QUEUE_REDIS_*`, and secrets exist in the environment before starting.
+Ensure `DATABASE_URL`, `QUEUE_REDIS_*`, `RUNTIME_APPS_SCRIPT_ENABLED=true`, and secrets exist in the environment before starting.
 
 ## Webhooks
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -17,7 +17,7 @@ This guide covers the quickest path to booting the platform locally with Docker 
    npm run bootstrap:secrets
    ```
    This script backfills strong random values for `ENCRYPTION_MASTER_KEY` and `JWT_SECRET`, matching the minimum length enforced by `EncryptionService`.
-3. Edit `.env.development` to match your local setup. Fill in any provider API keys you plan to exercise (OpenAI, Anthropic, Claude, Google, Gemini). Leave them blank to disable those integrations locally.
+3. Edit `.env.development` to match your local setup. Keep `RUNTIME_APPS_SCRIPT_ENABLED=true` so the builder enables Apps Script executions and run buttons. Fill in any provider API keys you plan to exercise (OpenAI, Anthropic, Claude, Google, Gemini). Leave them blank to disable those integrations locally.
    The runtime now records whether a key came from AWS Secrets Manager, a local `.env` file, or the deterministic development fallback—check the admin-only `GET /api/health/credentials` endpoint when you need to confirm which secrets are active.
    The database layer now uses the standard [`node-postgres`](https://node-postgres.com/) driver via Drizzle ORM—set `DATABASE_SSL=true` when pointing at a managed cloud database that enforces TLS and leave it `false` (the default) for localhost or Docker Compose.
 


### PR DESCRIPTION
## Summary
- clarify in `.env.example` how to enable Apps Script execution via `RUNTIME_APPS_SCRIPT_ENABLED`
- update the README production checklist to call out the runtime flag
- note in the local development guide that the flag must stay true so the builder exposes Apps Script runs

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e8b8fd3b44833181488f7ac9ab6d62