### PR TITLE
Add Apps Script coverage reporting to connector validation

### DIFF
--- a/.github/workflows/connector-validation.yml
+++ b/.github/workflows/connector-validation.yml
@@ -42,3 +42,123 @@ jobs:
 
       - name: Verify Apps Script backlog sync
         run: npm run check:apps-script-backlog
+
+      - name: Generate Apps Script coverage report
+        run: npm run report:apps-script-coverage
+
+      - name: Upload Apps Script coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: apps-script-coverage
+          path: |
+            production/reports/apps-script-runtime-coverage.csv
+            production/reports/apps-script-runtime-coverage.json
+
+      - name: Comment Apps Script coverage summary
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const core = require('@actions/core');
+            const fs = require('fs/promises');
+            const path = require('path');
+
+            const summaryPath = path.join(process.env.GITHUB_WORKSPACE ?? '.', 'production', 'reports', 'apps-script-runtime-coverage.json');
+            const summary = JSON.parse(await fs.readFile(summaryPath, 'utf8'));
+
+            let baseSummary = null;
+            const baseSha = context.payload.pull_request?.base?.sha;
+            if (baseSha) {
+              try {
+                const { data } = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: 'production/reports/apps-script-runtime-coverage.json',
+                  ref: baseSha,
+                });
+                if (!Array.isArray(data) && data.content) {
+                  const decoded = Buffer.from(data.content, data.encoding).toString('utf8');
+                  baseSummary = JSON.parse(decoded);
+                }
+              } catch (error) {
+                core.warning(`Unable to load base Apps Script coverage report: ${error.message}`);
+              }
+            }
+
+            const formatPercent = value => `${(value * 100).toFixed(2)}%`;
+            const formatSigned = value => (value > 0 ? `+${value}` : value < 0 ? `${value}` : '0');
+            const formatDelta = (count, ratio) =>
+              baseSummary
+                ? `${formatSigned(count)} / ${(ratio >= 0 ? '+' : '') + (ratio * 100).toFixed(2)}%`
+                : 'n/a';
+
+            const currentOps = summary.coverage.operations;
+            const baseOps = baseSummary?.coverage?.operations;
+            const opsDeltaCount = baseOps ? currentOps.enabled - baseOps.enabled : 0;
+            const opsDeltaRatio = baseOps ? currentOps.ratio - baseOps.ratio : 0;
+
+            const currentConnectors = summary.coverage.connectors;
+            const baseConnectors = baseSummary?.coverage?.connectors;
+            const connectorDeltaCount = baseConnectors ? currentConnectors.full - baseConnectors.full : 0;
+            const connectorDeltaRatio = baseConnectors ? currentConnectors.ratio - baseConnectors.ratio : 0;
+
+            const metricsTable = [
+              '| Metric | Current | Δ vs. base |',
+              '| --- | --- | --- |',
+              `| Operations covered | ${currentOps.enabled} / ${currentOps.total} (${formatPercent(currentOps.ratio)}) | ${formatDelta(opsDeltaCount, opsDeltaRatio)} |`,
+              `| Full-coverage connectors | ${currentConnectors.full} / ${currentConnectors.total} (${formatPercent(currentConnectors.ratio)}) | ${formatDelta(connectorDeltaCount, connectorDeltaRatio)} |`,
+              `| Coverage target | ${formatPercent(summary.target)} | — |`,
+            ].join('\n');
+
+            let gapsSection = '_All connectors currently have full Apps Script coverage._';
+            if (summary.gaps.length > 0) {
+              const rows = summary.gaps
+                .slice(0, 10)
+                .map(gap => `| ${gap.app} | ${gap.appsScriptEnabled} / ${gap.totalOperations} |`);
+              const header = ['| Connector | Enabled Ops |', '| --- | --- |'];
+              gapsSection = [
+                '**Connectors missing full Apps Script coverage**',
+                '',
+                [...header, ...rows].join('\n'),
+              ].join('\n');
+              if (summary.gaps.length > rows.length) {
+                gapsSection += `\n...and ${summary.gaps.length - rows.length} more.`;
+              }
+            }
+
+            const commentBody = [
+              '## Apps Script Coverage Report',
+              '',
+              metricsTable,
+              '',
+              gapsSection,
+            ].join('\n');
+
+            const issueNumber = context.payload.pull_request.number;
+            const existingComments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const previous = existingComments.find(comment =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.includes('## Apps Script Coverage Report'),
+            );
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body: commentBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: commentBody,
+              });
+            }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "seed:encryption-key": "tsx scripts/seed-encryption-key.ts",
     "observability:check": "tsx scripts/observability-check.ts",
     "report:runtime": "tsx scripts/connector-runtime-status.ts",
