### PR TITLE
Implement Shopify create order Apps Script handler

### DIFF
--- a/docs/apps-script-rollout/credentials.md
+++ b/docs/apps-script-rollout/credentials.md
@@ -73,7 +73,7 @@ Before deploying a workflow, populate Script Properties with the credentials req
 | Slack | `SLACK_BOT_TOKEN`, `SLACK_WEBHOOK_URL` |
 | Salesforce | `SALESFORCE_ACCESS_TOKEN`, `SALESFORCE_INSTANCE_URL` |
 | Twilio | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER` |
-| Shopify | `SHOPIFY_API_KEY`, `SHOPIFY_SHOP_DOMAIN` |
+| Shopify | `SHOPIFY_ACCESS_TOKEN`, `SHOPIFY_SHOP_DOMAIN` |
 | Square | `SQUARE_ACCESS_TOKEN`, `SQUARE_APPLICATION_ID`, optional `SQUARE_ENVIRONMENT` (`sandbox` by default) |
 | Google Admin | `GOOGLE_ADMIN_ACCESS_TOKEN`, optional `GOOGLE_ADMIN_CUSTOMER_ID` (defaults to `my_customer`) |
 | DocuSign | `DOCUSIGN_ACCESS_TOKEN`, `DOCUSIGN_ACCOUNT_ID`, optional `DOCUSIGN_BASE_URI` |
@@ -205,6 +205,8 @@ This keeps connector code unchanged while letting the helper resolve prefixed pr
 | `SHOPIFY_SHOP_DOMAIN` | Yes | Shop domain used to resolve REST endpoints | `apps_script__shopify__shop_domain` |
 
 - Runbook: [Troubleshooting Playbook](../troubleshooting-playbook.md)
+- Required scopes: Apps Script order creation expects an access token authorized for `write_orders` so draft orders can be created, plus `read_customers`/`write_customers` when the workflow enriches or upserts customer profiles alongside the order payload.
+- Script Property tips: Populate `SHOPIFY_SHOP_DOMAIN` without the `https://` prefix (for example `acme-store`) so generated handlers can construct both Admin URLs and customer-facing order status links.
 
 #### Stripe
 

