### PR TITLE
feat: harden Google Sheets Apps Script handlers

### DIFF
--- a/docs/apps-script-rollout/script-properties.md
+++ b/docs/apps-script-rollout/script-properties.md
@@ -157,6 +157,12 @@ The table below is regenerated automatically. Required properties appear in the 
 - Populate `GMAIL_REFRESH_TOKEN` alongside the access token. A rotation job should exchange the refresh token at least daily; the Apps Script runtime expects fresh access tokens because Gmail REST calls fail once the one-hour access token expires.
 - Store both secrets in Script Properties (production and staging) before deploying new handlers. Missing tokens cause structured `gmail_missing_access_token` errors during runtime, surfacing misconfigurations quickly.
 
+### Google Sheets token management
+
+- Apps Script Google Sheets handlers require `GOOGLE_SHEETS_ACCESS_TOKEN` with the scopes `https://www.googleapis.com/auth/spreadsheets` and `https://www.googleapis.com/auth/drive.metadata.readonly`. Populate the Script Properties store before deployment—missing tokens surface as `sheets_missing_access_token` errors during trigger and action execution.
+- For delegated OAuth flows, store a matching `GOOGLE_SHEETS_REFRESH_TOKEN` so the rotation job can mint fresh access tokens without manual intervention. Rotate both tokens alongside Gmail to avoid stale credentials.
+- When using service accounts with domain-wide delegation, store the JSON key in `GOOGLE_SHEETS_SERVICE_ACCOUNT` and the impersonated principal in `GOOGLE_SHEETS_DELEGATED_SUBJECT`. The credential rotation task exchanges those secrets for `GOOGLE_SHEETS_ACCESS_TOKEN` on the cadence defined in the runbook.
+
 ## Machine-readable report
 
 Deployment tooling and Confluence dashboards rely on `production/reports/apps-script-properties.json`. Run `tsx scripts/verify-apps-script-properties.ts --write` after updating REAL_OPS handlers or connector manifests so the report and table stay in sync. CI will fail if the report or guide drifts from the generated output.

