### PR TITLE
Add runtime coverage CSV export with connector summaries

### DIFF
--- a/docs/apps-script-rollout/prioritization.md
+++ b/docs/apps-script-rollout/prioritization.md
@@ -42,3 +42,13 @@ Alternate header aliases such as `revenue`, `pipeline`, `executions`, or `ticket
 The generated CSV contains one row per connector with the merged metrics, calculated scores, assigned tier, and source attribution. Review the console output for a human-readable digest of Tier 0/1/2 priorities plus ARR, usage, and support context.
 
 Use the CSV to align Apps Script rollout sequencing, and update the CRM/usage/support exports to refresh the prioritization as new data arrives.
+
+## Regenerating the runtime coverage CSV
+
+Every rollout PR should refresh the Apps Script runtime coverage export so the tracker sheet stays accurate:
+
+1. Run `npm run report:runtime -- --output production/reports/apps-script-runtime-coverage.csv` after applying the rollout changes locally. This writes the operation-level dataset plus per-connector summaries consumed by the tracker.
+2. Commit the updated `production/reports/apps-script-runtime-coverage.csv` alongside the rollout PR so reviewers can confirm the diff.
+3. Upload the CSV to the shared tracker sheet (replace the existing data on the runtime coverage tab) once the PR merges.
+
+Regenerating the file every time keeps the rollout dashboard synchronized with the source of truth in the repository.

--- a/scripts/__tests__/connector-runtime-status.test.ts
+++ b/scripts/__tests__/connector-runtime-status.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCoverageReport } from '../connector-runtime-status.js';
+import type {
+  RuntimeCapabilityOperationSummary,
+  RuntimeCapabilitySummary,
+} from '../../server/runtime/registry.js';
+
+const operation = (
+  config: Omit<RuntimeCapabilityOperationSummary, 'issues'>,
+): RuntimeCapabilityOperationSummary => ({
+  ...config,
+  issues: [],
+});
+
+describe('connector runtime status coverage CSV', () => {
+  it('matches the expected schema', () => {
+    const capabilities: RuntimeCapabilitySummary[] = [
+      {
+        app: 'Alpha CRM',
+        normalizedAppId: 'alpha_crm',
+        actions: ['createRecord'],
+        triggers: [],
+        actionDetails: {
+          create_record: operation({
+            id: 'createRecord',
+            normalizedId: 'create_record',
+            kind: 'action',
+            nativeRuntimes: ['node', 'appsScript'],
+            fallbackRuntimes: [],
+            resolvedRuntime: 'node',
+            availability: 'native',
+            enabledNativeRuntimes: ['node', 'appsScript'],
+            enabledFallbackRuntimes: [],
+            disabledNativeRuntimes: [],
+            disabledFallbackRuntimes: [],
+          }),
+        },
+        triggerDetails: {},
+      },
+      {
+        app: 'Beta Support',
+        normalizedAppId: 'beta_support',
+        actions: ['createTicket'],
+        triggers: ['onTicket'],
+        actionDetails: {
+          create_ticket: operation({
+            id: 'createTicket',
+            normalizedId: 'create_ticket',
+            kind: 'action',
+            nativeRuntimes: ['node'],
+            fallbackRuntimes: [],
+            resolvedRuntime: 'node',
+            availability: 'native',
+            enabledNativeRuntimes: ['node'],
+            enabledFallbackRuntimes: [],
+            disabledNativeRuntimes: [],
+            disabledFallbackRuntimes: [],
+          }),
+        },
+        triggerDetails: {
+          on_ticket: operation({
+            id: 'onTicket',
+            normalizedId: 'on_ticket',
+            kind: 'trigger',
+            nativeRuntimes: ['node'],
+            fallbackRuntimes: ['appsScript'],
+            resolvedRuntime: 'node',
+            availability: 'fallback',
+            enabledNativeRuntimes: ['node'],
+            enabledFallbackRuntimes: [],
+            disabledNativeRuntimes: [],
+            disabledFallbackRuntimes: ['appsScript'],
+          }),
+        },
+      },
+    ];
+
+    const report = buildCoverageReport(capabilities);
+
+    expect(report.csv).toMatchInlineSnapshot(`
+"type,connector,normalized_connector,operation,normalized_operation,kind,node_available,node_enabled,apps_script_available,apps_script_enabled,apps_script_disabled,total_operations,apps_script_available_count,apps_script_enabled_count,apps_script_disabled_count\noperation,Alpha CRM,alpha_crm,createRecord,create_record,action,TRUE,TRUE,TRUE,TRUE,FALSE,,,,\nconnector_summary,Alpha CRM,alpha_crm,,,,,,,,,1,1,1,0\noperation,Beta Support,beta_support,createTicket,create_ticket,action,TRUE,TRUE,FALSE,FALSE,FALSE,,,,\noperation,Beta Support,beta_support,onTicket,on_ticket,trigger,TRUE,TRUE,TRUE,FALSE,TRUE,,,,\nconnector_summary,Beta Support,beta_support,,,,,,,,,2,1,0,1\n"`);
+  });
+});


### PR DESCRIPTION
## Summary
- extend the connector runtime status script to emit an Apps Script coverage CSV with per-connector summaries
- expose a reusable coverage report builder and protect the CSV schema with a Vitest snapshot
- document how to regenerate and publish the coverage report after each rollout PR

## Testing
- npx vitest run scripts/__tests__/connector-runtime-status.test.ts *(fails: npm registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb902fd6688331aae57d185469755b