### PR TITLE
Add Apps Script Gmail REST handlers and coverage

### DIFF
--- a/docs/apps-script-rollout/script-properties.md
+++ b/docs/apps-script-rollout/script-properties.md
@@ -58,6 +58,7 @@ The table below is regenerated automatically. Required properties appear in the 
 | ghost | `GHOST_ADMIN_API_KEY`<br>`GHOST_API_URL` | — | — |
 | GitHub | `GITHUB_ACCESS_TOKEN` | — | — |
 | GitLab | `GITLAB_ACCESS_TOKEN` | — | — |
+| Gmail | `GMAIL_ACCESS_TOKEN` | `GMAIL_REFRESH_TOKEN` | — |
 | google-ads | `GOOGLE_ADS_CUSTOMER_ID`<br>`GOOGLE_ADS_DEVELOPER_TOKEN` | — | — |
 | google-analytics | `GA_VIEW_ID` | — | — |
 | google-cloud-storage | `GCS_BUCKET`<br>`GCS_SERVICE_ACCOUNT_KEY` | — | — |
@@ -149,6 +150,12 @@ The table below is regenerated automatically. Required properties appear in the 
 | zoom | `ZOOM_API_KEY`<br>`ZOOM_API_SECRET` | — | — |
 
 <!-- END GENERATED APPS SCRIPT PROPERTIES -->
+
+### Gmail token management
+
+- Apps Script Gmail handlers require `GMAIL_ACCESS_TOKEN` scopes `https://www.googleapis.com/auth/gmail.send` and `https://www.googleapis.com/auth/gmail.readonly` to cover send, search, and polling flows. Provision tokens with both scopes so the same credential supports triggers and actions.
+- Populate `GMAIL_REFRESH_TOKEN` alongside the access token. A rotation job should exchange the refresh token at least daily; the Apps Script runtime expects fresh access tokens because Gmail REST calls fail once the one-hour access token expires.
+- Store both secrets in Script Properties (production and staging) before deploying new handlers. Missing tokens cause structured `gmail_missing_access_token` errors during runtime, surfacing misconfigurations quickly.
 
 ## Machine-readable report
 

--- a/production/reports/apps-script-properties.json
+++ b/production/reports/apps-script-properties.json
@@ -1704,7 +1704,32 @@
         "trigger.gmail:email_with_attachment",
         "trigger.gmail:new_email_received"
       ],
