### PR TITLE
Document Apps Script REAL_OPS coverage workflow

### DIFF
--- a/docs/apps-script-rollout/commands.md
+++ b/docs/apps-script-rollout/commands.md
@@ -13,6 +13,15 @@ The npm scripts below power the Apps Script rollout workflow. Use this quick ref
   - Console table showing every operation with runtime availability and enablement flags.
   - Writes `production/reports/apps-script-runtime-coverage.csv` by default (override with `--output <path>`).
 
+### `npm run report:apps-script-real-ops`
+- **Purpose:** Compares Apps Script-capable actions and triggers defined in `connectors/*/definition.json` against the `REAL_OPS` builders compiled in `server/workflow/compile-to-appsscript.ts`. Use it to confirm every Apps Script operation has a native implementation before promoting connectors.
+- **Prerequisites:**
+  - Install dependencies (`npm install`) so `npx tsx` can execute TypeScript entry points.
+  - Keep `server/workflow/compile-to-appsscript.ts` and `server/workflow/realOps.generated.ts` in sync (`npm run build:apps-script`) so coverage numbers reflect reality.
+- **Outputs:**
+  - Logs a coverage summary (`covered/total` operations plus per-connector gaps) and fails the process when coverage drops below `APPS_SCRIPT_REAL_OPS_TARGET` (defaults to `0`).
+  - Writes both `production/reports/apps-script-real-ops-coverage.json` (detailed connector breakdown) and `production/reports/apps-script-real-ops-coverage.csv` (spreadsheet-friendly view) for handoffs.
+
 ## Prioritization and backlog
 
 ### `npm run prioritize:apps-script`

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "observability:check": "tsx scripts/observability-check.ts",
     "report:runtime": "tsx scripts/connector-runtime-status.ts",
     "report:apps-script-coverage": "tsx scripts/report-apps-script-coverage.ts",
-    "report:apps-script-real-ops": "node --loader ./scripts/ts-loader.mjs scripts/apps-script-coverage.ts",
+    "report:apps-script-real-ops": "npx tsx scripts/apps-script-coverage.ts",
     "prioritize:apps-script": "node scripts/apps-script-prioritize-connectors.mjs",
     "update:apps-script-backlog": "node scripts/update-apps-script-backlog.mjs",
     "check:apps-script-backlog": "node scripts/check-apps-script-backlog.mjs",

--- a/production/reports/apps-script-real-ops-coverage.csv
+++ b/production/reports/apps-script-real-ops-coverage.csv
@@ -136,7 +136,7 @@ connector_id,connector_name,total_operations,covered_operations,coverage_ratio,m
 "trello","Trello","24","24","1.0000",""
 "trello-enhanced","Trello Enhanced","12","12","1.0000",""
 "twilio","Twilio","15","15","1.0000",""
-"typeform","Typeform","2","2","1.0000",""
+"typeform","Typeform","3","3","1.0000",""
 "victorops","VictorOps","15","15","1.0000",""
 "webex","Cisco Webex","13","13","1.0000",""
 "webflow","Webflow","18","18","1.0000",""

--- a/production/reports/apps-script-real-ops-coverage.json
+++ b/production/reports/apps-script-real-ops-coverage.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2025-10-13T05:00:38.160Z",
+  "generatedAt": "2025-10-13T10:18:50.080Z",
   "target": 0,
   "totals": {
-    "operations": 1861,
-    "covered": 1861,
+    "operations": 1862,
+    "covered": 1862,
     "missing": 0,
     "ratio": 1,
     "connectors": 149,
@@ -9845,11 +9845,16 @@
     {
       "connectorId": "typeform",
       "connectorName": "Typeform",
-      "totalOperations": 2,
-      "coveredOperations": 2,
+      "totalOperations": 3,
+      "coveredOperations": 3,
       "missingOperations": [],
       "coverageRatio": 1,
       "operations": [
+        {
+          "key": "action.typeform:create_form",
+          "type": "action",
+          "id": "create_form"
+        },
         {
           "key": "trigger.typeform:form_created",
           "type": "trigger",


### PR DESCRIPTION
## Summary
- switch the Apps Script REAL_OPS report npm script to run through `npx tsx`
- document how to run and interpret the REAL_OPS coverage check alongside other rollout commands
- refresh the JSON and CSV coverage artefacts after regenerating the report

## Testing
- node --loader ./scripts/ts-loader.mjs scripts/apps-script-coverage.ts

------
https://chatgpt.com/codex/tasks/task_e_68ecd15c0a7c8331b903e5d5bc81363b