--- a/server/workflow/__tests__/__snapshots__/apps-script.google-sheets.test.ts.snap
+++ b/server/workflow/__tests__/__snapshots__/apps-script.google-sheets.test.ts.snap
@@ -1,0 +1,481 @@
+exports[`Apps Script Google Sheets REAL_OPS builds trigger.sheets:onEdit 1`] = `
+function onEdit(e) {
+  return buildPollingWrapper('trigger.sheets:onEdit', function (runtime) {
+    var config = {
+      spreadsheetId: '',
+      sheetName: '',
+      valueRenderOption: 'UNFORMATTED_VALUE',
+      columns: []
+    };
+
+    if (!config.spreadsheetId) {
+      runtime.summary({ skipped: true, reason: 'missing_spreadsheet_id' });
+      logWarn('sheets_onedit_missing_spreadsheet_id', { operation: 'trigger.sheets:onEdit' });
+      return { skipped: true, reason: 'missing_spreadsheet_id' };
+    }
+
+    if (!e || !e.range) {
+      runtime.summary({ skipped: true, reason: 'missing_event_range', spreadsheetId: config.spreadsheetId });
+      logWarn('sheets_onedit_missing_event', { operation: 'trigger.sheets:onEdit' });
+      return { skipped: true, reason: 'missing_event_range' };
+    }
+
+    var eventSheet = e.range.getSheet ? e.range.getSheet() : null;
+    var eventSheetName = eventSheet && eventSheet.getName ? eventSheet.getName() : null;
+    if (config.sheetName && eventSheetName && config.sheetName !== eventSheetName) {
+      runtime.summary({ skipped: true, reason: 'sheet_mismatch', expected: config.sheetName, actual: eventSheetName });
+      return { skipped: true, reason: 'sheet_mismatch', expected: config.sheetName, actual: eventSheetName };
+    }
+
+    var sheetName = config.sheetName || eventSheetName || '';
+    var a1Notation = e.range.getA1Notation ? e.range.getA1Notation() : null;
+    var startRow = e.range.getRow ? e.range.getRow() : null;
+    var rowCount = e.range.getNumRows ? e.range.getNumRows() : 1;
+    var columnCount = e.range.getNumColumns ? e.range.getNumColumns() : 1;
+
+    if (!a1Notation || startRow === null) {
+      runtime.summary({ skipped: true, reason: 'unresolvable_range', sheet: sheetName || null });
+      logWarn('sheets_onedit_missing_notation', { operation: 'trigger.sheets:onEdit', sheet: sheetName || null });
+      return { skipped: true, reason: 'unresolvable_range' };
+    }
+
+    var qualifiedRange = sheetName ? sheetName + '!' + a1Notation : a1Notation;
+    var accessToken = getSecret('GOOGLE_SHEETS_ACCESS_TOKEN', { connectorKey: 'google-sheets-enhanced' });
+    if (!accessToken) {
+      runtime.summary({ skipped: true, reason: 'missing_access_token', sheet: sheetName || null, range: qualifiedRange });
+      logError('sheets_missing_access_token', { operation: 'trigger.sheets:onEdit' });
+      return { skipped: true, reason: 'missing_access_token' };
+    }
+
+    var url = 'https://sheets.googleapis.com/v4/spreadsheets/' + encodeURIComponent(config.spreadsheetId) +
+      '/values/' + encodeURIComponent(qualifiedRange) +
+      '?majorDimension=ROWS&valueRenderOption=' + encodeURIComponent(config.valueRenderOption || 'UNFORMATTED_VALUE');
+
+    var response;
+    try {
+      response = withRetries(function () {
+        return fetchJson({
+          url: url,
+          method: 'GET',
+          headers: {
+            Authorization: 'Bearer ' + accessToken
+          }
+        });
+      });
+    } catch (error) {
+      var status = error && typeof error.status === 'number' ? error.status : null;
+      var message = error && error.message ? error.message : String(error);
+      logError('sheets_onedit_fetch_failed', {
+        sheet: sheetName || null,
+        range: qualifiedRange,
+        status: status,
+        message: message
+      });
+      throw error;
+    }
+
+    var values = (response && response.body && response.body.values) || [];
+    var entries = [];
+
+    for (var index = 0; index < rowCount; index++) {
+      var rowValues = values[index] || [];
+      var rowNumber = (startRow || 0) + index;
+      var rowRange = e.range.offset && typeof e.range.offset === 'function'
+        ? e.range.offset(index, 0, 1, columnCount)
+        : null;
+      var rowNotation = rowRange && rowRange.getA1Notation ? rowRange.getA1Notation() : a1Notation;
+      var qualifiedRowRange = sheetName ? sheetName + '!' + rowNotation : rowNotation;
+      var record = {};
+      if (Array.isArray(config.columns) && config.columns.length) {
+        for (var colIndex = 0; colIndex < config.columns.length; colIndex++) {
+          var key = config.columns[colIndex];
+          if (!key) {
+            continue;
+          }
+          record[key] = rowValues[colIndex] !== undefined ? rowValues[colIndex] : null;
+        }
+      }
+
+      entries.push({
+        spreadsheetId: config.spreadsheetId,
+        sheet: sheetName || null,
+        range: qualifiedRowRange,
+        rowNumber: rowNumber,
+        values: rowValues,
+        record: record
+      });
+    }
+
+    var batch = runtime.dispatchBatch(entries, function (entry) {
+      return {
+        spreadsheetId: entry.spreadsheetId,
+        sheet: entry.sheet,
+        range: entry.range,
+        rowNumber: entry.rowNumber,
+        values: entry.values,
+        record: entry.record
+      };
+    });
+
+    runtime.state.lastSpreadsheetId = config.spreadsheetId;
+    runtime.state.lastSheet = sheetName || null;
+    runtime.state.lastRange = qualifiedRange;
+    runtime.state.lastRow = (startRow || 0) + rowCount - 1;
+    runtime.state.lastValues = values;
+    runtime.state.lastUpdatedAt = new Date().toISOString();
+
+    runtime.summary({
+      spreadsheetId: config.spreadsheetId,
+      sheet: sheetName || null,
+      range: qualifiedRange,
+      rowsAttempted: batch.attempted,
+      rowsDispatched: batch.succeeded,
+      rowsFailed: batch.failed
+    });
+
+    return {
+      spreadsheetId: config.spreadsheetId,
+      sheet: sheetName || null,
+      range: qualifiedRange,
+      rowsAttempted: batch.attempted,
+      rowsDispatched: batch.succeeded,
+      rowsFailed: batch.failed
+    };
+  });
+}`;
+
+exports[`Apps Script Google Sheets REAL_OPS builds action.sheets:getRow 1`] = `
+function step_getSheetsRow(ctx) {
+  ctx = ctx || {};
+
+  var spreadsheetIdTemplate = '';
+  var sheetNameTemplate = '';
+  var rangeTemplate = '';
+  var rowNumberTemplate = '';
+  var columns = [];
+  var valueRenderOption = 'UNFORMATTED_VALUE';
+
+  var spreadsheetId = spreadsheetIdTemplate ? interpolate(spreadsheetIdTemplate, ctx).trim() : '';
+  if (!spreadsheetId) {
+    logError('sheets_missing_spreadsheet_id', { operation: 'action.sheets:getRow' });
+    throw new Error('Spreadsheet ID is required for action.sheets:getRow');
+  }
+
+  var sheetName = sheetNameTemplate ? interpolate(sheetNameTemplate, ctx).trim() : '';
+  if (!sheetName) {
+    var fallbackSheet = ctx.sheet || ctx.sheetName;
+    if (typeof fallbackSheet === 'string') {
+      sheetName = fallbackSheet.trim();
+    }
+  }
+
+  var range = rangeTemplate ? interpolate(rangeTemplate, ctx).trim() : '';
+  var rowNumberRaw = rowNumberTemplate ? interpolate(rowNumberTemplate, ctx).trim() : '';
+  var rowNumber = rowNumberRaw ? Number(rowNumberRaw) : null;
+  if (!rowNumber || isNaN(rowNumber)) {
+    if (typeof ctx.rowNumber === 'number') {
+      rowNumber = ctx.rowNumber;
+    } else if (typeof ctx.row === 'number') {
+      rowNumber = ctx.row;
+    } else if (typeof ctx.sheetsLastAppendRowNumber === 'number') {
+      rowNumber = ctx.sheetsLastAppendRowNumber;
+    }
+  }
+  if (!rowNumber || isNaN(rowNumber)) {
+    rowNumber = 1;
+  }
+  rowNumber = Math.max(1, Math.floor(Number(rowNumber)));
+
+  function columnLabel(count) {
+    if (!count || count < 1) {
+      return 'A';
+    }
+    var dividend = count;
+    var label = '';
+    while (dividend > 0) {
+      var modulo = (dividend - 1) % 26;
+      label = String.fromCharCode(65 + modulo) + label;
+      dividend = Math.floor((dividend - modulo) / 26);
+    }
+    return label;
+  }
+
+  if (!range) {
+    if (!sheetName) {
+      logError('sheets_missing_sheet_name', { operation: 'action.sheets:getRow' });
+      throw new Error('Sheet name or range is required for action.sheets:getRow');
+    }
+    var columnCount = columns.length > 0 ? columns.length : 0;
+    if (!columnCount && Array.isArray(ctx.rowValues) && ctx.rowValues.length) {
+      columnCount = ctx.rowValues.length;
+    }
+    if (!columnCount && typeof ctx.columnCount === 'number') {
+      columnCount = ctx.columnCount;
+    }
+    if (!columnCount) {
+      columnCount = 26;
+    }
+    var endColumn = columnLabel(columnCount);
+    range = sheetName + '!A' + rowNumber + ':' + endColumn + rowNumber;
+  } else if (range.indexOf('!') === -1 && sheetName) {
+    range = sheetName + '!' + range;
+  }
+
+  var accessToken = getSecret('GOOGLE_SHEETS_ACCESS_TOKEN', { connectorKey: 'google-sheets-enhanced' });
+  if (!accessToken) {
+    logError('sheets_missing_access_token', { operation: 'action.sheets:getRow' });
+    throw new Error('Missing Google Sheets access token for action.sheets:getRow');
+  }
+
+  var url = 'https://sheets.googleapis.com/v4/spreadsheets/' + encodeURIComponent(spreadsheetId) +
+    '/values/' + encodeURIComponent(range) +
+    '?majorDimension=ROWS&valueRenderOption=' + encodeURIComponent(valueRenderOption);
+
+  var response;
+  try {
+    response = withRetries(function () {
+      return fetchJson({
+        url: url,
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer ' + accessToken
+        }
+      });
+    });
+  } catch (error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var message = error && error.message ? error.message : String(error);
+    logError('sheets_get_row_failed', {
+      spreadsheetId: spreadsheetId,
+      range: range,
+      status: status,
+      message: message
+    });
+    throw error;
+  }
+
+  var values = response && response.body && Array.isArray(response.body.values) ? response.body.values : [];
+  var rowValues = values.length > 0 && Array.isArray(values[0]) ? values[0] : [];
+  var record = {};
+  if (columns.length) {
+    for (var i = 0; i < columns.length; i++) {
+      var key = columns[i];
+      if (!key) {
+        continue;
+      }
+      record[key] = rowValues[i] !== undefined ? rowValues[i] : null;
+    }
+  } else {
+    for (var index = 0; index < rowValues.length; index++) {
+      record['column_' + (index + 1)] = rowValues[index];
+    }
+  }
+
+  ctx.rowValues = rowValues.slice();
+  ctx.rowRecord = Object.assign({}, record);
+  ctx.sheets = ctx.sheets || {};
+  ctx.sheets.lastRead = {
+    spreadsheetId: spreadsheetId,
+    sheet: sheetName || null,
+    range: range,
+    rowNumber: rowNumber,
+    values: rowValues.slice(),
+    record: Object.assign({}, record)
+  };
+  ctx.sheetsLastReadRange = range;
+  ctx.sheetsLastReadValues = rowValues.slice();
+  ctx.sheetsLastReadRecord = Object.assign({}, record);
+  ctx.sheetsLastReadRowNumber = rowNumber;
+
+  logInfo('sheets_get_row_success', {
+    spreadsheetId: spreadsheetId,
+    range: range,
+    rowNumber: rowNumber,
+    valueCount: rowValues.length
+  });
+
+  return ctx;
+}`;
+
+exports[`Apps Script Google Sheets REAL_OPS builds action.sheets:append_row 1`] = `
+function step_appendSheetsRow(ctx) {
+  ctx = ctx || {};
+
+  var spreadsheetIdTemplate = '';
+  var sheetNameTemplate = '';
+  var rangeTemplate = '';
+  var valueInputOption = 'USER_ENTERED';
+  var columns = [];
+  var configuredValues = [];
+
+  var spreadsheetId = spreadsheetIdTemplate ? interpolate(spreadsheetIdTemplate, ctx).trim() : '';
+  if (!spreadsheetId) {
+    logError('sheets_missing_spreadsheet_id', { operation: 'action.sheets:append_row' });
+    throw new Error('Spreadsheet ID is required for action.sheets:append_row');
+  }
+
+  var sheetName = sheetNameTemplate ? interpolate(sheetNameTemplate, ctx).trim() : '';
+  var range = rangeTemplate ? interpolate(rangeTemplate, ctx).trim() : '';
+  if (!range) {
+    range = sheetName;
+  }
+  if (!range) {
+    logError('sheets_missing_range', { operation: 'action.sheets:append_row' });
+    throw new Error('Sheet name or range is required for action.sheets:append_row');
+  }
+
+  var accessToken = getSecret('GOOGLE_SHEETS_ACCESS_TOKEN', { connectorKey: 'google-sheets-enhanced' });
+  if (!accessToken) {
+    logError('sheets_missing_access_token', { operation: 'action.sheets:append_row' });
+    throw new Error('Missing Google Sheets access token for action.sheets:append_row');
+  }
+
+  function coerceValue(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    return value;
+  }
+
+  function resolveValue(key) {
+    if (!key) {
+      return '';
+    }
+    if (Object.prototype.hasOwnProperty.call(ctx, key)) {
+      return ctx[key];
+    }
+    if (ctx.record && typeof ctx.record === 'object' && Object.prototype.hasOwnProperty.call(ctx.record, key)) {
+      return ctx.record[key];
+    }
+    if (ctx.payload && typeof ctx.payload === 'object' && Object.prototype.hasOwnProperty.call(ctx.payload, key)) {
+      return ctx.payload[key];
+    }
+    if (ctx.row && typeof ctx.row === 'object' && Object.prototype.hasOwnProperty.call(ctx.row, key)) {
+      return ctx.row[key];
+    }
+    return '';
+  }
+
+  var rowValues = [];
+  if (configuredValues.length) {
+    for (var valueIndex = 0; valueIndex < configuredValues.length; valueIndex++) {
+      var template = configuredValues[valueIndex];
+      if (typeof template === 'string') {
+        rowValues.push(interpolate(template, ctx));
+      } else {
+        rowValues.push(template);
+      }
+    }
+  } else if (columns.length) {
+    for (var columnIndex = 0; columnIndex < columns.length; columnIndex++) {
+      var columnKey = columns[columnIndex];
+      rowValues.push(resolveValue(columnKey));
+    }
+  } else if (Array.isArray(ctx.rowValues)) {
+    rowValues = ctx.rowValues.slice();
+  } else if (Array.isArray(ctx.values)) {
+    rowValues = ctx.values.slice();
+  }
+
+  if (!rowValues.length) {
+    logError('sheets_append_row_missing_values', { operation: 'action.sheets:append_row' });
+    throw new Error('At least one value is required for action.sheets:append_row');
+  }
+
+  for (var normalizeIndex = 0; normalizeIndex < rowValues.length; normalizeIndex++) {
+    rowValues[normalizeIndex] = coerceValue(rowValues[normalizeIndex]);
+  }
+
+  var record = {};
+  if (columns.length) {
+    for (var recordIndex = 0; recordIndex < columns.length; recordIndex++) {
+      var recordKey = columns[recordIndex];
+      if (!recordKey) {
+        continue;
+      }
+      record[recordKey] = rowValues[recordIndex] !== undefined ? rowValues[recordIndex] : '';
+    }
+  }
+
+  var url = 'https://sheets.googleapis.com/v4/spreadsheets/' + encodeURIComponent(spreadsheetId) +
+    '/values/' + encodeURIComponent(range) +
+    ':append?valueInputOption=' + encodeURIComponent(valueInputOption || 'USER_ENTERED') +
+    '&insertDataOption=INSERT_ROWS&includeValuesInResponse=true';
+
+  var requestBody = {
+    majorDimension: 'ROWS',
+    values: [rowValues]
+  };
+
+  var response;
+  try {
+    response = withRetries(function () {
+      return fetchJson({
+        url: url,
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        },
+        payload: JSON.stringify(requestBody),
+        contentType: 'application/json'
+      });
+    });
+  } catch (error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var message = error && error.message ? error.message : String(error);
+    logError('sheets_append_row_failed', {
+      spreadsheetId: spreadsheetId,
+      range: range,
+      status: status,
+      message: message
+    });
+    throw error;
+  }
+
+  var updates = response && response.body && response.body.updates ? response.body.updates : {};
+  var updatedRange = updates.updatedRange || (response && response.body && response.body.tableRange) || null;
+  var updatedRows = updates.updatedRows;
+  if (typeof updatedRows === 'string') {
+    updatedRows = Number(updatedRows);
+  }
+  if (typeof updatedRows !== 'number' || isNaN(updatedRows)) {
+    updatedRows = 1;
+  }
+
+  var appendedRowNumber = null;
+  if (updatedRange) {
+    var match = String(updatedRange).match(/!.*?(\\d+)(?::.*?(\\d+))?$/);
+    if (match) {
+      var parsed = match[2] ? Number(match[2]) : Number(match[1]);
+      if (!isNaN(parsed) && parsed > 0) {
+        appendedRowNumber = parsed;
+      }
+    }
+  }
+
+  ctx.sheets = ctx.sheets || {};
+  ctx.sheets.lastAppend = {
+    spreadsheetId: spreadsheetId,
+    sheet: sheetName || null,
+    range: updatedRange || range,
+    values: rowValues.slice(),
+    updatedRows: updatedRows,
+    record: Object.assign({}, record),
+    rowNumber: appendedRowNumber
+  };
+  ctx.sheetsLastAppendRange = updatedRange || range;
+  ctx.sheetsLastAppendValues = rowValues.slice();
+  ctx.sheetsLastAppendUpdatedRows = updatedRows;
+  if (appendedRowNumber) {
+    ctx.sheetsLastAppendRowNumber = appendedRowNumber;
+  }
+
+  logInfo('sheets_append_row_success', {
+    spreadsheetId: spreadsheetId,
+    range: updatedRange || range,
+    updatedRows: updatedRows
+  });
+
+  return ctx;
+}`;

