### PR TITLE
Ensure AuthService fails without database

### DIFF
--- a/server/services/__tests__/AuthService.test.ts
+++ b/server/services/__tests__/AuthService.test.ts
@@ -1,9 +1,8 @@
 import assert from 'node:assert/strict';
 
-process.env.NODE_ENV = 'development';
+process.env.NODE_ENV = 'test';
 
-const { AuthService } = await import('../AuthService.js');
-const { users } = await import('../../database/schema.js');
+const { users, setDatabaseClientForTests } = await import('../../database/schema.js');
 
 interface MockUserRecord {
   id: string;
@@ -69,8 +68,11 @@ function mapSelection(record: MockUserRecord, selection?: Record<string, unknown
   return result;
 }
 
-const authService = new AuthService();
-(authService as any).db = mockDb;
+setDatabaseClientForTests(mockDb as any);
+
+const { AuthService } = await import('../AuthService.js');
+
+const authService = new AuthService(mockDb as any);
 (authService as any).getUserByEmail = async (email: string) => {
   return mockUsers.find((user) => user.email === email.toLowerCase()) ?? null;
 };


### PR DESCRIPTION
## Summary
- require an initialized database client when constructing AuthService and guard all database calls
- add a startup check that verifies database connectivity before continuing API initialization
- update the AuthService unit test to provide a mock database client before importing the service

## Testing
- `npm exec tsx server/services/__tests__/AuthService.test.ts` *(fails in this environment: npm cannot download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ea2d8bd5e48331a15638306897219d