### PR TITLE
feat: harden Google Sheets Apps Script handlers

### DIFF
--- a/docs/apps-script-rollout/handler-authoring.md
+++ b/docs/apps-script-rollout/handler-authoring.md
@@ -55,6 +55,15 @@ When implementing polling or time-driven triggers:
 - Call `syncTriggerRegistry(activeKeys)` inside `setupTriggers()` after registering new triggers via `buildTimeTrigger`. This ensures removed triggers are cleaned up and avoids duplicate schedules.
 - Set `ephemeral: true` on one-off delay triggers so they are not recorded in the persistent registry.
 
+### Google Sheets authentication requirements
+
+Apps Script handlers that call the Google Sheets REST API now require explicit Script Properties so deployments can choose between delegated OAuth tokens and service accounts:
+
+- **Delegated OAuth:** populate `GOOGLE_SHEETS_ACCESS_TOKEN` (or its aliased `apps_script__sheets__access_token`) with a user token that includes the `https://www.googleapis.com/auth/spreadsheets` scope. The handler automatically downgrades read-only calls to `https://www.googleapis.com/auth/spreadsheets.readonly` when possible.
+- **Service accounts:** provide `GOOGLE_SHEETS_SERVICE_ACCOUNT` containing the JSON key and, when using domain-wide delegation, set `GOOGLE_SHEETS_DELEGATED_EMAIL` to the impersonated user. The runtime exchanges the JWT for an access token on every execution and surfaces structured errors when the payload is malformed.
+
+Document the chosen credential type in rollout plans and double-check that staging/production Script Properties include the same scopes before promoting Tier-0 automations.
+
 ## Concrete examples
 
 ### Slack `send_message`

