### PR TITLE
Add Apps Script coverage enforcement to CI

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -35,3 +35,111 @@ jobs:
           QUEUE_REDIS_HOST: 127.0.0.1
           QUEUE_REDIS_PORT: 6379
         run: npm run ci:smoke-local
+
+  apps-script-coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm install
+
+      - name: Prepare coverage workspace
+        run: mkdir -p coverage
+
+      - name: Fetch baseline Apps Script coverage
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1 || true
+          if git show origin/${{ github.base_ref }}:production/reports/apps-script-runtime-coverage.json > coverage/apps-script-runtime-coverage.base.json 2>/dev/null; then
+            echo "Baseline Apps Script coverage loaded."
+          else
+            echo '{}' > coverage/apps-script-runtime-coverage.base.json
+            echo "No baseline coverage found for ${GITHUB_BASE_REF:-base}; using empty summary." >&2
+          fi
+
+      - name: Default baseline Apps Script coverage
+        if: github.event_name != 'pull_request'
+        run: echo '{}' > coverage/apps-script-runtime-coverage.base.json
+
+      - name: Generate Apps Script coverage report
+        id: coverage
+        continue-on-error: true
+        env:
+          APPS_SCRIPT_COVERAGE_TARGET: '1'
+        run: |
+          npm run report:apps-script-coverage -- --json coverage/apps-script-runtime-coverage.json --csv coverage/apps-script-runtime-coverage.csv
+
+      - name: Upload Apps Script coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: apps-script-coverage
+          if-no-files-found: warn
+          path: |
+            coverage/apps-script-runtime-coverage.json
+            coverage/apps-script-runtime-coverage.csv
+
+      - name: Summarize Apps Script coverage
+        if: always()
+        id: coverage-summary
+        run: |
+          node scripts/summarize-apps-script-coverage.js \
+            --current coverage/apps-script-runtime-coverage.json \
+            --baseline coverage/apps-script-runtime-coverage.base.json
+
+      - name: Post Apps Script coverage comment
+        if: github.event_name == 'pull_request' && steps.coverage-summary.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          COVERAGE_COMMENT: ${{ steps.coverage-summary.outputs.comment }}
+        with:
+          script: |
+            const marker = '<!-- apps-script-coverage -->';
+            const body = process.env.COVERAGE_COMMENT;
+            if (!body) {
+              core.warning('No Apps Script coverage comment body was generated.');
+              return;
+            }
+
+            const finalBody = body.includes(marker) ? body : `${marker}\n${body}`;
+            const { owner, repo, number } = context.issue;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(comment => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body: finalBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: number,
+                body: finalBody,
+              });
+            }
+
+      - name: Fail if Apps Script coverage is below target
+        if: steps.coverage.outcome == 'failure'
+        run: |
+          echo 'Apps Script coverage is below the configured target.' >&2
+          exit 1