+    "report:apps-script-coverage": "tsx scripts/report-apps-script-coverage.ts",
     "prioritize:apps-script": "node scripts/apps-script-prioritize-connectors.mjs",
     "update:apps-script-backlog": "node scripts/update-apps-script-backlog.mjs",
     "check:apps-script-backlog": "node scripts/check-apps-script-backlog.mjs",

--- a/scripts/report-apps-script-coverage.ts
+++ b/scripts/report-apps-script-coverage.ts
@@ -1,0 +1,212 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { parseArgs } from 'node:util';
+
+import { connectorRegistry } from '../server/ConnectorRegistry.js';
+import { getRuntimeCapabilities } from '../server/runtime/registry.js';
+
+import { buildCoverageReport, type CoverageReport } from './connector-runtime-status.js';
+
+type CliOptions = {
+  csvPath: string;
+  jsonPath: string;
+  target: number;
+};
+
+type CoverageSummary = {
+  generatedAt: string;
+  target: number;
+  coverage: {
+    operations: {
+      total: number;
+      enabled: number;
+      disabled: number;
+      ratio: number;
+    };
+    connectors: {
+      total: number;
+      full: number;
+      partial: number;
+      none: number;
+      ratio: number;
+    };
+  };
+  gaps: Array<{
+    app: string;
+    normalizedAppId: string;
+    totalOperations: number;
+    appsScriptEnabled: number;
+    appsScriptDisabled: number;
+  }>;
+};
+
+const DEFAULT_CSV_PATH = 'production/reports/apps-script-runtime-coverage.csv';
+const DEFAULT_JSON_PATH = 'production/reports/apps-script-runtime-coverage.json';
+const DEFAULT_TARGET = 1;
+
+const parseTarget = (rawTarget: string | undefined): number => {
+  if (rawTarget === undefined || rawTarget === null || rawTarget.trim() === '') {
+    return DEFAULT_TARGET;
+  }
+
+  const value = Number.parseFloat(rawTarget);
+  if (!Number.isFinite(value) || value <= 0 || value > 1) {
+    throw new Error(`Invalid Apps Script coverage target: "${rawTarget}".`);
+  }
+
+  return value;
+};
+
+const parseCliOptions = (argv: string[]): CliOptions => {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      csv: { type: 'string' },
+      json: { type: 'string' },
+      target: { type: 'string' },
+    },
+  });
+
+  const target =
+    typeof values.target === 'string'
+      ? parseTarget(values.target)
+      : parseTarget(process.env.APPS_SCRIPT_COVERAGE_TARGET);
+
+  return {
+    csvPath:
+      typeof values.csv === 'string' && values.csv.trim() !== ''
+        ? values.csv
+        : DEFAULT_CSV_PATH,
+    jsonPath:
+      typeof values.json === 'string' && values.json.trim() !== ''
+        ? values.json
+        : DEFAULT_JSON_PATH,
+    target,
+  };
+};
+
+const ensureDirectory = async (filePath: string): Promise<void> => {
+  const directory = dirname(filePath);
+  await mkdir(directory, { recursive: true });
+};
+
+const toPercentage = (ratio: number): string => `${(ratio * 100).toFixed(2)}%`;
+
+const buildSummary = (report: CoverageReport, target: number): CoverageSummary => {
+  const operationsTotal = report.totals.operations;
+  const operationsEnabled = report.totals.appsScriptSupported;
+  const operationsDisabled = Math.max(operationsTotal - operationsEnabled, 0);
+  const operationsRatio = operationsTotal === 0 ? 1 : operationsEnabled / operationsTotal;
+
+  let connectorsFull = 0;
+  let connectorsPartial = 0;
+  let connectorsNone = 0;
+
+  const gaps: CoverageSummary['gaps'] = [];
+
+  for (const connector of report.apps) {
+    const { totalOperations, appsScriptEnabled, appsScriptDisabled } = connector.summary;
+    if (appsScriptEnabled === totalOperations && totalOperations > 0) {
+      connectorsFull += 1;
+    } else if (appsScriptEnabled > 0) {
+      connectorsPartial += 1;
+    } else {
+      connectorsNone += 1;
+    }
+
+    if (appsScriptDisabled > 0 || appsScriptEnabled < totalOperations) {
+      gaps.push({
+        app: connector.app,
+        normalizedAppId: connector.normalizedAppId,
+        totalOperations,
+        appsScriptEnabled,
+        appsScriptDisabled,
+      });
+    }
+  }
+
+  const connectorsTotal = report.apps.length;
+  const connectorsRatio = connectorsTotal === 0 ? 1 : connectorsFull / connectorsTotal;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    target,
+    coverage: {
+      operations: {
+        total: operationsTotal,
+        enabled: operationsEnabled,
+        disabled: operationsDisabled,
+        ratio: operationsRatio,
+      },
+      connectors: {
+        total: connectorsTotal,
+        full: connectorsFull,
+        partial: connectorsPartial,
+        none: connectorsNone,
+        ratio: connectorsRatio,
+      },
+    },
+    gaps,
+  };
+};
+
+const logSummary = (summary: CoverageSummary): void => {
+  const operations = summary.coverage.operations;
+  const connectors = summary.coverage.connectors;
+
+  console.log('📊 Apps Script Coverage Summary');
+  console.log('-------------------------------');
+  console.log(`Operations: ${operations.enabled}/${operations.total} (${toPercentage(operations.ratio)})`);
+  console.log(`Connectors (full coverage): ${connectors.full}/${connectors.total} (${toPercentage(connectors.ratio)})`);
+
+  if (summary.gaps.length > 0) {
+    console.log('\nConnectors missing full Apps Script coverage:');
+    for (const gap of summary.gaps) {
+      const enabled = `${gap.appsScriptEnabled}/${gap.totalOperations}`;
+      console.log(`  • ${gap.app}: ${enabled} operations enabled`);
+    }
+  } else {
+    console.log('\nAll connectors have full Apps Script coverage. ✅');
+  }
+};
+
+const run = async (): Promise<void> => {
+  process.env.NODE_ENV ??= 'development';
+
+  const options = parseCliOptions(process.argv.slice(2));
+
+  await connectorRegistry.init();
+
+  const capabilities = getRuntimeCapabilities();
+  const report = buildCoverageReport(capabilities);
+  const summary = buildSummary(report, options.target);
+
+  logSummary(summary);
+
+  await Promise.all([
+    (async () => {
+      await ensureDirectory(options.csvPath);
+      await writeFile(options.csvPath, report.csv, 'utf8');
+    })(),
+    (async () => {
+      await ensureDirectory(options.jsonPath);
+      await writeFile(options.jsonPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    })(),
+  ]);
+
+  if (summary.coverage.operations.ratio + Number.EPSILON < options.target) {
+    console.error(
+      `\n❌ Apps Script coverage ${toPercentage(summary.coverage.operations.ratio)} is below the target ${toPercentage(options.target)}.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`\n✅ Apps Script coverage meets the target of ${toPercentage(options.target)}.`);
+};
+
+run().catch(error => {
+  console.error('Failed to generate Apps Script coverage report.');
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a coverage-report script that emits CSV/JSON summaries for Apps Script runtime support and enforces a configurable coverage target
- extend the connector validation workflow to run the coverage report, upload the artifacts, and comment on pull requests with coverage deltas

## Testing
- not run (local environment npm install repeatedly exceeded time limits)


------
https://chatgpt.com/codex/tasks/task_e_68ec8183994483318f00f6b5bc11e39c