### PR TITLE
Add Apps Script rollout kickoff checklist and CLI

### DIFF
--- a/docs/apps-script-rollout/kickoff-checklist.md
+++ b/docs/apps-script-rollout/kickoff-checklist.md
@@ -1,0 +1,60 @@
+# Apps Script Rollout Kickoff Checklist
+
+The kickoff checklist confirms that Apps Script launches begin with the required
+access, credentials, configuration hygiene, and approvals. Product managers must
+clear every item before engineering schedules a new connector batch.
+
+## Checklist Summary
+
+| Item | Owner | Status |
+| --- | --- | --- |
+| Sandbox access granted for the Apps Script execution project | PM / IT | ☐ |
+| Production credentials requested or issued for the launch connectors | PM | ☐ |
+| Script Properties follow the shared naming, scoping, and audit rules | PM / Eng | ☐ |
+| Security approvals captured in the rollout record | PM / Security | ☐ |
+
+Use the CLI helper to review the checklist from your terminal:
+
+```bash
+npm run apps-script:checklist
+```
+
+## Sandbox Access
+
+- Confirm the Apps Script sandbox (clasp project or execution deployment) exists
+  for the launch connectors.
+- Validate that PMs, engineers, and QA accounts are on the allow list for the
+  sandbox project and that they can execute dry runs.
+- File access requests with IT/Sec for any missing stakeholders and wait for
+  confirmation before scheduling the batch kickoff.
+- Document the project ID and access approvers in the rollout tracker.
+
+## Credential Provisioning
+
+- Ensure OAuth clients or service accounts are provisioned for every connector
+  in the upcoming batch. Capture credential IDs, redirect URIs, and owner teams
+  in the tracker.
+- Confirm secrets are stored in the shared secret manager (Vault, Secrets
+  Manager, etc.) and mapped to environment variables for staging and production.
+- Validate test accounts exist for QA and that scopes/permissions match the
+  production request.
+
+## Script Property Standards
+
+- Prefix automation-specific Script Properties with `AUTOMATION_` to avoid
+  collisions with historical scripts.
+- Store IDs, tokens, and secrets in Script Properties only when they meet the
+  encryption requirements documented in [`docs/operations/secret-management.md`](../operations/secret-management.md).
+- Record a README entry for each property: name, purpose, owning team, and
+  rotation cadence.
+- Remove obsolete properties during rollout prep so migration scripts do not
+  rehydrate stale configuration.
+
+## Security Approvals
+
+- Record a risk assessment or SOC checklist entry for the Apps Script launch in
+  the security tracker, referencing scope, data flows, and contact owners.
+- Confirm Data Protection and Security Engineering have acknowledged the launch
+  window (email or ticket).
+- Verify production monitoring (logging, alerts) is configured before rollout.
+- Update the rollout tracker with the approval ticket links and review dates.

--- a/docs/apps-script-rollout/rollout-tracker.md
+++ b/docs/apps-script-rollout/rollout-tracker.md
@@ -1,0 +1,38 @@
+# Apps Script Rollout Tracker
+
+This tracker centralises the readiness state for each Apps Script connector
+batch. Update the boolean columns as PMs complete the kickoff checklist items
+outlined in [kickoff-checklist.md](./kickoff-checklist.md).
+
+| Wave | Connector | Sandbox Access | Credentials Provisioned | Script Properties Standard | Security Approved | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| Batch 1 | hubspot-enhanced | false | false | false | false | |
+| Batch 1 | trello | false | false | false | false | |
+| Batch 1 | twilio | false | false | false | false | |
+| Batch 1 | jira | false | false | false | false | |
+| Batch 1 | kustomer | false | false | false | false | |
+| Batch 1 | mailgun | false | false | false | false | |
+| Batch 1 | stripe | false | false | false | false | |
+| Batch 1 | slack | false | false | false | false | |
+| Batch 1 | asana-enhanced | false | false | false | false | |
+| Batch 1 | zendesk | false | false | false | false | |
+| Batch 1 | github-enhanced | false | false | false | false | |
+| Batch 1 | pipedrive | false | false | false | false | |
+| Batch 1 | dropbox | false | false | false | false | |
+| Batch 1 | salesforce | false | false | false | false | |
+| Batch 1 | mailchimp | false | false | false | false | |
+| Batch 1 | google-drive | false | false | false | false | |
+| Batch 1 | google-calendar | false | false | false | false | |
+| Batch 1 | typeform | false | false | false | false | |
+
+- **Sandbox Access** – mark `true` when all delivery stakeholders can run Apps
+  Script executions in the sandbox project.
+- **Credentials Provisioned** – mark `true` when production/staging credentials
+  exist and secret storage has the mappings documented.
+- **Script Properties Standard** – mark `true` after property names and
+  documentation follow the conventions from the kickoff checklist.
+- **Security Approved** – mark `true` once the relevant approvals or tickets are
+  linked in the tracker.
+
+Use this tracker during weekly rollout syncs to unblock missing items before the
+engineering hand-off.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@
   - docs/phases/phase-0.md
   - docs/phases/coverage-levels.md
   - docs/phases/phase-0-risks.md
+  - docs/apps-script-rollout/kickoff-checklist.md
+  - docs/apps-script-rollout/rollout-tracker.md
 - Phase 1
   - docs/phases/phase-1.md
   - docs/phases/phase-1-usage.md