-      "properties": [],
+      "properties": [
+        {
+          "name": "GMAIL_ACCESS_TOKEN",
+          "optional": false,
+          "operations": [
+            "action.gmail:send_email",
+            "action.gmail:search_emails",
+            "trigger.gmail:email_received"
+          ],
+          "contexts": [
+            "getSecret"
+          ]
+        },
+        {
+          "name": "GMAIL_REFRESH_TOKEN",
+          "optional": true,
+          "operations": [
+            "action.gmail:send_email",
+            "action.gmail:search_emails",
+            "trigger.gmail:email_received"
+          ],
+          "contexts": [
+            "scriptProperties"
+          ]
+        }
+      ],
       "environmentProperties": []
     },
     {

--- a/server/workflow/__tests__/__snapshots__/apps-script.gmail.test.ts.snap
+++ b/server/workflow/__tests__/__snapshots__/apps-script.gmail.test.ts.snap
@@ -1,0 +1,526 @@
+exports[`Apps Script Gmail REAL_OPS builds trigger.gmail:email_received 1`] = `
+function onNewEmail() {
+  return buildPollingWrapper('trigger.gmail:email_received', function (runtime) {
+    const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+    if (!accessToken) {
+      logError('gmail_missing_access_token', { operation: 'trigger.gmail:email_received' });
+      throw new Error('Missing Gmail access token for gmail.email_received trigger');
+    }
+
+    const interpolationContext = runtime.state && runtime.state.lastPayload ? runtime.state.lastPayload : {};
+    const query = interpolate('${esc(c.query || 'is:unread')}', interpolationContext).trim();
+    const labelIdsConfig = ${JSON.stringify(c.labelIds || [])};
+    const labelIds = [];
+    if (Array.isArray(labelIdsConfig)) {
+      for (let i = 0; i < labelIdsConfig.length; i++) {
+        const value = typeof labelIdsConfig[i] === 'string' ? interpolate(labelIdsConfig[i], interpolationContext).trim() : '';
+        if (value) {
+          labelIds.push(value);
+        }
+      }
+    }
+
+    const headers = { Authorization: 'Bearer ' + accessToken };
+    const baseUrl = 'https://gmail.googleapis.com/gmail/v1/users/me';
+    const cursor = (runtime.state && typeof runtime.state.cursor === 'object') ? runtime.state.cursor : {};
+    const lastInternalDate = cursor && cursor.internalDate ? Number(cursor.internalDate) : null;
+    const afterSeconds = lastInternalDate ? Math.floor(lastInternalDate / 1000) : null;
+    const effectiveQuery = afterSeconds ? ((query ? query + ' ' : '') + 'after:' + afterSeconds) : query;
+    const messages = [];
+    let pageToken = null;
+    let pageCount = 0;
+
+    function decodeBase64Url(data) {
+      if (!data) {
+        return '';
+      }
+      try {
+        const normalized = data.replace(/-/g, '+').replace(/_/g, '/');
+        const bytes = Utilities.base64Decode(normalized);
+        return Utilities.newBlob(bytes).getDataAsString('UTF-8');
+      } catch (error) {
+        logWarn('gmail_message_body_decode_failed', {
+          message: error && error.message ? error.message : String(error)
+        });
+        return '';
+      }
+    }
+
+    function extractHeader(all, name) {
+      if (!Array.isArray(all)) {
+        return '';
+      }
+      const target = name.toLowerCase();
+      for (let i = 0; i < all.length; i++) {
+        const header = all[i];
+        if (!header || typeof header.name !== 'string') {
+          continue;
+        }
+        if (header.name.toLowerCase() === target) {
+          return header.value || '';
+        }
+      }
+      return '';
+    }
+
+    function parseAddressList(value) {
+      if (!value) {
+        return [];
+      }
+      return value.split(',').map(part => part.trim()).filter(Boolean);
+    }
+
+    function collectAttachments(parts, bucket) {
+      if (!Array.isArray(parts)) {
+        return;
+      }
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        if (!part) {
+          continue;
+        }
+        if (part.filename && part.body && part.body.attachmentId) {
+          bucket.push({
+            attachmentId: part.body.attachmentId,
+            filename: part.filename,
+            mimeType: part.mimeType || 'application/octet-stream',
+            size: part.body.size || 0
+          });
+        }
+        if (Array.isArray(part.parts) && part.parts.length) {
+          collectAttachments(part.parts, bucket);
+        }
+      }
+    }
+
+    function extractBodies(payload) {
+      const result = {};
+      if (!payload) {
+        return result;
+      }
+
+      const queue = [payload];
+      while (queue.length > 0) {
+        const node = queue.shift();
+        if (!node) {
+          continue;
+        }
+        if (node.mimeType === 'text/plain' && node.body && node.body.data) {
+          result.plain = decodeBase64Url(node.body.data);
+        } else if (node.mimeType === 'text/html' && node.body && node.body.data) {
+          result.html = decodeBase64Url(node.body.data);
+        }
+        if (Array.isArray(node.parts)) {
+          for (let p = 0; p < node.parts.length; p++) {
+            queue.push(node.parts[p]);
+          }
+        }
+      }
+
+      if (!result.plain && payload.body && payload.body.data) {
+        result.plain = decodeBase64Url(payload.body.data);
+      }
+
+      return result;
+    }
+
+    try {
+      do {
+        const params = ['maxResults=25'];
+        if (effectiveQuery) {
+          params.push('q=' + encodeURIComponent(effectiveQuery));
+        }
+        if (Array.isArray(labelIds) && labelIds.length) {
+        for (let i = 0; i < labelIds.length; i++) {
+          params.push('labelIds=' + encodeURIComponent(labelIds[i]));
+        }
+      }
+      if (pageToken) {
+        params.push('pageToken=' + encodeURIComponent(pageToken));
+      }
+
+      const listResponse = rateLimitAware(
+        () => fetchJson({
+          url: baseUrl + '/messages?' + params.join('&'),
+          method: 'GET',
+          headers: headers
+        }),
+        { attempts: 5, backoffMs: 500 }
+      );
+
+      const listBody = listResponse.body || {};
+      const candidates = Array.isArray(listBody.messages) ? listBody.messages : [];
+      for (let i = 0; i < candidates.length; i++) {
+        const messageId = candidates[i] && candidates[i].id;
+        if (!messageId) {
+          continue;
+        }
+
+        const messageResponse = rateLimitAware(
+          () => fetchJson({
+            url: baseUrl + '/messages/' + encodeURIComponent(messageId) + '?format=full',
+            method: 'GET',
+            headers: headers
+          }),
+          { attempts: 5, backoffMs: 500 }
+        );
+
+        const detail = messageResponse.body || {};
+        const payload = detail.payload || {};
+        const headersList = payload.headers || [];
+        const bodies = extractBodies(payload);
+        const attachments = [];
+        collectAttachments(payload.parts, attachments);
+
+        const internalDate = detail.internalDate ? Number(detail.internalDate) : null;
+        if (lastInternalDate && internalDate && internalDate <= lastInternalDate) {
+          continue;
+        }
+
+        const from = extractHeader(headersList, 'From');
+        const to = parseAddressList(extractHeader(headersList, 'To'));
+        const cc = parseAddressList(extractHeader(headersList, 'Cc'));
+        const bcc = parseAddressList(extractHeader(headersList, 'Bcc'));
+        const replyTo = parseAddressList(extractHeader(headersList, 'Reply-To'));
+        const deliveredTo = extractHeader(headersList, 'Delivered-To');
+        const subject = extractHeader(headersList, 'Subject') || null;
+        const historyId = detail.historyId ? String(detail.historyId) : null;
+
+        const fromName = from && from.indexOf('<') !== -1 ? from.split('<')[0].trim() : null;
+
+        messages.push({
+          internalDate: internalDate || Date.now(),
+          historyId: historyId,
+          payload: {
+            id: detail.id || messageId,
+            threadId: detail.threadId || null,
+            historyId: historyId,
+            labelIds: Array.isArray(detail.labelIds) ? detail.labelIds : [],
+            subject: subject,
+            snippet: detail.snippet || '',
+            from: from,
+            fromName: fromName,
+            to: to,
+            cc: cc,
+            bcc: bcc,
+            replyTo: replyTo,
+            deliveredTo: deliveredTo || null,
+            receivedAt: internalDate ? new Date(internalDate).toISOString() : new Date().toISOString(),
+            sizeEstimate: detail.sizeEstimate || null,
+            bodyPlain: bodies.plain || '',
+            bodyHtml: bodies.html || '',
+            attachments: attachments,
+            _meta: { raw: detail }
+          }
+        });
+      }
+
+      pageToken = listBody.nextPageToken || null;
+      pageCount += 1;
+    } while (pageToken && messages.length < 50 && pageCount < 5);
+
+      if (messages.length === 0) {
+        runtime.summary({
+          messagesAttempted: 0,
+          messagesDispatched: 0,
+          messagesFailed: 0,
+          query: effectiveQuery,
+          labelIds: labelIds
+        });
+        return { messagesAttempted: 0, messagesDispatched: 0, messagesFailed: 0, query: effectiveQuery, labelIds: labelIds };
+      }
+
+      messages.sort(function (a, b) {
+        return (a.internalDate || 0) - (b.internalDate || 0);
+      });
+
+      const batch = runtime.dispatchBatch(messages, function (entry) {
+        return entry.payload;
+      });
+
+      const last = messages[messages.length - 1];
+      runtime.state.cursor = runtime.state.cursor && typeof runtime.state.cursor === 'object' ? runtime.state.cursor : {};
+      runtime.state.cursor.internalDate = String(last.internalDate || Date.now());
+      if (last.historyId) {
+        runtime.state.cursor.historyId = last.historyId;
+      }
+      runtime.state.cursor.lastMessageId = last.payload.id;
+      runtime.state.lastPayload = last.payload;
+
+      runtime.summary({
+        messagesAttempted: batch.attempted,
+        messagesDispatched: batch.succeeded,
+        messagesFailed: batch.failed,
+        query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      });
+
+      logInfo('gmail_email_received_success', {
+        query: effectiveQuery,
+        dispatched: batch.succeeded,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      });
+
+      return {
+        messagesAttempted: batch.attempted,
+        messagesDispatched: batch.succeeded,
+        messagesFailed: batch.failed,
+        query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      };
+    } catch (error) {
+      const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+      const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+      const status = error && typeof error.status === 'number' ? error.status : null;
+      const message = providerMessage || (error && error.message ? error.message : String(error));
+      logError('gmail_email_received_failed', {
+        status: status,
+        providerCode: providerCode,
+        message: message
+      });
+      throw error;
+    }
+  });
+}
+`;
+
+exports[`Apps Script Gmail REAL_OPS builds action.gmail:send_email 1`] = `
+function step_action_gmail_send_email(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:send_email' });
+    throw new Error('Missing Gmail access token for gmail.send_email operation');
+  }
+
+  const to = interpolate('${esc(c.to || '')}', ctx).trim();
+  const subject = interpolate('${esc(c.subject || '')}', ctx).trim();
+  const body = interpolate('${esc(c.body || '')}', ctx);
+  const cc = interpolate('${esc(c.cc || '')}', ctx).trim();
+  const bcc = interpolate('${esc(c.bcc || '')}', ctx).trim();
+  const attachmentsConfig = ${JSON.stringify(c.attachments || [])};
+
+  function ensureParam(value, field) {
+    if (!value) {
+      logError('gmail_send_email_missing_param', { field: field });
+      throw new Error('Missing required Gmail send_email param: ' + field);
+    }
+    return value;
+  }
+
+  ensureParam(to, 'to');
+  ensureParam(subject, 'subject');
+  ensureParam(body, 'body');
+
+  const recipients = to.split(',').map(function (entry) { return entry.trim(); }).filter(Boolean);
+  const ccList = cc ? cc.split(',').map(function (entry) { return entry.trim(); }).filter(Boolean) : [];
+  const bccList = bcc ? bcc.split(',').map(function (entry) { return entry.trim(); }).filter(Boolean) : [];
+
+  const headerLines = ['To: ' + recipients.join(', ')];
+  if (ccList.length) {
+    headerLines.push('Cc: ' + ccList.join(', '));
+  }
+  if (bccList.length) {
+    headerLines.push('Bcc: ' + bccList.join(', '));
+  }
+  headerLines.push('Subject: ' + subject);
+  headerLines.push('MIME-Version: 1.0');
+
+  const attachments = [];
+  if (Array.isArray(attachmentsConfig)) {
+    for (let i = 0; i < attachmentsConfig.length; i++) {
+      const descriptor = attachmentsConfig[i] || {};
+      let filename = descriptor.filename;
+      if (typeof filename === 'string') {
+        filename = interpolate(filename, ctx).trim();
+      }
+      let mimeType = descriptor.mimeType || descriptor.contentType || 'application/octet-stream';
+      if (typeof mimeType === 'string') {
+        mimeType = interpolate(mimeType, ctx).trim() || 'application/octet-stream';
+      }
+      let content = descriptor.content;
+      if (typeof content === 'string') {
+        content = interpolate(content, ctx);
+      }
+      if (!filename || !content) {
+        continue;
+      }
+
+      let encoded = '';
+      try {
+        const decoded = Utilities.base64Decode(String(content));
+        encoded = Utilities.base64Encode(decoded);
+      } catch (error) {
+        logWarn('gmail_send_email_attachment_decode_failed', {
+          index: i,
+          message: error && error.message ? error.message : String(error)
+        });
+        const fallbackBytes = Utilities.newBlob(String(content)).getBytes();
+        encoded = Utilities.base64Encode(fallbackBytes);
+      }
+
+      attachments.push({ filename: filename, mimeType: mimeType, data: encoded });
+    }
+  }
+
+  let messageBody = '';
+  if (attachments.length === 0) {
+    headerLines.push('Content-Type: text/plain; charset="UTF-8"');
+    headerLines.push('Content-Transfer-Encoding: 7bit');
+    messageBody = headerLines.join('\r\n') + '\r\n\r\n' + body;
+  } else {
+    const boundary = 'apps-script-gmail-' + Utilities.getUuid();
+    headerLines.push('Content-Type: multipart/mixed; boundary="' + boundary + '"');
+    const parts = [];
+    parts.push('--' + boundary);
+    parts.push('Content-Type: text/plain; charset="UTF-8"');
+    parts.push('Content-Transfer-Encoding: 7bit');
+    parts.push('');
+    parts.push(body);
+    parts.push('');
+    for (let a = 0; a < attachments.length; a++) {
+      const attachment = attachments[a];
+      parts.push('--' + boundary);
+      parts.push('Content-Type: ' + attachment.mimeType);
+      parts.push('Content-Disposition: attachment; filename="' + attachment.filename.replace(/"/g, '\\"') + '"');
+      parts.push('Content-Transfer-Encoding: base64');
+      parts.push('');
+      parts.push(attachment.data);
+      parts.push('');
+    }
+    parts.push('--' + boundary + '--');
+    messageBody = headerLines.join('\r\n') + '\r\n\r\n' + parts.join('\r\n');
+  }
+
+  const raw = Utilities.base64EncodeWebSafe(messageBody);
+
+  try {
+    const response = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/send',
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        },
+        payload: JSON.stringify({ raw: raw })
+      }),
+      { attempts: 5, backoffMs: 500 }
+    );
+
+    const responseBody = response.body || {};
+    ctx.messageId = responseBody.id || ctx.messageId || null;
+    ctx.gmailMessageId = responseBody.id || null;
+    ctx.gmailThreadId = responseBody.threadId || null;
+    ctx.gmailLabelIds = Array.isArray(responseBody.labelIds) ? responseBody.labelIds : [];
+    ctx.gmailSendEmailResponse = responseBody;
+
+    logInfo('gmail_send_email_success', {
+      messageId: ctx.gmailMessageId || null,
+      threadId: ctx.gmailThreadId || null,
+      toCount: recipients.length,
+      ccCount: ccList.length,
+      bccCount: bccList.length,
+      attachments: attachments.length
+    });
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_send_email_failed', {
+      operation: 'action.gmail:send_email',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail send_email failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}
+`;
+
+exports[`Apps Script Gmail REAL_OPS builds action.gmail:search_emails 1`] = `
+function step_action_gmail_search_emails(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:search_emails' });
+    throw new Error('Missing Gmail access token for gmail.search_emails operation');
+  }
+
+  const query = interpolate('${esc(c.query || '')}', ctx).trim();
+  if (!query) {
+    logError('gmail_search_emails_missing_param', { field: 'query' });
+    throw new Error('Missing required Gmail search_emails param: query');
+  }
+
+  const rawMaxResults = interpolate('${esc(c.maxResults !== undefined ? String(c.maxResults) : '')}', ctx).trim();
+  let maxResults = rawMaxResults ? Number(rawMaxResults) : ${typeof c.maxResults === 'number' ? c.maxResults : 10};
+  if (isNaN(maxResults) || maxResults <= 0) {
+    maxResults = ${typeof c.maxResults === 'number' ? c.maxResults : 10};
+  }
+  maxResults = Math.max(1, Math.min(500, Math.floor(maxResults)));
+
+  const includeSpamRaw = interpolate('${esc(c.includeSpamTrash !== undefined ? String(c.includeSpamTrash) : '')}', ctx)
+    .trim()
+    .toLowerCase();
+  const includeSpamTrash = includeSpamRaw
+    ? includeSpamRaw === 'true' || includeSpamRaw === '1'
+    : ${c.includeSpamTrash ? 'true' : 'false'};
+
+  const pageToken = ctx.nextPageToken || ctx.gmailNextPageToken || null;
+  const params = ['maxResults=' + maxResults, 'q=' + encodeURIComponent(query)];
+  if (includeSpamTrash) {
+    params.push('includeSpamTrash=true');
+  }
+  if (pageToken) {
+    params.push('pageToken=' + encodeURIComponent(pageToken));
+  }
+
+  try {
+    const response = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages?' + params.join('&'),
+        method: 'GET',
+        headers: { Authorization: 'Bearer ' + accessToken }
+      }),
+      { attempts: 5, backoffMs: 500 }
+    );
+
+    const body = response.body || {};
+    ctx.gmailMessages = Array.isArray(body.messages) ? body.messages : [];
+    ctx.gmailNextPageToken = body.nextPageToken || null;
+    ctx.nextPageToken = ctx.gmailNextPageToken;
+    ctx.resultSizeEstimate = typeof body.resultSizeEstimate === 'number' ? body.resultSizeEstimate : null;
+    ctx.gmailQuery = query;
+    ctx.gmailIncludeSpamTrash = includeSpamTrash;
+    ctx.gmailSearchResponse = body;
+
+    logInfo('gmail_search_emails_success', {
+      query: query,
+      returned: ctx.gmailMessages.length,
+      includeSpamTrash: includeSpamTrash,
+      hasNextPage: Boolean(ctx.gmailNextPageToken)
+    });
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_search_emails_failed', {
+      operation: 'action.gmail:search_emails',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail search_emails failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}
+`;

--- a/server/workflow/__tests__/apps-script-fixtures/gmail-send-email.json
+++ b/server/workflow/__tests__/apps-script-fixtures/gmail-send-email.json
@@ -1,0 +1,89 @@
+{
+  "id": "gmail-send-email",
+  "description": "Sends a Gmail message using the REST API and records identifiers in context.",
+  "graph": {
+    "id": "fixture-gmail-send-email",
+    "name": "Gmail send email",
+    "nodes": [
+      {
+        "id": "gmail-action",
+        "type": "action.gmail",
+        "app": "gmail",
+        "name": "Send Gmail notification",
+        "op": "action.gmail:send_email",
+        "params": {
+          "operation": "send_email",
+          "to": "alerts@example.com",
+          "subject": "Integration Test",
+          "body": "Hello world"
+        },
+        "data": {
+          "operation": "send_email",
+          "config": {
+            "to": "alerts@example.com",
+            "subject": "Integration Test",
+            "body": "Hello world"
+          }
+        }
+      }
+    ],
+    "edges": []
+  },
+  "entry": {
+    "context": {
+      "incidentId": "INC-9000"
+    }
+  },
+  "secrets": {
+    "GMAIL_ACCESS_TOKEN": "ya29.test-access-token"
+  },
+  "http": [
+    {
+      "name": "gmail-send",
+      "request": {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+        "method": "POST",
+        "headers": {
+          "authorization": "Bearer ya29.test-access-token",
+          "content-type": "application/json"
+        },
+        "payload": {
+          "raw": "VG86IGFsZXJ0c0BleGFtcGxlLmNvbQ0KU3ViamVjdDogSW50ZWdyYXRpb24gVGVzdA0KTUlNRS1WZXJzaW9uOiAxLjANCkNvbnRlbnQtVHlwZTogdGV4dC9wbGFpbjsgY2hhcnNldD0iVVRGLTgiDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiA3Yml0DQoNCkhlbGxvIHdvcmxk"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "id": "msg-123",
+          "threadId": "thread-001",
+          "labelIds": [
+            "SENT"
+          ]
+        }
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "incidentId": "INC-9000",
+      "messageId": "msg-123",
+      "gmailMessageId": "msg-123",
+      "gmailThreadId": "thread-001",
+      "gmailLabelIds": [
+        "SENT"
+      ]
+    },
+    "logs": [
+      {
+        "level": "log",
+        "includes": "gmail_send_email_success"
+      }
+    ],
+    "httpCalls": [
+      {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+        "method": "POST"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script.gmail.test.ts
+++ b/server/workflow/__tests__/apps-script.gmail.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { REAL_OPS } from '../compile-to-appsscript';
+import { runSingleFixture } from '../appsScriptDryRunHarness';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturesDir = path.join(__dirname, 'apps-script-fixtures');
+
+describe('Apps Script Gmail REAL_OPS', () => {
+  it('builds trigger.gmail:email_received', () => {
+    expect(REAL_OPS['trigger.gmail:email_received']({})).toMatchSnapshot();
+  });
+
+  it('builds action.gmail:send_email', () => {
+    expect(REAL_OPS['action.gmail:send_email']({})).toMatchSnapshot();
+  });
+
+  it('builds action.gmail:search_emails', () => {
+    expect(REAL_OPS['action.gmail:search_emails']({})).toMatchSnapshot();
+  });
+});
+
+describe('Apps Script Gmail integration', () => {
+  it('sends email via Gmail REST API', async () => {
+    const result = await runSingleFixture('gmail-send-email', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.context.gmailMessageId).toBe('msg-123');
+    expect(result.context.gmailThreadId).toBe('thread-001');
+    expect(result.context.gmailLabelIds).toEqual(['SENT']);
+    expect(result.httpCalls).toHaveLength(1);
+    expect(result.httpCalls[0].url).toBe('https://gmail.googleapis.com/gmail/v1/users/me/messages/send');
+  });
+});

--- a/server/workflow/compile-to-appsscript.ts
+++ b/server/workflow/compile-to-appsscript.ts
@@ -12946,54 +12946,9 @@ function ${functionName}(inputData, params) {
 const opKey = (n: any) => `${n.type}:${n.data?.operation}`;
 
 const OPS: Record<string, (c: any) => string> = {
-  'trigger.gmail:email_received': (c) => `
-function onNewEmail() {
-  return buildPollingWrapper('trigger.gmail:email_received', function (runtime) {
-    const query = '${esc(c.query || 'is:unread')}';
-    const threads = GmailApp.search(query, 0, 10);
-    const lastRunAt = runtime.state && runtime.state.lastRunAt ? new Date(runtime.state.lastRunAt) : null;
-    const items = [];
-
-    threads.forEach(thread => {
-      const messages = thread.getMessages();
-      messages.forEach(message => {
-        const messageDate = typeof message.getDate === 'function' ? message.getDate() : null;
-        if (lastRunAt && messageDate && messageDate <= lastRunAt) {
-          return;
-        }
-        items.push({ thread: thread, message: message });
-      });
-    });
-
-    const batch = runtime.dispatchBatch(items, function (entry) {
-      const message = entry.message;
-      return {
-        from: message.getFrom(),
-        subject: message.getSubject(),
-        body: message.getPlainBody(),
-        thread: entry.thread
-      };
-    });
-
-    runtime.state.lastRunAt = new Date().toISOString();
-    runtime.state.lastMessageCount = batch.succeeded;
-
-    runtime.summary({
-      threads: threads.length,
-      messagesAttempted: batch.attempted,
-      messagesDispatched: batch.succeeded,
-      messagesFailed: batch.failed,
-      query: query
-    });
-    return {
-      threads: threads.length,
-      messagesAttempted: batch.attempted,
-      messagesDispatched: batch.succeeded,
-      messagesFailed: batch.failed,
-      query: query
-    };
-  });
-}`,
+  'trigger.gmail:email_received': (c) => REAL_OPS['trigger.gmail:email_received']
+    ? REAL_OPS['trigger.gmail:email_received'](c)
+    : '',
 
   'action.gmail:send_reply': (c) => `
 function step_sendReply(ctx) {
@@ -13381,6 +13336,293 @@ function funcName(n: any) {
 // Real Apps Script operations mapping - P0 CRITICAL EXPANSION
 const REAL_OPS: Record<string, (c: any) => string> = {
   ...GENERATED_REAL_OPS,
+  'trigger.gmail:email_received': (c) => `
+function onNewEmail() {
+  return buildPollingWrapper('trigger.gmail:email_received', function (runtime) {
+    const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+    if (!accessToken) {
+      logError('gmail_missing_access_token', { operation: 'trigger.gmail:email_received' });
+      throw new Error('Missing Gmail access token for gmail.email_received trigger');
+    }
+
+    const interpolationContext = runtime.state && runtime.state.lastPayload ? runtime.state.lastPayload : {};
+    const query = interpolate('${esc(c.query || 'is:unread')}', interpolationContext).trim();
+    const labelIdsConfig = ${JSON.stringify(c.labelIds || [])};
+    const labelIds = [];
+    if (Array.isArray(labelIdsConfig)) {
+      for (let i = 0; i < labelIdsConfig.length; i++) {
+        const value = typeof labelIdsConfig[i] === 'string' ? interpolate(labelIdsConfig[i], interpolationContext).trim() : '';
+        if (value) {
+          labelIds.push(value);
+        }
+      }
+    }
+
+    const headers = { Authorization: 'Bearer ' + accessToken };
+    const baseUrl = 'https://gmail.googleapis.com/gmail/v1/users/me';
+    const cursor = (runtime.state && typeof runtime.state.cursor === 'object') ? runtime.state.cursor : {};
+    const lastInternalDate = cursor && cursor.internalDate ? Number(cursor.internalDate) : null;
+    const afterSeconds = lastInternalDate ? Math.floor(lastInternalDate / 1000) : null;
+    const effectiveQuery = afterSeconds ? ((query ? query + ' ' : '') + 'after:' + afterSeconds) : query;
+    const messages = [];
+    let pageToken = null;
+    let pageCount = 0;
+
+    function decodeBase64Url(data) {
+      if (!data) {
+        return '';
+      }
+      try {
+        const normalized = data.replace(/-/g, '+').replace(/_/g, '/');
+        const bytes = Utilities.base64Decode(normalized);
+        return Utilities.newBlob(bytes).getDataAsString('UTF-8');
+      } catch (error) {
+        logWarn('gmail_message_body_decode_failed', {
+          message: error && error.message ? error.message : String(error)
+        });
+        return '';
+      }
+    }
+
+    function extractHeader(all, name) {
+      if (!Array.isArray(all)) {
+        return '';
+      }
+      const target = name.toLowerCase();
+      for (let i = 0; i < all.length; i++) {
+        const header = all[i];
+        if (!header || typeof header.name !== 'string') {
+          continue;
+        }
+        if (header.name.toLowerCase() === target) {
+          return header.value || '';
+        }
+      }
+      return '';
+    }
+
+    function parseAddressList(value) {
+      if (!value) {
+        return [];
+      }
+      return value.split(',').map(part => part.trim()).filter(Boolean);
+    }
+
+    function collectAttachments(parts, bucket) {
+      if (!Array.isArray(parts)) {
+        return;
+      }
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        if (!part) {
+          continue;
+        }
+        if (part.filename && part.body && part.body.attachmentId) {
+          bucket.push({
+            attachmentId: part.body.attachmentId,
+            filename: part.filename,
+            mimeType: part.mimeType || 'application/octet-stream',
+            size: part.body.size || 0
+          });
+        }
+        if (Array.isArray(part.parts) && part.parts.length) {
+          collectAttachments(part.parts, bucket);
+        }
+      }
+    }
+
+    function extractBodies(payload) {
+      const result = {};
+      if (!payload) {
+        return result;
+      }
+
+      const queue = [payload];
+      while (queue.length > 0) {
+        const node = queue.shift();
+        if (!node) {
+          continue;
+        }
+        if (node.mimeType === 'text/plain' && node.body && node.body.data) {
+          result.plain = decodeBase64Url(node.body.data);
+        } else if (node.mimeType === 'text/html' && node.body && node.body.data) {
+          result.html = decodeBase64Url(node.body.data);
+        }
+        if (Array.isArray(node.parts)) {
+          for (let p = 0; p < node.parts.length; p++) {
+            queue.push(node.parts[p]);
+          }
+        }
+      }
+
+      if (!result.plain && payload.body && payload.body.data) {
+        result.plain = decodeBase64Url(payload.body.data);
+      }
+
+      return result;
+    }
+
+    try {
+      do {
+        const params = ['maxResults=25'];
+        if (effectiveQuery) {
+          params.push('q=' + encodeURIComponent(effectiveQuery));
+        }
+        if (Array.isArray(labelIds) && labelIds.length) {
+        for (let i = 0; i < labelIds.length; i++) {
+          params.push('labelIds=' + encodeURIComponent(labelIds[i]));
+        }
+      }
+      if (pageToken) {
+        params.push('pageToken=' + encodeURIComponent(pageToken));
+      }
+
+      const listResponse = rateLimitAware(
+        () => fetchJson({
+          url: baseUrl + '/messages?' + params.join('&'),
+          method: 'GET',
+          headers: headers
+        }),
+        { attempts: 5, backoffMs: 500 }
+      );
+
+      const listBody = listResponse.body || {};
+      const candidates = Array.isArray(listBody.messages) ? listBody.messages : [];
+      for (let i = 0; i < candidates.length; i++) {
+        const messageId = candidates[i] && candidates[i].id;
+        if (!messageId) {
+          continue;
+        }
+
+        const messageResponse = rateLimitAware(
+          () => fetchJson({
+            url: baseUrl + '/messages/' + encodeURIComponent(messageId) + '?format=full',
+            method: 'GET',
+            headers: headers
+          }),
+          { attempts: 5, backoffMs: 500 }
+        );
+
+        const detail = messageResponse.body || {};
+        const payload = detail.payload || {};
+        const headersList = payload.headers || [];
+        const bodies = extractBodies(payload);
+        const attachments = [];
+        collectAttachments(payload.parts, attachments);
+
+        const internalDate = detail.internalDate ? Number(detail.internalDate) : null;
+        if (lastInternalDate && internalDate && internalDate <= lastInternalDate) {
+          continue;
+        }
+
+        const from = extractHeader(headersList, 'From');
+        const to = parseAddressList(extractHeader(headersList, 'To'));
+        const cc = parseAddressList(extractHeader(headersList, 'Cc'));
+        const bcc = parseAddressList(extractHeader(headersList, 'Bcc'));
+        const replyTo = parseAddressList(extractHeader(headersList, 'Reply-To'));
+        const deliveredTo = extractHeader(headersList, 'Delivered-To');
+        const subject = extractHeader(headersList, 'Subject') || null;
+        const historyId = detail.historyId ? String(detail.historyId) : null;
+
+        const fromName = from && from.indexOf('<') !== -1 ? from.split('<')[0].trim() : null;
+
+        messages.push({
+          internalDate: internalDate || Date.now(),
+          historyId: historyId,
+          payload: {
+            id: detail.id || messageId,
+            threadId: detail.threadId || null,
+            historyId: historyId,
+            labelIds: Array.isArray(detail.labelIds) ? detail.labelIds : [],
+            subject: subject,
+            snippet: detail.snippet || '',
+            from: from,
+            fromName: fromName,
+            to: to,
+            cc: cc,
+            bcc: bcc,
+            replyTo: replyTo,
+            deliveredTo: deliveredTo || null,
+            receivedAt: internalDate ? new Date(internalDate).toISOString() : new Date().toISOString(),
+            sizeEstimate: detail.sizeEstimate || null,
+            bodyPlain: bodies.plain || '',
+            bodyHtml: bodies.html || '',
+            attachments: attachments,
+            _meta: { raw: detail }
+          }
+        });
+      }
+
+      pageToken = listBody.nextPageToken || null;
+      pageCount += 1;
+    } while (pageToken && messages.length < 50 && pageCount < 5);
+
+      if (messages.length === 0) {
+        runtime.summary({
+          messagesAttempted: 0,
+          messagesDispatched: 0,
+          messagesFailed: 0,
+          query: effectiveQuery,
+          labelIds: labelIds
+        });
+        return { messagesAttempted: 0, messagesDispatched: 0, messagesFailed: 0, query: effectiveQuery, labelIds: labelIds };
+      }
+
+      messages.sort(function (a, b) {
+        return (a.internalDate || 0) - (b.internalDate || 0);
+      });
+
+      const batch = runtime.dispatchBatch(messages, function (entry) {
+        return entry.payload;
+      });
+
+      const last = messages[messages.length - 1];
+      runtime.state.cursor = runtime.state.cursor && typeof runtime.state.cursor === 'object' ? runtime.state.cursor : {};
+      runtime.state.cursor.internalDate = String(last.internalDate || Date.now());
+      if (last.historyId) {
+        runtime.state.cursor.historyId = last.historyId;
+      }
+      runtime.state.cursor.lastMessageId = last.payload.id;
+      runtime.state.lastPayload = last.payload;
+
+      runtime.summary({
+        messagesAttempted: batch.attempted,
+        messagesDispatched: batch.succeeded,
+        messagesFailed: batch.failed,
+        query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      });
+
+      logInfo('gmail_email_received_success', {
+        query: effectiveQuery,
+        dispatched: batch.succeeded,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      });
+
+      return {
+        messagesAttempted: batch.attempted,
+        messagesDispatched: batch.succeeded,
+        messagesFailed: batch.failed,
+        query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      };
+    } catch (error) {
+      const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+      const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+      const status = error && typeof error.status === 'number' ? error.status : null;
+      const message = providerMessage || (error && error.message ? error.message : String(error));
+      logError('gmail_email_received_failed', {
+        status: status,
+        providerCode: providerCode,
+        message: message
+      });
+      throw error;
+    }
+  });
+}`,
   'trigger.sheets:onEdit': (c) => `
 function onEdit(e) {
   return buildPollingWrapper('trigger.sheets:onEdit', function (runtime) {
@@ -13459,48 +13701,240 @@ function step_getRow(ctx) {
   }
 }`,
 
-  'action.gmail:sendEmail': (c) => `
-function step_sendEmail(ctx) {
-  const to = interpolate('${c.to || '{{candidate_email}}'}', ctx);
-  const subject = interpolate('${c.subject || 'Interview Invitation'}', ctx);
-  const body = interpolate('${c.body || 'Hello {{candidate_name}}, you are selected for the interview'}', ctx);
-  GmailApp.sendEmail(to, subject, body);
-  return ctx;
+  'action.gmail:send_email': (c) => `
+function step_action_gmail_send_email(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:send_email' });
+    throw new Error('Missing Gmail access token for gmail.send_email operation');
+  }
+
+  const to = interpolate('${esc(c.to || '')}', ctx).trim();
+  const subject = interpolate('${esc(c.subject || '')}', ctx).trim();
+  const body = interpolate('${esc(c.body || '')}', ctx);
+  const cc = interpolate('${esc(c.cc || '')}', ctx).trim();
+  const bcc = interpolate('${esc(c.bcc || '')}', ctx).trim();
+  const attachmentsConfig = ${JSON.stringify(c.attachments || [])};
+
+  function ensureParam(value, field) {
+    if (!value) {
+      logError('gmail_send_email_missing_param', { field: field });
+      throw new Error('Missing required Gmail send_email param: ' + field);
+    }
+    return value;
+  }
+
+  ensureParam(to, 'to');
+  ensureParam(subject, 'subject');
+  ensureParam(body, 'body');
+
+  const recipients = to.split(',').map(function (entry) { return entry.trim(); }).filter(Boolean);
+  const ccList = cc ? cc.split(',').map(function (entry) { return entry.trim(); }).filter(Boolean) : [];
+  const bccList = bcc ? bcc.split(',').map(function (entry) { return entry.trim(); }).filter(Boolean) : [];
+
+  const headerLines = ['To: ' + recipients.join(', ')];
+  if (ccList.length) {
+    headerLines.push('Cc: ' + ccList.join(', '));
+  }
+  if (bccList.length) {
+    headerLines.push('Bcc: ' + bccList.join(', '));
+  }
+  headerLines.push('Subject: ' + subject);
+  headerLines.push('MIME-Version: 1.0');
+
+  const attachments = [];
+  if (Array.isArray(attachmentsConfig)) {
+    for (let i = 0; i < attachmentsConfig.length; i++) {
+      const descriptor = attachmentsConfig[i] || {};
+      let filename = descriptor.filename;
+      if (typeof filename === 'string') {
+        filename = interpolate(filename, ctx).trim();
+      }
+      let mimeType = descriptor.mimeType || descriptor.contentType || 'application/octet-stream';
+      if (typeof mimeType === 'string') {
+        mimeType = interpolate(mimeType, ctx).trim() || 'application/octet-stream';
+      }
+      let content = descriptor.content;
+      if (typeof content === 'string') {
+        content = interpolate(content, ctx);
+      }
+      if (!filename || !content) {
+        continue;
+      }
+
+      let encoded = '';
+      try {
+        const decoded = Utilities.base64Decode(String(content));
+        encoded = Utilities.base64Encode(decoded);
+      } catch (error) {
+        logWarn('gmail_send_email_attachment_decode_failed', {
+          index: i,
+          message: error && error.message ? error.message : String(error)
+        });
+        const fallbackBytes = Utilities.newBlob(String(content)).getBytes();
+        encoded = Utilities.base64Encode(fallbackBytes);
+      }
+
+      attachments.push({ filename: filename, mimeType: mimeType, data: encoded });
+    }
+  }
+
+  let messageBody = '';
+  if (attachments.length === 0) {
+    headerLines.push('Content-Type: text/plain; charset="UTF-8"');
+    headerLines.push('Content-Transfer-Encoding: 7bit');
+    messageBody = headerLines.join('\r\n') + '\r\n\r\n' + body;
+  } else {
+    const boundary = 'apps-script-gmail-' + Utilities.getUuid();
+    headerLines.push('Content-Type: multipart/mixed; boundary="' + boundary + '"');
+    const parts = [];
+    parts.push('--' + boundary);
+    parts.push('Content-Type: text/plain; charset="UTF-8"');
+    parts.push('Content-Transfer-Encoding: 7bit');
+    parts.push('');
+    parts.push(body);
+    parts.push('');
+    for (let a = 0; a < attachments.length; a++) {
+      const attachment = attachments[a];
+      parts.push('--' + boundary);
+      parts.push('Content-Type: ' + attachment.mimeType);
+      parts.push('Content-Disposition: attachment; filename="' + attachment.filename.replace(/"/g, '\\"') + '"');
+      parts.push('Content-Transfer-Encoding: base64');
+      parts.push('');
+      parts.push(attachment.data);
+      parts.push('');
+    }
+    parts.push('--' + boundary + '--');
+    messageBody = headerLines.join('\r\n') + '\r\n\r\n' + parts.join('\r\n');
+  }
+
+  const raw = Utilities.base64EncodeWebSafe(messageBody);
+
+  try {
+    const response = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/send',
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        },
+        payload: JSON.stringify({ raw: raw })
+      }),
+      { attempts: 5, backoffMs: 500 }
+    );
+
+    const responseBody = response.body || {};
+    ctx.messageId = responseBody.id || ctx.messageId || null;
+    ctx.gmailMessageId = responseBody.id || null;
+    ctx.gmailThreadId = responseBody.threadId || null;
+    ctx.gmailLabelIds = Array.isArray(responseBody.labelIds) ? responseBody.labelIds : [];
+    ctx.gmailSendEmailResponse = responseBody;
+
+    logInfo('gmail_send_email_success', {
+      messageId: ctx.gmailMessageId || null,
+      threadId: ctx.gmailThreadId || null,
+      toCount: recipients.length,
+      ccCount: ccList.length,
+      bccCount: bccList.length,
+      attachments: attachments.length
+    });
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_send_email_failed', {
+      operation: 'action.gmail:send_email',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail send_email failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
 }`,
 
   'action.gmail:search_emails': (c) => `
-function step_searchEmails(ctx) {
-  const query = '${c.query || 'is:unread'}';
-  const maxResults = ${c.maxResults || 50};
-  
-  const threads = GmailApp.search(query, 0, maxResults);
-  const invoices = [];
-  
-  threads.forEach(thread => {
-    const messages = thread.getMessages();
-    messages.forEach(message => {
-      // Extract invoice data from email
-      const subject = message.getSubject();
-      const body = message.getPlainBody();
-      const from = message.getFrom();
-      const date = message.getDate();
-      
-      // Simple data extraction (can be enhanced)
-      const invoiceData = {
-        from: from,
-        subject: subject,
-        date: date.toISOString(),
-        body: body.substring(0, 200), // First 200 chars
-        extractedData: '${c.extractData || 'Manual extraction needed'}'
-      };
-      
-      invoices.push(invoiceData);
+function step_action_gmail_search_emails(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:search_emails' });
+    throw new Error('Missing Gmail access token for gmail.search_emails operation');
+  }
+
+  const query = interpolate('${esc(c.query || '')}', ctx).trim();
+  if (!query) {
+    logError('gmail_search_emails_missing_param', { field: 'query' });
+    throw new Error('Missing required Gmail search_emails param: query');
+  }
+
+  const rawMaxResults = interpolate('${esc(c.maxResults !== undefined ? String(c.maxResults) : '')}', ctx).trim();
+  let maxResults = rawMaxResults ? Number(rawMaxResults) : ${typeof c.maxResults === 'number' ? c.maxResults : 10};
+  if (isNaN(maxResults) || maxResults <= 0) {
+    maxResults = ${typeof c.maxResults === 'number' ? c.maxResults : 10};
+  }
+  maxResults = Math.max(1, Math.min(500, Math.floor(maxResults)));
+
+  const includeSpamRaw = interpolate('${esc(c.includeSpamTrash !== undefined ? String(c.includeSpamTrash) : '')}', ctx)
+    .trim()
+    .toLowerCase();
+  const includeSpamTrash = includeSpamRaw
+    ? includeSpamRaw === 'true' || includeSpamRaw === '1'
+    : ${c.includeSpamTrash ? 'true' : 'false'};
+
+  const pageToken = ctx.nextPageToken || ctx.gmailNextPageToken || null;
+  const params = ['maxResults=' + maxResults, 'q=' + encodeURIComponent(query)];
+  if (includeSpamTrash) {
+    params.push('includeSpamTrash=true');
+  }
+  if (pageToken) {
+    params.push('pageToken=' + encodeURIComponent(pageToken));
+  }
+
+  try {
+    const response = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages?' + params.join('&'),
+        method: 'GET',
+        headers: { Authorization: 'Bearer ' + accessToken }
+      }),
+      { attempts: 5, backoffMs: 500 }
+    );
+
+    const body = response.body || {};
+    ctx.gmailMessages = Array.isArray(body.messages) ? body.messages : [];
+    ctx.gmailNextPageToken = body.nextPageToken || null;
+    ctx.nextPageToken = ctx.gmailNextPageToken;
+    ctx.resultSizeEstimate = typeof body.resultSizeEstimate === 'number' ? body.resultSizeEstimate : null;
+    ctx.gmailQuery = query;
+    ctx.gmailIncludeSpamTrash = includeSpamTrash;
+    ctx.gmailSearchResponse = body;
+
+    logInfo('gmail_search_emails_success', {
+      query: query,
+      returned: ctx.gmailMessages.length,
+      includeSpamTrash: includeSpamTrash,
+      hasNextPage: Boolean(ctx.gmailNextPageToken)
     });
-  });
-  
-  ctx.invoices = invoices;
-  console.log('📧 Found ' + invoices.length + ' potential invoices');
-  return ctx;
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_search_emails_failed', {
+      operation: 'action.gmail:search_emails',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail search_emails failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
 }`,
 
   'trigger.time:schedule': (c) => `


### PR DESCRIPTION
## Summary
- implement Gmail send_email, search_emails, and email_received Apps Script handlers that call the Gmail REST API with retries, rate-limit awareness, structured logging, and cursor persistence
- add vitest snapshots plus a dry-run fixture to exercise the Gmail handlers for Tier-0 coverage
- document Gmail script property requirements and update the generated properties report

## Testing
- `npx vitest run server/workflow/__tests__/apps-script.gmail.test.ts --update` *(fails: npm registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec884ce2148331912bb97a14e3ffaf