### PR TITLE
Add Webflow Apps Script handlers and tests

### DIFF
--- a/docs/apps-script-rollout/script-properties.md
+++ b/docs/apps-script-rollout/script-properties.md
@@ -138,7 +138,7 @@ Salesforce workflows must populate both properties before deployment. Access tok
 | vimeo | `VIMEO_ACCESS_TOKEN` | — | — |
 | vonage | `VONAGE_API_KEY`<br>`VONAGE_API_SECRET` | — | — |
 | wave | `WAVE_ACCESS_TOKEN` | — | — |
-| Webflow | `WEBFLOW_API_TOKEN` | — | — |
+| Webflow | `WEBFLOW_API_TOKEN`<br>`WEBFLOW_DEFAULT_SITE_ID` | — | `WEBFLOW_DEFAULT_SITE_ID` |
 | whatsapp | `WHATSAPP_ACCESS_TOKEN`<br>`WHATSAPP_PHONE_NUMBER_ID` | — | — |
 | wistia | `WISTIA_API_KEY` | — | — |
 | WooCommerce | `WOOCOMMERCE_CONSUMER_KEY`<br>`WOOCOMMERCE_CONSUMER_SECRET`<br>`WOOCOMMERCE_STORE_URL` | — | — |

--- a/server/workflow/__tests__/__snapshots__/apps-script.webflow.test.ts.snap
+++ b/server/workflow/__tests__/__snapshots__/apps-script.webflow.test.ts.snap
@@ -1,0 +1,1151 @@
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:test_connection 1`] = `
+function step_action_webflow_test_connection(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites',
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const sites = Array.isArray(response.body)
+      ? response.body
+      : (response.body && Array.isArray(response.body.sites) ? response.body.sites : []);
+
+    ctx.webflowConnectionTested = true;
+    ctx.webflowSiteCount = sites.length;
+
+    logInfo('webflow_test_connection_success', {
+      status: response.status,
+      siteCount: sites.length
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_test_connection_failed', {
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:list_sites 1`] = `
+function step_action_webflow_list_sites(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites',
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const sites = Array.isArray(response.body)
+      ? response.body
+      : (response.body && Array.isArray(response.body.sites) ? response.body.sites : []);
+
+    ctx.webflowSites = sites;
+    ctx.webflowSiteCount = sites.length;
+
+    logInfo('webflow_list_sites_success', {
+      status: response.status,
+      siteCount: sites.length
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_list_sites_failed', {
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:get_site 1`] = `
+function step_action_webflow_get_site(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"site_id":"site-123"};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow get_site requires a Site ID. Provide one in the node configuration or store WEBFLOW_DEFAULT_SITE_ID in Script Properties.');
+  }
+
+  const siteId = resolveSiteId();
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites/' + encodeURIComponent(siteId),
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowSite = response.body || {};
+
+    logInfo('webflow_get_site_success', {
+      status: response.status,
+      siteId: siteId
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_get_site_failed', {
+      siteId: siteId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:list_collections 1`] = `
+function step_action_webflow_list_collections(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"site_id":"site-123"};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow list_collections requires a Site ID. Configure one or set WEBFLOW_DEFAULT_SITE_ID.');
+  }
+
+  const siteId = resolveSiteId();
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites/' + encodeURIComponent(siteId) + '/collections',
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const collections = Array.isArray(response.body)
+      ? response.body
+      : (response.body && Array.isArray(response.body.collections) ? response.body.collections : []);
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowCollections = collections;
+
+    logInfo('webflow_list_collections_success', {
+      status: response.status,
+      siteId: siteId,
+      collectionCount: collections.length
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_list_collections_failed', {
+      siteId: siteId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:get_collection 1`] = `
+function step_action_webflow_get_collection(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"collection_id":"collection-123"};
+
+  function resolveCollectionId() {
+    const template = config.collection_id || config.collectionId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow get_collection requires a Collection ID.');
+    }
+    return resolved;
+  }
+
+  const collectionId = resolveCollectionId();
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/collections/' + encodeURIComponent(collectionId),
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowCollection = response.body || {};
+
+    logInfo('webflow_get_collection_success', {
+      status: response.status,
+      collectionId: collectionId
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_get_collection_failed', {
+      collectionId: collectionId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:list_collection_items 1`] = `
+function step_action_webflow_list_collection_items(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"collection_id":"collection-123","offset":10,"limit":25};
+
+  function resolveCollectionId() {
+    const template = config.collection_id || config.collectionId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow list_collection_items requires a Collection ID.');
+    }
+    return resolved;
+  }
+
+  function resolveNumber(value, fallback) {
+    if (value === null || value === undefined) {
+      return typeof fallback === 'number' ? fallback : 0;
+    }
+    if (typeof value === 'number') {
+      return value;
+    }
+    const resolved = interpolate(String(value), ctx).trim();
+    if (!resolved) {
+      return typeof fallback === 'number' ? fallback : 0;
+    }
+    const parsed = Number(resolved);
+    return isNaN(parsed) ? (typeof fallback === 'number' ? fallback : 0) : parsed;
+  }
+
+  const collectionId = resolveCollectionId();
+  const offset = resolveNumber(config.offset, 0);
+  const limit = resolveNumber(config.limit, 100);
+
+  const params = ['offset=' + Math.max(offset, 0), 'limit=' + Math.min(Math.max(limit, 1), 100)];
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/collections/' + encodeURIComponent(collectionId) + '/items?' + params.join('&'),
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const items = response.body && Array.isArray(response.body.items)
+      ? response.body.items
+      : (Array.isArray(response.body) ? response.body : []);
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowCollectionItems = items;
+    ctx.webflowCollectionCount = items.length;
+
+    logInfo('webflow_list_collection_items_success', {
+      status: response.status,
+      collectionId: collectionId,
+      count: items.length,
+      offset: offset,
+      limit: limit
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_list_collection_items_failed', {
+      collectionId: collectionId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:get_collection_item 1`] = `
+function step_action_webflow_get_collection_item(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"collection_id":"collection-123","item_id":"item-456"};
+
+  function resolveId(value, label) {
+    const template = value || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow get_collection_item requires a ' + label + '.');
+    }
+    return resolved;
+  }
+
+  const collectionId = resolveId(config.collection_id || config.collectionId, 'Collection ID');
+  const itemId = resolveId(config.item_id || config.itemId, 'Item ID');
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url:
+        'https://api.webflow.com/collections/' +
+        encodeURIComponent(collectionId) +
+        '/items/' +
+        encodeURIComponent(itemId),
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowItemId = itemId;
+    ctx.webflowItem = response.body || {};
+
+    logInfo('webflow_get_collection_item_success', {
+      status: response.status,
+      collectionId: collectionId,
+      itemId: itemId
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_get_collection_item_failed', {
+      collectionId: collectionId,
+      itemId: itemId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:create_collection_item 1`] = `
+function step_action_webflow_create_collection_item(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"collection_id":"collection-123","fields":{"name":"{{lead.name}}","slug":"new-item"},"live":true};
+
+  function resolveId(value, label) {
+    const template = value || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow create_collection_item requires ' + label + '.');
+    }
+    return resolved;
+  }
+
+  function resolveBoolean(value, fallback) {
+    if (value === null || value === undefined) {
+      return !!fallback;
+    }
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    const normalized = interpolate(String(value), ctx).trim().toLowerCase();
+    if (!normalized) {
+      return !!fallback;
+    }
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  function resolveStructured(value) {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        result.push(resolveStructured(value[i]));
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+          result[key] = resolveStructured(value[key]);
+        }
+      }
+      return result;
+    }
+    if (typeof value === 'string') {
+      return interpolate(value, ctx);
+    }
+    return value;
+  }
+
+  const collectionId = resolveId(config.collection_id || config.collectionId, 'a Collection ID');
+  const fields = resolveStructured(config.fields) || {};
+  const live = resolveBoolean(config.live, false);
+
+  if (!fields || typeof fields !== 'object' || Object.keys(fields).length === 0) {
+    throw new Error('Webflow create_collection_item requires at least one field value.');
+  }
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url:
+        'https://api.webflow.com/collections/' +
+        encodeURIComponent(collectionId) +
+        '/items?live=' + (live ? 'true' : 'false'),
+      method: 'POST',
+      headers: headers,
+      payload: JSON.stringify({ fields: fields }),
+      contentType: 'application/json'
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const body = response.body || {};
+    const itemId =
+      (body && (body._id || body.id)) ||
+      (body.item && (body.item._id || body.item.id)) ||
+      null;
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowItemId = itemId;
+    ctx.webflowItem = body;
+    ctx.webflowItemPublished = live;
+
+    logInfo('webflow_create_collection_item_success', {
+      status: response.status,
+      collectionId: collectionId,
+      itemId: itemId,
+      live: live
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_create_collection_item_failed', {
+      collectionId: collectionId,
+      live: live,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:update_collection_item 1`] = `
+function step_action_webflow_update_collection_item(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"collection_id":"collection-123","item_id":"item-456","fields":{"name":"Updated Title"},"live":false};
+
+  function resolveId(value, label) {
+    const template = value || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow update_collection_item requires ' + label + '.');
+    }
+    return resolved;
+  }
+
+  function resolveBoolean(value, fallback) {
+    if (value === null || value === undefined) {
+      return !!fallback;
+    }
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    const normalized = interpolate(String(value), ctx).trim().toLowerCase();
+    if (!normalized) {
+      return !!fallback;
+    }
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  function resolveStructured(value) {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        result.push(resolveStructured(value[i]));
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+          result[key] = resolveStructured(value[key]);
+        }
+      }
+      return result;
+    }
+    if (typeof value === 'string') {
+      return interpolate(value, ctx);
+    }
+    return value;
+  }
+
+  const collectionId = resolveId(config.collection_id || config.collectionId, 'a Collection ID');
+  const itemId = resolveId(config.item_id || config.itemId, 'an Item ID');
+  const fields = resolveStructured(config.fields) || {};
+  const live = resolveBoolean(config.live, false);
+
+  if (!fields || typeof fields !== 'object' || Object.keys(fields).length === 0) {
+    throw new Error('Webflow update_collection_item requires at least one field value.');
+  }
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url:
+        'https://api.webflow.com/collections/' +
+        encodeURIComponent(collectionId) +
+        '/items/' +
+        encodeURIComponent(itemId) +
+        '?live=' + (live ? 'true' : 'false'),
+      method: 'PUT',
+      headers: headers,
+      payload: JSON.stringify({ fields: fields }),
+      contentType: 'application/json'
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const body = response.body || {};
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowItemId = itemId;
+    ctx.webflowItem = body;
+    ctx.webflowItemPublished = live;
+
+    logInfo('webflow_update_collection_item_success', {
+      status: response.status,
+      collectionId: collectionId,
+      itemId: itemId,
+      live: live
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_update_collection_item_failed', {
+      collectionId: collectionId,
+      itemId: itemId,
+      live: live,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:delete_collection_item 1`] = `
+function step_action_webflow_delete_collection_item(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"collection_id":"collection-123","item_id":"item-456","live":true};
+
+  function resolveId(value, label) {
+    const template = value || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow delete_collection_item requires ' + label + '.');
+    }
+    return resolved;
+  }
+
+  function resolveBoolean(value, fallback) {
+    if (value === null || value === undefined) {
+      return !!fallback;
+    }
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    const normalized = interpolate(String(value), ctx).trim().toLowerCase();
+    if (!normalized) {
+      return !!fallback;
+    }
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  const collectionId = resolveId(config.collection_id || config.collectionId, 'a Collection ID');
+  const itemId = resolveId(config.item_id || config.itemId, 'an Item ID');
+  const live = resolveBoolean(config.live, false);
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url:
+        'https://api.webflow.com/collections/' +
+        encodeURIComponent(collectionId) +
+        '/items/' +
+        encodeURIComponent(itemId) +
+        '?live=' + (live ? 'true' : 'false'),
+      method: 'DELETE',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowItemId = itemId;
+    ctx.webflowItemDeleted = true;
+    ctx.webflowItemPublished = live;
+
+    logInfo('webflow_delete_collection_item_success', {
+      status: response.status,
+      collectionId: collectionId,
+      itemId: itemId,
+      live: live
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_delete_collection_item_failed', {
+      collectionId: collectionId,
+      itemId: itemId,
+      live: live,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:publish_site 1`] = `
+function step_action_webflow_publish_site(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"site_id":"site-123","domains":["example.com","{{site.subdomain}}.webflow.io"]};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow publish_site requires a Site ID. Configure one or set WEBFLOW_DEFAULT_SITE_ID.');
+  }
+
+  function resolveDomains() {
+    const domainsConfig = config.domains || [];
+    const result = [];
+    if (Array.isArray(domainsConfig)) {
+      for (let i = 0; i < domainsConfig.length; i++) {
+        const entry = domainsConfig[i];
+        if (entry === null || entry === undefined) {
+          continue;
+        }
+        const resolved = typeof entry === 'string' ? interpolate(entry, ctx).trim() : String(entry).trim();
+        if (resolved) {
+          result.push(resolved);
+        }
+      }
+    }
+    return result;
+  }
+
+  const siteId = resolveSiteId();
+  const domains = resolveDomains();
+
+  if (!domains.length) {
+    logWarn('webflow_publish_site_no_domains', {
+      siteId: siteId,
+      message: 'Publishing without explicit domains uses Webflow defaults.'
+    });
+  }
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+  };
+
+  const payload = domains.length ? { domains: domains } : {};
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites/' + encodeURIComponent(siteId) + '/publish',
+      method: 'POST',
+      headers: headers,
+      payload: JSON.stringify(payload),
+      contentType: 'application/json'
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowPublishResponse = response.body || {};
+
+    logInfo('webflow_publish_site_success', {
+      status: response.status,
+      siteId: siteId,
+      domainCount: domains.length
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_publish_site_failed', {
+      siteId: siteId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:list_webhooks 1`] = `
+function step_action_webflow_list_webhooks(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"site_id":"site-123"};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow list_webhooks requires a Site ID. Configure one or set WEBFLOW_DEFAULT_SITE_ID.');
+  }
+
+  const siteId = resolveSiteId();
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites/' + encodeURIComponent(siteId) + '/webhooks',
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const webhooks = Array.isArray(response.body)
+      ? response.body
+      : (response.body && Array.isArray(response.body.webhooks) ? response.body.webhooks : []);
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowWebhooks = webhooks;
+
+    logInfo('webflow_list_webhooks_success', {
+      status: response.status,
+      siteId: siteId,
+      webhookCount: webhooks.length
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_list_webhooks_failed', {
+      siteId: siteId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:create_webhook 1`] = `
+function step_action_webflow_create_webhook(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"site_id":"site-123","triggerType":"form_submission","url":"https://hooks.example.com/webflow","filter":{"formId":"{{form.id}}"}};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow create_webhook requires a Site ID. Configure one or set WEBFLOW_DEFAULT_SITE_ID.');
+  }
+
+  function resolveString(value, label) {
+    if (value === null || value === undefined) {
+      throw new Error('Webflow create_webhook requires ' + label + '.');
+    }
+    const resolved = typeof value === 'string' ? interpolate(value, ctx).trim() : String(value).trim();
+    if (!resolved) {
+      throw new Error('Webflow create_webhook requires ' + label + '.');
+    }
+    return resolved;
+  }
+
+  function resolveFilter(value) {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        result.push(resolveFilter(value[i]));
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+          result[key] = resolveFilter(value[key]);
+        }
+      }
+      return result;
+    }
+    if (typeof value === 'string') {
+      return interpolate(value, ctx);
+    }
+    return value;
+  }
+
+  const siteId = resolveSiteId();
+  const triggerType = resolveString(config.triggerType, 'a trigger type');
+  const targetUrl = resolveString(config.url, 'a callback URL');
+  const filter = resolveFilter(config.filter);
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+  };
+
+  const payload = { triggerType: triggerType, url: targetUrl };
+  if (filter && typeof filter === 'object' && Object.keys(filter).length > 0) {
+    payload.filter = filter;
+  }
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites/' + encodeURIComponent(siteId) + '/webhooks',
+      method: 'POST',
+      headers: headers,
+      payload: JSON.stringify(payload),
+      contentType: 'application/json'
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const body = response.body || {};
+    const webhookId = body && (body._id || body.id) ? (body._id || body.id) : null;
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowWebhookId = webhookId;
+    ctx.webflowWebhook = body;
+
+    logInfo('webflow_create_webhook_success', {
+      status: response.status,
+      siteId: siteId,
+      triggerType: triggerType,
+      webhookId: webhookId
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_create_webhook_failed', {
+      siteId: siteId,
+      triggerType: triggerType,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds action.webflow:delete_webhook 1`] = `
+function step_action_webflow_delete_webhook(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = {"site_id":"site-123","webhook_id":"wh_001"};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow delete_webhook requires a Site ID. Configure one or set WEBFLOW_DEFAULT_SITE_ID.');
+  }
+
+  function resolveWebhookId() {
+    const template = config.webhook_id || config.webhookId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow delete_webhook requires a Webhook ID.');
+    }
+    return resolved;
+  }
+
+  const siteId = resolveSiteId();
+  const webhookId = resolveWebhookId();
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url:
+        'https://api.webflow.com/sites/' +
+        encodeURIComponent(siteId) +
+        '/webhooks/' +
+        encodeURIComponent(webhookId),
+      method: 'DELETE',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowWebhookId = webhookId;
+    ctx.webflowWebhookDeleted = true;
+
+    logInfo('webflow_delete_webhook_success', {
+      status: response.status,
+      siteId: siteId,
+      webhookId: webhookId
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_delete_webhook_failed', {
+      siteId: siteId,
+      webhookId: webhookId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds trigger.webflow:form_submission 1`] = `
+function trigger_trigger_webflow_form_submission(ctx) {
+  ctx = ctx || {};
+
+  const payload = ctx && ctx.webhookPayload ? ctx.webhookPayload : {};
+  const event = payload && payload.event ? payload.event : ctx.event || {};
+
+  ctx.webflowTrigger = 'form_submission';
+  ctx.webflowFormSubmission = payload;
+  ctx.webflowEvent = event;
+
+  logInfo('webflow_form_submission_received', {
+    trigger: 'form_submission',
+    formName: payload && payload.formName ? payload.formName : null
+  });
+
+  return ctx;
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds trigger.webflow:collection_item_created 1`] = `
+function trigger_trigger_webflow_collection_item_created(ctx) {
+  ctx = ctx || {};
+
+  const payload = ctx && ctx.webhookPayload ? ctx.webhookPayload : {};
+  const event = payload && payload.event ? payload.event : ctx.event || {};
+
+  ctx.webflowTrigger = 'collection_item_created';
+  ctx.webflowEvent = event;
+  ctx.webflowCollectionItem = payload;
+
+  logInfo('webflow_collection_item_created_received', {
+    trigger: 'collection_item_created',
+    collectionId: payload && payload.collectionId ? payload.collectionId : null,
+    itemId: payload && payload._id ? payload._id : (payload && payload.id ? payload.id : null)
+  });
+
+  return ctx;
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds trigger.webflow:collection_item_changed 1`] = `
+function trigger_trigger_webflow_collection_item_changed(ctx) {
+  ctx = ctx || {};
+
+  const payload = ctx && ctx.webhookPayload ? ctx.webhookPayload : {};
+  const event = payload && payload.event ? payload.event : ctx.event || {};
+
+  ctx.webflowTrigger = 'collection_item_changed';
+  ctx.webflowEvent = event;
+  ctx.webflowCollectionItem = payload;
+
+  logInfo('webflow_collection_item_changed_received', {
+    trigger: 'collection_item_changed',
+    collectionId: payload && payload.collectionId ? payload.collectionId : null,
+    itemId: payload && payload._id ? payload._id : (payload && payload.id ? payload.id : null)
+  });
+
+  return ctx;
+}
+`;
+
+exports[`Apps Script Webflow REAL_OPS builds trigger.webflow:site_published 1`] = `
+function trigger_trigger_webflow_site_published(ctx) {
+  ctx = ctx || {};
+
+  const payload = ctx && ctx.webhookPayload ? ctx.webhookPayload : {};
+  const event = payload && payload.event ? payload.event : ctx.event || {};
+
+  ctx.webflowTrigger = 'site_published';
+  ctx.webflowEvent = event;
+  ctx.webflowPublishDetails = payload;
+
+  logInfo('webflow_site_published_received', {
+    trigger: 'site_published',
+    siteId: payload && payload.siteId ? payload.siteId : null
+  });
+
+  return ctx;
+}
+`;

--- a/server/workflow/__tests__/apps-script-fixtures/webflow-create-cms-item.json
+++ b/server/workflow/__tests__/apps-script-fixtures/webflow-create-cms-item.json
@@ -1,0 +1,106 @@
+{
+  "id": "webflow-create-cms-item",
+  "description": "Creates a Webflow CMS item using the Apps Script runtime.",
+  "graph": {
+    "id": "fixture-webflow-create-cms-item",
+    "name": "Webflow create CMS item",
+    "nodes": [
+      {
+        "id": "webflow-create-item",
+        "type": "action.webflow",
+        "app": "webflow",
+        "name": "Create Webflow CMS item",
+        "op": "action.webflow:create_collection_item",
+        "params": {
+          "operation": "create_collection_item",
+          "collection_id": "collection-123",
+          "fields": {
+            "name": "{{lead.name}}",
+            "slug": "lead-{{lead.id}}"
+          },
+          "live": false
+        },
+        "data": {
+          "operation": "create_collection_item",
+          "config": {
+            "collection_id": "collection-123",
+            "fields": {
+              "name": "{{lead.name}}",
+              "slug": "lead-{{lead.id}}"
+            },
+            "live": false
+          }
+        }
+      }
+    ],
+    "edges": []
+  },
+  "entry": {
+    "context": {
+      "lead": {
+        "id": "42",
+        "name": "Sam Customer"
+      }
+    }
+  },
+  "secrets": {
+    "WEBFLOW_API_TOKEN": "wf-token"
+  },
+  "http": [
+    {
+      "name": "webflow-create-collection-item",
+      "request": {
+        "url": "https://api.webflow.com/collections/collection-123/items?live=false",
+        "method": "POST",
+        "headers": {
+          "authorization": "Bearer wf-token",
+          "accept-version": "1.0.0",
+          "accept": "application/json",
+          "content-type": "application/json"
+        },
+        "payload": {
+          "fields": {
+            "name": "Sam Customer",
+            "slug": "lead-42"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "_id": "item-987",
+          "collectionId": "collection-123",
+          "fields": {
+            "name": "Sam Customer",
+            "slug": "lead-42"
+          }
+        }
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "lead": {
+        "id": "42",
+        "name": "Sam Customer"
+      },
+      "webflowCollectionId": "collection-123",
+      "webflowItemId": "item-987",
+      "webflowItem": {
+        "_id": "item-987",
+        "collectionId": "collection-123",
+        "fields": {
+          "name": "Sam Customer",
+          "slug": "lead-42"
+        }
+      },
+      "webflowItemPublished": false
+    },
+    "httpCalls": [
+      {
+        "url": "https://api.webflow.com/collections/collection-123/items?live=false",
+        "method": "POST"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script-fixtures/webflow-create-form-webhook.json
+++ b/server/workflow/__tests__/apps-script-fixtures/webflow-create-form-webhook.json
@@ -1,0 +1,102 @@
+{
+  "id": "webflow-create-form-webhook",
+  "description": "Registers a Webflow form submission webhook.",
+  "graph": {
+    "id": "fixture-webflow-create-form-webhook",
+    "name": "Webflow create webhook",
+    "nodes": [
+      {
+        "id": "webflow-create-webhook",
+        "type": "action.webflow",
+        "app": "webflow",
+        "name": "Create Webflow form webhook",
+        "op": "action.webflow:create_webhook",
+        "params": {
+          "operation": "create_webhook",
+          "site_id": "site-123",
+          "triggerType": "form_submission",
+          "url": "https://hooks.example.com/webflow",
+          "filter": {
+            "formId": "{{form.id}}"
+          }
+        },
+        "data": {
+          "operation": "create_webhook",
+          "config": {
+            "site_id": "site-123",
+            "triggerType": "form_submission",
+            "url": "https://hooks.example.com/webflow",
+            "filter": {
+              "formId": "{{form.id}}"
+            }
+          }
+        }
+      }
+    ],
+    "edges": []
+  },
+  "entry": {
+    "context": {
+      "form": {
+        "id": "form-42"
+      }
+    }
+  },
+  "secrets": {
+    "WEBFLOW_API_TOKEN": "wf-token"
+  },
+  "http": [
+    {
+      "name": "webflow-create-webhook",
+      "request": {
+        "url": "https://api.webflow.com/sites/site-123/webhooks",
+        "method": "POST",
+        "headers": {
+          "authorization": "Bearer wf-token",
+          "accept-version": "1.0.0",
+          "accept": "application/json",
+          "content-type": "application/json"
+        },
+        "payload": {
+          "triggerType": "form_submission",
+          "url": "https://hooks.example.com/webflow",
+          "filter": {
+            "formId": "form-42"
+          }
+        }
+      },
+      "response": {
+        "status": 201,
+        "body": {
+          "_id": "wh_001",
+          "triggerType": "form_submission",
+          "siteId": "site-123",
+          "createdOn": "2024-05-10T16:15:00.000Z",
+          "url": "https://hooks.example.com/webflow"
+        }
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "form": {
+        "id": "form-42"
+      },
+      "webflowSiteId": "site-123",
+      "webflowWebhookId": "wh_001",
+      "webflowWebhook": {
+        "_id": "wh_001",
+        "triggerType": "form_submission",
+        "siteId": "site-123",
+        "createdOn": "2024-05-10T16:15:00.000Z",
+        "url": "https://hooks.example.com/webflow"
+      }
+    },
+    "httpCalls": [
+      {
+        "url": "https://api.webflow.com/sites/site-123/webhooks",
+        "method": "POST"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script.webflow.test.ts
+++ b/server/workflow/__tests__/apps-script.webflow.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { REAL_OPS } from '../compile-to-appsscript';
+import { runSingleFixture } from '../appsScriptDryRunHarness';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturesDir = path.join(__dirname, 'apps-script-fixtures');
+
+describe('Apps Script Webflow REAL_OPS', () => {
+  const cases: Array<[string, Record<string, any>]> = [
+    ['action.webflow:test_connection', {}],
+    ['action.webflow:list_sites', {}],
+    ['action.webflow:get_site', { site_id: 'site-123' }],
+    ['action.webflow:list_collections', { site_id: 'site-123' }],
+    ['action.webflow:get_collection', { collection_id: 'collection-123' }],
+    ['action.webflow:list_collection_items', { collection_id: 'collection-123', offset: 10, limit: 25 }],
+    ['action.webflow:get_collection_item', { collection_id: 'collection-123', item_id: 'item-456' }],
+    [
+      'action.webflow:create_collection_item',
+      {
+        collection_id: 'collection-123',
+        fields: {
+          name: '{{lead.name}}',
+          slug: 'new-item'
+        },
+        live: true
+      }
+    ],
+    [
+      'action.webflow:update_collection_item',
+      {
+        collection_id: 'collection-123',
+        item_id: 'item-456',
+        fields: {
+          name: 'Updated Title'
+        },
+        live: false
+      }
+    ],
+    ['action.webflow:delete_collection_item', { collection_id: 'collection-123', item_id: 'item-456', live: true }],
+    [
+      'action.webflow:publish_site',
+      {
+        site_id: 'site-123',
+        domains: ['example.com', '{{site.subdomain}}.webflow.io']
+      }
+    ],
+    ['action.webflow:list_webhooks', { site_id: 'site-123' }],
+    [
+      'action.webflow:create_webhook',
+      {
+        site_id: 'site-123',
+        triggerType: 'form_submission',
+        url: 'https://hooks.example.com/webflow',
+        filter: { formId: '{{form.id}}' }
+      }
+    ],
+    ['action.webflow:delete_webhook', { site_id: 'site-123', webhook_id: 'wh_001' }],
+    ['trigger.webflow:form_submission', {}],
+    ['trigger.webflow:collection_item_created', {}],
+    ['trigger.webflow:collection_item_changed', {}],
+    ['trigger.webflow:site_published', {}]
+  ];
+
+  for (const [operation, config] of cases) {
+    it(`builds ${operation}`, () => {
+      const builder = REAL_OPS[operation];
+      expect(builder).toBeDefined();
+      expect(builder(config)).toMatchSnapshot();
+    });
+  }
+});
+
+describe('Apps Script Webflow dry run', () => {
+  it('creates a CMS item', async () => {
+    const result = await runSingleFixture('webflow-create-cms-item', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.context.webflowCollectionId).toBe('collection-123');
+    expect(result.context.webflowItemId).toBe('item-987');
+    expect(result.context.webflowItem).toMatchObject({
+      _id: 'item-987',
+      collectionId: 'collection-123',
+      fields: {
+        name: 'Sam Customer',
+        slug: 'lead-42'
+      }
+    });
+    expect(result.context.webflowItemPublished).toBe(false);
+    expect(result.httpCalls).toHaveLength(1);
+    expect(result.httpCalls[0].url).toBe('https://api.webflow.com/collections/collection-123/items?live=false');
+    expect(result.httpCalls[0].method).toBe('POST');
+  });
+
+  it('registers a form submission webhook', async () => {
+    const result = await runSingleFixture('webflow-create-form-webhook', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.context.webflowSiteId).toBe('site-123');
+    expect(result.context.webflowWebhookId).toBe('wh_001');
+    expect(result.context.webflowWebhook).toMatchObject({
+      _id: 'wh_001',
+      triggerType: 'form_submission',
+      siteId: 'site-123'
+    });
+    expect(result.httpCalls).toHaveLength(1);
+    expect(result.httpCalls[0].url).toBe('https://api.webflow.com/sites/site-123/webhooks');
+    expect(result.httpCalls[0].method).toBe('POST');
+  });
+});

--- a/server/workflow/compile-to-appsscript.ts
+++ b/server/workflow/compile-to-appsscript.ts
@@ -9948,25 +9948,25 @@ function ${functionName}(inputData, params) {
 
 function generateWebflowFunction(functionName: string, node: WorkflowNode): string {
   const operation = node.params?.operation || node.op?.split('.').pop() || 'create_collection_item';
-  
+
   return `
 function ${functionName}(inputData, params) {
   console.log('🌊 Executing Webflow: ${params.operation || '${operation}'}');
-  
-  const accessToken = getSecret('WEBFLOW_ACCESS_TOKEN');
-  
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+
   if (!accessToken) {
-    console.warn('⚠️ Webflow access token not configured');
-    return { ...inputData, webflowSkipped: true, error: 'Missing access token' };
+    console.warn('⚠️ Webflow API token not configured');
+    return { ...inputData, webflowSkipped: true, error: 'Missing API token' };
   }
-  
+
   try {
     const operation = params.operation || '${operation}';
     if (operation === 'test_connection') {
       console.log('✅ Webflow connection test successful');
       return { ...inputData, connectionTest: 'success' };
     }
-    
+
     console.log('✅ Webflow operation completed:', operation);
     return { ...inputData, webflowResult: 'success', operation };
   } catch (error) {
@@ -15986,6 +15986,1159 @@ function step_action_slack_test_connection(ctx) {
     });
     throw error;
   }
+}
+`,
+
+  // Webflow REST actions & triggers
+  'action.webflow:test_connection': (_c) => `
+function step_action_webflow_test_connection(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites',
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const sites = Array.isArray(response.body)
+      ? response.body
+      : (response.body && Array.isArray(response.body.sites) ? response.body.sites : []);
+
+    ctx.webflowConnectionTested = true;
+    ctx.webflowSiteCount = sites.length;
+
+    logInfo('webflow_test_connection_success', {
+      status: response.status,
+      siteCount: sites.length
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_test_connection_failed', {
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:list_sites': (_c) => `
+function step_action_webflow_list_sites(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites',
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const sites = Array.isArray(response.body)
+      ? response.body
+      : (response.body && Array.isArray(response.body.sites) ? response.body.sites : []);
+
+    ctx.webflowSites = sites;
+    ctx.webflowSiteCount = sites.length;
+
+    logInfo('webflow_list_sites_success', {
+      status: response.status,
+      siteCount: sites.length
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_list_sites_failed', {
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:get_site': (c) => `
+function step_action_webflow_get_site(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow get_site requires a Site ID. Provide one in the node configuration or store WEBFLOW_DEFAULT_SITE_ID in Script Properties.');
+  }
+
+  const siteId = resolveSiteId();
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites/' + encodeURIComponent(siteId),
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowSite = response.body || {};
+
+    logInfo('webflow_get_site_success', {
+      status: response.status,
+      siteId: siteId
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_get_site_failed', {
+      siteId: siteId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:list_collections': (c) => `
+function step_action_webflow_list_collections(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow list_collections requires a Site ID. Configure one or set WEBFLOW_DEFAULT_SITE_ID.');
+  }
+
+  const siteId = resolveSiteId();
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites/' + encodeURIComponent(siteId) + '/collections',
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const collections = Array.isArray(response.body)
+      ? response.body
+      : (response.body && Array.isArray(response.body.collections) ? response.body.collections : []);
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowCollections = collections;
+
+    logInfo('webflow_list_collections_success', {
+      status: response.status,
+      siteId: siteId,
+      collectionCount: collections.length
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_list_collections_failed', {
+      siteId: siteId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:get_collection': (c) => `
+function step_action_webflow_get_collection(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function resolveCollectionId() {
+    const template = config.collection_id || config.collectionId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow get_collection requires a Collection ID.');
+    }
+    return resolved;
+  }
+
+  const collectionId = resolveCollectionId();
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/collections/' + encodeURIComponent(collectionId),
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowCollection = response.body || {};
+
+    logInfo('webflow_get_collection_success', {
+      status: response.status,
+      collectionId: collectionId
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_get_collection_failed', {
+      collectionId: collectionId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:list_collection_items': (c) => `
+function step_action_webflow_list_collection_items(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function resolveCollectionId() {
+    const template = config.collection_id || config.collectionId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow list_collection_items requires a Collection ID.');
+    }
+    return resolved;
+  }
+
+  function resolveNumber(value, fallback) {
+    if (value === null || value === undefined) {
+      return typeof fallback === 'number' ? fallback : 0;
+    }
+    if (typeof value === 'number') {
+      return value;
+    }
+    const resolved = interpolate(String(value), ctx).trim();
+    if (!resolved) {
+      return typeof fallback === 'number' ? fallback : 0;
+    }
+    const parsed = Number(resolved);
+    return isNaN(parsed) ? (typeof fallback === 'number' ? fallback : 0) : parsed;
+  }
+
+  const collectionId = resolveCollectionId();
+  const offset = resolveNumber(config.offset, 0);
+  const limit = resolveNumber(config.limit, 100);
+
+  const params = ['offset=' + Math.max(offset, 0), 'limit=' + Math.min(Math.max(limit, 1), 100)];
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/collections/' + encodeURIComponent(collectionId) + '/items?' + params.join('&'),
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const items = response.body && Array.isArray(response.body.items)
+      ? response.body.items
+      : (Array.isArray(response.body) ? response.body : []);
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowCollectionItems = items;
+    ctx.webflowCollectionCount = items.length;
+
+    logInfo('webflow_list_collection_items_success', {
+      status: response.status,
+      collectionId: collectionId,
+      count: items.length,
+      offset: offset,
+      limit: limit
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_list_collection_items_failed', {
+      collectionId: collectionId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:get_collection_item': (c) => `
+function step_action_webflow_get_collection_item(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function resolveId(value, label) {
+    const template = value || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow get_collection_item requires a ' + label + '.');
+    }
+    return resolved;
+  }
+
+  const collectionId = resolveId(config.collection_id || config.collectionId, 'Collection ID');
+  const itemId = resolveId(config.item_id || config.itemId, 'Item ID');
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url:
+        'https://api.webflow.com/collections/' +
+        encodeURIComponent(collectionId) +
+        '/items/' +
+        encodeURIComponent(itemId),
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowItemId = itemId;
+    ctx.webflowItem = response.body || {};
+
+    logInfo('webflow_get_collection_item_success', {
+      status: response.status,
+      collectionId: collectionId,
+      itemId: itemId
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_get_collection_item_failed', {
+      collectionId: collectionId,
+      itemId: itemId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:create_collection_item': (c) => `
+function step_action_webflow_create_collection_item(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function resolveId(value, label) {
+    const template = value || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow create_collection_item requires ' + label + '.');
+    }
+    return resolved;
+  }
+
+  function resolveBoolean(value, fallback) {
+    if (value === null || value === undefined) {
+      return !!fallback;
+    }
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    const normalized = interpolate(String(value), ctx).trim().toLowerCase();
+    if (!normalized) {
+      return !!fallback;
+    }
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  function resolveStructured(value) {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        result.push(resolveStructured(value[i]));
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+          result[key] = resolveStructured(value[key]);
+        }
+      }
+      return result;
+    }
+    if (typeof value === 'string') {
+      return interpolate(value, ctx);
+    }
+    return value;
+  }
+
+  const collectionId = resolveId(config.collection_id || config.collectionId, 'a Collection ID');
+  const fields = resolveStructured(config.fields) || {};
+  const live = resolveBoolean(config.live, false);
+
+  if (!fields || typeof fields !== 'object' || Object.keys(fields).length === 0) {
+    throw new Error('Webflow create_collection_item requires at least one field value.');
+  }
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url:
+        'https://api.webflow.com/collections/' +
+        encodeURIComponent(collectionId) +
+        '/items?live=' + (live ? 'true' : 'false'),
+      method: 'POST',
+      headers: headers,
+      payload: JSON.stringify({ fields: fields }),
+      contentType: 'application/json'
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const body = response.body || {};
+    const itemId =
+      (body && (body._id || body.id)) ||
+      (body.item && (body.item._id || body.item.id)) ||
+      null;
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowItemId = itemId;
+    ctx.webflowItem = body;
+    ctx.webflowItemPublished = live;
+
+    logInfo('webflow_create_collection_item_success', {
+      status: response.status,
+      collectionId: collectionId,
+      itemId: itemId,
+      live: live
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_create_collection_item_failed', {
+      collectionId: collectionId,
+      live: live,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:update_collection_item': (c) => `
+function step_action_webflow_update_collection_item(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function resolveId(value, label) {
+    const template = value || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow update_collection_item requires ' + label + '.');
+    }
+    return resolved;
+  }
+
+  function resolveBoolean(value, fallback) {
+    if (value === null || value === undefined) {
+      return !!fallback;
+    }
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    const normalized = interpolate(String(value), ctx).trim().toLowerCase();
+    if (!normalized) {
+      return !!fallback;
+    }
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  function resolveStructured(value) {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        result.push(resolveStructured(value[i]));
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+          result[key] = resolveStructured(value[key]);
+        }
+      }
+      return result;
+    }
+    if (typeof value === 'string') {
+      return interpolate(value, ctx);
+    }
+    return value;
+  }
+
+  const collectionId = resolveId(config.collection_id || config.collectionId, 'a Collection ID');
+  const itemId = resolveId(config.item_id || config.itemId, 'an Item ID');
+  const fields = resolveStructured(config.fields) || {};
+  const live = resolveBoolean(config.live, false);
+
+  if (!fields || typeof fields !== 'object' || Object.keys(fields).length === 0) {
+    throw new Error('Webflow update_collection_item requires at least one field value.');
+  }
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url:
+        'https://api.webflow.com/collections/' +
+        encodeURIComponent(collectionId) +
+        '/items/' +
+        encodeURIComponent(itemId) +
+        '?live=' + (live ? 'true' : 'false'),
+      method: 'PUT',
+      headers: headers,
+      payload: JSON.stringify({ fields: fields }),
+      contentType: 'application/json'
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const body = response.body || {};
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowItemId = itemId;
+    ctx.webflowItem = body;
+    ctx.webflowItemPublished = live;
+
+    logInfo('webflow_update_collection_item_success', {
+      status: response.status,
+      collectionId: collectionId,
+      itemId: itemId,
+      live: live
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_update_collection_item_failed', {
+      collectionId: collectionId,
+      itemId: itemId,
+      live: live,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:delete_collection_item': (c) => `
+function step_action_webflow_delete_collection_item(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function resolveId(value, label) {
+    const template = value || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow delete_collection_item requires ' + label + '.');
+    }
+    return resolved;
+  }
+
+  function resolveBoolean(value, fallback) {
+    if (value === null || value === undefined) {
+      return !!fallback;
+    }
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    const normalized = interpolate(String(value), ctx).trim().toLowerCase();
+    if (!normalized) {
+      return !!fallback;
+    }
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  const collectionId = resolveId(config.collection_id || config.collectionId, 'a Collection ID');
+  const itemId = resolveId(config.item_id || config.itemId, 'an Item ID');
+  const live = resolveBoolean(config.live, false);
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url:
+        'https://api.webflow.com/collections/' +
+        encodeURIComponent(collectionId) +
+        '/items/' +
+        encodeURIComponent(itemId) +
+        '?live=' + (live ? 'true' : 'false'),
+      method: 'DELETE',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowCollectionId = collectionId;
+    ctx.webflowItemId = itemId;
+    ctx.webflowItemDeleted = true;
+    ctx.webflowItemPublished = live;
+
+    logInfo('webflow_delete_collection_item_success', {
+      status: response.status,
+      collectionId: collectionId,
+      itemId: itemId,
+      live: live
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_delete_collection_item_failed', {
+      collectionId: collectionId,
+      itemId: itemId,
+      live: live,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:publish_site': (c) => `
+function step_action_webflow_publish_site(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow publish_site requires a Site ID. Configure one or set WEBFLOW_DEFAULT_SITE_ID.');
+  }
+
+  function resolveDomains() {
+    const domainsConfig = config.domains || [];
+    const result = [];
+    if (Array.isArray(domainsConfig)) {
+      for (let i = 0; i < domainsConfig.length; i++) {
+        const entry = domainsConfig[i];
+        if (entry === null || entry === undefined) {
+          continue;
+        }
+        const resolved = typeof entry === 'string' ? interpolate(entry, ctx).trim() : String(entry).trim();
+        if (resolved) {
+          result.push(resolved);
+        }
+      }
+    }
+    return result;
+  }
+
+  const siteId = resolveSiteId();
+  const domains = resolveDomains();
+
+  if (!domains.length) {
+    logWarn('webflow_publish_site_no_domains', {
+      siteId: siteId,
+      message: 'Publishing without explicit domains uses Webflow defaults.'
+    });
+  }
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+  };
+
+  const payload = domains.length ? { domains: domains } : {};
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites/' + encodeURIComponent(siteId) + '/publish',
+      method: 'POST',
+      headers: headers,
+      payload: JSON.stringify(payload),
+      contentType: 'application/json'
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowPublishResponse = response.body || {};
+
+    logInfo('webflow_publish_site_success', {
+      status: response.status,
+      siteId: siteId,
+      domainCount: domains.length
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_publish_site_failed', {
+      siteId: siteId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:list_webhooks': (c) => `
+function step_action_webflow_list_webhooks(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow list_webhooks requires a Site ID. Configure one or set WEBFLOW_DEFAULT_SITE_ID.');
+  }
+
+  const siteId = resolveSiteId();
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites/' + encodeURIComponent(siteId) + '/webhooks',
+      method: 'GET',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const webhooks = Array.isArray(response.body)
+      ? response.body
+      : (response.body && Array.isArray(response.body.webhooks) ? response.body.webhooks : []);
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowWebhooks = webhooks;
+
+    logInfo('webflow_list_webhooks_success', {
+      status: response.status,
+      siteId: siteId,
+      webhookCount: webhooks.length
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_list_webhooks_failed', {
+      siteId: siteId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:create_webhook': (c) => `
+function step_action_webflow_create_webhook(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow create_webhook requires a Site ID. Configure one or set WEBFLOW_DEFAULT_SITE_ID.');
+  }
+
+  function resolveString(value, label) {
+    if (value === null || value === undefined) {
+      throw new Error('Webflow create_webhook requires ' + label + '.');
+    }
+    const resolved = typeof value === 'string' ? interpolate(value, ctx).trim() : String(value).trim();
+    if (!resolved) {
+      throw new Error('Webflow create_webhook requires ' + label + '.');
+    }
+    return resolved;
+  }
+
+  function resolveFilter(value) {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        result.push(resolveFilter(value[i]));
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+          result[key] = resolveFilter(value[key]);
+        }
+      }
+      return result;
+    }
+    if (typeof value === 'string') {
+      return interpolate(value, ctx);
+    }
+    return value;
+  }
+
+  const siteId = resolveSiteId();
+  const triggerType = resolveString(config.triggerType, 'a trigger type');
+  const targetUrl = resolveString(config.url, 'a callback URL');
+  const filter = resolveFilter(config.filter);
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+  };
+
+  const payload = { triggerType: triggerType, url: targetUrl };
+  if (filter && typeof filter === 'object' && Object.keys(filter).length > 0) {
+    payload.filter = filter;
+  }
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url: 'https://api.webflow.com/sites/' + encodeURIComponent(siteId) + '/webhooks',
+      method: 'POST',
+      headers: headers,
+      payload: JSON.stringify(payload),
+      contentType: 'application/json'
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    const body = response.body || {};
+    const webhookId = body && (body._id || body.id) ? (body._id || body.id) : null;
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowWebhookId = webhookId;
+    ctx.webflowWebhook = body;
+
+    logInfo('webflow_create_webhook_success', {
+      status: response.status,
+      siteId: siteId,
+      triggerType: triggerType,
+      webhookId: webhookId
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_create_webhook_failed', {
+      siteId: siteId,
+      triggerType: triggerType,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'action.webflow:delete_webhook': (c) => `
+function step_action_webflow_delete_webhook(ctx) {
+  ctx = ctx || {};
+
+  const accessToken = getSecret('WEBFLOW_API_TOKEN', { connectorKey: 'webflow' });
+  const config = ${JSON.stringify(prepareValueForCode(c ?? {}))};
+
+  function optionalSecret(name) {
+    try {
+      return getSecret(name, { connectorKey: 'webflow' });
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function resolveSiteId() {
+    const template = config.site_id || config.siteId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (resolved) {
+      return resolved;
+    }
+    const fallback = optionalSecret('WEBFLOW_DEFAULT_SITE_ID');
+    if (fallback) {
+      return fallback;
+    }
+    throw new Error('Webflow delete_webhook requires a Site ID. Configure one or set WEBFLOW_DEFAULT_SITE_ID.');
+  }
+
+  function resolveWebhookId() {
+    const template = config.webhook_id || config.webhookId || '';
+    const resolved = template ? interpolate(String(template), ctx).trim() : '';
+    if (!resolved) {
+      throw new Error('Webflow delete_webhook requires a Webhook ID.');
+    }
+    return resolved;
+  }
+
+  const siteId = resolveSiteId();
+  const webhookId = resolveWebhookId();
+
+  const headers = {
+    Authorization: 'Bearer ' + accessToken,
+    'accept-version': '1.0.0',
+    Accept: 'application/json'
+  };
+
+  try {
+    const response = rateLimitAware(() => fetchJson({
+      url:
+        'https://api.webflow.com/sites/' +
+        encodeURIComponent(siteId) +
+        '/webhooks/' +
+        encodeURIComponent(webhookId),
+      method: 'DELETE',
+      headers: headers
+    }), { attempts: 4, initialDelayMs: 750, jitter: 0.25 });
+
+    ctx.webflowSiteId = siteId;
+    ctx.webflowWebhookId = webhookId;
+    ctx.webflowWebhookDeleted = true;
+
+    logInfo('webflow_delete_webhook_success', {
+      status: response.status,
+      siteId: siteId,
+      webhookId: webhookId
+    });
+
+    return ctx;
+  } catch (error) {
+    logError('webflow_delete_webhook_failed', {
+      siteId: siteId,
+      webhookId: webhookId,
+      status: error && error.status ? error.status : null,
+      message: error && error.message ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+`,
+
+  'trigger.webflow:form_submission': (_c) => `
+function trigger_trigger_webflow_form_submission(ctx) {
+  ctx = ctx || {};
+
+  const payload = ctx && ctx.webhookPayload ? ctx.webhookPayload : {};
+  const event = payload && payload.event ? payload.event : ctx.event || {};
+
+  ctx.webflowTrigger = 'form_submission';
+  ctx.webflowFormSubmission = payload;
+  ctx.webflowEvent = event;
+
+  logInfo('webflow_form_submission_received', {
+    trigger: 'form_submission',
+    formName: payload && payload.formName ? payload.formName : null
+  });
+
+  return ctx;
+}
+`,
+
+  'trigger.webflow:collection_item_created': (_c) => `
+function trigger_trigger_webflow_collection_item_created(ctx) {
+  ctx = ctx || {};
+
+  const payload = ctx && ctx.webhookPayload ? ctx.webhookPayload : {};
+  const event = payload && payload.event ? payload.event : ctx.event || {};
+
+  ctx.webflowTrigger = 'collection_item_created';
+  ctx.webflowEvent = event;
+  ctx.webflowCollectionItem = payload;
+
+  logInfo('webflow_collection_item_created_received', {
+    trigger: 'collection_item_created',
+    collectionId: payload && payload.collectionId ? payload.collectionId : null,
+    itemId: payload && payload._id ? payload._id : (payload && payload.id ? payload.id : null)
+  });
+
+  return ctx;
+}
+`,
+
+  'trigger.webflow:collection_item_changed': (_c) => `
+function trigger_trigger_webflow_collection_item_changed(ctx) {
+  ctx = ctx || {};
+
+  const payload = ctx && ctx.webhookPayload ? ctx.webhookPayload : {};
+  const event = payload && payload.event ? payload.event : ctx.event || {};
+
+  ctx.webflowTrigger = 'collection_item_changed';
+  ctx.webflowEvent = event;
+  ctx.webflowCollectionItem = payload;
+
+  logInfo('webflow_collection_item_changed_received', {
+    trigger: 'collection_item_changed',
+    collectionId: payload && payload.collectionId ? payload.collectionId : null,
+    itemId: payload && payload._id ? payload._id : (payload && payload.id ? payload.id : null)
+  });
+
+  return ctx;
+}
+`,
+
+  'trigger.webflow:site_published': (_c) => `
+function trigger_trigger_webflow_site_published(ctx) {
+  ctx = ctx || {};
+
+  const payload = ctx && ctx.webhookPayload ? ctx.webhookPayload : {};
+  const event = payload && payload.event ? payload.event : ctx.event || {};
+
+  ctx.webflowTrigger = 'site_published';
+  ctx.webflowEvent = event;
+  ctx.webflowPublishDetails = payload;
+
+  logInfo('webflow_site_published_received', {
+    trigger: 'site_published',
+    siteId: payload && payload.siteId ? payload.siteId : null
+  });
+
+  return ctx;
 }
 `,
   'action.slack:send_message': (c) => `


### PR DESCRIPTION
## Summary
- implement Webflow Apps Script handlers for actions and triggers using the REST API
- add Apps Script dry-run fixtures and Vitest coverage for CMS item and webhook workflows
- document the required Webflow Script Properties for API tokens and default site IDs

## Testing
- `npx vitest run server/workflow/__tests__/apps-script.webflow.test.ts` *(fails: package registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecb9c3e7288331ae6220c6efc0c4fa