--- a/server/workflow/__tests__/__snapshots__/apps-script.google-sheets.test.ts.snap
+++ b/server/workflow/__tests__/__snapshots__/apps-script.google-sheets.test.ts.snap
@@ -1,0 +1,724 @@
+exports[`Apps Script Google Sheets REAL_OPS builds trigger.sheets:onEdit 1`] = `
+function onEdit(e) {
+  return buildPollingWrapper('trigger.sheets:onEdit', function (runtime) {
+    var spreadsheetIdTemplate = '';
+    var spreadsheetUrlTemplate = '';
+    var sheetNameTemplate = '';
+    var rangeTemplate = '';
+    var renderOptionTemplate = 'FORMATTED_VALUE';
+
+    function resolveSpreadsheetId(context) {
+      var id = spreadsheetIdTemplate ? interpolate(spreadsheetIdTemplate, context).trim() : '';
+      if (!id && spreadsheetUrlTemplate) {
+        var urlCandidate = interpolate(spreadsheetUrlTemplate, context).trim();
+        if (urlCandidate) {
+          var match = urlCandidate.match(/spreadsheets\/d\/([a-zA-Z0-9-_]+)/);
+          if (match && match[1]) {
+            id = match[1];
+          }
+        }
+      }
+      if (!id) {
+        throw new Error('trigger.sheets:onEdit requires a spreadsheetId or spreadsheetUrl');
+      }
+      return id;
+    }
+
+    function resolveSheetName(context, fallback) {
+      if (sheetNameTemplate) {
+        var configured = interpolate(sheetNameTemplate, context).trim();
+        if (configured) {
+          return configured;
+        }
+      }
+      if (fallback) {
+        return fallback;
+      }
+      return 'Sheet1';
+    }
+
+    function resolveRange(context, sheet, startRow, endRow) {
+      if (rangeTemplate) {
+        var raw = interpolate(rangeTemplate, context).trim();
+        if (raw) {
+          if (raw.indexOf('!') === -1 && sheet) {
+            return sheet + '!' + raw;
+          }
+          return raw;
+        }
+      }
+      if (!startRow || !endRow) {
+        throw new Error('trigger.sheets:onEdit requires a configured range or event rows');
+      }
+      var prefix = sheet ? sheet + '!' : '';
+      return prefix + startRow + ':' + endRow;
+    }
+
+    function getSheetsAccessToken(scopeList) {
+      var scopes = Array.isArray(scopeList) && scopeList.length ? scopeList : ['https://www.googleapis.com/auth/spreadsheets.readonly'];
+      try {
+        return requireOAuthToken('google-sheets', { scopes: scopes });
+      } catch (oauthError) {
+        var properties = PropertiesService.getScriptProperties();
+        var rawServiceAccount = properties.getProperty('GOOGLE_SHEETS_SERVICE_ACCOUNT');
+        if (!rawServiceAccount) {
+          throw oauthError;
+        }
+        var delegatedUser = properties.getProperty('GOOGLE_SHEETS_DELEGATED_EMAIL');
+
+        function base64UrlEncode(value) {
+          if (Object.prototype.toString.call(value) === '[object Array]') {
+            return Utilities.base64EncodeWebSafe(value).replace(/=+$/, '');
+          }
+          return Utilities.base64EncodeWebSafe(value, Utilities.Charset.UTF_8).replace(/=+$/, '');
+        }
+
+        try {
+          var parsed = typeof rawServiceAccount === 'string' ? JSON.parse(rawServiceAccount) : rawServiceAccount;
+          if (!parsed || typeof parsed !== 'object') {
+            throw new Error('Service account payload must be valid JSON.');
+          }
+          var clientEmail = parsed.client_email;
+          var privateKey = parsed.private_key;
+          if (!clientEmail || !privateKey) {
+            throw new Error('Service account JSON must include client_email and private_key.');
+          }
+
+          var now = Math.floor(Date.now() / 1000);
+          var headerSegment = base64UrlEncode(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+          var claimPayload = {
+            iss: clientEmail,
+            scope: scopes.join(' '),
+            aud: 'https://oauth2.googleapis.com/token',
+            exp: now + 3600,
+            iat: now
+          };
+          if (delegatedUser) {
+            claimPayload.sub = delegatedUser;
+          }
+          var claimSegment = base64UrlEncode(JSON.stringify(claimPayload));
+          var signingInput = headerSegment + '.' + claimSegment;
+          var signatureBytes = Utilities.computeRsaSha256Signature(signingInput, privateKey);
+          var signatureSegment = base64UrlEncode(signatureBytes);
+          var assertion = signingInput + '.' + signatureSegment;
+
+          var tokenResponse = rateLimitAware(function () {
+            return fetchJson({
+              url: 'https://oauth2.googleapis.com/token',
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Accept': 'application/json'
+              },
+              payload: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=' + encodeURIComponent(assertion),
+              contentType: 'application/x-www-form-urlencoded'
+            });
+          }, { attempts: 3, initialDelayMs: 500, jitter: 0.25 });
+
+          var token = tokenResponse.body && tokenResponse.body.access_token;
+          if (!token) {
+            throw new Error('Service account token exchange did not return an access_token.');
+          }
+          return token;
+        } catch (serviceError) {
+          var serviceMessage = serviceError && serviceError.message ? serviceError.message : String(serviceError);
+          throw new Error('Google Sheets service account authentication failed: ' + serviceMessage);
+        }
+      }
+    }
+
+    function fetchEditedRows(spreadsheetId, range, accessToken, valueRenderOption) {
+      var url = 'https://sheets.googleapis.com/v4/spreadsheets/' + encodeURIComponent(spreadsheetId) + '/values/' + encodeURIComponent(range) + '?majorDimension=ROWS&valueRenderOption=' + encodeURIComponent(valueRenderOption || 'FORMATTED_VALUE');
+      var response = rateLimitAware(function () {
+        return fetchJson({
+          url: url,
+          method: 'GET',
+          headers: {
+            'Authorization': 'Bearer ' + accessToken,
+            'Accept': 'application/json'
+          }
+        });
+      }, { attempts: 3, initialDelayMs: 500, jitter: 0.2 });
+      return response.body && response.body.values ? response.body.values : [];
+    }
+
+    if (!e || !e.range || typeof e.range.getRow !== 'function') {
+      runtime.summary({ skipped: true, reason: 'missing_range' });
+      return { skipped: true, reason: 'missing_range' };
+    }
+
+    var interpolationContext = {};
+    var runtimeState = runtime.state && typeof runtime.state === 'object' ? runtime.state : {};
+    for (var stateKey in runtimeState) {
+      if (Object.prototype.hasOwnProperty.call(runtimeState, stateKey)) {
+        interpolationContext[stateKey] = runtimeState[stateKey];
+      }
+    }
+
+    var spreadsheetId = resolveSpreadsheetId(interpolationContext);
+    var activeSheetName = null;
+    if (typeof e.range.getSheet === 'function') {
+      var activeSheet = e.range.getSheet();
+      if (activeSheet && typeof activeSheet.getName === 'function') {
+        activeSheetName = activeSheet.getName();
+      }
+    }
+
+    var sheetName = resolveSheetName(interpolationContext, activeSheetName);
+    var startRow = e.range.getRow();
+    var rowCount = typeof e.range.getNumRows === 'function' ? e.range.getNumRows() : 1;
+    var endRow = startRow + Math.max(rowCount, 1) - 1;
+    var resolvedRange = resolveRange(interpolationContext, sheetName, startRow, endRow);
+    var valueRenderOption = renderOptionTemplate || 'FORMATTED_VALUE';
+
+    try {
+      var accessToken = getSheetsAccessToken(['https://www.googleapis.com/auth/spreadsheets.readonly']);
+      var values = fetchEditedRows(spreadsheetId, resolvedRange, accessToken, valueRenderOption);
+      var items = [];
+
+      for (var offset = 0; offset < Math.max(rowCount, 1); offset++) {
+        var rowNumber = startRow + offset;
+        var rowValues = values[offset] || [];
+        var singleRange = sheetName ? sheetName + '!' + rowNumber + ':' + rowNumber : rowNumber + ':' + rowNumber;
+        items.push({
+          spreadsheetId: spreadsheetId,
+          sheetName: sheetName,
+          rowNumber: rowNumber,
+          range: singleRange,
+          values: rowValues
+        });
+      }
+
+      var batch = runtime.dispatchBatch(items, function (entry) {
+        return {
+          spreadsheetId: entry.spreadsheetId,
+          sheetName: entry.sheetName,
+          rowNumber: entry.rowNumber,
+          range: entry.range,
+          values: entry.values
+        };
+      });
+
+      runtime.state.lastSpreadsheetId = spreadsheetId;
+      runtime.state.lastSheet = sheetName;
+      runtime.state.lastProcessedRange = resolvedRange;
+      runtime.state.lastRow = endRow;
+      runtime.state.lastRowCount = rowCount;
+
+      runtime.summary({
+        spreadsheetId: spreadsheetId,
+        sheet: sheetName,
+        range: resolvedRange,
+        rowsAttempted: batch.attempted,
+        rowsDispatched: batch.succeeded,
+        rowsFailed: batch.failed
+      });
+
+      logInfo('google_sheets_onedit_success', {
+        spreadsheetId: spreadsheetId,
+        sheet: sheetName,
+        range: resolvedRange,
+        rowsAttempted: batch.attempted,
+        rowsDispatched: batch.succeeded,
+        rowsFailed: batch.failed
+      });
+
+      return {
+        spreadsheetId: spreadsheetId,
+        sheet: sheetName,
+        range: resolvedRange,
+        rowsAttempted: batch.attempted,
+        rowsDispatched: batch.succeeded,
+        rowsFailed: batch.failed,
+        lastRow: endRow
+      };
+    } catch (error) {
+      var message = error && error.message ? error.message : String(error);
+      logError('google_sheets_onedit_failure', {
+        spreadsheetId: spreadsheetId,
+        sheet: sheetName,
+        range: resolvedRange,
+        message: message
+      });
+      throw error;
+    }
+  });
+}
+`;
+
+exports[`Apps Script Google Sheets REAL_OPS builds action.sheets:getRow 1`] = `
+function step_getRow(ctx) {
+  ctx = ctx || {};
+
+  var spreadsheetIdTemplate = '';
+  var spreadsheetUrlTemplate = '';
+  var sheetNameTemplate = '';
+  var rangeTemplate = '';
+  var valueRenderOption = 'FORMATTED_VALUE';
+  var majorDimension = 'ROWS';
+  var rowNumberConfig = "";
+
+  function resolveSpreadsheetId(context) {
+    var id = spreadsheetIdTemplate ? interpolate(spreadsheetIdTemplate, context).trim() : '';
+    if (!id && spreadsheetUrlTemplate) {
+      var urlCandidate = interpolate(spreadsheetUrlTemplate, context).trim();
+      if (urlCandidate) {
+        var match = urlCandidate.match(/spreadsheets\/d\/([a-zA-Z0-9-_]+)/);
+        if (match && match[1]) {
+          id = match[1];
+        }
+      }
+    }
+    if (!id) {
+      throw new Error('action.sheets:getRow requires a spreadsheetId or spreadsheetUrl');
+    }
+    return id;
+  }
+
+  function resolveSheetName(context) {
+    if (sheetNameTemplate) {
+      var configured = interpolate(sheetNameTemplate, context).trim();
+      if (configured) {
+        return configured;
+      }
+    }
+    if (context.sheetName) {
+      return String(context.sheetName);
+    }
+    if (context.sheet) {
+      return String(context.sheet);
+    }
+    return 'Sheet1';
+  }
+
+  function resolveRowNumber(context) {
+    var candidate = rowNumberConfig;
+    if (typeof candidate === 'string') {
+      var interpolated = interpolate(candidate, context).trim();
+      if (interpolated) {
+        candidate = interpolated;
+      }
+    }
+    if (candidate === null || candidate === undefined || candidate === '') {
+      if (context.rowNumber !== undefined && context.rowNumber !== null) {
+        candidate = context.rowNumber;
+      } else if (context.row !== undefined && context.row !== null) {
+        candidate = context.row;
+      }
+    }
+    var parsed = Number(candidate);
+    if (!parsed || isNaN(parsed) || parsed < 1) {
+      throw new Error('action.sheets:getRow requires a positive rowNumber');
+    }
+    return Math.floor(parsed);
+  }
+
+  function resolveRange(context, sheetName, rowNumber) {
+    if (rangeTemplate) {
+      var raw = interpolate(rangeTemplate, context).trim();
+      if (raw) {
+        if (raw.indexOf('!') === -1 && sheetName) {
+          return sheetName + '!' + raw;
+        }
+        return raw;
+      }
+    }
+    var prefix = sheetName ? sheetName + '!' : '';
+    return prefix + rowNumber + ':' + rowNumber;
+  }
+
+  function getSheetsAccessToken(scopeList) {
+    var scopes = Array.isArray(scopeList) && scopeList.length ? scopeList : ['https://www.googleapis.com/auth/spreadsheets.readonly'];
+    try {
+      return requireOAuthToken('google-sheets', { scopes: scopes });
+    } catch (oauthError) {
+      var properties = PropertiesService.getScriptProperties();
+      var rawServiceAccount = properties.getProperty('GOOGLE_SHEETS_SERVICE_ACCOUNT');
+      if (!rawServiceAccount) {
+        throw oauthError;
+      }
+      var delegatedUser = properties.getProperty('GOOGLE_SHEETS_DELEGATED_EMAIL');
+
+      function base64UrlEncode(value) {
+        if (Object.prototype.toString.call(value) === '[object Array]') {
+          return Utilities.base64EncodeWebSafe(value).replace(/=+$/, '');
+        }
+        return Utilities.base64EncodeWebSafe(value, Utilities.Charset.UTF_8).replace(/=+$/, '');
+      }
+
+      try {
+        var parsed = typeof rawServiceAccount === 'string' ? JSON.parse(rawServiceAccount) : rawServiceAccount;
+        if (!parsed || typeof parsed !== 'object') {
+          throw new Error('Service account payload must be valid JSON.');
+        }
+        var clientEmail = parsed.client_email;
+        var privateKey = parsed.private_key;
+        if (!clientEmail || !privateKey) {
+          throw new Error('Service account JSON must include client_email and private_key.');
+        }
+
+        var now = Math.floor(Date.now() / 1000);
+        var headerSegment = base64UrlEncode(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+        var claimPayload = {
+          iss: clientEmail,
+          scope: scopes.join(' '),
+          aud: 'https://oauth2.googleapis.com/token',
+          exp: now + 3600,
+          iat: now
+        };
+        if (delegatedUser) {
+          claimPayload.sub = delegatedUser;
+        }
+        var claimSegment = base64UrlEncode(JSON.stringify(claimPayload));
+        var signingInput = headerSegment + '.' + claimSegment;
+        var signatureBytes = Utilities.computeRsaSha256Signature(signingInput, privateKey);
+        var signatureSegment = base64UrlEncode(signatureBytes);
+        var assertion = signingInput + '.' + signatureSegment;
+
+        var tokenResponse = rateLimitAware(function () {
+          return fetchJson({
+            url: 'https://oauth2.googleapis.com/token',
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+              'Accept': 'application/json'
+            },
+            payload: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=' + encodeURIComponent(assertion),
+            contentType: 'application/x-www-form-urlencoded'
+          });
+        }, { attempts: 3, initialDelayMs: 500, jitter: 0.25 });
+
+        var token = tokenResponse.body && tokenResponse.body.access_token;
+        if (!token) {
+          throw new Error('Service account token exchange did not return an access_token.');
+        }
+        return token;
+      } catch (serviceError) {
+        var serviceMessage = serviceError && serviceError.message ? serviceError.message : String(serviceError);
+        throw new Error('Google Sheets service account authentication failed: ' + serviceMessage);
+      }
+    }
+  }
+
+  var spreadsheetId = resolveSpreadsheetId(ctx);
+  var sheetName = resolveSheetName(ctx);
+  var rowNumber = resolveRowNumber(ctx);
+  var resolvedRange = resolveRange(ctx, sheetName, rowNumber);
+  var accessToken = getSheetsAccessToken(['https://www.googleapis.com/auth/spreadsheets.readonly']);
+
+  var requestUrl = 'https://sheets.googleapis.com/v4/spreadsheets/' + encodeURIComponent(spreadsheetId) + '/values/' + encodeURIComponent(resolvedRange) + '?majorDimension=' + encodeURIComponent(majorDimension || 'ROWS') + '&valueRenderOption=' + encodeURIComponent(valueRenderOption || 'FORMATTED_VALUE');
+
+  try {
+    var response = rateLimitAware(function () {
+      return fetchJson({
+        url: requestUrl,
+        method: 'GET',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Accept': 'application/json'
+        }
+      });
+    }, { attempts: 3, initialDelayMs: 500, jitter: 0.2 });
+
+    var values = response.body && response.body.values ? response.body.values : [];
+    var rowValues = [];
+    if (majorDimension === 'COLUMNS') {
+      for (var colIndex = 0; colIndex < values.length; colIndex++) {
+        var column = values[colIndex];
+        if (Array.isArray(column)) {
+          rowValues.push(column[0] !== undefined ? column[0] : null);
+        } else {
+          rowValues.push(column);
+        }
+      }
+    } else {
+      rowValues = values.length > 0 && Array.isArray(values[0]) ? values[0] : [];
+    }
+
+    var result = {
+      spreadsheetId: spreadsheetId,
+      sheetName: sheetName,
+      rowNumber: rowNumber,
+      range: resolvedRange,
+      values: rowValues,
+      valueRenderOption: valueRenderOption || 'FORMATTED_VALUE'
+    };
+
+    ctx.rowNumber = rowNumber;
+    ctx.row = rowNumber;
+    ctx.sheetName = sheetName;
+    ctx.rowValues = rowValues;
+    ctx.googleSheetsRowValues = rowValues;
+    ctx.googleSheetsLastRead = result;
+
+    logInfo('google_sheets_get_row_success', {
+      spreadsheetId: spreadsheetId,
+      sheetName: sheetName,
+      rowNumber: rowNumber,
+      range: resolvedRange
+    });
+
+    return ctx;
+  } catch (error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    if (status && status >= 400 && status < 500 && status !== 429) {
+      error.retryable = false;
+    }
+    var message = error && error.message ? error.message : String(error);
+    logError('google_sheets_get_row_failure', {
+      spreadsheetId: spreadsheetId,
+      sheetName: sheetName,
+      rowNumber: rowNumber,
+      range: resolvedRange,
+      status: status,
+      message: message
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Google Sheets REAL_OPS builds action.sheets:append_row 1`] = `
+function step_appendRow(ctx) {
+  ctx = ctx || {};
+
+  var spreadsheetIdTemplate = '';
+  var spreadsheetUrlTemplate = '';
+  var sheetNameTemplate = '';
+  var rangeTemplate = '';
+  var valueInputOption = 'USER_ENTERED';
+  var insertDataOption = 'INSERT_ROWS';
+  var includeValuesInResponse = true;
+  var valuesConfig = ["{{email}}","{{status}}"];
+
+  function resolveSpreadsheetId(context) {
+    var id = spreadsheetIdTemplate ? interpolate(spreadsheetIdTemplate, context).trim() : '';
+    if (!id && spreadsheetUrlTemplate) {
+      var urlCandidate = interpolate(spreadsheetUrlTemplate, context).trim();
+      if (urlCandidate) {
+        var match = urlCandidate.match(/spreadsheets\/d\/([a-zA-Z0-9-_]+)/);
+        if (match && match[1]) {
+          id = match[1];
+        }
+      }
+    }
+    if (!id) {
+      throw new Error('action.sheets:append_row requires a spreadsheetId or spreadsheetUrl');
+    }
+    return id;
+  }
+
+  function resolveSheetName(context) {
+    if (sheetNameTemplate) {
+      var configured = interpolate(sheetNameTemplate, context).trim();
+      if (configured) {
+        return configured;
+      }
+    }
+    if (context.sheetName) {
+      return String(context.sheetName);
+    }
+    if (context.sheet) {
+      return String(context.sheet);
+    }
+    return 'Sheet1';
+  }
+
+  function resolveRange(context, sheetName) {
+    if (rangeTemplate) {
+      var raw = interpolate(rangeTemplate, context).trim();
+      if (raw) {
+        if (raw.indexOf('!') === -1 && sheetName) {
+          return sheetName + '!' + raw;
+        }
+        return raw;
+      }
+    }
+    if (sheetName) {
+      return sheetName;
+    }
+    throw new Error('action.sheets:append_row requires a sheetName when range is not provided');
+  }
+
+  function resolveValues(context) {
+    var rawValues = Array.isArray(valuesConfig) ? valuesConfig : [];
+    var resolved = [];
+    for (var index = 0; index < rawValues.length; index++) {
+      var entry = rawValues[index];
+      var value = entry;
+      if (typeof value === 'string') {
+        value = interpolate(value, context);
+      } else if (value && typeof value === 'object' && typeof value.value !== 'undefined' && value.mode === 'static') {
+        value = value.value;
+      }
+      resolved.push(value);
+    }
+    return resolved;
+  }
+
+  function getSheetsAccessToken(scopeList) {
+    var scopes = Array.isArray(scopeList) && scopeList.length ? scopeList : ['https://www.googleapis.com/auth/spreadsheets'];
+    try {
+      return requireOAuthToken('google-sheets', { scopes: scopes });
+    } catch (oauthError) {
+      var properties = PropertiesService.getScriptProperties();
+      var rawServiceAccount = properties.getProperty('GOOGLE_SHEETS_SERVICE_ACCOUNT');
+      if (!rawServiceAccount) {
+        throw oauthError;
+      }
+      var delegatedUser = properties.getProperty('GOOGLE_SHEETS_DELEGATED_EMAIL');
+
+      function base64UrlEncode(value) {
+        if (Object.prototype.toString.call(value) === '[object Array]') {
+          return Utilities.base64EncodeWebSafe(value).replace(/=+$/, '');
+        }
+        return Utilities.base64EncodeWebSafe(value, Utilities.Charset.UTF_8).replace(/=+$/, '');
+      }
+
+      try {
+        var parsed = typeof rawServiceAccount === 'string' ? JSON.parse(rawServiceAccount) : rawServiceAccount;
+        if (!parsed || typeof parsed !== 'object') {
+          throw new Error('Service account payload must be valid JSON.');
+        }
+        var clientEmail = parsed.client_email;
+        var privateKey = parsed.private_key;
+        if (!clientEmail || !privateKey) {
+          throw new Error('Service account JSON must include client_email and private_key.');
+        }
+
+        var now = Math.floor(Date.now() / 1000);
+        var headerSegment = base64UrlEncode(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+        var claimPayload = {
+          iss: clientEmail,
+          scope: scopes.join(' '),
+          aud: 'https://oauth2.googleapis.com/token',
+          exp: now + 3600,
+          iat: now
+        };
+        if (delegatedUser) {
+          claimPayload.sub = delegatedUser;
+        }
+        var claimSegment = base64UrlEncode(JSON.stringify(claimPayload));
+        var signingInput = headerSegment + '.' + claimSegment;
+        var signatureBytes = Utilities.computeRsaSha256Signature(signingInput, privateKey);
+        var signatureSegment = base64UrlEncode(signatureBytes);
+        var assertion = signingInput + '.' + signatureSegment;
+
+        var tokenResponse = rateLimitAware(function () {
+          return fetchJson({
+            url: 'https://oauth2.googleapis.com/token',
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+              'Accept': 'application/json'
+            },
+            payload: 'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=' + encodeURIComponent(assertion),
+            contentType: 'application/x-www-form-urlencoded'
+          });
+        }, { attempts: 3, initialDelayMs: 500, jitter: 0.25 });
+
+        var token = tokenResponse.body && tokenResponse.body.access_token;
+        if (!token) {
+          throw new Error('Service account token exchange did not return an access_token.');
+        }
+        return token;
+      } catch (serviceError) {
+        var serviceMessage = serviceError && serviceError.message ? serviceError.message : String(serviceError);
+        throw new Error('Google Sheets service account authentication failed: ' + serviceMessage);
+      }
+    }
+  }
+
+  var spreadsheetId = resolveSpreadsheetId(ctx);
+  var sheetName = resolveSheetName(ctx);
+  var targetRange = resolveRange(ctx, sheetName);
+  var rowValues = resolveValues(ctx);
+
+  if (!Array.isArray(rowValues) || rowValues.length === 0) {
+    throw new Error('action.sheets:append_row requires a non-empty values array');
+  }
+
+  var accessToken = getSheetsAccessToken(['https://www.googleapis.com/auth/spreadsheets']);
+  var baseUrl = 'https://sheets.googleapis.com/v4/spreadsheets/' + encodeURIComponent(spreadsheetId) + '/values/' + encodeURIComponent(targetRange) + ':append';
+  var query = '?valueInputOption=' + encodeURIComponent(valueInputOption || 'USER_ENTERED') + '&insertDataOption=' + encodeURIComponent(insertDataOption || 'INSERT_ROWS');
+  if (includeValuesInResponse) {
+    query += '&includeValuesInResponse=true';
+  }
+
+  var requestBody = { values: [rowValues] };
+
+  try {
+    var response = rateLimitAware(function () {
+      return fetchJson({
+        url: baseUrl + query,
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        },
+        payload: JSON.stringify(requestBody),
+        contentType: 'application/json'
+      });
+    }, { attempts: 4, initialDelayMs: 500, jitter: 0.25 });
+
+    var updates = response.body && response.body.updates ? response.body.updates : {};
+    var updatedRange = updates.updatedRange || (updates.updatedData && updates.updatedData.range) || null;
+    var updatedRows = typeof updates.updatedRows === 'number' ? updates.updatedRows : Number(updates.updatedRows || 0);
+    var appendedValues = updates.updatedData && updates.updatedData.values && updates.updatedData.values[0]
+      ? updates.updatedData.values[0]
+      : rowValues;
+
+    var appendedRowNumber = null;
+    if (updatedRange) {
+      var rowMatch = String(updatedRange).match(/(\d+)/);
+      if (rowMatch && rowMatch[1]) {
+        appendedRowNumber = Number(rowMatch[1]);
+      }
+    }
+
+    var appendSummary = {
+      spreadsheetId: spreadsheetId,
+      sheetName: sheetName,
+      range: targetRange,
+      updatedRange: updatedRange,
+      updatedRows: updatedRows,
+      values: appendedValues,
+      rowNumber: appendedRowNumber
+    };
+
+    ctx.googleSheetsLastAppend = appendSummary;
+    ctx.googleSheetsRowValues = appendedValues;
+    ctx.rowValues = appendedValues;
+    if (appendedRowNumber !== null) {
+      ctx.googleSheetsRowNumber = appendedRowNumber;
+      ctx.rowNumber = appendedRowNumber;
+      ctx.row = appendedRowNumber;
+    }
+
+    logInfo('google_sheets_append_row_success', {
+      spreadsheetId: spreadsheetId,
+      sheetName: sheetName,
+      range: targetRange,
+      updatedRange: updatedRange,
+      updatedRows: updatedRows
+    });
+
+    return ctx;
+  } catch (error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    if (status && status >= 400 && status < 500 && status !== 429) {
+      error.retryable = false;
+    }
+    var message = error && error.message ? error.message : String(error);
+    logError('google_sheets_append_row_failure', {
+      spreadsheetId: spreadsheetId,
+      sheetName: sheetName,
+      range: targetRange,
+      status: status,
+      message: message
+    });
+    throw error;
+  }
+}
+`;