--- a/docs/phases/phase-0.md
+++ b/docs/phases/phase-0.md
@@ -5,6 +5,7 @@ Checklist (maintained as we progress)
 - [ ] Inventory connectors (count, categories, availability, enhanced/standard pairs)
 - [ ] Generate machine-readable report (JSON) and human summary (Markdown)
 - [ ] Define coverage levels (Bronze/Silver/Gold) with acceptance criteria
+- [ ] PM confirms [Apps Script rollout kickoff checklist](../apps-script-rollout/kickoff-checklist.md) is complete before scheduling a new connector batch
 - [x] Propose Batch 1 candidates (see production/reports/batch1-proposal.md)
 - [x] Align UI labels for availability (Stable/Experimental/Coming Soon)
   - API now exposes `statusLabel`, `hasImplementation`, `availability`, `hasWebhooks`

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "seed:encryption-key": "tsx scripts/seed-encryption-key.ts",
     "observability:check": "tsx scripts/observability-check.ts",
     "report:runtime": "tsx scripts/connector-runtime-status.ts",
-    "check:connectors": "tsx scripts/validate-connectors.ts && tsx scripts/validate-connector-ops.ts"
+    "check:connectors": "tsx scripts/validate-connectors.ts && tsx scripts/validate-connector-ops.ts",
+    "apps-script:checklist": "tsx scripts/print-apps-script-checklist.ts"
   },
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.676.0",

--- a/scripts/print-apps-script-checklist.ts
+++ b/scripts/print-apps-script-checklist.ts
@@ -1,0 +1,85 @@
+const checklistItems = [
+  {
+    id: 'sandbox-access',
+    label: 'Sandbox access granted for the Apps Script execution project',
+    envVar: 'APPS_SCRIPT_SANDBOX_ACCESS',
+    docAnchor: '#sandbox-access',
+  },
+  {
+    id: 'credentials',
+    label: 'Production credentials provisioned or requested for launch connectors',
+    envVar: 'APPS_SCRIPT_CREDENTIALS_READY',
+    docAnchor: '#credential-provisioning',
+  },
+  {
+    id: 'script-properties',
+    label: 'Script Properties documented and following naming standards',
+    envVar: 'APPS_SCRIPT_PROPERTIES_STANDARD',
+    docAnchor: '#script-property-standards',
+  },
+  {
+    id: 'security',
+    label: 'Security approvals logged with references in the rollout tracker',
+    envVar: 'APPS_SCRIPT_SECURITY_APPROVED',
+    docAnchor: '#security-approvals',
+  },
+] as const;
+
+type ChecklistState = 'complete' | 'missing';
+
+type ChecklistResult = {
+  item: (typeof checklistItems)[number];
+  state: ChecklistState;
+  rawValue: string | undefined;
+};
+
+const truthyValues = new Set(['1', 'true', 't', 'yes', 'y', 'on']);
+
+const toLower = (value: string | undefined): string | undefined =>
+  value === undefined ? undefined : value.toLowerCase();
+
+const parseState = (value: string | undefined): ChecklistState =>
+  truthyValues.has(toLower(value) ?? '') ? 'complete' : 'missing';
+
+const colour = (code: number, value: string): string => `\u001b[${code}m${value}\u001b[0m`;
+const green = (value: string): string => colour(32, value);
+const red = (value: string): string => colour(31, value);
+const cyan = (value: string): string => colour(36, value);
+const bold = (value: string): string => `\u001b[1m${value}\u001b[0m`;
+const dim = (value: string): string => colour(2, value);
+
+const formatState = (state: ChecklistState): string =>
+  state === 'complete' ? green('✔ Complete') : red('✖ Missing');
+
+const results: ChecklistResult[] = checklistItems.map(item => ({
+  item,
+  state: parseState(process.env[item.envVar]),
+  rawValue: process.env[item.envVar],
+}));
+
+console.log(bold('Apps Script Rollout Kickoff Checklist'));
+console.log(dim('Source: docs/apps-script-rollout/kickoff-checklist.md'));
+console.log('');
+
+for (const result of results) {
+  const line = `${formatState(result.state)} — ${result.item.label}`;
+  console.log(line);
+  const note =
+    result.rawValue === undefined
+      ? dim(`  env var ${result.item.envVar} is not set`)
+      : dim(`  env var ${result.item.envVar} = ${result.rawValue}`);
+  console.log(note);
+  console.log(dim(`  See ${cyan(`docs/apps-script-rollout/kickoff-checklist.md${result.item.docAnchor}`)}`));
+  console.log('');
+}
+
+const missing = results.filter(result => result.state === 'missing');
+
+if (missing.length === 0) {
+  console.log(green('All preconditions satisfied. Proceed with the connector batch.'));
+} else {
+  console.log(red('Blocked: complete the following before kickoff:'));
+  for (const result of missing) {
+    console.log(`  • ${result.item.label} (${result.item.envVar})`);
+  }
+}


### PR DESCRIPTION
## Summary
- add an Apps Script rollout kickoff checklist covering sandbox access, credential provisioning, script property standards, and security approvals
- publish a rollout tracker with boolean readiness columns and link both docs from the onboarding phase index
- introduce a CLI helper plus npm script to print the checklist and flag missing preconditions

## Testing
- npm run apps-script:checklist *(fails in container: tsx binary unavailable without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68eb889ac5e4833193de35bded634f2c