--- a/scripts/summarize-apps-script-coverage.js
+++ b/scripts/summarize-apps-script-coverage.js
@@ -1,0 +1,144 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
+
+const parseCliOptions = () => {
+  const { values } = parseArgs({
+    options: {
+      current: { type: 'string' },
+      baseline: { type: 'string' },
+      limit: { type: 'string' },
+    },
+  });
+
+  if (typeof values.current !== 'string' || values.current.trim() === '') {
+    throw new Error('Missing required --current option for Apps Script coverage summary.');
+  }
+
+  return {
+    currentPath: values.current,
+    baselinePath:
+      typeof values.baseline === 'string' && values.baseline.trim() !== ''
+        ? values.baseline
+        : undefined,
+    gapLimit:
+      typeof values.limit === 'string' && values.limit.trim() !== ''
+        ? Math.max(Number.parseInt(values.limit, 10) || 0, 0)
+        : 5,
+  };
+};
+
+const readSummary = async path => {
+  if (!path) {
+    return undefined;
+  }
+
+  try {
+    const content = await readFile(path, 'utf8');
+    if (!content || content.trim() === '') {
+      return undefined;
+    }
+
+    return JSON.parse(content);
+  } catch (error) {
+    return undefined;
+  }
+};
+
+const toPercentage = value => `${(value * 100).toFixed(2)}%`;
+
+const formatSigned = (value, decimals = 0, suffix = '') => {
+  const fixed = value.toFixed(decimals);
+  const prefix = value > 0 ? '+' : '';
+  return `${prefix}${fixed}${suffix}`;
+};
+
+const buildCoverageCell = coverage =>
+  `${coverage.enabled}/${coverage.total} (${toPercentage(coverage.ratio)})`;
+
+const buildConnectorCell = coverage =>
+  `${coverage.full}/${coverage.total} (${toPercentage(coverage.ratio)})`;
+
+const buildDeltaCell = (current, previous, key, unit) => {
+  if (!previous) {
+    return 'N/A';
+  }
+
+  const countDelta = current[key] - previous[key];
+  const ratioDelta = (current.ratio - previous.ratio) * 100;
+  return `${formatSigned(countDelta, 0, ` ${unit}`)} (${formatSigned(ratioDelta, 2, 'pp')})`;
+};
+
+const formatGapLine = gap => {
+  const enabled = `${gap.appsScriptEnabled}/${gap.totalOperations}`;
+  const missing = Math.max(gap.totalOperations - gap.appsScriptEnabled, 0);
+  return `- ${gap.app}: ${enabled} operations enabled (${missing} missing)`;
+};
+
+const run = async () => {
+  const options = parseCliOptions();
+  const current = await readSummary(options.currentPath);
+
+  if (!current) {
+    throw new Error('Unable to read current Apps Script coverage summary.');
+  }
+
+  const baseline = await readSummary(options.baselinePath);
+  const operations = current.coverage.operations;
+  const connectors = current.coverage.connectors;
+  const baselineOperations = baseline?.coverage?.operations;
+  const baselineConnectors = baseline?.coverage?.connectors;
+
+  const meetsTarget = operations.ratio + Number.EPSILON >= current.target;
+
+  const hasBaselineOps =
+    typeof baselineOperations?.enabled === 'number' &&
+    typeof baselineOperations?.total === 'number' &&
+    typeof baselineOperations?.ratio === 'number';
+  const hasBaselineConnectors =
+    typeof baselineConnectors?.full === 'number' &&
+    typeof baselineConnectors?.total === 'number' &&
+    typeof baselineConnectors?.ratio === 'number';
+
+  const table = [
+    '| Metric | Base | PR | Δ |',
+    '| --- | --- | --- | --- |',
+    `| Operations enabled | ${hasBaselineOps ? buildCoverageCell(baselineOperations) : 'N/A'} | ${buildCoverageCell(operations)} | ${buildDeltaCell(operations, hasBaselineOps ? baselineOperations : undefined, 'enabled', 'ops')} |`,
+    `| Full coverage connectors | ${hasBaselineConnectors ? buildConnectorCell(baselineConnectors) : 'N/A'} | ${buildConnectorCell(connectors)} | ${buildDeltaCell(connectors, hasBaselineConnectors ? baselineConnectors : undefined, 'full', 'connectors')} |`,
+  ];
+
+  const lines = ['<!-- apps-script-coverage -->', '### Apps Script Coverage', '', `${meetsTarget ? '✅' : '❌'} Operations coverage ${toPercentage(operations.ratio)} (target ${toPercentage(current.target)}).`, '', ...table];
+
+  if (current.gaps?.length > 0) {
+    const limit = options.gapLimit > 0 ? options.gapLimit : current.gaps.length;
+    const visible = current.gaps.slice(0, limit);
+    lines.push('', `**Connectors missing full coverage (top ${visible.length}):**`);
+    for (const gap of visible) {
+      lines.push(formatGapLine(gap));
+    }
+
+    const remaining = current.gaps.length - visible.length;
+    if (remaining > 0) {
+      lines.push('', `...and ${remaining} more connector${remaining === 1 ? '' : 's'}.`);
+    }
+  } else {
+    lines.push('', 'All connectors have full coverage. ✅');
+  }
+
+  const comment = lines.join('\n');
+  console.log(comment);
+
+  if (process.env.GITHUB_OUTPUT) {
+    const delimiter = 'COVERAGE_COMMENT';
+    await writeFile(
+      process.env.GITHUB_OUTPUT,
+      `comment<<${delimiter}\n${comment}\n${delimiter}\nstatus=${meetsTarget ? 'pass' : 'fail'}\n`,
+      { flag: 'a' },
+    );
+  }
+};
+
+run().catch(error => {
+  console.error('Failed to summarize Apps Script coverage.');
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a dedicated workflow job that runs the Apps Script coverage report on every PR and uploads the CSV/JSON artifacts
- generate a markdown summary with coverage deltas for reviewers and post/update a PR comment automatically
- ensure the workflow fails when coverage drops below the configured target while still publishing the artifacts for inspection

## Testing
- Not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ecd15e57cc83318f12fd2eb3707ec9