--- a/server/workflow/__tests__/apps-script-fixtures/google-sheets-append-read.json
+++ b/server/workflow/__tests__/apps-script-fixtures/google-sheets-append-read.json
@@ -1,0 +1,167 @@
+{
+  "id": "google-sheets-append-read",
+  "description": "Tier-0 workflow that appends and reads Google Sheets rows via REST",
+  "graph": {
+    "id": "fixture-google-sheets-append-read",
+    "name": "Google Sheets append and read",
+    "nodes": [
+      {
+        "id": "append",
+        "type": "action.sheets",
+        "app": "sheets",
+        "name": "Append automation result",
+        "op": "action.sheets:append_row",
+        "params": {
+          "spreadsheetId": "sheet-123",
+          "sheetName": "Automation Log",
+          "values": ["{{stage}}", "{{result}}"]
+        },
+        "data": {
+          "operation": "append_row",
+          "config": {
+            "spreadsheetId": "sheet-123",
+            "sheetName": "Automation Log",
+            "values": ["{{stage}}", "{{result}}"]
+          }
+        }
+      },
+      {
+        "id": "read",
+        "type": "action.sheets",
+        "app": "sheets",
+        "name": "Read appended row",
+        "op": "action.sheets:getRow",
+        "params": {
+          "spreadsheetId": "sheet-123",
+          "sheetName": "Automation Log",
+          "rowNumber": { "mode": "ref", "nodeId": "append", "path": "googleSheetsLastAppend.rowNumber" }
+        },
+        "data": {
+          "operation": "getRow",
+          "config": {
+            "spreadsheetId": "sheet-123",
+            "sheetName": "Automation Log",
+            "rowNumber": { "mode": "ref", "nodeId": "append", "path": "googleSheetsLastAppend.rowNumber" }
+          }
+        }
+      }
+    ],
+    "edges": [
+      { "id": "flow-append-read", "from": "append", "to": "read", "source": "append", "target": "read" }
+    ]
+  },
+  "entry": {
+    "context": {
+      "stage": "Tier 0",
+      "result": "Success"
+    }
+  },
+  "secrets": {
+    "GOOGLE_SHEETS_ACCESS_TOKEN": "ya29.test-sheets-token"
+  },
+  "http": [
+    {
+      "name": "sheets-append",
+      "request": {
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/sheet-123/values/Automation%20Log:append?valueInputOption=USER_ENTERED&insertDataOption=INSERT_ROWS&includeValuesInResponse=true",
+        "method": "POST",
+        "headers": {
+          "authorization": "Bearer ya29.test-sheets-token",
+          "content-type": "application/json",
+          "accept": "application/json"
+        },
+        "payload": {
+          "values": [
+            [
+              "Tier 0",
+              "Success"
+            ]
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "updates": {
+            "spreadsheetId": "sheet-123",
+            "updatedRange": "Automation Log!A5:B5",
+            "updatedRows": 1,
+            "updatedColumns": 2,
+            "updatedData": {
+              "range": "Automation Log!A5:B5",
+              "values": [
+                [
+                  "Tier 0",
+                  "Success"
+                ]
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "sheets-get-row",
+      "request": {
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/sheet-123/values/Automation%20Log!5%3A5?majorDimension=ROWS&valueRenderOption=FORMATTED_VALUE",
+        "method": "GET",
+        "headers": {
+          "authorization": "Bearer ya29.test-sheets-token",
+          "accept": "application/json"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "range": "Automation Log!A5:B5",
+          "majorDimension": "ROWS",
+          "values": [
+            [
+              "Tier 0",
+              "Success"
+            ]
+          ]
+        }
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "stage": "Tier 0",
+      "result": "Success",
+      "sheetName": "Automation Log",
+      "rowNumber": 5,
+      "row": 5,
+      "rowValues": ["Tier 0", "Success"],
+      "googleSheetsRowNumber": 5,
+      "googleSheetsRowValues": ["Tier 0", "Success"],
+      "googleSheetsLastAppend": {
+        "spreadsheetId": "sheet-123",
+        "sheetName": "Automation Log",
+        "range": "Automation Log",
+        "updatedRange": "Automation Log!A5:B5",
+        "updatedRows": 1,
+        "values": ["Tier 0", "Success"],
+        "rowNumber": 5
+      },
+      "googleSheetsLastRead": {
+        "spreadsheetId": "sheet-123",
+        "sheetName": "Automation Log",
+        "rowNumber": 5,
+        "range": "Automation Log!5:5",
+        "values": ["Tier 0", "Success"],
+        "valueRenderOption": "FORMATTED_VALUE"
+      }
+    },
+    "httpCalls": [
+      {
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/sheet-123/values/Automation%20Log:append?valueInputOption=USER_ENTERED&insertDataOption=INSERT_ROWS&includeValuesInResponse=true",
+        "method": "POST"
+      },
+      {
+        "url": "https://sheets.googleapis.com/v4/spreadsheets/sheet-123/values/Automation%20Log!5%3A5?majorDimension=ROWS&valueRenderOption=FORMATTED_VALUE",
+        "method": "GET"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script.google-sheets.test.ts
+++ b/server/workflow/__tests__/apps-script.google-sheets.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { REAL_OPS } from '../compile-to-appsscript';
+import { runSingleFixture } from '../appsScriptDryRunHarness';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturesDir = path.join(__dirname, 'apps-script-fixtures');
+
+describe('Apps Script Google Sheets REAL_OPS', () => {
+  it('builds trigger.sheets:onEdit', () => {
+    expect(REAL_OPS['trigger.sheets:onEdit']({})).toMatchSnapshot();
+  });
+
+  it('builds action.sheets:getRow', () => {
+    expect(REAL_OPS['action.sheets:getRow']({})).toMatchSnapshot();
+  });
+
+  it('builds action.sheets:append_row', () => {
+    expect(
+      REAL_OPS['action.sheets:append_row']({
+        values: ['{{email}}', '{{status}}'],
+      }),
+    ).toMatchSnapshot();
+  });
+});
+
+describe('Apps Script Google Sheets integration', () => {
+  it('appends and reads rows via the Sheets REST API', async () => {
+    const result = await runSingleFixture('google-sheets-append-read', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.context.googleSheetsLastAppend).toBeDefined();
+    expect(result.context.googleSheetsLastAppend?.rowNumber).toBe(5);
+    expect(result.context.googleSheetsLastRead?.values).toEqual(['Tier 0', 'Success']);
+    expect(result.httpCalls).toHaveLength(2);
+    expect(result.httpCalls[0].url).toContain('/values/Automation%20Log:append');
+    expect(result.httpCalls[1].url).toContain('/values/Automation%20Log!5%3A5');
+  });
+});


### PR DESCRIPTION
## Summary
- reworked the Google Sheets trigger and actions to validate manifests, call the Sheets REST API with retries, and persist trigger state deterministically
- added Google Sheets snapshot coverage plus a Tier-0 append/read integration fixture exercising the new handlers
- documented the required Script Properties and OAuth/service-account scopes for Google Sheets in the handler authoring runbook

## Testing
- not run (vitest unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ec94941c1c83319308beabd1f3f95e