### PR TITLE
Add Apps Script trigger helpers and webhook stubs

### DIFF
--- a/docs/apps-script-rollout/templates.md
+++ b/docs/apps-script-rollout/templates.md
@@ -19,3 +19,21 @@ All `REAL_OPS` snippets that talk to third-party APIs must:
 3. Replace `console.log`/`console.warn` usage with the structured logging helpers (`logInfo`, `logWarn`, `logError`).
 
 When authoring new templates, follow the existing patterns (e.g., Slack, Salesforce, Mailchimp) to ensure outbound requests opt into the shared retry policy and logging. Doing so keeps the generated Apps Script code resilient, debuggable, and consistent across connectors.
+
+## Trigger helper utilities
+
+Time-based triggers and event handlers are orchestrated through additional helpers emitted by `appsScriptHttpHelpers()`:
+
+- `buildTimeTrigger(config)`: registers time-driven triggers and deduplicates them by key. Provide `handler`, a stable `key`, and any scheduling fields (`everyHours`, `everyWeeks`, `atHour`, `runAt`, etc.). Use the `ephemeral` flag for one-off triggers such as delay handlers so the registry is not persisted.
+- `syncTriggerRegistry(activeKeys)`: call once from `setupTriggers()` after provisioning triggers to remove any stale project triggers and keep the script properties registry authoritative.
+- `buildPollingWrapper(triggerKey, executor)`: wrap trigger bodies to receive lifecycle logging automatically. The executor receives a `runtime` object with `dispatch(payload)` (invokes `main` safely) and `summary(partial)` (merges metadata for the logging payload). All trigger implementations should return the wrapper invocation so success and error signals flow through the shared logger.
+- `clearTriggerByKey(triggerKey)`: optional cleanup utility for bespoke teardown scenarios when a trigger key should be removed manually.
+
+When generating new trigger templates:
+
+1. Wrap the handler body with `buildPollingWrapper` and use `runtime.dispatch(...)` to invoke `main` for each payload.
+2. Record meaningful metadata via `runtime.summary(...)` so execution logs capture counts, query parameters, or any skip reasons.
+3. Emit registration logic through `buildTimeTrigger` inside `setupTriggers()` and keep the returned keys in an array passed to `syncTriggerRegistry`.
+4. Prefer `logInfo`/`logWarn`/`logError` for structured messages instead of raw `console` calls.
+
+Following these patterns ensures recurring schedules, polling triggers, and ad-hoc delay triggers are self-healing (no duplicate triggers), observable, and aligned with the rest of the generated runtime.


### PR DESCRIPTION
## Summary
- introduce trigger registry, time trigger builder, and polling wrapper helpers that are emitted with the Apps Script runtime
- refactor schedule, Gmail, Sheets, and delay triggers to rely on the shared helpers for deduped trigger creation and structured logging, and emit webhook stubs from capability metadata
- document the new trigger helper usage patterns in the rollout guide

## Testing
- npm run test:apps-script *(fails: vitest not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebadefb57883319c075b0f46b305a4