### PR TITLE
Mask Apps Script logs and forward telemetry

### DIFF
--- a/server/workflow/__tests__/compile-to-appsscript.helpers.test.ts
+++ b/server/workflow/__tests__/compile-to-appsscript.helpers.test.ts
@@ -16,6 +16,8 @@ describe('appsScriptHttpHelpers', () => {
     );
     expect(helpers).toContain('var transport = __resolveLogTransport();');
     expect(helpers).toContain('UrlFetchApp.fetch(transport.url');
+    expect(helpers).toContain("'CENTRAL_TELEMETRY_ENDPOINT'");
+    expect(helpers).toContain("logStructured('INFO', event, mask(details));");
     expect(helpers.trim()).toMatchInlineSnapshot(
 `var __HTTP_RETRY_DEFAULTS = {
   maxAttempts: 5,
@@ -110,6 +112,10 @@ function __resolveLogTransport() {
   try {
     if (typeof CENTRAL_LOG_TRANSPORT !== 'undefined' && CENTRAL_LOG_TRANSPORT) {
       candidate = CENTRAL_LOG_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_TRANSPORT !== 'undefined' && CENTRAL_TELEMETRY_TRANSPORT) {
+      candidate = CENTRAL_TELEMETRY_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_ENDPOINT !== 'undefined' && CENTRAL_TELEMETRY_ENDPOINT) {
+      candidate = { url: CENTRAL_TELEMETRY_ENDPOINT };
     } else if (typeof LOG_TRANSPORT_URL !== 'undefined' && LOG_TRANSPORT_URL) {
       candidate = { url: LOG_TRANSPORT_URL };
     } else if (typeof APPS_SCRIPT_LOG_TRANSPORT !== 'undefined' && APPS_SCRIPT_LOG_TRANSPORT) {
@@ -122,6 +128,7 @@ function __resolveLogTransport() {
     try {
       var props = PropertiesService.getScriptProperties();
       var urlCandidates = [
+        'CENTRAL_TELEMETRY_ENDPOINT',
         'CENTRAL_LOG_TRANSPORT_URL',
         'APPS_SCRIPT_LOG_TRANSPORT_URL',
         'CENTRAL_LOGGING_ENDPOINT',
@@ -136,7 +143,7 @@ function __resolveLogTransport() {
         }
       }
       if (!candidate) {
-        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
+        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'CENTRAL_TELEMETRY_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
         for (var j = 0; j < objectCandidates.length; j++) {
           var raw = props.getProperty(objectCandidates[j]);
           if (!raw) {
@@ -298,15 +305,15 @@ function logStructured(level, event, details) {
 }
 
 function logInfo(event, details) {
-  logStructured('INFO', event, details);
+  logStructured('INFO', event, mask(details));
 }
 
 function logWarn(event, details) {
-  logStructured('WARN', event, details);
+  logStructured('WARN', event, mask(details));
 }
 
 function logError(event, details) {
-  logStructured('ERROR', event, details);
+  logStructured('ERROR', event, mask(details));
 }
 
 logStructured.mask = mask;

--- a/server/workflow/__tests__/fixtures/apps-script/__snapshots__/tier-0-critical.Code.gs.snap
+++ b/server/workflow/__tests__/fixtures/apps-script/__snapshots__/tier-0-critical.Code.gs.snap
@@ -102,6 +102,10 @@ function __resolveLogTransport() {
   try {
     if (typeof CENTRAL_LOG_TRANSPORT !== 'undefined' && CENTRAL_LOG_TRANSPORT) {
       candidate = CENTRAL_LOG_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_TRANSPORT !== 'undefined' && CENTRAL_TELEMETRY_TRANSPORT) {
+      candidate = CENTRAL_TELEMETRY_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_ENDPOINT !== 'undefined' && CENTRAL_TELEMETRY_ENDPOINT) {
+      candidate = { url: CENTRAL_TELEMETRY_ENDPOINT };
     } else if (typeof LOG_TRANSPORT_URL !== 'undefined' && LOG_TRANSPORT_URL) {
       candidate = { url: LOG_TRANSPORT_URL };
     } else if (typeof APPS_SCRIPT_LOG_TRANSPORT !== 'undefined' && APPS_SCRIPT_LOG_TRANSPORT) {
@@ -114,6 +118,7 @@ function __resolveLogTransport() {
     try {
       var props = PropertiesService.getScriptProperties();
       var urlCandidates = [
+        'CENTRAL_TELEMETRY_ENDPOINT',
         'CENTRAL_LOG_TRANSPORT_URL',
         'APPS_SCRIPT_LOG_TRANSPORT_URL',
         'CENTRAL_LOGGING_ENDPOINT',
@@ -128,7 +133,7 @@ function __resolveLogTransport() {
         }
       }
       if (!candidate) {
-        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
+        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'CENTRAL_TELEMETRY_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
         for (var j = 0; j < objectCandidates.length; j++) {
           var raw = props.getProperty(objectCandidates[j]);
           if (!raw) {
@@ -290,15 +295,15 @@ function logStructured(level, event, details) {
 }
 
 function logInfo(event, details) {
-  logStructured('INFO', event, details);
+  logStructured('INFO', event, mask(details));
 }
 
 function logWarn(event, details) {
-  logStructured('WARN', event, details);
+  logStructured('WARN', event, mask(details));
 }
 
 function logError(event, details) {
-  logStructured('ERROR', event, details);
+  logStructured('ERROR', event, mask(details));
 }
 
 logStructured.mask = mask;

--- a/server/workflow/__tests__/fixtures/apps-script/__snapshots__/tier-1-growth.Code.gs.snap
+++ b/server/workflow/__tests__/fixtures/apps-script/__snapshots__/tier-1-growth.Code.gs.snap
@@ -102,6 +102,10 @@ function __resolveLogTransport() {
   try {
     if (typeof CENTRAL_LOG_TRANSPORT !== 'undefined' && CENTRAL_LOG_TRANSPORT) {
       candidate = CENTRAL_LOG_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_TRANSPORT !== 'undefined' && CENTRAL_TELEMETRY_TRANSPORT) {
+      candidate = CENTRAL_TELEMETRY_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_ENDPOINT !== 'undefined' && CENTRAL_TELEMETRY_ENDPOINT) {
+      candidate = { url: CENTRAL_TELEMETRY_ENDPOINT };
     } else if (typeof LOG_TRANSPORT_URL !== 'undefined' && LOG_TRANSPORT_URL) {
       candidate = { url: LOG_TRANSPORT_URL };
     } else if (typeof APPS_SCRIPT_LOG_TRANSPORT !== 'undefined' && APPS_SCRIPT_LOG_TRANSPORT) {
@@ -114,6 +118,7 @@ function __resolveLogTransport() {
     try {
       var props = PropertiesService.getScriptProperties();
       var urlCandidates = [
+        'CENTRAL_TELEMETRY_ENDPOINT',
         'CENTRAL_LOG_TRANSPORT_URL',
         'APPS_SCRIPT_LOG_TRANSPORT_URL',
         'CENTRAL_LOGGING_ENDPOINT',
@@ -128,7 +133,7 @@ function __resolveLogTransport() {
         }
       }
       if (!candidate) {
-        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
+        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'CENTRAL_TELEMETRY_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
         for (var j = 0; j < objectCandidates.length; j++) {
           var raw = props.getProperty(objectCandidates[j]);
           if (!raw) {
@@ -290,15 +295,15 @@ function logStructured(level, event, details) {
 }
 
 function logInfo(event, details) {
-  logStructured('INFO', event, details);
+  logStructured('INFO', event, mask(details));
 }
 
 function logWarn(event, details) {
-  logStructured('WARN', event, details);
+  logStructured('WARN', event, mask(details));
 }
 
 function logError(event, details) {
-  logStructured('ERROR', event, details);
+  logStructured('ERROR', event, mask(details));
 }
 
 logStructured.mask = mask;

--- a/server/workflow/__tests__/fixtures/apps-script/__snapshots__/tier-1-storage.Code.gs.snap
+++ b/server/workflow/__tests__/fixtures/apps-script/__snapshots__/tier-1-storage.Code.gs.snap
@@ -102,6 +102,10 @@ function __resolveLogTransport() {
   try {
     if (typeof CENTRAL_LOG_TRANSPORT !== 'undefined' && CENTRAL_LOG_TRANSPORT) {
       candidate = CENTRAL_LOG_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_TRANSPORT !== 'undefined' && CENTRAL_TELEMETRY_TRANSPORT) {
+      candidate = CENTRAL_TELEMETRY_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_ENDPOINT !== 'undefined' && CENTRAL_TELEMETRY_ENDPOINT) {
+      candidate = { url: CENTRAL_TELEMETRY_ENDPOINT };
     } else if (typeof LOG_TRANSPORT_URL !== 'undefined' && LOG_TRANSPORT_URL) {
       candidate = { url: LOG_TRANSPORT_URL };
     } else if (typeof APPS_SCRIPT_LOG_TRANSPORT !== 'undefined' && APPS_SCRIPT_LOG_TRANSPORT) {
@@ -114,6 +118,7 @@ function __resolveLogTransport() {
     try {
       var props = PropertiesService.getScriptProperties();
       var urlCandidates = [
+        'CENTRAL_TELEMETRY_ENDPOINT',
         'CENTRAL_LOG_TRANSPORT_URL',
         'APPS_SCRIPT_LOG_TRANSPORT_URL',
         'CENTRAL_LOGGING_ENDPOINT',
@@ -128,7 +133,7 @@ function __resolveLogTransport() {
         }
       }
       if (!candidate) {
-        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
+        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'CENTRAL_TELEMETRY_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
         for (var j = 0; j < objectCandidates.length; j++) {
           var raw = props.getProperty(objectCandidates[j]);
           if (!raw) {
@@ -290,15 +295,15 @@ function logStructured(level, event, details) {
 }
 
 function logInfo(event, details) {
-  logStructured('INFO', event, details);
+  logStructured('INFO', event, mask(details));
 }
 
 function logWarn(event, details) {
-  logStructured('WARN', event, details);
+  logStructured('WARN', event, mask(details));
 }
 
 function logError(event, details) {
-  logStructured('ERROR', event, details);
+  logStructured('ERROR', event, mask(details));
 }
 
 logStructured.mask = mask;

--- a/server/workflow/__tests__/fixtures/apps-script/__snapshots__/tier-2-long-tail.Code.gs.snap
+++ b/server/workflow/__tests__/fixtures/apps-script/__snapshots__/tier-2-long-tail.Code.gs.snap
@@ -102,6 +102,10 @@ function __resolveLogTransport() {
   try {
     if (typeof CENTRAL_LOG_TRANSPORT !== 'undefined' && CENTRAL_LOG_TRANSPORT) {
       candidate = CENTRAL_LOG_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_TRANSPORT !== 'undefined' && CENTRAL_TELEMETRY_TRANSPORT) {
+      candidate = CENTRAL_TELEMETRY_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_ENDPOINT !== 'undefined' && CENTRAL_TELEMETRY_ENDPOINT) {
+      candidate = { url: CENTRAL_TELEMETRY_ENDPOINT };
     } else if (typeof LOG_TRANSPORT_URL !== 'undefined' && LOG_TRANSPORT_URL) {
       candidate = { url: LOG_TRANSPORT_URL };
     } else if (typeof APPS_SCRIPT_LOG_TRANSPORT !== 'undefined' && APPS_SCRIPT_LOG_TRANSPORT) {
@@ -114,6 +118,7 @@ function __resolveLogTransport() {
     try {
       var props = PropertiesService.getScriptProperties();
       var urlCandidates = [
+        'CENTRAL_TELEMETRY_ENDPOINT',
         'CENTRAL_LOG_TRANSPORT_URL',
         'APPS_SCRIPT_LOG_TRANSPORT_URL',
         'CENTRAL_LOGGING_ENDPOINT',
@@ -128,7 +133,7 @@ function __resolveLogTransport() {
         }
       }
       if (!candidate) {
-        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
+        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'CENTRAL_TELEMETRY_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
         for (var j = 0; j < objectCandidates.length; j++) {
           var raw = props.getProperty(objectCandidates[j]);
           if (!raw) {
@@ -290,15 +295,15 @@ function logStructured(level, event, details) {
 }
 
 function logInfo(event, details) {
-  logStructured('INFO', event, details);
+  logStructured('INFO', event, mask(details));
 }
 
 function logWarn(event, details) {
-  logStructured('WARN', event, details);
+  logStructured('WARN', event, mask(details));
 }
 
 function logError(event, details) {
-  logStructured('ERROR', event, details);
+  logStructured('ERROR', event, mask(details));
 }
 
 logStructured.mask = mask;

--- a/server/workflow/compile-to-appsscript.ts
+++ b/server/workflow/compile-to-appsscript.ts
@@ -264,6 +264,10 @@ function __resolveLogTransport() {
   try {
     if (typeof CENTRAL_LOG_TRANSPORT !== 'undefined' && CENTRAL_LOG_TRANSPORT) {
       candidate = CENTRAL_LOG_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_TRANSPORT !== 'undefined' && CENTRAL_TELEMETRY_TRANSPORT) {
+      candidate = CENTRAL_TELEMETRY_TRANSPORT;
+    } else if (typeof CENTRAL_TELEMETRY_ENDPOINT !== 'undefined' && CENTRAL_TELEMETRY_ENDPOINT) {
+      candidate = { url: CENTRAL_TELEMETRY_ENDPOINT };
     } else if (typeof LOG_TRANSPORT_URL !== 'undefined' && LOG_TRANSPORT_URL) {
       candidate = { url: LOG_TRANSPORT_URL };
     } else if (typeof APPS_SCRIPT_LOG_TRANSPORT !== 'undefined' && APPS_SCRIPT_LOG_TRANSPORT) {
@@ -276,6 +280,7 @@ function __resolveLogTransport() {
     try {
       var props = PropertiesService.getScriptProperties();
       var urlCandidates = [
+        'CENTRAL_TELEMETRY_ENDPOINT',
         'CENTRAL_LOG_TRANSPORT_URL',
         'APPS_SCRIPT_LOG_TRANSPORT_URL',
         'CENTRAL_LOGGING_ENDPOINT',
@@ -290,7 +295,7 @@ function __resolveLogTransport() {
         }
       }
       if (!candidate) {
-        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
+        var objectCandidates = ['CENTRAL_LOG_TRANSPORT', 'CENTRAL_TELEMETRY_TRANSPORT', 'APPS_SCRIPT_LOG_TRANSPORT'];
         for (var j = 0; j < objectCandidates.length; j++) {
           var raw = props.getProperty(objectCandidates[j]);
           if (!raw) {
@@ -452,15 +457,15 @@ function logStructured(level, event, details) {
 }
 
 function logInfo(event, details) {
-  logStructured('INFO', event, details);
+  logStructured('INFO', event, mask(details));
 }
 
 function logWarn(event, details) {
-  logStructured('WARN', event, details);
+  logStructured('WARN', event, mask(details));
 }
 
 function logError(event, details) {
-  logStructured('ERROR', event, details);
+  logStructured('ERROR', event, mask(details));
 }
 
 logStructured.mask = mask;


### PR DESCRIPTION
## Summary
- mask structured log helper calls so console logging redacts sensitive details
- extend the Apps Script log transport resolver to honor CENTRAL_TELEMETRY endpoint/transport values
- refresh helper tests and snapshots to capture the new logging behavior

## Testing
- npm exec vitest run server/workflow/__tests__/compile-to-appsscript.helpers.test.ts *(fails: npm registry access forbidden in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecbfd9e80c8331b6a53b9aa01d259e