### PR TITLE
Implement HubSpot Apps Script handlers and tests

### DIFF
--- a/docs/phases/oauth-setup.md
+++ b/docs/phases/oauth-setup.md
@@ -16,9 +16,15 @@ HubSpot
 
 - Create a Private App or OAuth App
 - Set Redirect URL: `${BASE_URL}/api/oauth/callback/hubspot`
-- Scopes (minimum for contacts): `contacts`, optionally `content`, `reports`, `timeline`
+- Scopes required for Apps Script HubSpot actions:
+  - `crm.objects.contacts.write` (and `crm.objects.contacts.read` for lookups)
+  - `crm.objects.deals.write` and `crm.objects.deals.read`
+  - `crm.objects.companies.write`
+  - `crm.objects.tickets.write`
+  - `crm.objects.notes.write`
 - Save into `.env`: `HUBSPOT_CLIENT_ID`, `HUBSPOT_CLIENT_SECRET`
 - Start flow: `POST /api/oauth/authorize` with `{ provider: "hubspot" }`
+- OAuth Manager persists the OAuth access token as `HUBSPOT_ACCESS_TOKEN` for Apps Script deployments
 
 Zendesk
 

--- a/scripts/generate-hubspot-snapshots.js
+++ b/scripts/generate-hubspot-snapshots.js
@@ -1,0 +1,468 @@
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+function prepareValueForCode(value) {
+  return value;
+}
+
+function buildHubSpotAction(slug, operationName, config, scopes, bodyLines) {
+  const configLiteral = JSON.stringify(prepareValueForCode(config ?? {}));
+  const scopesLiteral = JSON.stringify(scopes);
+
+  return `
+function step_action_hubspot_${slug}(ctx) {
+  ctx = ctx || {};
+  const config = ${configLiteral};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ${scopesLiteral} });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('${operationName} requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('${operationName} requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('${operationName} requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('${operationName} requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('${operationName} requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_${slug}_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = '${operationName} failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+${bodyLines.join('\n')}
+
+}
+`;
+}
+
+const operations = [
+  ['create_contact', 'HubSpot create_contact', { email: '{{lead.email}}', firstname: '{{lead.firstName}}', lastname: 'Customer' }, ['crm.objects.contacts.write'], [
+    "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+    "  var properties = buildProperties(source, { operation: true });",
+    "  if (!properties.email) {",
+    "    throw new Error('HubSpot create_contact requires the email field.');",
+    "  }",
+    "  var response = executeRequest(requestOptions('/crm/v3/objects/contacts', 'POST', { properties: properties }));",
+    "  var contact = response && response.body ? response.body : {};",
+    "  ctx.hubspotContactId = contact.id || null;",
+    "  ctx.hubspotContact = contact;",
+    "  logInfo('hubspot_create_contact', { contactId: ctx.hubspotContactId || null });",
+    "  return ctx;"
+  ]],
+  ['update_contact', 'HubSpot update_contact', { contactId: '12345', phone: '{{lead.phone}}' }, ['crm.objects.contacts.write'], [
+    "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+    "  var contactId = resolveValue(config.contactId, { required: true, label: 'contactId' });",
+    "  var properties = buildProperties(source, { contactId: true, operation: true });",
+    "  if (Object.keys(properties).length === 0) {",
+    "    throw new Error('HubSpot update_contact requires at least one property to update.');",
+    "  }",
+    "  var response = executeRequest(requestOptions('/crm/v3/objects/contacts/' + encodeURIComponent(contactId), 'PATCH', { properties: properties }));",
+    "  var contact = response && response.body ? response.body : {};",
+    "  ctx.hubspotContactId = contact.id || contactId;",
+    "  ctx.hubspotContact = contact;",
+    "  logInfo('hubspot_update_contact', { contactId: ctx.hubspotContactId || contactId });",
+    "  return ctx;"
+  ]],
+  ['get_contact', 'HubSpot get_contact', { email: '{{lead.email}}', properties: ['firstname', 'lastname'] }, ['crm.objects.contacts.read'], [
+    "  var identifier = resolveValue(config.contactId, { allowEmpty: true, label: 'contactId' });",
+    "  var queryParts = [];",
+    "  if (!identifier) {",
+    "    var emailIdentifier = resolveValue(config.email, { required: true, label: 'email' });",
+    "    identifier = emailIdentifier;",
+    "    queryParts.push('idProperty=email');",
+    "  }",
+    "  if (config && Array.isArray(config.properties)) {",
+    "    for (var i = 0; i < config.properties.length; i++) {",
+    "      var propertyName = resolveValue(config.properties[i], {});",
+    "      if (propertyName) {",
+    "        queryParts.push('properties=' + encodeURIComponent(propertyName));",
+    "      }",
+    "    }",
+    "  }",
+    "  var path = '/crm/v3/objects/contacts/' + encodeURIComponent(identifier);",
+    "  if (queryParts.length > 0) {",
+    "    path += '?' + queryParts.join('&');",
+    "  }",
+    "  var response = executeRequest(requestOptions(path, 'GET'));",
+    "  var contact = response && response.body ? response.body : {};",
+    "  ctx.hubspotContactId = contact.id || identifier;",
+    "  ctx.hubspotContact = contact;",
+    "  logInfo('hubspot_get_contact', { contactId: ctx.hubspotContactId || identifier });",
+    "  return ctx;"
+  ]],
+  ['create_deal', 'HubSpot create_deal', { dealname: 'Q4 Renewal', amount: '15000' }, ['crm.objects.deals.write'], [
+    "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+    "  var properties = buildProperties(source, { operation: true });",
+    "  if (!properties.dealname) {",
+    "    throw new Error('HubSpot create_deal requires the dealname field.');",
+    "  }",
+    "  var response = executeRequest(requestOptions('/crm/v3/objects/deals', 'POST', { properties: properties }));",
+    "  var deal = response && response.body ? response.body : {};",
+    "  ctx.hubspotDealId = deal.id || null;",
+    "  ctx.hubspotDeal = deal;",
+    "  logInfo('hubspot_create_deal', { dealId: ctx.hubspotDealId || null });",
+    "  return ctx;"
+  ]],
+  ['update_deal', 'HubSpot update_deal', { dealId: '98765', dealstage: 'closedwon', amount: '17500' }, ['crm.objects.deals.write'], [
+    "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+    "  var dealId = resolveValue(config.dealId, { required: true, label: 'dealId' });",
+    "  var properties = buildProperties(source, { dealId: true, operation: true });",
+    "  if (Object.keys(properties).length === 0) {",
+    "    throw new Error('HubSpot update_deal requires at least one property to update.');",
+    "  }",
+    "  var response = executeRequest(requestOptions('/crm/v3/objects/deals/' + encodeURIComponent(dealId), 'PATCH', { properties: properties }));",
+    "  var deal = response && response.body ? response.body : {};",
+    "  ctx.hubspotDealId = deal.id || dealId;",
+    "  ctx.hubspotDeal = deal;",
+    "  logInfo('hubspot_update_deal', { dealId: ctx.hubspotDealId || dealId });",
+    "  return ctx;"
+  ]],
+  ['update_deal_stage', 'HubSpot update_deal_stage', { dealId: '98765', properties: { dealstage: 'presentationscheduled' } }, ['crm.objects.deals.write'], [
+    "  var dealId = resolveValue(config.dealId, { required: true, label: 'dealId' });",
+    "  var propertySource = config && typeof config.properties === 'object' ? config.properties : {};",
+    "  var properties = buildProperties(propertySource, {});",
+    "  if (Object.keys(properties).length === 0) {",
+    "    throw new Error('HubSpot update_deal_stage requires properties for the update.');",
+    "  }",
+    "  var response = executeRequest(requestOptions('/crm/v3/objects/deals/' + encodeURIComponent(dealId), 'PATCH', { properties: properties }));",
+    "  var deal = response && response.body ? response.body : {};",
+    "  ctx.hubspotDealId = deal.id || dealId;",
+    "  ctx.hubspotDeal = deal;",
+    "  logInfo('hubspot_update_deal_stage', { dealId: ctx.hubspotDealId || dealId });",
+    "  return ctx;"
+  ]],
+  ['get_deal', 'HubSpot get_deal', { dealId: '98765', properties: ['dealname', 'amount'] }, ['crm.objects.deals.read'], [
+    "  var dealId = resolveValue(config.dealId, { required: true, label: 'dealId' });",
+    "  var queryParts = [];",
+    "  if (config && Array.isArray(config.properties)) {",
+    "    for (var i = 0; i < config.properties.length; i++) {",
+    "      var propertyName = resolveValue(config.properties[i], {});",
+    "      if (propertyName) {",
+    "        queryParts.push('properties=' + encodeURIComponent(propertyName));",
+    "      }",
+    "    }",
+    "  }",
+    "  var path = '/crm/v3/objects/deals/' + encodeURIComponent(dealId);",
+    "  if (queryParts.length > 0) {",
+    "    path += '?' + queryParts.join('&');",
+    "  }",
+    "  var response = executeRequest(requestOptions(path, 'GET'));",
+    "  var deal = response && response.body ? response.body : {};",
+    "  ctx.hubspotDealId = deal.id || dealId;",
+    "  ctx.hubspotDeal = deal;",
+    "  logInfo('hubspot_get_deal', { dealId: ctx.hubspotDealId || dealId });",
+    "  return ctx;"
+  ]],
+  ['create_company', 'HubSpot create_company', { name: 'Acme Corp', domain: 'acme.example.com' }, ['crm.objects.companies.write'], [
+    "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+    "  var properties = buildProperties(source, { operation: true });",
+    "  if (!properties.name && !properties.domain) {",
+    "    throw new Error('HubSpot create_company requires at least the name or domain field.');",
+    "  }",
+    "  var response = executeRequest(requestOptions('/crm/v3/objects/companies', 'POST', { properties: properties }));",
+    "  var company = response && response.body ? response.body : {};",
+    "  ctx.hubspotCompanyId = company.id || null;",
+    "  ctx.hubspotCompany = company;",
+    "  logInfo('hubspot_create_company', { companyId: ctx.hubspotCompanyId || null });",
+    "  return ctx;"
+  ]],
+  ['create_ticket', 'HubSpot create_ticket', { subject: 'Onboarding help', content: 'Customer requested assistance.' }, ['crm.objects.tickets.write'], [
+    "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+    "  var properties = buildProperties(source, { operation: true });",
+    "  if (!properties.subject) {",
+    "    throw new Error('HubSpot create_ticket requires the subject field.');",
+    "  }",
+    "  var response = executeRequest(requestOptions('/crm/v3/objects/tickets', 'POST', { properties: properties }));",
+    "  var ticket = response && response.body ? response.body : {};",
+    "  ctx.hubspotTicketId = ticket.id || null;",
+    "  ctx.hubspotTicket = ticket;",
+    "  logInfo('hubspot_create_ticket', { ticketId: ctx.hubspotTicketId || null });",
+    "  return ctx;"
+  ]],
+  ['create_note', 'HubSpot create_note', {
+    hs_note_body: 'Follow up with {{lead.owner}}',
+    associations: [
+      {
+        to: { id: '12345', type: 'contact' },
+        types: [
+          {
+            associationCategory: 'HUBSPOT_DEFINED',
+            associationTypeId: 280
+          }
+        ]
+      }
+    ]
+  }, ['crm.objects.notes.write'], [
+    "  var propertySource = config && typeof config.properties === 'object' ? config.properties : config;",
+    "  var properties = buildProperties(propertySource, { associations: true, operation: true });",
+    "  if (!properties.hs_note_body) {",
+    "    throw new Error('HubSpot create_note requires the hs_note_body field.');",
+    "  }",
+    "  var associations = [];",
+    "  if (config && Array.isArray(config.associations)) {",
+    "    associations = resolveValue(config.associations, { items: {} }) || [];",
+    "  }",
+    "  var payload = { properties: properties };",
+    "  if (associations && associations.length) {",
+    "    payload.associations = associations;",
+    "  }",
+    "  var response = executeRequest(requestOptions('/crm/v3/objects/notes', 'POST', payload));",
+    "  var note = response && response.body ? response.body : {};",
+    "  ctx.hubspotNoteId = note.id || null;",
+    "  ctx.hubspotNote = note;",
+    "  logInfo('hubspot_create_note', { noteId: ctx.hubspotNoteId || null });",
+    "  return ctx;"
+  ]]
+];
+
+const snapshotLines = [];
+for (const [slug, name, config, scopes, body] of operations) {
+  const source = buildHubSpotAction(slug, name, config, scopes, body);
+  const escaped = source.replace(/`/g, '\\`');
+  snapshotLines.push(`exports[\`Apps Script HubSpot REAL_OPS builds action.hubspot:${slug} 1\`] = \`${escaped}\`;\n`);
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const snapshotPath = join(__dirname, '../server/workflow/__tests__/__snapshots__/apps-script.hubspot.test.ts.snap');
+writeFileSync(snapshotPath, snapshotLines.join('\n'));

--- a/server/workflow/__tests__/__snapshots__/apps-script.hubspot.test.ts.snap
+++ b/server/workflow/__tests__/__snapshots__/apps-script.hubspot.test.ts.snap
@@ -1,0 +1,2773 @@
+exports[`Apps Script HubSpot REAL_OPS builds action.hubspot:create_contact 1`] = `
+function step_action_hubspot_create_contact(ctx) {
+  ctx = ctx || {};
+  const config = {"email":"{{lead.email}}","firstname":"{{lead.firstName}}","lastname":"Customer"};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ["crm.objects.contacts.write"] });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('HubSpot create_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('HubSpot create_contact requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('HubSpot create_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('HubSpot create_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('HubSpot create_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_create_contact_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = 'HubSpot create_contact failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+  var source = config && typeof config.properties === 'object' ? config.properties : config;
+  var properties = buildProperties(source, { operation: true });
+  if (!properties.email) {
+    throw new Error('HubSpot create_contact requires the email field.');
+  }
+  var response = executeRequest(requestOptions('/crm/v3/objects/contacts', 'POST', { properties: properties }));
+  var contact = response && response.body ? response.body : {};
+  ctx.hubspotContactId = contact.id || null;
+  ctx.hubspotContact = contact;
+  logInfo('hubspot_create_contact', { contactId: ctx.hubspotContactId || null });
+  return ctx;
+
+}
+`;
+
+exports[`Apps Script HubSpot REAL_OPS builds action.hubspot:update_contact 1`] = `
+function step_action_hubspot_update_contact(ctx) {
+  ctx = ctx || {};
+  const config = {"contactId":"12345","phone":"{{lead.phone}}"};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ["crm.objects.contacts.write"] });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('HubSpot update_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('HubSpot update_contact requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('HubSpot update_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('HubSpot update_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('HubSpot update_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_update_contact_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = 'HubSpot update_contact failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+  var source = config && typeof config.properties === 'object' ? config.properties : config;
+  var contactId = resolveValue(config.contactId, { required: true, label: 'contactId' });
+  var properties = buildProperties(source, { contactId: true, operation: true });
+  if (Object.keys(properties).length === 0) {
+    throw new Error('HubSpot update_contact requires at least one property to update.');
+  }
+  var response = executeRequest(requestOptions('/crm/v3/objects/contacts/' + encodeURIComponent(contactId), 'PATCH', { properties: properties }));
+  var contact = response && response.body ? response.body : {};
+  ctx.hubspotContactId = contact.id || contactId;
+  ctx.hubspotContact = contact;
+  logInfo('hubspot_update_contact', { contactId: ctx.hubspotContactId || contactId });
+  return ctx;
+
+}
+`;
+
+exports[`Apps Script HubSpot REAL_OPS builds action.hubspot:get_contact 1`] = `
+function step_action_hubspot_get_contact(ctx) {
+  ctx = ctx || {};
+  const config = {"email":"{{lead.email}}","properties":["firstname","lastname"]};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ["crm.objects.contacts.read"] });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('HubSpot get_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('HubSpot get_contact requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('HubSpot get_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('HubSpot get_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('HubSpot get_contact requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_get_contact_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = 'HubSpot get_contact failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+  var identifier = resolveValue(config.contactId, { allowEmpty: true, label: 'contactId' });
+  var queryParts = [];
+  if (!identifier) {
+    var emailIdentifier = resolveValue(config.email, { required: true, label: 'email' });
+    identifier = emailIdentifier;
+    queryParts.push('idProperty=email');
+  }
+  if (config && Array.isArray(config.properties)) {
+    for (var i = 0; i < config.properties.length; i++) {
+      var propertyName = resolveValue(config.properties[i], {});
+      if (propertyName) {
+        queryParts.push('properties=' + encodeURIComponent(propertyName));
+      }
+    }
+  }
+  var path = '/crm/v3/objects/contacts/' + encodeURIComponent(identifier);
+  if (queryParts.length > 0) {
+    path += '?' + queryParts.join('&');
+  }
+  var response = executeRequest(requestOptions(path, 'GET'));
+  var contact = response && response.body ? response.body : {};
+  ctx.hubspotContactId = contact.id || identifier;
+  ctx.hubspotContact = contact;
+  logInfo('hubspot_get_contact', { contactId: ctx.hubspotContactId || identifier });
+  return ctx;
+
+}
+`;
+
+exports[`Apps Script HubSpot REAL_OPS builds action.hubspot:create_deal 1`] = `
+function step_action_hubspot_create_deal(ctx) {
+  ctx = ctx || {};
+  const config = {"dealname":"Q4 Renewal","amount":"15000"};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ["crm.objects.deals.write"] });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('HubSpot create_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('HubSpot create_deal requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('HubSpot create_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('HubSpot create_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('HubSpot create_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_create_deal_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = 'HubSpot create_deal failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+  var source = config && typeof config.properties === 'object' ? config.properties : config;
+  var properties = buildProperties(source, { operation: true });
+  if (!properties.dealname) {
+    throw new Error('HubSpot create_deal requires the dealname field.');
+  }
+  var response = executeRequest(requestOptions('/crm/v3/objects/deals', 'POST', { properties: properties }));
+  var deal = response && response.body ? response.body : {};
+  ctx.hubspotDealId = deal.id || null;
+  ctx.hubspotDeal = deal;
+  logInfo('hubspot_create_deal', { dealId: ctx.hubspotDealId || null });
+  return ctx;
+
+}
+`;
+
+exports[`Apps Script HubSpot REAL_OPS builds action.hubspot:update_deal 1`] = `
+function step_action_hubspot_update_deal(ctx) {
+  ctx = ctx || {};
+  const config = {"dealId":"98765","dealstage":"closedwon","amount":"17500"};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ["crm.objects.deals.write"] });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('HubSpot update_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('HubSpot update_deal requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('HubSpot update_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('HubSpot update_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('HubSpot update_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_update_deal_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = 'HubSpot update_deal failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+  var source = config && typeof config.properties === 'object' ? config.properties : config;
+  var dealId = resolveValue(config.dealId, { required: true, label: 'dealId' });
+  var properties = buildProperties(source, { dealId: true, operation: true });
+  if (Object.keys(properties).length === 0) {
+    throw new Error('HubSpot update_deal requires at least one property to update.');
+  }
+  var response = executeRequest(requestOptions('/crm/v3/objects/deals/' + encodeURIComponent(dealId), 'PATCH', { properties: properties }));
+  var deal = response && response.body ? response.body : {};
+  ctx.hubspotDealId = deal.id || dealId;
+  ctx.hubspotDeal = deal;
+  logInfo('hubspot_update_deal', { dealId: ctx.hubspotDealId || dealId });
+  return ctx;
+
+}
+`;
+
+exports[`Apps Script HubSpot REAL_OPS builds action.hubspot:update_deal_stage 1`] = `
+function step_action_hubspot_update_deal_stage(ctx) {
+  ctx = ctx || {};
+  const config = {"dealId":"98765","properties":{"dealstage":"presentationscheduled"}};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ["crm.objects.deals.write"] });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('HubSpot update_deal_stage requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('HubSpot update_deal_stage requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('HubSpot update_deal_stage requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('HubSpot update_deal_stage requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('HubSpot update_deal_stage requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_update_deal_stage_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = 'HubSpot update_deal_stage failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+  var dealId = resolveValue(config.dealId, { required: true, label: 'dealId' });
+  var propertySource = config && typeof config.properties === 'object' ? config.properties : {};
+  var properties = buildProperties(propertySource, {});
+  if (Object.keys(properties).length === 0) {
+    throw new Error('HubSpot update_deal_stage requires properties for the update.');
+  }
+  var response = executeRequest(requestOptions('/crm/v3/objects/deals/' + encodeURIComponent(dealId), 'PATCH', { properties: properties }));
+  var deal = response && response.body ? response.body : {};
+  ctx.hubspotDealId = deal.id || dealId;
+  ctx.hubspotDeal = deal;
+  logInfo('hubspot_update_deal_stage', { dealId: ctx.hubspotDealId || dealId });
+  return ctx;
+
+}
+`;
+
+exports[`Apps Script HubSpot REAL_OPS builds action.hubspot:get_deal 1`] = `
+function step_action_hubspot_get_deal(ctx) {
+  ctx = ctx || {};
+  const config = {"dealId":"98765","properties":["dealname","amount"]};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ["crm.objects.deals.read"] });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('HubSpot get_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('HubSpot get_deal requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('HubSpot get_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('HubSpot get_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('HubSpot get_deal requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_get_deal_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = 'HubSpot get_deal failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+  var dealId = resolveValue(config.dealId, { required: true, label: 'dealId' });
+  var queryParts = [];
+  if (config && Array.isArray(config.properties)) {
+    for (var i = 0; i < config.properties.length; i++) {
+      var propertyName = resolveValue(config.properties[i], {});
+      if (propertyName) {
+        queryParts.push('properties=' + encodeURIComponent(propertyName));
+      }
+    }
+  }
+  var path = '/crm/v3/objects/deals/' + encodeURIComponent(dealId);
+  if (queryParts.length > 0) {
+    path += '?' + queryParts.join('&');
+  }
+  var response = executeRequest(requestOptions(path, 'GET'));
+  var deal = response && response.body ? response.body : {};
+  ctx.hubspotDealId = deal.id || dealId;
+  ctx.hubspotDeal = deal;
+  logInfo('hubspot_get_deal', { dealId: ctx.hubspotDealId || dealId });
+  return ctx;
+
+}
+`;
+
+exports[`Apps Script HubSpot REAL_OPS builds action.hubspot:create_company 1`] = `
+function step_action_hubspot_create_company(ctx) {
+  ctx = ctx || {};
+  const config = {"name":"Acme Corp","domain":"acme.example.com"};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ["crm.objects.companies.write"] });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('HubSpot create_company requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('HubSpot create_company requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('HubSpot create_company requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('HubSpot create_company requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('HubSpot create_company requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_create_company_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = 'HubSpot create_company failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+  var source = config && typeof config.properties === 'object' ? config.properties : config;
+  var properties = buildProperties(source, { operation: true });
+  if (!properties.name && !properties.domain) {
+    throw new Error('HubSpot create_company requires at least the name or domain field.');
+  }
+  var response = executeRequest(requestOptions('/crm/v3/objects/companies', 'POST', { properties: properties }));
+  var company = response && response.body ? response.body : {};
+  ctx.hubspotCompanyId = company.id || null;
+  ctx.hubspotCompany = company;
+  logInfo('hubspot_create_company', { companyId: ctx.hubspotCompanyId || null });
+  return ctx;
+
+}
+`;
+
+exports[`Apps Script HubSpot REAL_OPS builds action.hubspot:create_ticket 1`] = `
+function step_action_hubspot_create_ticket(ctx) {
+  ctx = ctx || {};
+  const config = {"subject":"Onboarding help","content":"Customer requested assistance."};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ["crm.objects.tickets.write"] });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('HubSpot create_ticket requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('HubSpot create_ticket requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('HubSpot create_ticket requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('HubSpot create_ticket requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('HubSpot create_ticket requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_create_ticket_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = 'HubSpot create_ticket failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+  var source = config && typeof config.properties === 'object' ? config.properties : config;
+  var properties = buildProperties(source, { operation: true });
+  if (!properties.subject) {
+    throw new Error('HubSpot create_ticket requires the subject field.');
+  }
+  var response = executeRequest(requestOptions('/crm/v3/objects/tickets', 'POST', { properties: properties }));
+  var ticket = response && response.body ? response.body : {};
+  ctx.hubspotTicketId = ticket.id || null;
+  ctx.hubspotTicket = ticket;
+  logInfo('hubspot_create_ticket', { ticketId: ctx.hubspotTicketId || null });
+  return ctx;
+
+}
+`;
+
+exports[`Apps Script HubSpot REAL_OPS builds action.hubspot:create_note 1`] = `
+function step_action_hubspot_create_note(ctx) {
+  ctx = ctx || {};
+  const config = {"hs_note_body":"Follow up with {{lead.owner}}","associations":[{"to":{"id":"12345","type":"contact"},"types":[{"associationCategory":"HUBSPOT_DEFINED","associationTypeId":280}]}]};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ["crm.objects.notes.write"] });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('HubSpot create_note requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('HubSpot create_note requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('HubSpot create_note requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('HubSpot create_note requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('HubSpot create_note requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_create_note_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = 'HubSpot create_note failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+  var propertySource = config && typeof config.properties === 'object' ? config.properties : config;
+  var properties = buildProperties(propertySource, { associations: true, operation: true });
+  if (!properties.hs_note_body) {
+    throw new Error('HubSpot create_note requires the hs_note_body field.');
+  }
+  var associations = [];
+  if (config && Array.isArray(config.associations)) {
+    associations = resolveValue(config.associations, { items: {} }) || [];
+  }
+  var payload = { properties: properties };
+  if (associations && associations.length) {
+    payload.associations = associations;
+  }
+  var response = executeRequest(requestOptions('/crm/v3/objects/notes', 'POST', payload));
+  var note = response && response.body ? response.body : {};
+  ctx.hubspotNoteId = note.id || null;
+  ctx.hubspotNote = note;
+  logInfo('hubspot_create_note', { noteId: ctx.hubspotNoteId || null });
+  return ctx;
+
+}
+`;

--- a/server/workflow/__tests__/apps-script-fixtures/hubspot-create-contact.json
+++ b/server/workflow/__tests__/apps-script-fixtures/hubspot-create-contact.json
@@ -1,0 +1,98 @@
+{
+  "id": "hubspot-create-contact",
+  "description": "Creates a HubSpot contact using the Apps Script runtime.",
+  "graph": {
+    "id": "fixture-hubspot-create-contact",
+    "name": "HubSpot create contact",
+    "nodes": [
+      {
+        "id": "hubspot-action",
+        "type": "action.hubspot",
+        "app": "hubspot",
+        "name": "Create HubSpot contact",
+        "op": "action.hubspot:create_contact",
+        "params": {
+          "operation": "create_contact",
+          "email": "{{lead.email}}",
+          "firstname": "{{lead.firstName}}",
+          "lastname": "Customer"
+        },
+        "data": {
+          "operation": "create_contact",
+          "config": {
+            "email": "{{lead.email}}",
+            "firstname": "{{lead.firstName}}",
+            "lastname": "Customer"
+          }
+        }
+      }
+    ],
+    "edges": []
+  },
+  "entry": {
+    "context": {
+      "lead": {
+        "email": "sam@example.com",
+        "firstName": "Sam"
+      }
+    }
+  },
+  "secrets": {
+    "HUBSPOT_ACCESS_TOKEN": "hs-access-token"
+  },
+  "http": [
+    {
+      "name": "hubspot-create-contact",
+      "request": {
+        "url": "https://api.hubapi.com/crm/v3/objects/contacts",
+        "method": "POST",
+        "headers": {
+          "authorization": "Bearer hs-access-token",
+          "accept": "application/json",
+          "content-type": "application/json"
+        },
+        "payload": {
+          "properties": {
+            "email": "sam@example.com",
+            "firstname": "Sam",
+            "lastname": "Customer"
+          }
+        }
+      },
+      "response": {
+        "status": 201,
+        "body": {
+          "id": "12345",
+          "properties": {
+            "email": "sam@example.com",
+            "firstname": "Sam",
+            "lastname": "Customer"
+          }
+        }
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "lead": {
+        "email": "sam@example.com",
+        "firstName": "Sam"
+      },
+      "hubspotContactId": "12345",
+      "hubspotContact": {
+        "id": "12345",
+        "properties": {
+          "email": "sam@example.com",
+          "firstname": "Sam",
+          "lastname": "Customer"
+        }
+      }
+    },
+    "httpCalls": [
+      {
+        "url": "https://api.hubapi.com/crm/v3/objects/contacts",
+        "method": "POST"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script.hubspot.test.ts
+++ b/server/workflow/__tests__/apps-script.hubspot.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { REAL_OPS } from '../compile-to-appsscript';
+import { runSingleFixture } from '../appsScriptDryRunHarness';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturesDir = path.join(__dirname, 'apps-script-fixtures');
+
+describe('Apps Script HubSpot REAL_OPS', () => {
+  const cases: Array<[string, Record<string, any>]> = [
+    ['action.hubspot:create_contact', { email: '{{lead.email}}', firstname: '{{lead.firstName}}', lastname: 'Customer' }],
+    ['action.hubspot:update_contact', { contactId: '12345', phone: '{{lead.phone}}' }],
+    ['action.hubspot:get_contact', { email: '{{lead.email}}', properties: ['firstname', 'lastname'] }],
+    ['action.hubspot:create_deal', { dealname: 'Q4 Renewal', amount: '15000' }],
+    ['action.hubspot:update_deal', { dealId: '98765', dealstage: 'closedwon', amount: '17500' }],
+    ['action.hubspot:update_deal_stage', { dealId: '98765', properties: { dealstage: 'presentationscheduled' } }],
+    ['action.hubspot:get_deal', { dealId: '98765', properties: ['dealname', 'amount'] }],
+    ['action.hubspot:create_company', { name: 'Acme Corp', domain: 'acme.example.com' }],
+    ['action.hubspot:create_ticket', { subject: 'Onboarding help', content: 'Customer requested assistance.' }],
+    [
+      'action.hubspot:create_note',
+      {
+        hs_note_body: 'Follow up with {{lead.owner}}',
+        associations: [
+          {
+            to: { id: '12345', type: 'contact' },
+            types: [
+              {
+                associationCategory: 'HUBSPOT_DEFINED',
+                associationTypeId: 280
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  ];
+
+  for (const [operation, config] of cases) {
+    it(`builds ${operation}`, () => {
+      const builder = REAL_OPS[operation];
+      expect(builder).toBeDefined();
+      expect(builder(config)).toMatchSnapshot();
+    });
+  }
+});
+
+describe('Apps Script HubSpot Tier-0 dry run', () => {
+  it('creates a contact and records the HubSpot contact details', async () => {
+    const result = await runSingleFixture('hubspot-create-contact', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.context.hubspotContactId).toBe('12345');
+    expect(result.context.hubspotContact).toMatchObject({
+      id: '12345',
+      properties: {
+        email: 'sam@example.com',
+        firstname: 'Sam',
+        lastname: 'Customer'
+      }
+    });
+
+    expect(result.httpCalls).toHaveLength(1);
+    const call = result.httpCalls[0];
+    expect(call.url).toBe('https://api.hubapi.com/crm/v3/objects/contacts');
+    expect(call.method).toBe('POST');
+    expect(call.headers['authorization']).toBe('Bearer hs-access-token');
+    expect(call.headers['accept']).toBe('application/json');
+    expect(call.headers['content-type']).toBe('application/json');
+    expect(call.payload).toEqual({
+      properties: {
+        email: 'sam@example.com',
+        firstname: 'Sam',
+        lastname: 'Customer'
+      }
+    });
+  });
+});

--- a/server/workflow/compile-to-appsscript.ts
+++ b/server/workflow/compile-to-appsscript.ts
@@ -1023,7 +1023,9 @@ var __SECRET_HELPER_DEFAULT_OVERRIDES = {
       GOOGLE_ADMIN_CUSTOMER_ID: { aliases: ['apps_script__google_admin__customer_id'] }
     },
     hubspot: {
-      HUBSPOT_API_KEY: { aliases: ['apps_script__hubspot__api_key'] }
+      HUBSPOT_ACCESS_TOKEN: {
+        aliases: ['apps_script__hubspot__access_token', 'HUBSPOT_API_KEY', 'apps_script__hubspot__api_key']
+      }
     },
     jira: {
       JIRA_API_TOKEN: { aliases: ['apps_script__jira__api_token'] },
@@ -1132,6 +1134,12 @@ var __CONNECTOR_OAUTH_TOKEN_METADATA = {
     property: 'GOOGLE_SHEETS_ACCESS_TOKEN',
     description: 'OAuth access token',
     aliases: ['apps_script__google_sheets_enhanced__access_token', 'apps_script__google_sheets__access_token', 'apps_script__sheets__access_token']
+  },
+  hubspot: {
+    displayName: 'HubSpot',
+    property: 'HUBSPOT_ACCESS_TOKEN',
+    description: 'OAuth access token',
+    aliases: ['apps_script__hubspot__access_token', 'HUBSPOT_API_KEY', 'apps_script__hubspot__api_key']
   },
   jira: {
     displayName: 'Jira',
@@ -6365,137 +6373,22 @@ function handleMailchimpTestConnection(baseUrl, apiKey, params, inputData) {
 // Comprehensive HubSpot implementation  
 function generateHubspotEnhancedFunction(functionName: string, node: WorkflowNode): string {
   const operation = node.params?.operation || node.op?.split('.').pop() || 'create_contact';
-  
+  const key = `action.hubspot:${operation}`;
+  const builder = REAL_OPS[key];
+  const config = node.data?.config ?? node.params ?? {};
+
+  if (typeof builder === 'function') {
+    const generated = builder(config);
+    if (typeof generated === 'string' && generated.trim().length > 0) {
+      return generated.replace(/function\s+step_action_hubspot_[^(]+\(/, `function ${functionName}(`);
+    }
+  }
+
   return `
-function ${functionName}(inputData, params) {
-  console.log('🎯 Executing HubSpot: ${node.name || operation}');
-  
-  const operation = params.operation || '${operation}';
-  const accessToken = getSecret('HUBSPOT_ACCESS_TOKEN');
-  
-  if (!accessToken) {
-    console.warn('⚠️ HubSpot access token not configured');
-    return { ...inputData, hubspotSkipped: true, error: 'Missing access token' };
-  }
-  
-  try {
-    const baseUrl = 'https://api.hubapi.com';
-    
-    switch (operation) {
-      case 'create_contact':
-        return handleCreateHubSpotContact(baseUrl, accessToken, params, inputData);
-      case 'update_contact':
-        return handleUpdateHubSpotContact(baseUrl, accessToken, params, inputData);
-      case 'get_contact':
-        return handleGetHubSpotContact(baseUrl, accessToken, params, inputData);
-      case 'search_contacts':
-        return handleSearchHubSpotContacts(baseUrl, accessToken, params, inputData);
-      case 'create_deal':
-        return handleCreateHubSpotDeal(baseUrl, accessToken, params, inputData);
-      case 'update_deal':
-        return handleUpdateHubSpotDeal(baseUrl, accessToken, params, inputData);
-      case 'create_company':
-        return handleCreateHubSpotCompany(baseUrl, accessToken, params, inputData);
-      case 'create_task':
-        return handleCreateHubSpotTask(baseUrl, accessToken, params, inputData);
-      case 'test_connection':
-        return handleHubSpotTestConnection(baseUrl, accessToken, params, inputData);
-      case 'contact_created':
-      case 'deal_updated':
-        return handleHubSpotTrigger(baseUrl, accessToken, params, inputData);
-      default:
-        console.warn(\`⚠️ Unknown HubSpot operation: \${operation}\`);
-        return { ...inputData, hubspotWarning: \`Unsupported operation: \${operation}\` };
-    }
-    
-  } catch (error) {
-    console.error(\`❌ HubSpot \${operation} failed:\`, error);
-    return { ...inputData, hubspotError: error.toString(), hubspotSuccess: false };
-  }
-}
-
-function handleCreateHubSpotContact(baseUrl, accessToken, params, inputData) {
-  const contactData = {
-    properties: {
-      firstname: params.firstName || params.first_name || inputData.firstName || inputData.first_name || '',
-      lastname: params.lastName || params.last_name || inputData.lastName || inputData.last_name || '',
-      email: params.email || inputData.email || '',
-      company: params.company || inputData.company || '',
-      phone: params.phone || inputData.phone || '',
-      website: params.website || inputData.website || '',
-      jobtitle: params.jobTitle || params.job_title || inputData.jobTitle || '',
-      lifecyclestage: params.lifecycleStage || 'lead'
-    }
-  };
-  
-  const response = UrlFetchApp.fetch(\`\${baseUrl}/crm/v3/objects/contacts\`, {
-    method: 'POST',
-    headers: {
-      'Authorization': \`Bearer \${accessToken}\`,
-      'Content-Type': 'application/json'
-    },
-    payload: JSON.stringify(contactData)
-  });
-  
-  if (response.getResponseCode() === 201) {
-    const data = JSON.parse(response.getContentText());
-    console.log(\`✅ Created HubSpot contact: \${data.id}\`);
-    return { ...inputData, hubspotContactCreated: true, contactId: data.id, email: contactData.properties.email };
-  } else {
-    throw new Error(\`Create contact failed: \${response.getResponseCode()}\`);
-  }
-}
-
-function handleCreateHubSpotDeal(baseUrl, accessToken, params, inputData) {
-  const dealData = {
-    properties: {
-      dealname: params.dealName || params.deal_name || 'New Deal from Automation',
-      amount: params.amount || '0',
-      dealstage: params.dealStage || params.deal_stage || 'appointmentscheduled',
-      pipeline: params.pipeline || 'default',
-      closedate: params.closeDate || params.close_date || null,
-      dealtype: params.dealType || params.deal_type || 'newbusiness'
-    }
-  };
-  
-  const response = UrlFetchApp.fetch(\`\${baseUrl}/crm/v3/objects/deals\`, {
-    method: 'POST',
-    headers: {
-      'Authorization': \`Bearer \${accessToken}\`,
-      'Content-Type': 'application/json'
-    },
-    payload: JSON.stringify(dealData)
-  });
-  
-  if (response.getResponseCode() === 201) {
-    const data = JSON.parse(response.getContentText());
-    console.log(\`✅ Created HubSpot deal: \${data.id}\`);
-    return { ...inputData, hubspotDealCreated: true, dealId: data.id, dealName: dealData.properties.dealname };
-  } else {
-    throw new Error(\`Create deal failed: \${response.getResponseCode()}\`);
-  }
-}
-
-function handleHubSpotTestConnection(baseUrl, accessToken, params, inputData) {
-  try {
-    const response = UrlFetchApp.fetch(\`\${baseUrl}/crm/v3/owners\`, {
-      method: 'GET',
-      headers: {
-        'Authorization': \`Bearer \${accessToken}\`
-      }
-    });
-    
-    if (response.getResponseCode() === 200) {
-      const data = JSON.parse(response.getContentText());
-      console.log(\`✅ HubSpot connection test successful. Found \${data.results.length} owners\`);
-      return { ...inputData, connectionTest: 'success', ownerCount: data.results.length };
-    } else {
-      throw new Error(\`Test failed: \${response.getResponseCode()}\`);
-    }
-  } catch (error) {
-    console.error('❌ HubSpot connection test failed:', error);
-    return { ...inputData, connectionTest: 'failed', error: error.toString() };
-  }
+function ${functionName}(ctx) {
+  ctx = ctx || {};
+  logWarn('hubspot_operation_missing', { operation: '${operation}' });
+  throw new Error('HubSpot operation "${operation}" is not implemented in Apps Script runtime.');
 }`;
 }
 
@@ -13864,6 +13757,281 @@ function funcName(n: any) {
   return `step_${op}`;
 }
 
+function buildHubSpotAction(
+  slug: string,
+  operationName: string,
+  config: any,
+  scopes: string[],
+  bodyLines: string[]
+): string {
+  const configLiteral = JSON.stringify(prepareValueForCode(config ?? {}));
+  const scopesLiteral = JSON.stringify(scopes);
+
+  return `
+function step_action_hubspot_${slug}(ctx) {
+  ctx = ctx || {};
+  const config = ${configLiteral};
+  const baseUrl = 'https://api.hubapi.com';
+  const accessToken = requireOAuthToken('hubspot', { scopes: ${scopesLiteral} });
+  const rateConfig = { attempts: 5, initialDelayMs: 500, maxDelayMs: 8000, jitter: 0.2 };
+
+  function resolveValue(value, opts) {
+    opts = opts || {};
+    if (value === null || value === undefined) {
+      if (opts.required) {
+        throw new Error('${operationName} requires ' + (opts.label || 'a value') + '.');
+      }
+      return opts.allowEmpty ? '' : undefined;
+    }
+    if (typeof value === 'string') {
+      var trimmed = value.trim();
+      if (!trimmed) {
+        if (opts.required && !opts.allowEmpty) {
+          throw new Error('${operationName} requires ' + (opts.label || 'a value') + '.');
+        }
+        return opts.allowEmpty ? '' : undefined;
+      }
+      var resolved = interpolate(trimmed, ctx);
+      if (!resolved && opts.required && !opts.allowEmpty) {
+        throw new Error('${operationName} requires ' + (opts.label || 'a value') + '.');
+      }
+      if (opts.transform === 'number') {
+        var num = Number(resolved);
+        if (isNaN(num)) {
+          throw new Error((opts.label || 'Value') + ' must be numeric.');
+        }
+        return num;
+      }
+      return resolved;
+    }
+    if (Array.isArray(value)) {
+      var arr = [];
+      for (var i = 0; i < value.length; i++) {
+        var entry = resolveValue(value[i], opts.items || {});
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (typeof entry === 'string') {
+          if (!entry && !(opts.items && opts.items.allowEmpty)) {
+            continue;
+          }
+        } else if (Array.isArray(entry) && entry.length === 0 && !(opts.items && opts.items.keepEmptyArrays)) {
+          continue;
+        } else if (typeof entry === 'object' && Object.keys(entry).length === 0 && !(opts.items && opts.items.keepEmptyObjects)) {
+          continue;
+        }
+        arr.push(entry);
+      }
+      if (opts.required && arr.length === 0) {
+        throw new Error('${operationName} requires ' + (opts.label || 'a value') + '.');
+      }
+      return arr;
+    }
+    if (typeof value === 'object') {
+      var obj = {};
+      for (var key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        var resolved = resolveValue(value[key], (opts.properties && opts.properties[key]) || {});
+        if (resolved === undefined || resolved === null) {
+          continue;
+        }
+        if (typeof resolved === 'string') {
+          if (!resolved && !(opts.properties && opts.properties[key] && opts.properties[key].allowEmpty)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (Array.isArray(resolved)) {
+          if (resolved.length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyArrays)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else if (typeof resolved === 'object') {
+          if (Object.keys(resolved).length === 0 && !(opts.properties && opts.properties[key] && opts.properties[key].keepEmptyObjects)) {
+            continue;
+          }
+          obj[key] = resolved;
+        } else {
+          obj[key] = resolved;
+        }
+      }
+      if (opts.required && Object.keys(obj).length === 0) {
+        throw new Error('${operationName} requires ' + (opts.label || 'a value') + '.');
+      }
+      return obj;
+    }
+    return value;
+  }
+
+  function buildProperties(source, skip) {
+    var props = {};
+    if (!source || typeof source !== 'object') {
+      return props;
+    }
+    var omit = {};
+    if (Array.isArray(skip)) {
+      for (var i = 0; i < skip.length; i++) {
+        omit[skip[i]] = true;
+      }
+    } else if (skip && typeof skip === 'object') {
+      for (var key in skip) {
+        if (Object.prototype.hasOwnProperty.call(skip, key)) {
+          omit[key] = skip[key];
+        }
+      }
+    }
+    for (var key in source) {
+      if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+      if (omit[key]) continue;
+      var value = resolveValue(source[key], {});
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string') {
+        if (!value.trim()) continue;
+      } else if (Array.isArray(value) && value.length === 0) {
+        continue;
+      } else if (typeof value === 'object' && Object.keys(value).length === 0) {
+        continue;
+      }
+      props[key] = value;
+    }
+    return props;
+  }
+
+  function requestOptions(path, method, payload) {
+    var request = {
+      url: baseUrl + path,
+      method: method,
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Accept': 'application/json'
+      }
+    };
+    if (payload !== undefined) {
+      request.headers['Content-Type'] = 'application/json';
+      request.payload = JSON.stringify(payload);
+      request.contentType = 'application/json';
+    }
+    return request;
+  }
+
+  function executeRequest(options) {
+    try {
+      return rateLimitAware(
+        function () {
+          return fetchJson(options);
+        },
+        rateConfig
+      );
+    } catch (error) {
+      handleError(error);
+    }
+  }
+
+  function handleError(error) {
+    var status = error && typeof error.status === 'number' ? error.status : null;
+    var body = error && error.body ? error.body : null;
+    var message = body && body.message ? body.message : (error && error.message ? error.message : 'Unknown HubSpot error');
+    var correlationId = null;
+    if (body && (body.correlationId || body.requestId || body.traceId)) {
+      correlationId = body.correlationId || body.requestId || body.traceId;
+    } else if (error && (error.correlationId || error.requestId || error.traceId)) {
+      correlationId = error.correlationId || error.requestId || error.traceId;
+    }
+    var details = [];
+    if (body && Array.isArray(body.errors)) {
+      for (var i = 0; i < body.errors.length; i++) {
+        var entry = body.errors[i];
+        if (!entry) continue;
+        var summary = [];
+        if (entry.errorType || entry.error) {
+          summary.push(entry.errorType || entry.error);
+        }
+        if (entry.field) {
+          summary.push(entry.field);
+        }
+        if (entry.message) {
+          summary.push(entry.message);
+        }
+        if (summary.length) {
+          details.push(summary.join(': '));
+        }
+      }
+    }
+    if (body && body.category) {
+      details.push('Category: ' + body.category);
+    }
+    if (body && body.subCategory) {
+      details.push('Sub-category: ' + body.subCategory);
+    }
+    if (body && body.context && typeof body.context === 'object') {
+      var contextParts = [];
+      for (var key in body.context) {
+        if (!Object.prototype.hasOwnProperty.call(body.context, key)) continue;
+        var value = body.context[key];
+        var rendered;
+        if (Array.isArray(value)) {
+          rendered = value.join(', ');
+        } else if (value && typeof value === 'object') {
+          rendered = JSON.stringify(value);
+        } else {
+          rendered = value;
+        }
+        if (rendered === undefined || rendered === null || rendered === '') {
+          continue;
+        }
+        contextParts.push(key + ': ' + rendered);
+      }
+      if (contextParts.length) {
+        details.push('Context: ' + contextParts.join('; '));
+      }
+    }
+    var infoParts = details.slice();
+    if (correlationId) {
+      infoParts.push('Correlation ID: ' + correlationId);
+    }
+    var statusLabel = status ? ' (' + status + ')' : '';
+    var suffix = infoParts.length ? ' (' + infoParts.join('; ') + ')' : '';
+    logError('hubspot_${slug}_failed', {
+      status: status,
+      correlationId: correlationId || null,
+      message: message,
+      errors: details,
+      category: body && body.category ? body.category : null,
+      context: body && body.context ? body.context : null
+    });
+    var finalError = error && typeof error === 'object' ? error : new Error(message);
+    finalError.message = '${operationName} failed' + statusLabel + ': ' + message + suffix;
+    if (typeof finalError.status !== 'number' && status !== null) {
+      finalError.status = status;
+    }
+    if (!finalError.correlationId && correlationId) {
+      finalError.correlationId = correlationId;
+    }
+    if (body && body.category && !finalError.category) {
+      finalError.category = body.category;
+    }
+    if (body && body.context && !finalError.context) {
+      finalError.context = body.context;
+    }
+    finalError.details = finalError.details || {};
+    finalError.details.errors = details;
+    if (body && body.category) {
+      finalError.details.category = body.category;
+    }
+    if (body && body.context) {
+      finalError.details.context = body.context;
+    }
+    if (correlationId) {
+      finalError.details.correlationId = correlationId;
+    }
+    throw finalError;
+  }
+
+${bodyLines.join('\n')}
+
+}
+`;
+}
+
 // Real Apps Script operations mapping - P0 CRITICAL EXPANSION
 const REAL_OPS: Record<string, (c: any) => string> = {
   ...GENERATED_REAL_OPS,
@@ -15352,39 +15520,241 @@ function step_createSalesforceLead(ctx) {
   return ctx;
 }`,
 
-  // HubSpot - CRM  
-  'action.hubspot:create_contact': (c) => `
-function step_createHubSpotContact(ctx) {
-  const apiKey = getSecret('HUBSPOT_API_KEY');
-
-  if (!apiKey) {
-    logWarn('hubspot_missing_api_key', { message: 'HubSpot API key not configured' });
-    return ctx;
-  }
-
-  const contactData = {
-    properties: {
-      firstname: interpolate('${c.firstName || '{{first_name}}'}', ctx),
-      lastname: interpolate('${c.lastName || '{{last_name}}'}', ctx),
-      email: interpolate('${c.email || '{{email}}'}', ctx)
-    }
-  };
-  
-  const response = withRetries(() => fetchJson('https://api.hubapi.com/crm/v3/objects/contacts', {
-    method: 'POST',
-    headers: {
-      'Authorization': \`Bearer \${apiKey}\`,
-      'Content-Type': 'application/json'
-    },
-    payload: JSON.stringify(contactData),
-    contentType: 'application/json'
-  }));
-
-  ctx.hubspotContactId = response.body && response.body.id;
-  logInfo('hubspot_create_contact', { contactId: ctx.hubspotContactId || null });
-  return ctx;
-}`,
-
+  // HubSpot - CRM
+  'action.hubspot:create_contact': (c) =>
+    buildHubSpotAction(
+      'create_contact',
+      'HubSpot create_contact',
+      c,
+      ['crm.objects.contacts.write'],
+      [
+        "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+        "  var properties = buildProperties(source, { operation: true });",
+        "  if (!properties.email) {",
+        "    throw new Error('HubSpot create_contact requires the email field.');",
+        "  }",
+        "  var response = executeRequest(requestOptions('/crm/v3/objects/contacts', 'POST', { properties: properties }));",
+        "  var contact = response && response.body ? response.body : {};",
+        "  ctx.hubspotContactId = contact.id || null;",
+        "  ctx.hubspotContact = contact;",
+        "  logInfo('hubspot_create_contact', { contactId: ctx.hubspotContactId || null });",
+        "  return ctx;",
+      ]
+    ),
+  'action.hubspot:update_contact': (c) =>
+    buildHubSpotAction(
+      'update_contact',
+      'HubSpot update_contact',
+      c,
+      ['crm.objects.contacts.write'],
+      [
+        "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+        "  var contactId = resolveValue(config.contactId, { required: true, label: 'contactId' });",
+        "  var properties = buildProperties(source, { contactId: true, operation: true });",
+        "  if (Object.keys(properties).length === 0) {",
+        "    throw new Error('HubSpot update_contact requires at least one property to update.');",
+        "  }",
+        "  var response = executeRequest(requestOptions('/crm/v3/objects/contacts/' + encodeURIComponent(contactId), 'PATCH', { properties: properties }));",
+        "  var contact = response && response.body ? response.body : {};",
+        "  ctx.hubspotContactId = contact.id || contactId;",
+        "  ctx.hubspotContact = contact;",
+        "  logInfo('hubspot_update_contact', { contactId: ctx.hubspotContactId || contactId });",
+        "  return ctx;",
+      ]
+    ),
+  'action.hubspot:get_contact': (c) =>
+    buildHubSpotAction(
+      'get_contact',
+      'HubSpot get_contact',
+      c,
+      ['crm.objects.contacts.read'],
+      [
+        "  var identifier = resolveValue(config.contactId, { allowEmpty: true, label: 'contactId' });",
+        "  var queryParts = [];",
+        "  if (!identifier) {",
+        "    var emailIdentifier = resolveValue(config.email, { required: true, label: 'email' });",
+        "    identifier = emailIdentifier;",
+        "    queryParts.push('idProperty=email');",
+        "  }",
+        "  if (config && Array.isArray(config.properties)) {",
+        "    for (var i = 0; i < config.properties.length; i++) {",
+        "      var propertyName = resolveValue(config.properties[i], {});",
+        "      if (propertyName) {",
+        "        queryParts.push('properties=' + encodeURIComponent(propertyName));",
+        "      }",
+        "    }",
+        "  }",
+        "  var path = '/crm/v3/objects/contacts/' + encodeURIComponent(identifier);",
+        "  if (queryParts.length > 0) {",
+        "    path += '?' + queryParts.join('&');",
+        "  }",
+        "  var response = executeRequest(requestOptions(path, 'GET'));",
+        "  var contact = response && response.body ? response.body : {};",
+        "  ctx.hubspotContactId = contact.id || identifier;",
+        "  ctx.hubspotContact = contact;",
+        "  logInfo('hubspot_get_contact', { contactId: ctx.hubspotContactId || identifier });",
+        "  return ctx;",
+      ]
+    ),
+  'action.hubspot:create_deal': (c) =>
+    buildHubSpotAction(
+      'create_deal',
+      'HubSpot create_deal',
+      c,
+      ['crm.objects.deals.write'],
+      [
+        "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+        "  var properties = buildProperties(source, { operation: true });",
+        "  if (!properties.dealname) {",
+        "    throw new Error('HubSpot create_deal requires the dealname field.');",
+        "  }",
+        "  var response = executeRequest(requestOptions('/crm/v3/objects/deals', 'POST', { properties: properties }));",
+        "  var deal = response && response.body ? response.body : {};",
+        "  ctx.hubspotDealId = deal.id || null;",
+        "  ctx.hubspotDeal = deal;",
+        "  logInfo('hubspot_create_deal', { dealId: ctx.hubspotDealId || null });",
+        "  return ctx;",
+      ]
+    ),
+  'action.hubspot:update_deal': (c) =>
+    buildHubSpotAction(
+      'update_deal',
+      'HubSpot update_deal',
+      c,
+      ['crm.objects.deals.write'],
+      [
+        "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+        "  var dealId = resolveValue(config.dealId, { required: true, label: 'dealId' });",
+        "  var properties = buildProperties(source, { dealId: true, operation: true });",
+        "  if (Object.keys(properties).length === 0) {",
+        "    throw new Error('HubSpot update_deal requires at least one property to update.');",
+        "  }",
+        "  var response = executeRequest(requestOptions('/crm/v3/objects/deals/' + encodeURIComponent(dealId), 'PATCH', { properties: properties }));",
+        "  var deal = response && response.body ? response.body : {};",
+        "  ctx.hubspotDealId = deal.id || dealId;",
+        "  ctx.hubspotDeal = deal;",
+        "  logInfo('hubspot_update_deal', { dealId: ctx.hubspotDealId || dealId });",
+        "  return ctx;",
+      ]
+    ),
+  'action.hubspot:update_deal_stage': (c) =>
+    buildHubSpotAction(
+      'update_deal_stage',
+      'HubSpot update_deal_stage',
+      c,
+      ['crm.objects.deals.write'],
+      [
+        "  var dealId = resolveValue(config.dealId, { required: true, label: 'dealId' });",
+        "  var propertySource = config && typeof config.properties === 'object' ? config.properties : {};",
+        "  var properties = buildProperties(propertySource, {});",
+        "  if (Object.keys(properties).length === 0) {",
+        "    throw new Error('HubSpot update_deal_stage requires properties for the update.');",
+        "  }",
+        "  var response = executeRequest(requestOptions('/crm/v3/objects/deals/' + encodeURIComponent(dealId), 'PATCH', { properties: properties }));",
+        "  var deal = response && response.body ? response.body : {};",
+        "  ctx.hubspotDealId = deal.id || dealId;",
+        "  ctx.hubspotDeal = deal;",
+        "  logInfo('hubspot_update_deal_stage', { dealId: ctx.hubspotDealId || dealId });",
+        "  return ctx;",
+      ]
+    ),
+  'action.hubspot:get_deal': (c) =>
+    buildHubSpotAction(
+      'get_deal',
+      'HubSpot get_deal',
+      c,
+      ['crm.objects.deals.read'],
+      [
+        "  var dealId = resolveValue(config.dealId, { required: true, label: 'dealId' });",
+        "  var queryParts = [];",
+        "  if (config && Array.isArray(config.properties)) {",
+        "    for (var i = 0; i < config.properties.length; i++) {",
+        "      var propertyName = resolveValue(config.properties[i], {});",
+        "      if (propertyName) {",
+        "        queryParts.push('properties=' + encodeURIComponent(propertyName));",
+        "      }",
+        "    }",
+        "  }",
+        "  var path = '/crm/v3/objects/deals/' + encodeURIComponent(dealId);",
+        "  if (queryParts.length > 0) {",
+        "    path += '?' + queryParts.join('&');",
+        "  }",
+        "  var response = executeRequest(requestOptions(path, 'GET'));",
+        "  var deal = response && response.body ? response.body : {};",
+        "  ctx.hubspotDealId = deal.id || dealId;",
+        "  ctx.hubspotDeal = deal;",
+        "  logInfo('hubspot_get_deal', { dealId: ctx.hubspotDealId || dealId });",
+        "  return ctx;",
+      ]
+    ),
+  'action.hubspot:create_company': (c) =>
+    buildHubSpotAction(
+      'create_company',
+      'HubSpot create_company',
+      c,
+      ['crm.objects.companies.write'],
+      [
+        "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+        "  var properties = buildProperties(source, { operation: true });",
+        "  if (!properties.name && !properties.domain) {",
+        "    throw new Error('HubSpot create_company requires at least the name or domain field.');",
+        "  }",
+        "  var response = executeRequest(requestOptions('/crm/v3/objects/companies', 'POST', { properties: properties }));",
+        "  var company = response && response.body ? response.body : {};",
+        "  ctx.hubspotCompanyId = company.id || null;",
+        "  ctx.hubspotCompany = company;",
+        "  logInfo('hubspot_create_company', { companyId: ctx.hubspotCompanyId || null });",
+        "  return ctx;",
+      ]
+    ),
+  'action.hubspot:create_ticket': (c) =>
+    buildHubSpotAction(
+      'create_ticket',
+      'HubSpot create_ticket',
+      c,
+      ['crm.objects.tickets.write'],
+      [
+        "  var source = config && typeof config.properties === 'object' ? config.properties : config;",
+        "  var properties = buildProperties(source, { operation: true });",
+        "  if (!properties.subject) {",
+        "    throw new Error('HubSpot create_ticket requires the subject field.');",
+        "  }",
+        "  var response = executeRequest(requestOptions('/crm/v3/objects/tickets', 'POST', { properties: properties }));",
+        "  var ticket = response && response.body ? response.body : {};",
+        "  ctx.hubspotTicketId = ticket.id || null;",
+        "  ctx.hubspotTicket = ticket;",
+        "  logInfo('hubspot_create_ticket', { ticketId: ctx.hubspotTicketId || null });",
+        "  return ctx;",
+      ]
+    ),
+  'action.hubspot:create_note': (c) =>
+    buildHubSpotAction(
+      'create_note',
+      'HubSpot create_note',
+      c,
+      ['crm.objects.notes.write'],
+      [
+        "  var propertySource = config && typeof config.properties === 'object' ? config.properties : config;",
+        "  var properties = buildProperties(propertySource, { associations: true, operation: true });",
+        "  if (!properties.hs_note_body) {",
+        "    throw new Error('HubSpot create_note requires the hs_note_body field.');",
+        "  }",
+        "  var associations = [];",
+        "  if (config && Array.isArray(config.associations)) {",
+        "    associations = resolveValue(config.associations, { items: {} }) || [];",
+        "  }",
+        "  var payload = { properties: properties };",
+        "  if (associations && associations.length) {",
+        "    payload.associations = associations;",
+        "  }",
+        "  var response = executeRequest(requestOptions('/crm/v3/objects/notes', 'POST', payload));",
+        "  var note = response && response.body ? response.body : {};",
+        "  ctx.hubspotNoteId = note.id || null;",
+        "  ctx.hubspotNote = note;",
+        "  logInfo('hubspot_create_note', { noteId: ctx.hubspotNoteId || null });",
+        "  return ctx;",
+      ]
+    ),
   // Stripe - Payments
   'action.stripe:create_payment': (c) => `
 function step_createStripePayment(ctx) {


### PR DESCRIPTION
## Summary
- implement manifest-driven HubSpot Apps Script action builders that require OAuth tokens, respect rate limiting, and translate HubSpot API errors into detailed exceptions
- add Tier-0 dry-run coverage, HubSpot Apps Script vitest snapshots, and a helper script to regenerate the snapshots
- document the HubSpot OAuth scopes and Apps Script token storage expectations in the OAuth setup runbook

## Testing
- npx vitest --run server/workflow/__tests__/apps-script.hubspot.test.ts *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eca0b2de888331b24d54720689742b