--- a/server/workflow/__tests__/apps-script-fixtures/google-sheets-append-read.json
+++ b/server/workflow/__tests__/apps-script-fixtures/google-sheets-append-read.json
@@ -1,0 +1,162 @@
+{
+  "id": "google-sheets-append-read",
+  "description": "Appends a Google Sheets row and reads it back using the REST API.",
+  "graph": {
+    "id": "fixture-google-sheets-append-read",
+    "name": "Google Sheets append and read",
+    "nodes": [
+      {
+        "id": "append-row",
+        "type": "action.google-sheets-enhanced",
+        "app": "google-sheets-enhanced",
+        "name": "Append incident row",
+        "op": "action.sheets:append_row",
+        "params": {
+          "operation": "append_row",
+          "spreadsheetId": "test-spreadsheet",
+          "sheetName": "Incidents",
+          "columns": ["incidentId", "status"],
+          "values": ["{{incidentId}}", "{{status}}"],
+          "valueInputOption": "USER_ENTERED"
+        },
+        "data": {
+          "operation": "append_row",
+          "config": {
+            "spreadsheetId": "test-spreadsheet",
+            "sheetName": "Incidents",
+            "columns": ["incidentId", "status"],
+            "values": ["{{incidentId}}", "{{status}}"],
+            "valueInputOption": "USER_ENTERED"
+          }
+        }
+      },
+      {
+        "id": "get-row",
+        "type": "action.google-sheets-enhanced",
+        "app": "google-sheets-enhanced",
+        "name": "Read appended row",
+        "op": "action.sheets:getRow",
+        "params": {
+          "operation": "getRow",
+          "spreadsheetId": "test-spreadsheet",
+          "sheetName": "Incidents",
+          "rowNumber": "{{sheetsLastAppendRowNumber}}",
+          "columns": ["incidentId", "status"],
+          "valueRenderOption": "UNFORMATTED_VALUE"
+        },
+        "data": {
+          "operation": "getRow",
+          "config": {
+            "spreadsheetId": "test-spreadsheet",
+            "sheetName": "Incidents",
+            "rowNumber": "{{sheetsLastAppendRowNumber}}",
+            "columns": ["incidentId", "status"],
+            "valueRenderOption": "UNFORMATTED_VALUE"
+          }
+        }
+      }
+    ],
+    "edges": [
+      {
+        "id": "edge-append-read",
+        "from": "append-row",
+        "to": "get-row",
+        "source": "append-row",
+        "target": "get-row"
+      }
+    ]
+  },
+  "entry": {
+    "context": {
+      "incidentId": "INC-9000",
+      "status": "Open"
+    }
+  },
+  "secrets": {
+    "GOOGLE_SHEETS_ACCESS_TOKEN": "ya29.sheets-access"
+  },
+  "http": [
+    {
+      "name": "sheets-append",
+      "request": {
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/test-spreadsheet/values/Incidents:append?valueInputOption=USER_ENTERED&insertDataOption=INSERT_ROWS&includeValuesInResponse=true",
+        "method": "POST",
+        "headers": {
+          "authorization": "Bearer ya29.sheets-access",
+          "content-type": "application/json"
+        },
+        "payload": {
+          "majorDimension": "ROWS",
+          "values": [["INC-9000", "Open"]]
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "updates": {
+            "spreadsheetId": "test-spreadsheet",
+            "updatedRange": "Incidents!A5:B5",
+            "updatedRows": 1,
+            "updatedColumns": 2,
+            "updatedCells": 2
+          }
+        }
+      }
+    },
+    {
+      "name": "sheets-get",
+      "request": {
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/test-spreadsheet/values/Incidents!A5:B5?majorDimension=ROWS&valueRenderOption=UNFORMATTED_VALUE",
+        "method": "GET",
+        "headers": {
+          "authorization": "Bearer ya29.sheets-access"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "range": "Incidents!A5:B5",
+          "majorDimension": "ROWS",
+          "values": [["INC-9000", "Open"]]
+        }
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "incidentId": "INC-9000",
+      "status": "Open",
+      "sheetsLastAppendRowNumber": 5,
+      "sheets": {
+        "lastAppend": {
+          "range": "Incidents!A5:B5",
+          "updatedRows": 1
+        },
+        "lastRead": {
+          "range": "Incidents!A5:B5",
+          "values": ["INC-9000", "Open"]
+        }
+      }
+    },
+    "logs": [
+      {
+        "level": "log",
+        "includes": "sheets_append_row_success"
+      },
+      {
+        "level": "log",
+        "includes": "sheets_get_row_success"
+      }
+    ],
+    "httpCalls": [
+      {
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/test-spreadsheet/values/Incidents:append?valueInputOption=USER_ENTERED&insertDataOption=INSERT_ROWS&includeValuesInResponse=true",
+        "method": "POST"
+      },
+      {
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/test-spreadsheet/values/Incidents!A5:B5?majorDimension=ROWS&valueRenderOption=UNFORMATTED_VALUE",
+        "method": "GET"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script.google-sheets.test.ts
+++ b/server/workflow/__tests__/apps-script.google-sheets.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { REAL_OPS } from '../compile-to-appsscript';
+import { runSingleFixture } from '../appsScriptDryRunHarness';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturesDir = path.join(__dirname, 'apps-script-fixtures');
+
+describe('Apps Script Google Sheets REAL_OPS', () => {
+  it('builds trigger.sheets:onEdit', () => {
+    expect(REAL_OPS['trigger.sheets:onEdit']({})).toMatchSnapshot();
+  });
+
+  it('builds action.sheets:getRow', () => {
+    expect(REAL_OPS['action.sheets:getRow']({})).toMatchSnapshot();
+  });
+
+  it('builds action.sheets:append_row', () => {
+    expect(REAL_OPS['action.sheets:append_row']({})).toMatchSnapshot();
+  });
+});
+
+describe('Apps Script Google Sheets integration', () => {
+  it('appends and reads rows via Google Sheets REST API', async () => {
+    const result = await runSingleFixture('google-sheets-append-read', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.context.sheets.lastAppend).toEqual(
+      expect.objectContaining({
+        spreadsheetId: 'test-spreadsheet',
+        sheet: 'Incidents',
+        range: 'Incidents!A5:B5',
+        updatedRows: 1,
+        rowNumber: 5,
+      })
+    );
+    expect(result.context.sheets.lastRead).toEqual(
+      expect.objectContaining({
+        spreadsheetId: 'test-spreadsheet',
+        sheet: 'Incidents',
+        range: 'Incidents!A5:B5',
+        rowNumber: 5,
+        values: ['INC-9000', 'Open'],
+        record: {
+          incidentId: 'INC-9000',
+          status: 'Open',
+        },
+      })
+    );
+    expect(result.httpCalls).toHaveLength(2);
+    expect(result.httpCalls[0].url).toContain('values/Incidents:append');
+    expect(result.httpCalls[1].url).toContain('values/Incidents%21A5%3AB5');
+  });
+});

--- a/server/workflow/compile-to-appsscript.ts
+++ b/server/workflow/compile-to-appsscript.ts
@@ -945,6 +945,7 @@ var __SECRET_HELPER_DEFAULT_OVERRIDES = {
     GITHUB_ACCESS_TOKEN: { aliases: ['apps_script__github__access_token'] },
     GOOGLE_ADMIN_ACCESS_TOKEN: { aliases: ['apps_script__google_admin__access_token'] },
     GOOGLE_ADMIN_CUSTOMER_ID: { aliases: ['apps_script__google_admin__customer_id'] },
+    GOOGLE_SHEETS_ACCESS_TOKEN: { aliases: ['apps_script__google_sheets__access_token', 'apps_script__google_sheets_enhanced__access_token'] },
     HUBSPOT_API_KEY: { aliases: ['apps_script__hubspot__api_key'] },
     JIRA_API_TOKEN: { aliases: ['apps_script__jira__api_token'] },
     JIRA_BASE_URL: { aliases: ['apps_script__jira__base_url'] },
@@ -994,6 +995,9 @@ var __SECRET_HELPER_DEFAULT_OVERRIDES = {
     'google-admin': {
       GOOGLE_ADMIN_ACCESS_TOKEN: { aliases: ['apps_script__google_admin__access_token'] },
       GOOGLE_ADMIN_CUSTOMER_ID: { aliases: ['apps_script__google_admin__customer_id'] }
+    },
+    'google-sheets-enhanced': {
+      GOOGLE_SHEETS_ACCESS_TOKEN: { aliases: ['apps_script__google_sheets__access_token', 'apps_script__google_sheets_enhanced__access_token'] }
     },
     hubspot: {
       HUBSPOT_API_KEY: { aliases: ['apps_script__hubspot__api_key'] }
@@ -1078,6 +1082,12 @@ var __CONNECTOR_OAUTH_TOKEN_METADATA = {
     property: 'GOOGLE_ADMIN_ACCESS_TOKEN',
     description: 'access token',
     aliases: ['apps_script__google_admin__access_token']
+  },
+  'google-sheets-enhanced': {
+    displayName: 'Google Sheets',
+    property: 'GOOGLE_SHEETS_ACCESS_TOKEN',
+    description: 'access token',
+    aliases: ['apps_script__google_sheets__access_token', 'apps_script__google_sheets_enhanced__access_token']
   },
   jira: {
     displayName: 'Jira',
@@ -14103,79 +14113,300 @@ function onNewEmail() {
   'trigger.sheets:onEdit': (c) => `
 function onEdit(e) {
   return buildPollingWrapper('trigger.sheets:onEdit', function (runtime) {
-    if (!e || !e.source) {
-      runtime.summary({ skipped: true, reason: 'missing_event' });
-      return { skipped: true, reason: 'missing_event' };
+    var config = {
+      spreadsheetId: '${esc(c.spreadsheetId || '')}',
+      sheetName: '${esc(c.sheetName || '')}',
+      valueRenderOption: '${esc(c.valueRenderOption || 'UNFORMATTED_VALUE')}',
+      columns: ${JSON.stringify(Array.isArray(c.columns) ? c.columns : [])}
+    };
+
+    if (!config.spreadsheetId) {
+      runtime.summary({ skipped: true, reason: 'missing_spreadsheet_id' });
+      logWarn('sheets_onedit_missing_spreadsheet_id', { operation: 'trigger.sheets:onEdit' });
+      return { skipped: true, reason: 'missing_spreadsheet_id' };
     }
 
-    const targetSheetName = '${esc(c.sheetName || 'Sheet1')}';
-    const sheet = e.source.getActiveSheet();
-    const activeSheetName = sheet ? sheet.getName() : null;
-
-    if (targetSheetName && sheet && activeSheetName !== targetSheetName) {
-      runtime.summary({ skipped: true, reason: 'sheet_mismatch', sheet: activeSheetName });
-      return { skipped: true, reason: 'sheet_mismatch', sheet: activeSheetName };
+    if (!e || !e.range) {
+      runtime.summary({ skipped: true, reason: 'missing_event_range', spreadsheetId: config.spreadsheetId });
+      logWarn('sheets_onedit_missing_event', { operation: 'trigger.sheets:onEdit' });
+      return { skipped: true, reason: 'missing_event_range' };
     }
 
-    const row = e.range.getRow();
-    const sheetName = activeSheetName || targetSheetName;
-    const batch = runtime.dispatchBatch([{ row: row, sheet: sheetName }], function (entry) {
-      return entry;
+    var eventSheet = e.range.getSheet ? e.range.getSheet() : null;
+    var eventSheetName = eventSheet && eventSheet.getName ? eventSheet.getName() : null;
+    if (config.sheetName && eventSheetName && config.sheetName !== eventSheetName) {
+      runtime.summary({ skipped: true, reason: 'sheet_mismatch', expected: config.sheetName, actual: eventSheetName });
+      return { skipped: true, reason: 'sheet_mismatch', expected: config.sheetName, actual: eventSheetName };
+    }
+
+    var sheetName = config.sheetName || eventSheetName || '';
+    var a1Notation = e.range.getA1Notation ? e.range.getA1Notation() : null;
+    var startRow = e.range.getRow ? e.range.getRow() : null;
+    var rowCount = e.range.getNumRows ? e.range.getNumRows() : 1;
+    var columnCount = e.range.getNumColumns ? e.range.getNumColumns() : 1;
+
+    if (!a1Notation || startRow === null) {
+      runtime.summary({ skipped: true, reason: 'unresolvable_range', sheet: sheetName || null });
+      logWarn('sheets_onedit_missing_notation', { operation: 'trigger.sheets:onEdit', sheet: sheetName || null });
+      return { skipped: true, reason: 'unresolvable_range' };
+    }
+
+    var qualifiedRange = sheetName ? sheetName + '!' + a1Notation : a1Notation;
+    var accessToken = getSecret('GOOGLE_SHEETS_ACCESS_TOKEN', { connectorKey: 'google-sheets-enhanced' });
+    if (!accessToken) {
+      runtime.summary({ skipped: true, reason: 'missing_access_token', sheet: sheetName || null, range: qualifiedRange });
+      logError('sheets_missing_access_token', { operation: 'trigger.sheets:onEdit' });
+      return { skipped: true, reason: 'missing_access_token' };
+    }
+
+    var url = 'https://sheets.googleapis.com/v4/spreadsheets/' + encodeURIComponent(config.spreadsheetId) +
+      '/values/' + encodeURIComponent(qualifiedRange) +
+      '?majorDimension=ROWS&valueRenderOption=' + encodeURIComponent(config.valueRenderOption || 'UNFORMATTED_VALUE');
+
+    var response;
+    try {
+      response = withRetries(function () {
+        return fetchJson({
+          url: url,
+          method: 'GET',
+          headers: {
+            Authorization: 'Bearer ' + accessToken
+          }
+        });
+      });
+    } catch (error) {
+      var status = error && typeof error.status === 'number' ? error.status : null;
+      var message = error && error.message ? error.message : String(error);
+      logError('sheets_onedit_fetch_failed', {
+        sheet: sheetName || null,
+        range: qualifiedRange,
+        status: status,
+        message: message
+      });
+      throw error;
+    }
+
+    var values = (response && response.body && response.body.values) || [];
+    var entries = [];
+
+    for (var index = 0; index < rowCount; index++) {
+      var rowValues = values[index] || [];
+      var rowNumber = (startRow || 0) + index;
+      var rowRange = e.range.offset && typeof e.range.offset === 'function'
+        ? e.range.offset(index, 0, 1, columnCount)
+        : null;
+      var rowNotation = rowRange && rowRange.getA1Notation ? rowRange.getA1Notation() : a1Notation;
+      var qualifiedRowRange = sheetName ? sheetName + '!' + rowNotation : rowNotation;
+      var record = {};
+      if (Array.isArray(config.columns) && config.columns.length) {
+        for (var colIndex = 0; colIndex < config.columns.length; colIndex++) {
+          var key = config.columns[colIndex];
+          if (!key) {
+            continue;
+          }
+          record[key] = rowValues[colIndex] !== undefined ? rowValues[colIndex] : null;
+        }
+      }
+
+      entries.push({
+        spreadsheetId: config.spreadsheetId,
+        sheet: sheetName || null,
+        range: qualifiedRowRange,
+        rowNumber: rowNumber,
+        values: rowValues,
+        record: record
+      });
+    }
+
+    var batch = runtime.dispatchBatch(entries, function (entry) {
+      return {
+        spreadsheetId: entry.spreadsheetId,
+        sheet: entry.sheet,
+        range: entry.range,
+        rowNumber: entry.rowNumber,
+        values: entry.values,
+        record: entry.record
+      };
     });
 
-    runtime.state.lastRunAt = new Date().toISOString();
-    runtime.state.lastSheet = sheetName;
-    runtime.state.lastRow = row;
+    runtime.state.lastSpreadsheetId = config.spreadsheetId;
+    runtime.state.lastSheet = sheetName || null;
+    runtime.state.lastRange = qualifiedRange;
+    runtime.state.lastRow = (startRow || 0) + rowCount - 1;
+    runtime.state.lastValues = values;
+    runtime.state.lastUpdatedAt = new Date().toISOString();
 
     runtime.summary({
-      sheet: sheetName,
-      row: row,
+      spreadsheetId: config.spreadsheetId,
+      sheet: sheetName || null,
+      range: qualifiedRange,
       rowsAttempted: batch.attempted,
       rowsDispatched: batch.succeeded,
       rowsFailed: batch.failed
     });
+
     return {
+      spreadsheetId: config.spreadsheetId,
+      sheet: sheetName || null,
+      range: qualifiedRange,
       rowsAttempted: batch.attempted,
       rowsDispatched: batch.succeeded,
-      rowsFailed: batch.failed,
-      row: row,
-      sheet: sheetName
+      rowsFailed: batch.failed
     };
   });
 }`,
 
   'action.sheets:getRow': (c) => `
-function step_getRow(ctx) {
-  // CRITICAL FIX: Safe spreadsheet access with validation
-  const spreadsheetId = '${c.spreadsheetId || ''}';
-  const sheetName = '${c.sheetName || 'Sheet1'}';
-  
+function step_getSheetsRow(ctx) {
+  ctx = ctx || {};
+
+  var spreadsheetIdTemplate = '${esc(c.spreadsheetId || '')}';
+  var sheetNameTemplate = '${esc(c.sheetName || c.sheet || '')}';
+  var rangeTemplate = '${esc(c.range || '')}';
+  var rowNumberTemplate = '${esc(c.rowNumber || '')}';
+  var columns = ${JSON.stringify(Array.isArray(c.columns) ? c.columns : [])};
+  var valueRenderOption = '${esc(c.valueRenderOption || 'UNFORMATTED_VALUE')}';
+
+  var spreadsheetId = spreadsheetIdTemplate ? interpolate(spreadsheetIdTemplate, ctx).trim() : '';
   if (!spreadsheetId) {
-    console.error('❌ CRITICAL: Spreadsheet ID is required but not provided');
-    throw new Error('Spreadsheet ID is required for getRow operation');
+    logError('sheets_missing_spreadsheet_id', { operation: 'action.sheets:getRow' });
+    throw new Error('Spreadsheet ID is required for action.sheets:getRow');
   }
-  
-  try {
-    const spreadsheet = SpreadsheetApp.openById(spreadsheetId);
-    const sheet = spreadsheet.getSheetByName(sheetName) || spreadsheet.getSheets()[0];
-    
-    if (!sheet) {
-      throw new Error(\`Sheet '\${sheetName}' not found in spreadsheet\`);
+
+  var sheetName = sheetNameTemplate ? interpolate(sheetNameTemplate, ctx).trim() : '';
+  if (!sheetName) {
+    var fallbackSheet = ctx.sheet || ctx.sheetName;
+    if (typeof fallbackSheet === 'string') {
+      sheetName = fallbackSheet.trim();
     }
-    
-    const row = ctx.row || 1;
-    const values = sheet.getRange(row, 1, 1, sheet.getLastColumn()).getValues()[0];
-    
-    ctx.candidate_email = values[1]; // assumes column B = email
-    ctx.candidate_name = values[0];  // assumes column A = name
-    ctx.rowValues = values;
-    
-    console.log('✅ Successfully read row ' + row + ' from sheet: ' + sheetName);
-    return ctx;
-  } catch (error) {
-    console.error('❌ CRITICAL: Failed to access spreadsheet:', error.message);
-    throw new Error(\`Failed to read from spreadsheet: \${error.message}\`);
   }
+
+  var range = rangeTemplate ? interpolate(rangeTemplate, ctx).trim() : '';
+  var rowNumberRaw = rowNumberTemplate ? interpolate(rowNumberTemplate, ctx).trim() : '';
+  var rowNumber = rowNumberRaw ? Number(rowNumberRaw) : null;
+  if (!rowNumber || isNaN(rowNumber)) {
+    if (typeof ctx.rowNumber === 'number') {
+      rowNumber = ctx.rowNumber;
+    } else if (typeof ctx.row === 'number') {
+      rowNumber = ctx.row;
+    } else if (typeof ctx.sheetsLastAppendRowNumber === 'number') {
+      rowNumber = ctx.sheetsLastAppendRowNumber;
+    }
+  }
+  if (!rowNumber || isNaN(rowNumber)) {
+    rowNumber = 1;
+  }
+  rowNumber = Math.max(1, Math.floor(Number(rowNumber)));
+
+  function columnLabel(count) {
+    if (!count || count < 1) {
+      return 'A';
+    }
+    var dividend = count;
+    var label = '';
+    while (dividend > 0) {
+      var modulo = (dividend - 1) % 26;
+      label = String.fromCharCode(65 + modulo) + label;
+      dividend = Math.floor((dividend - modulo) / 26);
+    }
+    return label;
+  }
+
+  if (!range) {
+    if (!sheetName) {
+      logError('sheets_missing_sheet_name', { operation: 'action.sheets:getRow' });
+      throw new Error('Sheet name or range is required for action.sheets:getRow');
+    }
+    var columnCount = columns.length > 0 ? columns.length : 0;
+    if (!columnCount && Array.isArray(ctx.rowValues) && ctx.rowValues.length) {
+      columnCount = ctx.rowValues.length;
+    }
+    if (!columnCount && typeof ctx.columnCount === 'number') {
+      columnCount = ctx.columnCount;
+    }
+    if (!columnCount) {
+      columnCount = 26;
+    }
+    var endColumn = columnLabel(columnCount);
+    range = sheetName + '!A' + rowNumber + ':' + endColumn + rowNumber;
+  } else if (range.indexOf('!') === -1 && sheetName) {
+    range = sheetName + '!' + range;
+  }
+
+  var accessToken = getSecret('GOOGLE_SHEETS_ACCESS_TOKEN', { connectorKey: 'google-sheets-enhanced' });
+  if (!accessToken) {
+    logError('sheets_missing_access_token', { operation: 'action.sheets:getRow' });
+    throw new Error('Missing Google Sheets access token for action.sheets:getRow');
+  }
+
+  var url = 'https://sheets.googleapis.com/v4/spreadsheets/' + encodeURIComponent(spreadsheetId) +
+    '/values/' + encodeURIComponent(range) +
+    '?majorDimension=ROWS&valueRenderOption=' + encodeURIComponent(valueRenderOption);
+
+  var response;
+  try {
+    response = withRetries(function () {
+      return fetchJson({
+        url: url,
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer ' + accessToken
+        }
+      });
+    });
+  } catch (error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var message = error && error.message ? error.message : String(error);
+    logError('sheets_get_row_failed', {
+      spreadsheetId: spreadsheetId,
+      range: range,
+      status: status,
+      message: message
+    });
+    throw error;
+  }
+
+  var values = response && response.body && Array.isArray(response.body.values) ? response.body.values : [];
+  var rowValues = values.length > 0 && Array.isArray(values[0]) ? values[0] : [];
+  var record = {};
+  if (columns.length) {
+    for (var i = 0; i < columns.length; i++) {
+      var key = columns[i];
+      if (!key) {
+        continue;
+      }
+      record[key] = rowValues[i] !== undefined ? rowValues[i] : null;
+    }
+  } else {
+    for (var index = 0; index < rowValues.length; index++) {
+      record['column_' + (index + 1)] = rowValues[index];
+    }
+  }
+
+  ctx.rowValues = rowValues.slice();
+  ctx.rowRecord = Object.assign({}, record);
+  ctx.sheets = ctx.sheets || {};
+  ctx.sheets.lastRead = {
+    spreadsheetId: spreadsheetId,
+    sheet: sheetName || null,
+    range: range,
+    rowNumber: rowNumber,
+    values: rowValues.slice(),
+    record: Object.assign({}, record)
+  };
+  ctx.sheetsLastReadRange = range;
+  ctx.sheetsLastReadValues = rowValues.slice();
+  ctx.sheetsLastReadRecord = Object.assign({}, record);
+  ctx.sheetsLastReadRowNumber = rowNumber;
+
+  logInfo('sheets_get_row_success', {
+    spreadsheetId: spreadsheetId,
+    range: range,
+    rowNumber: rowNumber,
+    valueCount: rowValues.length
+  });
+
+  return ctx;
 }`,
 
   'action.gmail:send_email': (c) => `
@@ -14590,66 +14821,186 @@ function step_sendReply(ctx) {
 }`,
 
   'action.sheets:append_row': (c) => `
-function step_appendRow(ctx) {
-  // CRITICAL FIX: Safe spreadsheet access with validation and proper column handling
-  const spreadsheetId = '${c.spreadsheetId || ''}';
-  const sheetName = '${c.sheetName || 'Sheet1'}';
-  
+function step_appendSheetsRow(ctx) {
+  ctx = ctx || {};
+
+  var spreadsheetIdTemplate = '${esc(c.spreadsheetId || '')}';
+  var sheetNameTemplate = '${esc(c.sheetName || c.sheet || '')}';
+  var rangeTemplate = '${esc(c.range || c.sheet || '')}';
+  var valueInputOption = '${esc(c.valueInputOption || 'USER_ENTERED')}';
+  var columns = ${JSON.stringify(Array.isArray(c.columns) ? c.columns : [])};
+  var configuredValues = ${JSON.stringify(Array.isArray(c.values) ? c.values : [])};
+
+  var spreadsheetId = spreadsheetIdTemplate ? interpolate(spreadsheetIdTemplate, ctx).trim() : '';
   if (!spreadsheetId) {
-    console.error('❌ CRITICAL: Spreadsheet ID is required but not provided');
-    throw new Error('Spreadsheet ID is required for append_row operation');
+    logError('sheets_missing_spreadsheet_id', { operation: 'action.sheets:append_row' });
+    throw new Error('Spreadsheet ID is required for action.sheets:append_row');
   }
-  
+
+  var sheetName = sheetNameTemplate ? interpolate(sheetNameTemplate, ctx).trim() : '';
+  var range = rangeTemplate ? interpolate(rangeTemplate, ctx).trim() : '';
+  if (!range) {
+    range = sheetName;
+  }
+  if (!range) {
+    logError('sheets_missing_range', { operation: 'action.sheets:append_row' });
+    throw new Error('Sheet name or range is required for action.sheets:append_row');
+  }
+
+  var accessToken = getSecret('GOOGLE_SHEETS_ACCESS_TOKEN', { connectorKey: 'google-sheets-enhanced' });
+  if (!accessToken) {
+    logError('sheets_missing_access_token', { operation: 'action.sheets:append_row' });
+    throw new Error('Missing Google Sheets access token for action.sheets:append_row');
+  }
+
+  function coerceValue(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    return value;
+  }
+
+  function resolveValue(key) {
+    if (!key) {
+      return '';
+    }
+    if (Object.prototype.hasOwnProperty.call(ctx, key)) {
+      return ctx[key];
+    }
+    if (ctx.record && typeof ctx.record === 'object' && Object.prototype.hasOwnProperty.call(ctx.record, key)) {
+      return ctx.record[key];
+    }
+    if (ctx.payload && typeof ctx.payload === 'object' && Object.prototype.hasOwnProperty.call(ctx.payload, key)) {
+      return ctx.payload[key];
+    }
+    if (ctx.row && typeof ctx.row === 'object' && Object.prototype.hasOwnProperty.call(ctx.row, key)) {
+      return ctx.row[key];
+    }
+    return '';
+  }
+
+  var rowValues = [];
+  if (configuredValues.length) {
+    for (var valueIndex = 0; valueIndex < configuredValues.length; valueIndex++) {
+      var template = configuredValues[valueIndex];
+      if (typeof template === 'string') {
+        rowValues.push(interpolate(template, ctx));
+      } else {
+        rowValues.push(template);
+      }
+    }
+  } else if (columns.length) {
+    for (var columnIndex = 0; columnIndex < columns.length; columnIndex++) {
+      var columnKey = columns[columnIndex];
+      rowValues.push(resolveValue(columnKey));
+    }
+  } else if (Array.isArray(ctx.rowValues)) {
+    rowValues = ctx.rowValues.slice();
+  } else if (Array.isArray(ctx.values)) {
+    rowValues = ctx.values.slice();
+  }
+
+  if (!rowValues.length) {
+    logError('sheets_append_row_missing_values', { operation: 'action.sheets:append_row' });
+    throw new Error('At least one value is required for action.sheets:append_row');
+  }
+
+  for (var normalizeIndex = 0; normalizeIndex < rowValues.length; normalizeIndex++) {
+    rowValues[normalizeIndex] = coerceValue(rowValues[normalizeIndex]);
+  }
+
+  var record = {};
+  if (columns.length) {
+    for (var recordIndex = 0; recordIndex < columns.length; recordIndex++) {
+      var recordKey = columns[recordIndex];
+      if (!recordKey) {
+        continue;
+      }
+      record[recordKey] = rowValues[recordIndex] !== undefined ? rowValues[recordIndex] : '';
+    }
+  }
+
+  var url = 'https://sheets.googleapis.com/v4/spreadsheets/' + encodeURIComponent(spreadsheetId) +
+    '/values/' + encodeURIComponent(range) +
+    ':append?valueInputOption=' + encodeURIComponent(valueInputOption || 'USER_ENTERED') +
+    '&insertDataOption=INSERT_ROWS&includeValuesInResponse=true';
+
+  var requestBody = {
+    majorDimension: 'ROWS',
+    values: [rowValues]
+  };
+
+  var response;
   try {
-    const spreadsheet = SpreadsheetApp.openById(spreadsheetId);
-    const sheet = spreadsheet.getSheetByName(sheetName) || spreadsheet.getSheets()[0];
-    
-    if (!sheet) {
-      throw new Error(\`Sheet '\${sheetName}' not found in spreadsheet\`);
-    }
-    
-    // CRITICAL FIX: Handle columns array properly
-    const columns = ${Array.isArray(c.columns) ? JSON.stringify(c.columns) : `'${c.columns || 'Data, Timestamp'}'.split(', ')`};
-    const timestamp = new Date().toISOString();
-    
-    // Intelligent row data mapping based on available context
-    let rowData = [];
-    if (ctx.emails && ctx.emails.length > 0) {
-      const email = ctx.emails[0];
-      rowData = [
-        email.from || 'Unknown',
-        email.subject || 'No Subject', 
-        email.body || 'No Body',
-        'Processed',
-        timestamp
-      ];
-    } else {
-      // Generic data extraction
-      rowData = [
-        ctx.from || ctx.sender || 'Unknown',
-        ctx.subject || ctx.title || 'No Subject',
-        ctx.body || ctx.content || 'No Body',
-        'Processed',
-        timestamp
-      ];
-    }
-    
-    // Ensure row data matches column count
-    while (rowData.length < columns.length) {
-      rowData.push('');
-    }
-    rowData = rowData.slice(0, columns.length);
-    
-    sheet.appendRow(rowData);
-    
-    console.log(\`✅ Successfully appended row to sheet: \${sheetName}\`);
-    console.log(\`📊 Columns: \${JSON.stringify(columns)}\`);
-    console.log(\`📊 Row data: \${JSON.stringify(rowData)}\`);
-    return ctx;
+    response = withRetries(function () {
+      return fetchJson({
+        url: url,
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        },
+        payload: JSON.stringify(requestBody),
+        contentType: 'application/json'
+      });
+    });
   } catch (error) {
-    console.error('❌ CRITICAL: Failed to append to spreadsheet:', error.message);
-    throw new Error(\`Failed to append to spreadsheet: \${error.message}\`);
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var message = error && error.message ? error.message : String(error);
+    logError('sheets_append_row_failed', {
+      spreadsheetId: spreadsheetId,
+      range: range,
+      status: status,
+      message: message
+    });
+    throw error;
   }
+
+  var updates = response && response.body && response.body.updates ? response.body.updates : {};
+  var updatedRange = updates.updatedRange || (response && response.body && response.body.tableRange) || null;
+  var updatedRows = updates.updatedRows;
+  if (typeof updatedRows === 'string') {
+    updatedRows = Number(updatedRows);
+  }
+  if (typeof updatedRows !== 'number' || isNaN(updatedRows)) {
+    updatedRows = 1;
+  }
+
+  var appendedRowNumber = null;
+  if (updatedRange) {
+    var match = String(updatedRange).match(/!.*?(\\d+)(?::.*?(\\d+))?$/);
+    if (match) {
+      var parsed = match[2] ? Number(match[2]) : Number(match[1]);
+      if (!isNaN(parsed) && parsed > 0) {
+        appendedRowNumber = parsed;
+      }
+    }
+  }
+
+  ctx.sheets = ctx.sheets || {};
+  ctx.sheets.lastAppend = {
+    spreadsheetId: spreadsheetId,
+    sheet: sheetName || null,
+    range: updatedRange || range,
+    values: rowValues.slice(),
+    updatedRows: updatedRows,
+    record: Object.assign({}, record),
+    rowNumber: appendedRowNumber
+  };
+  ctx.sheetsLastAppendRange = updatedRange || range;
+  ctx.sheetsLastAppendValues = rowValues.slice();
+  ctx.sheetsLastAppendUpdatedRows = updatedRows;
+  if (appendedRowNumber) {
+    ctx.sheetsLastAppendRowNumber = appendedRowNumber;
+  }
+
+  logInfo('sheets_append_row_success', {
+    spreadsheetId: spreadsheetId,
+    range: updatedRange || range,
+    updatedRows: updatedRows
+  });
+
+  return ctx;
 }`,
 
   // P0 CRITICAL: Add top 20 business apps to prevent false advertising


### PR DESCRIPTION
## Summary
- validate Google Sheets trigger/action manifest parameters and call the Sheets REST API with retries while updating ctx deterministically
- add integration coverage and snapshots for the Google Sheets REAL_OPS handlers
- document the Script Properties and scopes required to operate Google Sheets via Apps Script

## Testing
- npx vitest run server/workflow/__tests__/apps-script.google-sheets.test.ts --update *(fails: npm 403 when downloading vitest in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec914944dc8331985b144ebe96c32e