### PR TITLE
Enhance Typeform form creation handler and add Tier-1 coverage

### DIFF
--- a/connectors/typeform/definition.json
+++ b/connectors/typeform/definition.json
@@ -15,7 +15,78 @@
     }
   },
   "baseUrl": "https://api.typeform.com",
-  "actions": [],
+  "actions": [
+    {
+      "id": "create_form",
+      "name": "Create Form",
+      "description": "Create a new Typeform with optional questions",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Title shown at the top of the Typeform"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["quiz", "survey"],
+            "default": "quiz",
+            "description": "Typeform workspace mode"
+          },
+          "fields": {
+            "type": "array",
+            "description": "Questions to include in the form",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": { "type": "string", "description": "Question prompt" },
+                "type": { "type": "string", "description": "Question type" },
+                "properties": {
+                  "type": "object",
+                  "description": "Additional Typeform field settings",
+                  "additionalProperties": true
+                },
+                "validations": {
+                  "type": "object",
+                  "description": "Validation rules",
+                  "additionalProperties": true
+                }
+              },
+              "required": ["title", "type"],
+              "additionalProperties": true
+            }
+          }
+        },
+        "required": ["title"],
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "description": "Typeform form ID" },
+          "title": { "type": "string", "description": "Resolved form title" },
+          "type": { "type": "string", "description": "Resolved form type" },
+          "_links": {
+            "type": "object",
+            "description": "Hyperlinks returned by the API",
+            "additionalProperties": true
+          }
+        },
+        "required": ["id"],
+        "additionalProperties": true
+      },
+      "sample": {
+        "id": "01H9ZAX8V3M4P0JKQV1Y2Z3X4",
+        "title": "Customer feedback form",
+        "type": "survey"
+      },
+      "runtimes": [
+        "appsScript"
+      ],
+      "fallback": null
+    }
+  ],
   "triggers": [
     {
       "id": "form_response",

--- a/docs/apps-script-rollout/script-properties.md
+++ b/docs/apps-script-rollout/script-properties.md
@@ -131,7 +131,7 @@ The table below is regenerated automatically. Required properties appear in the 
 | Trello | `TRELLO_API_KEY`<br>`TRELLO_TOKEN` | — | — |
 | Twilio | `TWILIO_ACCOUNT_SID`<br>`TWILIO_AUTH_TOKEN`<br>`TWILIO_FROM_NUMBER` | — | — |
 | twitter | `TWITTER_BEARER_TOKEN` | — | — |
-| Typeform | `TYPEFORM_ACCESS_TOKEN` | — | — |
+| Typeform | `TYPEFORM_ACCESS_TOKEN` | `TYPEFORM_LAST_FORM_ID` | — |
 | vimeo | `VIMEO_ACCESS_TOKEN` | — | — |
 | vonage | `VONAGE_API_KEY`<br>`VONAGE_API_SECRET` | — | — |
 | wave | `WAVE_ACCESS_TOKEN` | — | — |

--- a/production/reports/apps-script-properties.json
+++ b/production/reports/apps-script-properties.json
@@ -5387,6 +5387,16 @@
           "contexts": [
             "getSecret"
           ]
+        },
+        {
+          "name": "TYPEFORM_LAST_FORM_ID",
+          "optional": true,
+          "operations": [
+            "action.typeform:create_form"
+          ],
+          "contexts": [
+            "scriptProperties"
+          ]
         }
       ],
       "environmentProperties": []