--- a/server/workflow/__tests__/apps-script-fixtures/shopify-create-order.json
+++ b/server/workflow/__tests__/apps-script-fixtures/shopify-create-order.json
@@ -1,0 +1,197 @@
+{
+  "id": "shopify-create-order",
+  "description": "Creates a Shopify order using validated line items and structured context persistence.",
+  "graph": {
+    "id": "fixture-shopify-create-order",
+    "name": "Shopify create order",
+    "nodes": [
+      {
+        "id": "shopify-action",
+        "type": "action.shopify",
+        "app": "shopify",
+        "name": "Create order",
+        "op": "action.shopify:create_order",
+        "params": {
+          "operation": "create_order",
+          "lineItems": [
+            {
+              "title": "Invoice {{values.number}}",
+              "price": "{{values.amount}}",
+              "quantity": "{{values.quantity}}",
+              "sku": "SKU-001"
+            }
+          ],
+          "customer": {
+            "email": "{{values.customer.email}}",
+            "first_name": "{{values.customer.firstName}}",
+            "last_name": "{{values.customer.lastName}}",
+            "phone": "{{values.customer.phone}}"
+          },
+          "shippingAddress": {
+            "first_name": "{{values.shipping.firstName}}",
+            "last_name": "{{values.shipping.lastName}}",
+            "address1": "{{values.shipping.address1}}",
+            "address2": "{{values.shipping.address2}}",
+            "city": "{{values.shipping.city}}",
+            "province": "{{values.shipping.state}}",
+            "zip": "{{values.shipping.postalCode}}",
+            "country": "{{values.shipping.country}}",
+            "phone": "{{values.customer.phone}}"
+          },
+          "tags": ["apps-script", "commerce"],
+          "note": "Created via Apps Script dry run"
+        },
+        "data": {
+          "operation": "create_order",
+          "config": {
+            "operation": "create_order",
+            "lineItems": [
+              {
+                "title": "Invoice {{values.number}}",
+                "price": "{{values.amount}}",
+                "quantity": "{{values.quantity}}",
+                "sku": "SKU-001"
+              }
+            ],
+            "customer": {
+              "email": "{{values.customer.email}}",
+              "first_name": "{{values.customer.firstName}}",
+              "last_name": "{{values.customer.lastName}}",
+              "phone": "{{values.customer.phone}}"
+            },
+            "shippingAddress": {
+              "first_name": "{{values.shipping.firstName}}",
+              "last_name": "{{values.shipping.lastName}}",
+              "address1": "{{values.shipping.address1}}",
+              "address2": "{{values.shipping.address2}}",
+              "city": "{{values.shipping.city}}",
+              "province": "{{values.shipping.state}}",
+              "zip": "{{values.shipping.postalCode}}",
+              "country": "{{values.shipping.country}}",
+              "phone": "{{values.customer.phone}}"
+            },
+            "tags": ["apps-script", "commerce"],
+            "note": "Created via Apps Script dry run"
+          }
+        }
+      }
+    ],
+    "edges": []
+  },
+  "entry": {
+    "context": {
+      "values": {
+        "number": "INV-001",
+        "amount": "149.99",
+        "quantity": "2",
+        "customer": {
+          "email": "customer@example.com",
+          "firstName": "Casey",
+          "lastName": "Jordan",
+          "phone": "+1-555-0100"
+        },
+        "shipping": {
+          "firstName": "Casey",
+          "lastName": "Jordan",
+          "address1": "123 Commerce St",
+          "address2": "Suite 5",
+          "city": "Springfield",
+          "state": "IL",
+          "postalCode": "62701",
+          "country": "US"
+        }
+      }
+    }
+  },
+  "secrets": {
+    "SHOPIFY_ACCESS_TOKEN": "shpat_test_123",
+    "SHOPIFY_SHOP_DOMAIN": "demo-shop"
+  },
+  "http": [
+    {
+      "name": "shopify-create-order",
+      "request": {
+        "url": "https://demo-shop.myshopify.com/admin/api/2024-01/orders.json",
+        "method": "POST",
+        "headers": {
+          "Content-Type": "application/json",
+          "X-Shopify-Access-Token": "shpat_test_123"
+        },
+        "payload": {
+          "order": {
+            "line_items": [
+              {
+                "quantity": 2,
+                "title": "Invoice INV-001",
+                "price": "149.99",
+                "sku": "SKU-001"
+              }
+            ],
+            "email": "customer@example.com",
+            "customer": {
+              "email": "customer@example.com",
+              "first_name": "Casey",
+              "last_name": "Jordan",
+              "phone": "+1-555-0100"
+            },
+            "shipping_address": {
+              "first_name": "Casey",
+              "last_name": "Jordan",
+              "address1": "123 Commerce St",
+              "address2": "Suite 5",
+              "city": "Springfield",
+              "province": "IL",
+              "zip": "62701",
+              "country": "US",
+              "phone": "+1-555-0100"
+            },
+            "note": "Created via Apps Script dry run",
+            "tags": "apps-script, commerce"
+          }
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "X-Shopify-Shop-Api-Call-Limit": "1/40"
+        },
+        "body": {
+          "order": {
+            "id": 1234567890,
+            "name": "#D1001",
+            "order_number": 1001,
+            "order_status_url": "https://demo-shop.myshopify.com/orders/1234567890/status",
+            "email": "customer@example.com",
+            "customer": {
+              "id": 99887766,
+              "email": "customer@example.com"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "shopifyOrderId": "1234567890",
+      "shopifyOrderName": "#D1001",
+      "shopifyOrderNumber": 1001,
+      "shopifyOrderUrl": "https://demo-shop.myshopify.com/orders/1234567890/status",
+      "shopifyOrderAdminUrl": "https://demo-shop.myshopify.com/admin/orders/1234567890",
+      "shopifyCustomerId": 99887766,
+      "shopifyOrderCustomerEmail": "customer@example.com"
+    },
+    "logs": [
+      {
+        "level": "log",
+        "includes": "shopify_create_order_success"
+      }
+    ],
+    "httpCalls": [
+      {
+        "url": "https://demo-shop.myshopify.com/admin/api/2024-01/orders.json",
+        "method": "POST"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/fixtures/apps-script/tier-1-commerce.workflow.json
+++ b/server/workflow/__tests__/fixtures/apps-script/tier-1-commerce.workflow.json
@@ -1,0 +1,126 @@
+{
+  "id": "apps-script-tier-1-commerce",
+  "name": "Tier 1 commerce handoff",
+  "meta": {
+    "appsScript": {
+      "tier": 1,
+      "description": "Capture spreadsheet orders and create Shopify drafts with enriched context",
+      "features": ["ecommerce", "authentication", "rate-limits"]
+    },
+    "automationType": "commerce_ops",
+    "prompt": "Whenever the commerce sheet receives a new paid order, create the order in Shopify."
+  },
+  "nodes": [
+    {
+      "id": "sheets-order",
+      "type": "trigger.sheets",
+      "app": "sheets",
+      "name": "New paid order row",
+      "op": "trigger.sheets:new_row",
+      "params": {
+        "spreadsheetId": "1AbCdEfGhIjKlMnOpQrStUvWxYz",
+        "worksheetName": "Paid Orders",
+        "pollingInterval": "5m"
+      },
+      "data": {
+        "operation": "new_row",
+        "config": {
+          "spreadsheetId": "1AbCdEfGhIjKlMnOpQrStUvWxYz",
+          "worksheetName": "Paid Orders",
+          "pollingInterval": "5m"
+        },
+        "metadata": {
+          "outputs": {
+            "values": { "type": "object" },
+            "row": { "type": "number" }
+          }
+        }
+      }
+    },
+    {
+      "id": "shopify-create-order",
+      "type": "action.shopify",
+      "app": "shopify",
+      "name": "Create Shopify order",
+      "op": "action.shopify:create_order",
+      "params": {
+        "operation": "create_order",
+        "lineItems": [
+          {
+            "title": "{{values.product_name}} preorder",
+            "price": "{{values.unit_price}}",
+            "quantity": "{{values.quantity}}",
+            "sku": "{{values.sku}}"
+          }
+        ],
+        "customer": {
+          "email": "{{values.customer_email}}",
+          "first_name": "{{values.customer_first_name}}",
+          "last_name": "{{values.customer_last_name}}",
+          "phone": "{{values.customer_phone}}"
+        },
+        "shippingAddress": {
+          "first_name": "{{values.recipient_first_name}}",
+          "last_name": "{{values.recipient_last_name}}",
+          "address1": "{{values.shipping_address_1}}",
+          "address2": "{{values.shipping_address_2}}",
+          "city": "{{values.shipping_city}}",
+          "province": "{{values.shipping_state}}",
+          "zip": "{{values.shipping_postal_code}}",
+          "country": "{{values.shipping_country}}",
+          "phone": "{{values.customer_phone}}"
+        },
+        "tags": ["apps-script", "tier-1"],
+        "note": "Created from Apps Script tier-1 commerce workflow"
+      },
+      "data": {
+        "operation": "create_order",
+        "config": {
+          "operation": "create_order",
+          "lineItems": [
+            {
+              "title": "{{values.product_name}} preorder",
+              "price": "{{values.unit_price}}",
+              "quantity": "{{values.quantity}}",
+              "sku": "{{values.sku}}"
+            }
+          ],
+          "customer": {
+            "email": "{{values.customer_email}}",
+            "first_name": "{{values.customer_first_name}}",
+            "last_name": "{{values.customer_last_name}}",
+            "phone": "{{values.customer_phone}}"
+          },
+          "shippingAddress": {
+            "first_name": "{{values.recipient_first_name}}",
+            "last_name": "{{values.recipient_last_name}}",
+            "address1": "{{values.shipping_address_1}}",
+            "address2": "{{values.shipping_address_2}}",
+            "city": "{{values.shipping_city}}",
+            "province": "{{values.shipping_state}}",
+            "zip": "{{values.shipping_postal_code}}",
+            "country": "{{values.shipping_country}}",
+            "phone": "{{values.customer_phone}}"
+          },
+          "tags": ["apps-script", "tier-1"],
+          "note": "Created from Apps Script tier-1 commerce workflow"
+        },
+        "metadata": {
+          "outputs": {
+            "shopifyOrderId": { "type": "string" },
+            "shopifyOrderUrl": { "type": "string" }
+          }
+        }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge-sheets-to-shopify",
+      "source": "sheets-order",
+      "target": "shopify-create-order",
+      "from": "sheets-order",
+      "to": "shopify-create-order"
+    }
+  ]
+}

--- a/server/workflow/__tests__/shopify.tier1.snapshot.test.ts
+++ b/server/workflow/__tests__/shopify.tier1.snapshot.test.ts
@@ -1,0 +1,532 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compileToAppsScript } from '../compile-to-appsscript';
+import type { WorkflowGraph } from '../../../common/workflow-types';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturesDir = path.join(__dirname, 'fixtures', 'apps-script');
+
+function loadWorkflowGraph(name: string): WorkflowGraph {
+  const workflowPath = path.join(fixturesDir, `${name}.workflow.json`);
+  const raw = readFileSync(workflowPath, 'utf-8');
+  return JSON.parse(raw) as WorkflowGraph;
+}
+
+describe('Tier-1 Shopify Apps Script snapshot', () => {
+  it('generates create_order handler with validation, rate limiting, and structured logs', () => {
+    const graph = loadWorkflowGraph('tier-1-commerce');
+    const result = compileToAppsScript(graph);
+
+    expect(result.workflowId).toBe(graph.id);
+
+    const codeFile = result.files.find(file => file.path === 'Code.gs');
+    expect(codeFile, 'compiled output should include Code.gs').toBeDefined();
+
+    const match = codeFile!.content.match(/function step_createShopifyOrder\(ctx\) {[\s\S]+?\n}\n/);
+    expect(match, 'Shopify create_order handler should be generated').not.toBeNull();
+
+    expect(match![0]).toMatchInlineSnapshot(`
+function step_createShopifyOrder(ctx) {
+  const accessToken = getSecret('SHOPIFY_ACCESS_TOKEN', { connectorKey: 'shopify' });
+  const shopDomain = getSecret('SHOPIFY_SHOP_DOMAIN', { connectorKey: 'shopify' });
+
+  if (!accessToken || !shopDomain) {
+    logWarn('shopify_missing_credentials', { message: 'Shopify credentials not configured' });
+    return ctx;
+  }
+
+  const apiVersion = '2024-01';
+
+  function interpolateValue(value) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      return interpolate(value, ctx);
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        result.push(interpolateValue(value[i]));
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+          continue;
+        }
+        result[key] = interpolateValue(value[key]);
+      }
+      return result;
+    }
+    return value;
+  }
+
+  function pickFirst(source, keys) {
+    if (!source || typeof source !== 'object') {
+      return undefined;
+    }
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (Object.prototype.hasOwnProperty.call(source, key) && source[key] !== undefined && source[key] !== null) {
+        return source[key];
+      }
+    }
+    return undefined;
+  }
+
+  function toTrimmedString(value) {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    return String(value).trim();
+  }
+
+  function toPositiveInteger(value) {
+    if (value === null || value === undefined || value === '') {
+      return null;
+    }
+    const numeric = Number(value);
+    if (!isFinite(numeric) || numeric <= 0) {
+      return null;
+    }
+    return Math.floor(numeric);
+  }
+
+  function toCurrencyString(value) {
+    if (value === null || value === undefined || value === '') {
+      return null;
+    }
+    const normalized = String(value).trim();
+    if (!normalized) {
+      return null;
+    }
+    const numeric = Number(normalized.replace(/[^0-9.-]/g, ''));
+    if (!isFinite(numeric)) {
+      return null;
+    }
+    return numeric.toFixed(2);
+  }
+
+  const manifestLineItems = interpolateValue([{ "title": "{{values.product_name}} preorder", "price": "{{values.unit_price}}", "quantity": "{{values.quantity}}", "sku": "{{values.sku}}" }]);
+  const fallbackLineItemConfig = interpolateValue({ "title": "{{values.product_name}} preorder", "price": "{{values.unit_price}}", "quantity": "{{values.quantity}}", "variant_id": "", "sku": "{{values.sku}}" });
+  const normalizedLineItems = [];
+
+  function appendLineItem(entry, indexLabel) {
+    if (!entry || typeof entry !== 'object') {
+      logWarn('shopify_line_item_skipped', { index: indexLabel, reason: 'Line item must be an object' });
+      return;
+    }
+
+    const normalized = {};
+    const variantIdRaw = pickFirst(entry, ['variant_id', 'variantId']);
+    const productIdRaw = pickFirst(entry, ['product_id', 'productId']);
+    const titleRaw = pickFirst(entry, ['title', 'name']);
+    const priceRaw = pickFirst(entry, ['price', 'amount']);
+    const quantityRaw = pickFirst(entry, ['quantity', 'qty', 'count']);
+
+    const quantity = toPositiveInteger(quantityRaw !== undefined ? quantityRaw : 1);
+    if (quantity === null) {
+      logWarn('shopify_line_item_skipped', { index: indexLabel, reason: 'Quantity must be a positive number', quantity: quantityRaw });
+      return;
+    }
+    normalized.quantity = quantity;
+
+    if (variantIdRaw !== undefined && variantIdRaw !== null) {
+      const variantId = toTrimmedString(variantIdRaw);
+      if (variantId) {
+        normalized.variant_id = variantId;
+      }
+    }
+
+    if (productIdRaw !== undefined && productIdRaw !== null) {
+      const productId = toTrimmedString(productIdRaw);
+      if (productId) {
+        normalized.product_id = productId;
+      }
+    }
+
+    const title = toTrimmedString(titleRaw);
+    if (title) {
+      normalized.title = title;
+    }
+
+    const price = toCurrencyString(priceRaw);
+    if (price) {
+      normalized.price = price;
+    }
+
+    if (!normalized.variant_id) {
+      if (!normalized.title) {
+        logWarn('shopify_line_item_skipped', { index: indexLabel, reason: 'Line item requires a title when variant_id is omitted' });
+        return;
+      }
+      if (!normalized.price) {
+        logWarn('shopify_line_item_skipped', { index: indexLabel, reason: 'Line item requires a numeric price when variant_id is omitted', title: normalized.title });
+        return;
+      }
+    }
+
+    const skuRaw = pickFirst(entry, ['sku']);
+    const requiresShippingRaw = pickFirst(entry, ['requires_shipping', 'requiresShipping']);
+    const taxableRaw = pickFirst(entry, ['taxable']);
+    const fulfillmentServiceRaw = pickFirst(entry, ['fulfillment_service', 'fulfillmentService']);
+    const compareAtPriceRaw = pickFirst(entry, ['compare_at_price', 'compareAtPrice']);
+
+    if (skuRaw !== undefined && skuRaw !== null) {
+      const sku = toTrimmedString(skuRaw);
+      if (sku) {
+        normalized.sku = sku;
+      }
+    }
+
+    if (requiresShippingRaw !== undefined && requiresShippingRaw !== null) {
+      normalized.requires_shipping = Boolean(requiresShippingRaw);
+    }
+
+    if (taxableRaw !== undefined && taxableRaw !== null) {
+      normalized.taxable = Boolean(taxableRaw);
+    }
+
+    if (fulfillmentServiceRaw !== undefined && fulfillmentServiceRaw !== null) {
+      const fulfillmentService = toTrimmedString(fulfillmentServiceRaw);
+      if (fulfillmentService) {
+        normalized.fulfillment_service = fulfillmentService;
+      }
+    }
+
+    if (compareAtPriceRaw !== undefined && compareAtPriceRaw !== null) {
+      const compareAtPrice = toCurrencyString(compareAtPriceRaw);
+      if (compareAtPrice) {
+        normalized.compare_at_price = compareAtPrice;
+      }
+    }
+
+    if (entry.properties && typeof entry.properties === 'object') {
+      const interpolatedProperties = interpolateValue(entry.properties);
+      if (interpolatedProperties && typeof interpolatedProperties === 'object') {
+        normalized.properties = interpolatedProperties;
+      }
+    }
+
+    normalizedLineItems.push(normalized);
+  }
+
+  if (Array.isArray(manifestLineItems)) {
+    for (let i = 0; i < manifestLineItems.length; i++) {
+      appendLineItem(manifestLineItems[i], i);
+    }
+  } else if (manifestLineItems) {
+    appendLineItem(manifestLineItems, 'config');
+  }
+
+  if (normalizedLineItems.length === 0 && fallbackLineItemConfig) {
+    appendLineItem(fallbackLineItemConfig, 'fallback');
+  }
+
+  if (normalizedLineItems.length === 0) {
+    throw new Error('Shopify create_order requires at least one valid line item with a positive quantity. Provide a variant_id or include both title and price.');
+  }
+
+  const manifestCustomer = interpolateValue({ "email": "{{values.customer_email}}", "first_name": "{{values.customer_first_name}}", "last_name": "{{values.customer_last_name}}", "phone": "{{values.customer_phone}}" });
+  const fallbackCustomer = interpolateValue({ "id": "", "email": "{{values.customer_email}}", "first_name": "{{values.customer_first_name}}", "last_name": "{{values.customer_last_name}}", "phone": "{{values.customer_phone}}" });
+  let resolvedCustomer = manifestCustomer && typeof manifestCustomer === 'object' ? manifestCustomer : null;
+  if ((!resolvedCustomer || Object.keys(resolvedCustomer).length === 0) && fallbackCustomer && typeof fallbackCustomer === 'object') {
+    resolvedCustomer = fallbackCustomer;
+  }
+
+  const customerPayload = {};
+  let hasCustomerIdentifier = false;
+  let orderEmail = null;
+
+  if (resolvedCustomer) {
+    const customerIdRaw = pickFirst(resolvedCustomer, ['id', 'customer_id', 'customerId']);
+    if (customerIdRaw !== undefined && customerIdRaw !== null) {
+      const customerId = toTrimmedString(customerIdRaw);
+      if (customerId) {
+        customerPayload.id = customerId;
+        hasCustomerIdentifier = true;
+      }
+    }
+
+    const emailRaw = pickFirst(resolvedCustomer, ['email', 'email_address', 'emailAddress']);
+    if (emailRaw !== undefined && emailRaw !== null) {
+      const email = toTrimmedString(emailRaw);
+      if (email) {
+        const emailPattern = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+        if (!emailPattern.test(email)) {
+          throw new Error('Shopify create_order received an invalid customer email "' + email + '". Provide a valid email address.');
+        }
+        customerPayload.email = email;
+        orderEmail = email;
+        hasCustomerIdentifier = true;
+      }
+    }
+
+    const firstNameRaw = pickFirst(resolvedCustomer, ['first_name', 'firstName']);
+    const lastNameRaw = pickFirst(resolvedCustomer, ['last_name', 'lastName']);
+    const phoneRaw = pickFirst(resolvedCustomer, ['phone', 'phone_number', 'phoneNumber']);
+    const acceptsMarketingRaw = pickFirst(resolvedCustomer, ['accepts_marketing', 'acceptsMarketing']);
+
+    const firstName = toTrimmedString(firstNameRaw);
+    if (firstName) {
+      customerPayload.first_name = firstName;
+      hasCustomerIdentifier = true;
+    }
+    const lastName = toTrimmedString(lastNameRaw);
+    if (lastName) {
+      customerPayload.last_name = lastName;
+      hasCustomerIdentifier = true;
+    }
+    const phone = toTrimmedString(phoneRaw);
+    if (phone) {
+      customerPayload.phone = phone;
+      hasCustomerIdentifier = true;
+    }
+    if (acceptsMarketingRaw !== undefined && acceptsMarketingRaw !== null) {
+      customerPayload.accepts_marketing = Boolean(acceptsMarketingRaw);
+      hasCustomerIdentifier = true;
+    }
+  }
+
+  if (!hasCustomerIdentifier) {
+    throw new Error('Shopify create_order requires a customer ID or email address. Update the workflow configuration to provide customer details.');
+  }
+
+  const shippingAddressManifest = interpolateValue({ "first_name": "{{values.recipient_first_name}}", "last_name": "{{values.recipient_last_name}}", "address1": "{{values.shipping_address_1}}", "address2": "{{values.shipping_address_2}}", "city": "{{values.shipping_city}}", "province": "{{values.shipping_state}}", "zip": "{{values.shipping_postal_code}}", "country": "{{values.shipping_country}}", "phone": "{{values.customer_phone}}" });
+  let shippingAddress = null;
+  if (shippingAddressManifest && typeof shippingAddressManifest === 'object') {
+    const shippingFields = {
+      first_name: ['first_name', 'firstName'],
+      last_name: ['last_name', 'lastName'],
+      company: ['company'],
+      address1: ['address1', 'address_1', 'line1', 'line_1'],
+      address2: ['address2', 'address_2', 'line2', 'line_2'],
+      city: ['city'],
+      province: ['province', 'state', 'region'],
+      zip: ['zip', 'postal_code', 'postalCode'],
+      country: ['country', 'country_code', 'countryCode'],
+      phone: ['phone', 'phone_number', 'phoneNumber']
+    };
+    const normalizedShipping = {};
+    for (const key in shippingFields) {
+      if (!Object.prototype.hasOwnProperty.call(shippingFields, key)) {
+        continue;
+      }
+      const value = pickFirst(shippingAddressManifest, shippingFields[key]);
+      if (value === undefined || value === null) {
+        continue;
+      }
+      const stringValue = toTrimmedString(value);
+      if (stringValue) {
+        normalizedShipping[key] = stringValue;
+      }
+    }
+    if (Object.keys(normalizedShipping).length > 0) {
+      shippingAddress = normalizedShipping;
+    }
+  }
+
+  const noteTemplate = 'Created from Apps Script tier-1 commerce workflow';
+  const note = noteTemplate ? interpolate(noteTemplate, ctx).trim() : '';
+  const tagsManifest = interpolateValue(["apps-script", "tier-1"]);
+  const normalizedTags = [];
+  if (Array.isArray(tagsManifest)) {
+    for (let i = 0; i < tagsManifest.length; i++) {
+      const tag = toTrimmedString(tagsManifest[i]);
+      if (tag) {
+        normalizedTags.push(tag);
+      }
+    }
+  } else if (typeof tagsManifest === 'string') {
+    const parts = tagsManifest.split(',');
+    for (let i = 0; i < parts.length; i++) {
+      const tag = toTrimmedString(parts[i]);
+      if (tag) {
+        normalizedTags.push(tag);
+      }
+    }
+  }
+
+  const orderPayload = {
+    order: {
+      line_items: normalizedLineItems
+    }
+  };
+
+  if (orderEmail) {
+    orderPayload.order.email = orderEmail;
+  }
+  if (customerPayload && Object.keys(customerPayload).length > 0) {
+    orderPayload.order.customer = customerPayload;
+  }
+  if (shippingAddress) {
+    orderPayload.order.shipping_address = shippingAddress;
+  }
+  if (note) {
+    orderPayload.order.note = note;
+  }
+  if (normalizedTags.length > 0) {
+    orderPayload.order.tags = normalizedTags.join(', ');
+  }
+
+  const requestUrl = 'https://' + shopDomain + '.myshopify.com/admin/api/' + apiVersion + '/orders.json';
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: requestUrl,
+      method: 'POST',
+      headers: {
+        'X-Shopify-Access-Token': accessToken,
+        'Content-Type': 'application/json'
+      },
+      payload: JSON.stringify(orderPayload),
+      contentType: 'application/json'
+    }), {
+      attempts: 5,
+      initialDelayMs: 1000,
+      maxDelayMs: 32000,
+      jitter: 0.2,
+      retryOn: function(context) {
+        var headers = {};
+        if (context && context.response && context.response.headers) {
+          headers = context.response.headers;
+        } else if (context && context.error && context.error.headers) {
+          headers = context.error.headers;
+        }
+        var normalized = __normalizeHeaders(headers || {});
+        var limitHeader = normalized['x-shopify-shop-api-call-limit'];
+        if (limitHeader) {
+          var parts = String(limitHeader).split('/');
+          if (parts.length === 2) {
+            var used = Number(parts[0]);
+            var limit = Number(parts[1]);
+            if (!isNaN(used) && !isNaN(limit) && limit > 0 && used >= limit) {
+              return { retry: true, delayMs: 2000 };
+            }
+          }
+        }
+        return null;
+      }
+    });
+
+    const body = response && response.body ? response.body : null;
+    const order = body && body.order ? body.order : body;
+    const orderId = order && order.id ? String(order.id) : null;
+    const orderName = order && order.name ? String(order.name) : null;
+    const orderNumber = order && Object.prototype.hasOwnProperty.call(order, 'order_number') ? order.order_number : null;
+    const orderStatusUrl = order && order.order_status_url ? String(order.order_status_url) : null;
+    const adminUrl = orderId ? 'https://' + shopDomain + '.myshopify.com/admin/orders/' + orderId : null;
+    const customerId = order && order.customer && order.customer.id ? order.customer.id : (customerPayload.id || null);
+    const resolvedCustomerEmail = order && order.email ? String(order.email) : (orderEmail || null);
+
+    ctx.shopifyOrderId = orderId;
+    ctx.shopifyOrderName = orderName;
+    ctx.shopifyOrderNumber = orderNumber;
+    ctx.shopifyOrderUrl = orderStatusUrl;
+    ctx.shopifyOrderAdminUrl = adminUrl;
+    ctx.shopifyCustomerId = customerId;
+    ctx.shopifyOrderCustomerEmail = resolvedCustomerEmail;
+
+    logInfo('shopify_create_order_success', {
+      orderId: orderId,
+      orderName: orderName,
+      orderNumber: orderNumber,
+      customerId: customerId,
+      customerEmail: resolvedCustomerEmail,
+      lineItemCount: normalizedLineItems.length,
+      statusUrl: orderStatusUrl,
+      adminUrl: adminUrl,
+      status: response && typeof response.status === 'number' ? response.status : null
+    });
+
+    return ctx;
+  } catch (error) {
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const headers = error && error.headers ? error.headers : {};
+    const payload = Object.prototype.hasOwnProperty.call(error || {}, 'body') ? error.body : null;
+    const details = [];
+
+    if (status) {
+      details.push('status ' + status);
+    }
+
+    let parsed = null;
+    if (payload && typeof payload === 'string') {
+      const trimmed = payload.trim();
+      if (trimmed) {
+        details.push(trimmed);
+      }
+      try {
+        parsed = JSON.parse(payload);
+      } catch (parseError) {
+        parsed = null;
+      }
+    } else if (payload && typeof payload === 'object') {
+      parsed = payload;
+    }
+
+    if (parsed && typeof parsed === 'object') {
+      if (parsed.errors) {
+        const errorsValue = parsed.errors;
+        if (typeof errorsValue === 'string') {
+          details.push(errorsValue);
+        } else if (Array.isArray(errorsValue)) {
+          for (let i = 0; i < errorsValue.length; i++) {
+            const entry = errorsValue[i];
+            if (entry) {
+              details.push(String(entry));
+            }
+          }
+        } else if (typeof errorsValue === 'object') {
+          for (const key in errorsValue) {
+            if (!Object.prototype.hasOwnProperty.call(errorsValue, key)) {
+              continue;
+            }
+            const value = errorsValue[key];
+            if (Array.isArray(value)) {
+              for (let i = 0; i < value.length; i++) {
+                const part = value[i];
+                if (part) {
+                  details.push(key + ': ' + part);
+                }
+              }
+            } else if (value) {
+              details.push(key + ': ' + value);
+            }
+          }
+        }
+      }
+      if (parsed.error && typeof parsed.error === 'string') {
+        details.push(parsed.error);
+      }
+      if (parsed.message && typeof parsed.message === 'string') {
+        details.push(parsed.message);
+      }
+    }
+
+    logError('shopify_create_order_failed', {
+      status: status,
+      customerId: customerPayload && customerPayload.id ? customerPayload.id : null,
+      lineItemCount: normalizedLineItems.length,
+      details: details
+    });
+
+    const message = 'Shopify create_order failed. ' + (details.length > 0 ? details.join(' ') : 'Unexpected error.');
+    const wrapped = new Error(message);
+    wrapped.status = status;
+    wrapped.headers = headers;
+    wrapped.body = payload;
+    wrapped.cause = error;
+    throw wrapped;
+  }
+}
+`);
+  });
+});

--- a/server/workflow/compile-to-appsscript.ts
+++ b/server/workflow/compile-to-appsscript.ts
@@ -15536,41 +15536,517 @@ function step_createStripePayment(ctx) {
   // Shopify - E-commerce
   'action.shopify:create_order': (c) => `
 function step_createShopifyOrder(ctx) {
-  const accessToken = getSecret('SHOPIFY_ACCESS_TOKEN');
-  const shopDomain = getSecret('SHOPIFY_SHOP_DOMAIN');
+  const accessToken = getSecret('SHOPIFY_ACCESS_TOKEN', { connectorKey: 'shopify' });
+  const shopDomain = getSecret('SHOPIFY_SHOP_DOMAIN', { connectorKey: 'shopify' });
 
   if (!accessToken || !shopDomain) {
     logWarn('shopify_missing_credentials', { message: 'Shopify credentials not configured' });
     return ctx;
   }
-  
-  const orderData = {
-    order: {
-      line_items: [{
-        title: interpolate('${c.productTitle || 'Product'}', ctx),
-        price: '${c.price || '0.00'}',
-        quantity: parseInt('${c.quantity || '1'}')
-      }],
-      customer: {
-        email: interpolate('${c.customerEmail || '{{email}}'}', ctx)
+
+  const apiVersion = '${esc(c.apiVersion || '2024-01')}';
+
+  function interpolateValue(value) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      return interpolate(value, ctx);
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        result.push(interpolateValue(value[i]));
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+          continue;
+        }
+        result[key] = interpolateValue(value[key]);
+      }
+      return result;
+    }
+    return value;
+  }
+
+  function pickFirst(source, keys) {
+    if (!source || typeof source !== 'object') {
+      return undefined;
+    }
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (Object.prototype.hasOwnProperty.call(source, key) && source[key] !== undefined && source[key] !== null) {
+        return source[key];
       }
     }
-  };
-  
-  const response = withRetries(() => fetchJson(\`https://\${shopDomain}.myshopify.com/admin/api/2024-01/orders.json\`, {
-    method: 'POST',
-    headers: {
-      'X-Shopify-Access-Token': accessToken,
-      'Content-Type': 'application/json'
-    },
-    payload: JSON.stringify(orderData),
-    contentType: 'application/json'
-  }));
+    return undefined;
+  }
 
-  ctx.shopifyOrderId = response.body && response.body.order ? response.body.order.id : null;
-  logInfo('shopify_create_order', { orderId: ctx.shopifyOrderId || null });
-  return ctx;
-}`,
+  function toTrimmedString(value) {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    return String(value).trim();
+  }
+
+  function toPositiveInteger(value) {
+    if (value === null || value === undefined || value === '') {
+      return null;
+    }
+    const numeric = Number(value);
+    if (!isFinite(numeric) || numeric <= 0) {
+      return null;
+    }
+    return Math.floor(numeric);
+  }
+
+  function toCurrencyString(value) {
+    if (value === null || value === undefined || value === '') {
+      return null;
+    }
+    const normalized = String(value).trim();
+    if (!normalized) {
+      return null;
+    }
+    const numeric = Number(normalized.replace(/[^0-9.-]/g, ''));
+    if (!isFinite(numeric)) {
+      return null;
+    }
+    return numeric.toFixed(2);
+  }
+
+  const manifestLineItems = interpolateValue(${JSON.stringify(c.lineItems ?? null)});
+  const fallbackLineItemConfig = interpolateValue(${JSON.stringify({
+    title: c.productTitle ?? '',
+    price: c.price ?? '',
+    quantity: c.quantity ?? '',
+    variant_id: c.variantId ?? '',
+    sku: c.sku ?? ''
+  })});
+  const normalizedLineItems = [];
+
+  function appendLineItem(entry, indexLabel) {
+    if (!entry || typeof entry !== 'object') {
+      logWarn('shopify_line_item_skipped', { index: indexLabel, reason: 'Line item must be an object' });
+      return;
+    }
+
+    const normalized = {};
+    const variantIdRaw = pickFirst(entry, ['variant_id', 'variantId']);
+    const productIdRaw = pickFirst(entry, ['product_id', 'productId']);
+    const titleRaw = pickFirst(entry, ['title', 'name']);
+    const priceRaw = pickFirst(entry, ['price', 'amount']);
+    const quantityRaw = pickFirst(entry, ['quantity', 'qty', 'count']);
+
+    const quantity = toPositiveInteger(quantityRaw !== undefined ? quantityRaw : 1);
+    if (quantity === null) {
+      logWarn('shopify_line_item_skipped', { index: indexLabel, reason: 'Quantity must be a positive number', quantity: quantityRaw });
+      return;
+    }
+    normalized.quantity = quantity;
+
+    if (variantIdRaw !== undefined && variantIdRaw !== null) {
+      const variantId = toTrimmedString(variantIdRaw);
+      if (variantId) {
+        normalized.variant_id = variantId;
+      }
+    }
+
+    if (productIdRaw !== undefined && productIdRaw !== null) {
+      const productId = toTrimmedString(productIdRaw);
+      if (productId) {
+        normalized.product_id = productId;
+      }
+    }
+
+    const title = toTrimmedString(titleRaw);
+    if (title) {
+      normalized.title = title;
+    }
+
+    const price = toCurrencyString(priceRaw);
+    if (price) {
+      normalized.price = price;
+    }
+
+    if (!normalized.variant_id) {
+      if (!normalized.title) {
+        logWarn('shopify_line_item_skipped', { index: indexLabel, reason: 'Line item requires a title when variant_id is omitted' });
+        return;
+      }
+      if (!normalized.price) {
+        logWarn('shopify_line_item_skipped', { index: indexLabel, reason: 'Line item requires a numeric price when variant_id is omitted', title: normalized.title });
+        return;
+      }
+    }
+
+    const skuRaw = pickFirst(entry, ['sku']);
+    const requiresShippingRaw = pickFirst(entry, ['requires_shipping', 'requiresShipping']);
+    const taxableRaw = pickFirst(entry, ['taxable']);
+    const fulfillmentServiceRaw = pickFirst(entry, ['fulfillment_service', 'fulfillmentService']);
+    const compareAtPriceRaw = pickFirst(entry, ['compare_at_price', 'compareAtPrice']);
+
+    if (skuRaw !== undefined && skuRaw !== null) {
+      const sku = toTrimmedString(skuRaw);
+      if (sku) {
+        normalized.sku = sku;
+      }
+    }
+
+    if (requiresShippingRaw !== undefined && requiresShippingRaw !== null) {
+      normalized.requires_shipping = Boolean(requiresShippingRaw);
+    }
+
+    if (taxableRaw !== undefined && taxableRaw !== null) {
+      normalized.taxable = Boolean(taxableRaw);
+    }
+
+    if (fulfillmentServiceRaw !== undefined && fulfillmentServiceRaw !== null) {
+      const fulfillmentService = toTrimmedString(fulfillmentServiceRaw);
+      if (fulfillmentService) {
+        normalized.fulfillment_service = fulfillmentService;
+      }
+    }
+
+    if (compareAtPriceRaw !== undefined && compareAtPriceRaw !== null) {
+      const compareAtPrice = toCurrencyString(compareAtPriceRaw);
+      if (compareAtPrice) {
+        normalized.compare_at_price = compareAtPrice;
+      }
+    }
+
+    if (entry.properties && typeof entry.properties === 'object') {
+      const interpolatedProperties = interpolateValue(entry.properties);
+      if (interpolatedProperties && typeof interpolatedProperties === 'object') {
+        normalized.properties = interpolatedProperties;
+      }
+    }
+
+    normalizedLineItems.push(normalized);
+  }
+
+  if (Array.isArray(manifestLineItems)) {
+    for (let i = 0; i < manifestLineItems.length; i++) {
+      appendLineItem(manifestLineItems[i], i);
+    }
+  } else if (manifestLineItems) {
+    appendLineItem(manifestLineItems, 'config');
+  }
+
+  if (normalizedLineItems.length === 0 && fallbackLineItemConfig) {
+    appendLineItem(fallbackLineItemConfig, 'fallback');
+  }
+
+  if (normalizedLineItems.length === 0) {
+    throw new Error('Shopify create_order requires at least one valid line item with a positive quantity. Provide a variant_id or include both title and price.');
+  }
+
+  const manifestCustomer = interpolateValue(${JSON.stringify(c.customer ?? null)});
+  const fallbackCustomer = interpolateValue(${JSON.stringify({
+    id: c.customerId ?? '',
+    email: c.customerEmail ?? '',
+    first_name: c.customerFirstName ?? '',
+    last_name: c.customerLastName ?? '',
+    phone: c.customerPhone ?? '',
+    accepts_marketing: c.customerAcceptsMarketing ?? undefined
+  })});
+  let resolvedCustomer = manifestCustomer && typeof manifestCustomer === 'object' ? manifestCustomer : null;
+  if ((!resolvedCustomer || Object.keys(resolvedCustomer).length === 0) && fallbackCustomer && typeof fallbackCustomer === 'object') {
+    resolvedCustomer = fallbackCustomer;
+  }
+
+  const customerPayload = {};
+  let hasCustomerIdentifier = false;
+  let orderEmail = null;
+
+  if (resolvedCustomer) {
+    const customerIdRaw = pickFirst(resolvedCustomer, ['id', 'customer_id', 'customerId']);
+    if (customerIdRaw !== undefined && customerIdRaw !== null) {
+      const customerId = toTrimmedString(customerIdRaw);
+      if (customerId) {
+        customerPayload.id = customerId;
+        hasCustomerIdentifier = true;
+      }
+    }
+
+    const emailRaw = pickFirst(resolvedCustomer, ['email', 'email_address', 'emailAddress']);
+    if (emailRaw !== undefined && emailRaw !== null) {
+      const email = toTrimmedString(emailRaw);
+      if (email) {
+        const emailPattern = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+        if (!emailPattern.test(email)) {
+          throw new Error('Shopify create_order received an invalid customer email "' + email + '". Provide a valid email address.');
+        }
+        customerPayload.email = email;
+        orderEmail = email;
+        hasCustomerIdentifier = true;
+      }
+    }
+
+    const firstNameRaw = pickFirst(resolvedCustomer, ['first_name', 'firstName']);
+    const lastNameRaw = pickFirst(resolvedCustomer, ['last_name', 'lastName']);
+    const phoneRaw = pickFirst(resolvedCustomer, ['phone', 'phone_number', 'phoneNumber']);
+    const acceptsMarketingRaw = pickFirst(resolvedCustomer, ['accepts_marketing', 'acceptsMarketing']);
+
+    const firstName = toTrimmedString(firstNameRaw);
+    if (firstName) {
+      customerPayload.first_name = firstName;
+      hasCustomerIdentifier = true;
+    }
+    const lastName = toTrimmedString(lastNameRaw);
+    if (lastName) {
+      customerPayload.last_name = lastName;
+      hasCustomerIdentifier = true;
+    }
+    const phone = toTrimmedString(phoneRaw);
+    if (phone) {
+      customerPayload.phone = phone;
+      hasCustomerIdentifier = true;
+    }
+    if (acceptsMarketingRaw !== undefined && acceptsMarketingRaw !== null) {
+      customerPayload.accepts_marketing = Boolean(acceptsMarketingRaw);
+      hasCustomerIdentifier = true;
+    }
+  }
+
+  if (!hasCustomerIdentifier) {
+    throw new Error('Shopify create_order requires a customer ID or email address. Update the workflow configuration to provide customer details.');
+  }
+
+  const shippingAddressManifest = interpolateValue(${JSON.stringify(c.shippingAddress ?? null)});
+  let shippingAddress = null;
+  if (shippingAddressManifest && typeof shippingAddressManifest === 'object') {
+    const shippingFields = {
+      first_name: ['first_name', 'firstName'],
+      last_name: ['last_name', 'lastName'],
+      company: ['company'],
+      address1: ['address1', 'address_1', 'line1', 'line_1'],
+      address2: ['address2', 'address_2', 'line2', 'line_2'],
+      city: ['city'],
+      province: ['province', 'state', 'region'],
+      zip: ['zip', 'postal_code', 'postalCode'],
+      country: ['country', 'country_code', 'countryCode'],
+      phone: ['phone', 'phone_number', 'phoneNumber']
+    };
+    const normalizedShipping = {};
+    for (const key in shippingFields) {
+      if (!Object.prototype.hasOwnProperty.call(shippingFields, key)) {
+        continue;
+      }
+      const value = pickFirst(shippingAddressManifest, shippingFields[key]);
+      if (value === undefined || value === null) {
+        continue;
+      }
+      const stringValue = toTrimmedString(value);
+      if (stringValue) {
+        normalizedShipping[key] = stringValue;
+      }
+    }
+    if (Object.keys(normalizedShipping).length > 0) {
+      shippingAddress = normalizedShipping;
+    }
+  }
+
+  const noteTemplate = '${esc(c.note ?? '')}';
+  const note = noteTemplate ? interpolate(noteTemplate, ctx).trim() : '';
+  const tagsManifest = interpolateValue(${JSON.stringify(c.tags ?? null)});
+  const normalizedTags = [];
+  if (Array.isArray(tagsManifest)) {
+    for (let i = 0; i < tagsManifest.length; i++) {
+      const tag = toTrimmedString(tagsManifest[i]);
+      if (tag) {
+        normalizedTags.push(tag);
+      }
+    }
+  } else if (typeof tagsManifest === 'string') {
+    const parts = tagsManifest.split(',');
+    for (let i = 0; i < parts.length; i++) {
+      const tag = toTrimmedString(parts[i]);
+      if (tag) {
+        normalizedTags.push(tag);
+      }
+    }
+  }
+
+  const orderPayload = {
+    order: {
+      line_items: normalizedLineItems
+    }
+  };
+
+  if (orderEmail) {
+    orderPayload.order.email = orderEmail;
+  }
+  if (customerPayload && Object.keys(customerPayload).length > 0) {
+    orderPayload.order.customer = customerPayload;
+  }
+  if (shippingAddress) {
+    orderPayload.order.shipping_address = shippingAddress;
+  }
+  if (note) {
+    orderPayload.order.note = note;
+  }
+  if (normalizedTags.length > 0) {
+    orderPayload.order.tags = normalizedTags.join(', ');
+  }
+
+  const requestUrl = 'https://' + shopDomain + '.myshopify.com/admin/api/' + apiVersion + '/orders.json';
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: requestUrl,
+      method: 'POST',
+      headers: {
+        'X-Shopify-Access-Token': accessToken,
+        'Content-Type': 'application/json'
+      },
+      payload: JSON.stringify(orderPayload),
+      contentType: 'application/json'
+    }), {
+      attempts: 5,
+      initialDelayMs: 1000,
+      maxDelayMs: 32000,
+      jitter: 0.2,
+      retryOn: function(context) {
+        var headers = {};
+        if (context && context.response && context.response.headers) {
+          headers = context.response.headers;
+        } else if (context && context.error && context.error.headers) {
+          headers = context.error.headers;
+        }
+        var normalized = __normalizeHeaders(headers || {});
+        var limitHeader = normalized['x-shopify-shop-api-call-limit'];
+        if (limitHeader) {
+          var parts = String(limitHeader).split('/');
+          if (parts.length === 2) {
+            var used = Number(parts[0]);
+            var limit = Number(parts[1]);
+            if (!isNaN(used) && !isNaN(limit) && limit > 0 && used >= limit) {
+              return { retry: true, delayMs: 2000 };
+            }
+          }
+        }
+        return null;
+      }
+    });
+
+    const body = response && response.body ? response.body : null;
+    const order = body && body.order ? body.order : body;
+    const orderId = order && order.id ? String(order.id) : null;
+    const orderName = order && order.name ? String(order.name) : null;
+    const orderNumber = order && Object.prototype.hasOwnProperty.call(order, 'order_number') ? order.order_number : null;
+    const orderStatusUrl = order && order.order_status_url ? String(order.order_status_url) : null;
+    const adminUrl = orderId ? 'https://' + shopDomain + '.myshopify.com/admin/orders/' + orderId : null;
+    const customerId = order && order.customer && order.customer.id ? order.customer.id : (customerPayload.id || null);
+    const resolvedCustomerEmail = order && order.email ? String(order.email) : (orderEmail || null);
+
+    ctx.shopifyOrderId = orderId;
+    ctx.shopifyOrderName = orderName;
+    ctx.shopifyOrderNumber = orderNumber;
+    ctx.shopifyOrderUrl = orderStatusUrl;
+    ctx.shopifyOrderAdminUrl = adminUrl;
+    ctx.shopifyCustomerId = customerId;
+    ctx.shopifyOrderCustomerEmail = resolvedCustomerEmail;
+
+    logInfo('shopify_create_order_success', {
+      orderId: orderId,
+      orderName: orderName,
+      orderNumber: orderNumber,
+      customerId: customerId,
+      customerEmail: resolvedCustomerEmail,
+      lineItemCount: normalizedLineItems.length,
+      statusUrl: orderStatusUrl,
+      adminUrl: adminUrl,
+      status: response && typeof response.status === 'number' ? response.status : null
+    });
+
+    return ctx;
+  } catch (error) {
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const headers = error && error.headers ? error.headers : {};
+    const payload = Object.prototype.hasOwnProperty.call(error || {}, 'body') ? error.body : null;
+    const details = [];
+
+    if (status) {
+      details.push('status ' + status);
+    }
+
+    let parsed = null;
+    if (payload && typeof payload === 'string') {
+      const trimmed = payload.trim();
+      if (trimmed) {
+        details.push(trimmed);
+      }
+      try {
+        parsed = JSON.parse(payload);
+      } catch (parseError) {
+        parsed = null;
+      }
+    } else if (payload && typeof payload === 'object') {
+      parsed = payload;
+    }
+
+    if (parsed && typeof parsed === 'object') {
+      if (parsed.errors) {
+        const errorsValue = parsed.errors;
+        if (typeof errorsValue === 'string') {
+          details.push(errorsValue);
+        } else if (Array.isArray(errorsValue)) {
+          for (let i = 0; i < errorsValue.length; i++) {
+            const entry = errorsValue[i];
+            if (entry) {
+              details.push(String(entry));
+            }
+          }
+        } else if (typeof errorsValue === 'object') {
+          for (const key in errorsValue) {
+            if (!Object.prototype.hasOwnProperty.call(errorsValue, key)) {
+              continue;
+            }
+            const value = errorsValue[key];
+            if (Array.isArray(value)) {
+              for (let i = 0; i < value.length; i++) {
+                const part = value[i];
+                if (part) {
+                  details.push(key + ': ' + part);
+                }
+              }
+            } else if (value) {
+              details.push(key + ': ' + value);
+            }
+          }
+        }
+      }
+      if (parsed.error && typeof parsed.error === 'string') {
+        details.push(parsed.error);
+      }
+      if (parsed.message && typeof parsed.message === 'string') {
+        details.push(parsed.message);
+      }
+    }
+
+    logError('shopify_create_order_failed', {
+      status: status,
+      customerId: customerPayload && customerPayload.id ? customerPayload.id : null,
+      lineItemCount: normalizedLineItems.length,
+      details: details
+    });
+
+    const message = 'Shopify create_order failed. ' + (details.length > 0 ? details.join(' ') : 'Unexpected error.');
+    const wrapped = new Error(message);
+    wrapped.status = status;
+    wrapped.headers = headers;
+    wrapped.body = payload;
+    wrapped.cause = error;
+    throw wrapped;
+  }
+}
+`,
+
 
   // BATCH 1: CRM Applications
   'action.pipedrive:create_deal': (c) => `


### PR DESCRIPTION
## Summary
- implement the Shopify create_order Apps Script handler with input validation, rate-limit aware fetches, and structured context logging for downstream steps
- add Tier-1 Apps Script workflow and snapshot coverage plus a dry-run fixture exercising the new order flow
- document the Shopify Script Properties that must be configured along with required Admin API scopes

## Testing
- Tests failed (npm 403 while attempting to run vitest)


------
https://chatgpt.com/codex/tasks/task_e_68eca0b7288c8331bf75c0d8579fd6cb