--- a/server/workflow/__tests__/fixtures/apps-script/tier-1-feedback.workflow.json
+++ b/server/workflow/__tests__/fixtures/apps-script/tier-1-feedback.workflow.json
@@ -1,0 +1,108 @@
+{
+  "id": "apps-script-tier-1-feedback",
+  "name": "Tier 1 feedback automation",
+  "meta": {
+    "appsScript": {
+      "tier": 1,
+      "description": "Turn edited sheet rows into Typeform surveys with persisted context",
+      "features": ["authentication", "structured-logging", "http-retries"]
+    },
+    "automationType": "customer_feedback",
+    "prompt": "When a marketer edits the feedback tracker, create a fresh Typeform survey and capture the form ID for follow-up"
+  },
+  "nodes": [
+    {
+      "id": "sheet-trigger",
+      "type": "trigger.sheets",
+      "app": "sheets",
+      "name": "Feedback row updated",
+      "op": "trigger.sheets:onEdit",
+      "params": {
+        "sheetName": "Feedback",
+        "dispatchRow": true
+      },
+      "data": {
+        "operation": "onEdit",
+        "config": {
+          "sheetName": "Feedback",
+          "dispatchRow": true
+        },
+        "metadata": {
+          "outputs": {
+            "row": { "type": "number" },
+            "values": { "type": "object" }
+          }
+        }
+      }
+    },
+    {
+      "id": "typeform-create",
+      "type": "action.typeform",
+      "app": "typeform",
+      "name": "Create survey",
+      "op": "action.typeform:create_form",
+      "params": {
+        "title": "Feedback for {{values.campaign_name}}",
+        "type": "survey",
+        "fields": [
+          {
+            "title": "How would you rate {{values.campaign_name}}?",
+            "type": "opinion_scale",
+            "properties": {
+              "steps": 5,
+              "start_at_one": true,
+              "labels": {
+                "left": "Poor",
+                "right": "Excellent"
+              }
+            }
+          },
+          {
+            "title": "What should we improve next time?",
+            "type": "long_text",
+            "properties": {
+              "description": "Share details for the growth team"
+            }
+          }
+        ]
+      },
+      "data": {
+        "operation": "create_form",
+        "config": {
+          "title": "Feedback for {{values.campaign_name}}",
+          "type": "survey",
+          "fields": [
+            {
+              "title": "How would you rate {{values.campaign_name}}?",
+              "type": "opinion_scale",
+              "properties": {
+                "steps": 5,
+                "start_at_one": true,
+                "labels": {
+                  "left": "Poor",
+                  "right": "Excellent"
+                }
+              }
+            },
+            {
+              "title": "What should we improve next time?",
+              "type": "long_text",
+              "properties": {
+                "description": "Share details for the growth team"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge-sheet-to-typeform",
+      "from": "sheet-trigger",
+      "to": "typeform-create",
+      "source": "sheet-trigger",
+      "target": "typeform-create"
+    }
+  ]
+}

--- a/server/workflow/__tests__/typeform.tier1.snapshot.test.ts
+++ b/server/workflow/__tests__/typeform.tier1.snapshot.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compileToAppsScript } from '../compile-to-appsscript';
+import type { WorkflowGraph } from '../../../common/workflow-types';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturesDir = path.join(__dirname, 'fixtures', 'apps-script');
+
+function loadWorkflowGraph(name: string): WorkflowGraph {
+  const workflowPath = path.join(fixturesDir, `${name}.workflow.json`);
+  const raw = readFileSync(workflowPath, 'utf-8');
+  return JSON.parse(raw) as WorkflowGraph;
+}
+
+describe('Tier-1 Typeform Apps Script snapshot', () => {
+  it('generates a persisted Typeform create_form handler with structured logging', () => {
+    const graph = loadWorkflowGraph('tier-1-feedback');
+    const result = compileToAppsScript(graph);
+
+    expect(result.workflowId).toBe(graph.id);
+
+    const codeFile = result.files.find(file => file.path === 'Code.gs');
+    expect(codeFile, 'compiled output should include Code.gs').toBeDefined();
+
+    const match = codeFile!.content.match(/function step_createTypeform\(ctx\) {[\s\S]+?\n}\n/);
+    expect(match, 'Typeform handler should be generated').not.toBeNull();
+
+    expect(match![0]).toMatchInlineSnapshot(`
+function step_createTypeform(ctx) {
+  const accessToken = getSecret('TYPEFORM_ACCESS_TOKEN', { connectorKey: 'typeform' });
+
+  if (!accessToken) {
+    logWarn('typeform_missing_access_token', { message: 'Typeform access token not configured' });
+    return ctx;
+  }
+
+  const titleTemplate = 'Feedback for {{values.campaign_name}}';
+  if (!titleTemplate) {
+    throw new Error('Typeform create_form manifest is missing the required Title parameter. Update the workflow configuration to provide a title.');
+  }
+
+  const resolvedTitle = interpolate(titleTemplate, ctx).trim();
+  if (!resolvedTitle) {
+    throw new Error('Typeform create_form requires a title. Configure the Title field or provide a template that resolves to text.');
+  }
+
+  const typeTemplate = 'survey';
+  const resolvedType = interpolate(typeTemplate, ctx).trim() || 'quiz';
+  const allowedTypes = ['quiz', 'survey'];
+  const normalizedType = allowedTypes.indexOf(resolvedType.toLowerCase()) !== -1 ? resolvedType.toLowerCase() : null;
+  if (!normalizedType) {
+    throw new Error('Typeform create_form received an invalid form type "' + resolvedType + '". Supported values: quiz, survey.');
+  }
+
+  const fieldsConfig = [{"title":"How would you rate {{values.campaign_name}}?","type":"opinion_scale","properties":{"steps":5,"start_at_one":true,"labels":{"left":"Poor","right":"Excellent"}}},{"title":"What should we improve next time?","type":"long_text","properties":{"description":"Share details for the growth team"}}];
+
+  function interpolateValue(value) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      return interpolate(value, ctx);
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        result.push(interpolateValue(value[i]));
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+          continue;
+        }
+        result[key] = interpolateValue(value[key]);
+      }
+      return result;
+    }
+    return value;
+  }
+
+  const normalizedFields = [];
+  if (Array.isArray(fieldsConfig)) {
+    for (let index = 0; index < fieldsConfig.length; index++) {
+      const entry = fieldsConfig[index];
+      if (!entry || typeof entry !== 'object') {
+        logWarn('typeform_field_skipped', { index: index, reason: 'Non-object field configuration' });
+        continue;
+      }
+      const interpolatedField = interpolateValue(entry) || {};
+      const fieldType = typeof interpolatedField.type === 'string' ? interpolatedField.type.trim() : '';
+      const fieldTitle = typeof interpolatedField.title === 'string' ? interpolatedField.title.trim() : '';
+
+      if (!fieldType || !fieldTitle) {
+        logWarn('typeform_field_skipped', { index: index, reason: 'Missing type or title' });
+        continue;
+      }
+
+      const normalizedField = {};
+      for (const key in interpolatedField) {
+        if (!Object.prototype.hasOwnProperty.call(interpolatedField, key)) {
+          continue;
+        }
+        normalizedField[key] = interpolatedField[key];
+      }
+
+      normalizedField.type = fieldType;
+      normalizedField.title = fieldTitle;
+      normalizedFields.push(normalizedField);
+    }
+  }
+
+  const formData = {
+    title: resolvedTitle,
+    type: normalizedType
+  };
+
+  if (normalizedFields.length > 0) {
+    formData.fields = normalizedFields;
+  }
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.typeform.com/forms',
+      method: 'POST',
+      headers: {
+        'Authorization': \`Bearer \${accessToken}\`,
+        'Content-Type': 'application/json'
+      },
+      payload: JSON.stringify(formData),
+      contentType: 'application/json'
+    }), { attempts: 4, initialDelayMs: 1000, jitter: 0.2 });
+
+    const body = response.body || {};
+    const formId = body && body.id ? String(body.id) : null;
+    ctx.typeformId = formId;
+    ctx.typeformFormUrl = body && body._links && body._links.display ? body._links.display : null;
+
+    if (formId && typeof PropertiesService !== 'undefined' && PropertiesService && typeof PropertiesService.getScriptProperties === 'function') {
+      try {
+        const scriptProps = PropertiesService.getScriptProperties();
+        scriptProps.setProperty('TYPEFORM_LAST_FORM_ID', formId);
+        scriptProps.setProperty('apps_script__typeform__last_form_id', formId);
+      } catch (persistError) {
+        logWarn('typeform_persist_form_id_failed', {
+          message: persistError && persistError.message ? persistError.message : String(persistError)
+        });
+      }
+    }
+
+    logInfo('typeform_create_form_success', {
+      formId: formId,
+      title: resolvedTitle,
+      type: normalizedType,
+      fieldCount: normalizedFields.length,
+      url: ctx.typeformFormUrl,
+      status: response && typeof response.status === 'number' ? response.status : null
+    });
+
+    return ctx;
+  } catch (error) {
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const headers = error && error.headers ? error.headers : {};
+    let payload = error && Object.prototype.hasOwnProperty.call(error, 'body') ? error.body : null;
+    const details = [];
+
+    if (status) {
+      details.push('status ' + status);
+    }
+
+    let parsed = null;
+    if (payload && typeof payload === 'string') {
+      details.push(payload);
+      try {
+        parsed = JSON.parse(payload);
+      } catch (parseError) {
+        parsed = null;
+      }
+    } else if (payload && typeof payload === 'object') {
+      parsed = payload;
+    }
+
+    if (parsed && typeof parsed === 'object') {
+      if (parsed.code) {
+        details.push('code ' + parsed.code);
+      }
+      if (parsed.description) {
+        details.push(String(parsed.description));
+      }
+      if (parsed.message) {
+        details.push(String(parsed.message));
+      }
+      if (Array.isArray(parsed.details)) {
+        for (let i = 0; i < parsed.details.length; i++) {
+          const item = parsed.details[i];
+          if (!item) {
+            continue;
+          }
+          const field = item.field ? String(item.field) : null;
+          const issue = item.message ? String(item.message) : null;
+          if (field || issue) {
+            details.push((field ? field + ': ' : '') + (issue || ''));
+          }
+        }
+      }
+    }
+
+    logError('typeform_create_form_failed', {
+      status: status,
+      title: resolvedTitle,
+      type: normalizedType,
+      details: details
+    });
+
+    const message = 'Typeform create_form failed. ' + (details.length > 0 ? details.join(' ') : 'Unexpected error.');
+    const wrapped = new Error(message);
+    wrapped.status = status;
+    wrapped.headers = headers;
+    wrapped.body = payload;
+    wrapped.cause = error;
+    throw wrapped;
+  }
+}
+`);
+  });
+});

--- a/server/workflow/compile-to-appsscript.ts
+++ b/server/workflow/compile-to-appsscript.ts
@@ -15878,31 +15878,201 @@ function step_createGitHubIssue(ctx) {
   // BATCH 9: Forms & Surveys
   'action.typeform:create_form': (c) => `
 function step_createTypeform(ctx) {
-  const accessToken = getSecret('TYPEFORM_ACCESS_TOKEN');
+  const accessToken = getSecret('TYPEFORM_ACCESS_TOKEN', { connectorKey: 'typeform' });
 
   if (!accessToken) {
     logWarn('typeform_missing_access_token', { message: 'Typeform access token not configured' });
     return ctx;
   }
-  
-  const formData = {
-    title: interpolate('${c.title || 'Automated Form'}', ctx),
-    type: '${c.type || 'quiz'}'
-  };
-  
-  const response = withRetries(() => fetchJson('https://api.typeform.com/forms', {
-    method: 'POST',
-    headers: {
-      'Authorization': \`Bearer \${accessToken}\`,
-      'Content-Type': 'application/json'
-    },
-    payload: JSON.stringify(formData),
-    contentType: 'application/json'
-  }));
 
-  ctx.typeformId = response.body && response.body.id;
-  logInfo('typeform_create_form', { formId: ctx.typeformId || null });
-  return ctx;
+  const titleTemplate = ${c.title !== undefined ? `'${escapeForSingleQuotes(String(c.title))}'` : 'null'};
+  if (!titleTemplate) {
+    throw new Error('Typeform create_form manifest is missing the required Title parameter. Update the workflow configuration to provide a title.');
+  }
+
+  const resolvedTitle = interpolate(titleTemplate, ctx).trim();
+  if (!resolvedTitle) {
+    throw new Error('Typeform create_form requires a title. Configure the Title field or provide a template that resolves to text.');
+  }
+
+  const typeTemplate = ${c.type !== undefined ? `'${escapeForSingleQuotes(String(c.type))}'` : "'quiz'"};
+  const resolvedType = interpolate(typeTemplate, ctx).trim() || 'quiz';
+  const allowedTypes = ['quiz', 'survey'];
+  const normalizedType = allowedTypes.indexOf(resolvedType.toLowerCase()) !== -1 ? resolvedType.toLowerCase() : null;
+  if (!normalizedType) {
+    throw new Error('Typeform create_form received an invalid form type "' + resolvedType + '". Supported values: quiz, survey.');
+  }
+
+  const fieldsConfig = ${JSON.stringify(Array.isArray(c.fields) ? c.fields : [])};
+
+  function interpolateValue(value) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      return interpolate(value, ctx);
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        result.push(interpolateValue(value[i]));
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+          continue;
+        }
+        result[key] = interpolateValue(value[key]);
+      }
+      return result;
+    }
+    return value;
+  }
+
+  const normalizedFields = [];
+  if (Array.isArray(fieldsConfig)) {
+    for (let index = 0; index < fieldsConfig.length; index++) {
+      const entry = fieldsConfig[index];
+      if (!entry || typeof entry !== 'object') {
+        logWarn('typeform_field_skipped', { index: index, reason: 'Non-object field configuration' });
+        continue;
+      }
+      const interpolatedField = interpolateValue(entry) || {};
+      const fieldType = typeof interpolatedField.type === 'string' ? interpolatedField.type.trim() : '';
+      const fieldTitle = typeof interpolatedField.title === 'string' ? interpolatedField.title.trim() : '';
+
+      if (!fieldType || !fieldTitle) {
+        logWarn('typeform_field_skipped', { index: index, reason: 'Missing type or title' });
+        continue;
+      }
+
+      const normalizedField = {};
+      for (const key in interpolatedField) {
+        if (!Object.prototype.hasOwnProperty.call(interpolatedField, key)) {
+          continue;
+        }
+        normalizedField[key] = interpolatedField[key];
+      }
+
+      normalizedField.type = fieldType;
+      normalizedField.title = fieldTitle;
+      normalizedFields.push(normalizedField);
+    }
+  }
+
+  const formData = {
+    title: resolvedTitle,
+    type: normalizedType
+  };
+
+  if (normalizedFields.length > 0) {
+    formData.fields = normalizedFields;
+  }
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.typeform.com/forms',
+      method: 'POST',
+      headers: {
+        'Authorization': \`Bearer \${accessToken}\`,
+        'Content-Type': 'application/json'
+      },
+      payload: JSON.stringify(formData),
+      contentType: 'application/json'
+    }), { attempts: 4, initialDelayMs: 1000, jitter: 0.2 });
+
+    const body = response.body || {};
+    const formId = body && body.id ? String(body.id) : null;
+    ctx.typeformId = formId;
+    ctx.typeformFormUrl = body && body._links && body._links.display ? body._links.display : null;
+
+    if (formId && typeof PropertiesService !== 'undefined' && PropertiesService && typeof PropertiesService.getScriptProperties === 'function') {
+      try {
+        const scriptProps = PropertiesService.getScriptProperties();
+        scriptProps.setProperty('TYPEFORM_LAST_FORM_ID', formId);
+        scriptProps.setProperty('apps_script__typeform__last_form_id', formId);
+      } catch (persistError) {
+        logWarn('typeform_persist_form_id_failed', {
+          message: persistError && persistError.message ? persistError.message : String(persistError)
+        });
+      }
+    }
+
+    logInfo('typeform_create_form_success', {
+      formId: formId,
+      title: resolvedTitle,
+      type: normalizedType,
+      fieldCount: normalizedFields.length,
+      url: ctx.typeformFormUrl,
+      status: response && typeof response.status === 'number' ? response.status : null
+    });
+
+    return ctx;
+  } catch (error) {
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const headers = error && error.headers ? error.headers : {};
+    let payload = error && Object.prototype.hasOwnProperty.call(error, 'body') ? error.body : null;
+    const details = [];
+
+    if (status) {
+      details.push('status ' + status);
+    }
+
+    let parsed = null;
+    if (payload && typeof payload === 'string') {
+      details.push(payload);
+      try {
+        parsed = JSON.parse(payload);
+      } catch (parseError) {
+        parsed = null;
+      }
+    } else if (payload && typeof payload === 'object') {
+      parsed = payload;
+    }
+
+    if (parsed && typeof parsed === 'object') {
+      if (parsed.code) {
+        details.push('code ' + parsed.code);
+      }
+      if (parsed.description) {
+        details.push(String(parsed.description));
+      }
+      if (parsed.message) {
+        details.push(String(parsed.message));
+      }
+      if (Array.isArray(parsed.details)) {
+        for (let i = 0; i < parsed.details.length; i++) {
+          const item = parsed.details[i];
+          if (!item) {
+            continue;
+          }
+          const field = item.field ? String(item.field) : null;
+          const issue = item.message ? String(item.message) : null;
+          if (field || issue) {
+            details.push((field ? field + ': ' : '') + (issue || '')); 
+          }
+        }
+      }
+    }
+
+    logError('typeform_create_form_failed', {
+      status: status,
+      title: resolvedTitle,
+      type: normalizedType,
+      details: details
+    });
+
+    const message = 'Typeform create_form failed. ' + (details.length > 0 ? details.join(' ') : 'Unexpected error.');
+    const wrapped = new Error(message);
+    wrapped.status = status;
+    wrapped.headers = headers;
+    wrapped.body = payload;
+    wrapped.cause = error;
+    throw wrapped;
+  }
 }`,
 
   'action.surveymonkey:create_survey': (c) => `


### PR DESCRIPTION
## Summary
- harden the Typeform `create_form` Apps Script handler with manifest validation, rate-limit aware execution, structured logging, and persisted IDs
- document the new Typeform script property requirements and expose the action in the connector manifest
- add a Tier-1 feedback workflow fixture and snapshot test that verifies the generated handler output

## Testing
- `UPDATE_APPSSCRIPT_SNAPSHOTS=1 npx vitest run server/workflow/__tests__/compile-to-appsscript.snapshots.test.ts` *(fails: npm registry access is forbidden in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68ec915a8f188331a56d671da4add9d7