### PR TITLE
Add Adobe Sign Apps Script handlers and tests

### DIFF
--- a/docs/apps-script-rollout/script-properties.md
+++ b/docs/apps-script-rollout/script-properties.md
@@ -21,7 +21,7 @@ The table below is regenerated automatically. Required properties appear in the 
 | activecampaign | `ACTIVECAMPAIGN_API_KEY`<br>`ACTIVECAMPAIGN_API_URL` | — | — |
 | adobe-acrobat | `ADOBE_PDF_CLIENT_ID`<br>`ADOBE_PDF_CLIENT_SECRET` | — | — |
 | adobe-creative | `ADOBE_CREATIVE_ACCESS_TOKEN` | — | — |
-| adobe-sign | `ADOBE_SIGN_ACCESS_TOKEN` | — | — |
+| adobe-sign | `ADOBE_SIGN_ACCESS_TOKEN` | `ADOBE_SIGN_REFRESH_TOKEN`<br>`ADOBE_SIGN_CLIENT_ID`<br>`ADOBE_SIGN_CLIENT_SECRET`<br>`ADOBE_SIGN_BASE_URL` (default `https://api.na1.echosign.com/api/rest/v6`)<br>`ADOBE_SIGN_TOKEN_URL` (default `https://api.na1.echosign.com/oauth/token`)<br>`ADOBE_SIGN_ACCOUNT_ID` | `ADOBE_SIGN_BASE_URL`, `ADOBE_SIGN_TOKEN_URL` |
 | Airtable | `AIRTABLE_API_KEY`<br>`AIRTABLE_BASE_ID` | — | — |
 | amazon | `AMAZON_ACCESS_KEY`<br>`AMAZON_SECRET_KEY` | — | — |
 | amplitude | `AMPLITUDE_API_KEY` | — | — |

--- a/production/reports/apps-script-properties.json
+++ b/production/reports/apps-script-properties.json
@@ -121,66 +121,107 @@
       ],
       "properties": [
         {
-          "name": "TEAMWORK_API_TOKEN",
+          "name": "ADOBE_SIGN_ACCESS_TOKEN",
           "optional": false,
           "operations": [
-            "action.teamwork:create_milestone",
-            "action.teamwork:create_project",
-            "action.teamwork:create_task",
-            "action.teamwork:create_time_entry",
-            "action.teamwork:get_project",
-            "action.teamwork:get_task",
-            "action.teamwork:get_time_entry",
-            "action.teamwork:list_milestones",
-            "action.teamwork:list_projects",
-            "action.teamwork:list_tasks",
-            "action.teamwork:list_time_entries",
-            "action.teamwork:test_connection",
-            "action.teamwork:update_project",
-            "action.teamwork:update_task"
-          ],
-          "triggers": [
-            "trigger.teamwork:project_created",
-            "trigger.teamwork:task_completed",
-            "trigger.teamwork:task_created",
-            "trigger.teamwork:time_entry_created"
+            "action.adobesign:cancel_agreement",
+            "action.adobesign:create_agreement",
+            "action.adobesign:get_agreement",
+            "action.adobesign:send_agreement",
+            "action.adobesign:test_connection"
           ],
           "contexts": [
-            "getSecret"
+            "readScriptProperty"
           ]
         },
         {
-          "name": "TEAMWORK_SITE_URL",
-          "optional": false,
+          "name": "ADOBE_SIGN_REFRESH_TOKEN",
+          "optional": true,
           "operations": [
-            "action.teamwork:create_milestone",
-            "action.teamwork:create_project",
-            "action.teamwork:create_task",
-            "action.teamwork:create_time_entry",
-            "action.teamwork:get_project",
-            "action.teamwork:get_task",
-            "action.teamwork:get_time_entry",
-            "action.teamwork:list_milestones",
-            "action.teamwork:list_projects",
-            "action.teamwork:list_tasks",
-            "action.teamwork:list_time_entries",
-            "action.teamwork:test_connection",
-            "action.teamwork:update_project",
-            "action.teamwork:update_task"
-          ],
-          "triggers": [
-            "trigger.teamwork:project_created",
-            "trigger.teamwork:task_completed",
-            "trigger.teamwork:task_created",
-            "trigger.teamwork:time_entry_created"
+            "action.adobesign:cancel_agreement",
+            "action.adobesign:create_agreement",
+            "action.adobesign:get_agreement",
+            "action.adobesign:send_agreement",
+            "action.adobesign:test_connection"
           ],
           "contexts": [
-            "getSecret"
+            "readScriptProperty"
+          ]
+        },
+        {
+          "name": "ADOBE_SIGN_CLIENT_ID",
+          "optional": true,
+          "operations": [
+            "action.adobesign:cancel_agreement",
+            "action.adobesign:create_agreement",
+            "action.adobesign:get_agreement",
+            "action.adobesign:send_agreement",
+            "action.adobesign:test_connection"
+          ],
+          "contexts": [
+            "readScriptProperty"
+          ]
+        },
+        {
+          "name": "ADOBE_SIGN_CLIENT_SECRET",
+          "optional": true,
+          "operations": [
+            "action.adobesign:cancel_agreement",
+            "action.adobesign:create_agreement",
+            "action.adobesign:get_agreement",
+            "action.adobesign:send_agreement",
+            "action.adobesign:test_connection"
+          ],
+          "contexts": [
+            "readScriptProperty"
+          ]
+        },
+        {
+          "name": "ADOBE_SIGN_BASE_URL",
+          "optional": true,
+          "operations": [
+            "action.adobesign:cancel_agreement",
+            "action.adobesign:create_agreement",
+            "action.adobesign:get_agreement",
+            "action.adobesign:send_agreement",
+            "action.adobesign:test_connection"
+          ],
+          "contexts": [
+            "readScriptProperty"
+          ]
+        },
+        {
+          "name": "ADOBE_SIGN_TOKEN_URL",
+          "optional": true,
+          "operations": [
+            "action.adobesign:cancel_agreement",
+            "action.adobesign:create_agreement",
+            "action.adobesign:get_agreement",
+            "action.adobesign:send_agreement",
+            "action.adobesign:test_connection"
+          ],
+          "contexts": [
+            "readScriptProperty"
+          ]
+        },
+        {
+          "name": "ADOBE_SIGN_ACCOUNT_ID",
+          "optional": true,
+          "operations": [
+            "action.adobesign:cancel_agreement",
+            "action.adobesign:create_agreement",
+            "action.adobesign:get_agreement",
+            "action.adobesign:send_agreement",
+            "action.adobesign:test_connection"
+          ],
+          "contexts": [
+            "readScriptProperty"
           ]
         }
       ],
       "environmentProperties": [
-        "TEAMWORK_SITE_URL"
+        "ADOBE_SIGN_BASE_URL",
+        "ADOBE_SIGN_TOKEN_URL"
       ]
     },
     {

--- a/server/workflow/__tests__/__snapshots__/apps-script.adobesign.test.ts.snap
+++ b/server/workflow/__tests__/__snapshots__/apps-script.adobesign.test.ts.snap
@@ -1,0 +1,2202 @@
+exports["Apps Script Adobe Sign REAL_OPS builds action.adobesign:test_connection 1"] = `
+
+function step_action_adobesign_test_connection(ctx) {
+  ctx = ctx || {};
+  const config = {};
+
+  const operationLabel = 'test_connection';
+  const scriptProps = PropertiesService.getScriptProperties();
+  const rateConfig = { attempts: 4, initialDelayMs: 500, maxDelayMs: 12000, jitter: 0.2 };
+  const defaultBaseUrl = 'https://api.na1.echosign.com/api/rest/v6';
+  const defaultTokenUrl = 'https://api.na1.echosign.com/oauth/token';
+
+  function readScriptProperty(primary, aliases) {
+    const keys = [primary].concat(Array.isArray(aliases) ? aliases : []);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (!key) {
+        continue;
+      }
+      const raw = scriptProps.getProperty(key);
+      if (raw !== null && raw !== undefined && String(raw).trim() !== '') {
+        return raw;
+      }
+    }
+    return null;
+  }
+
+  function normalizeBaseUrl(value) {
+    let raw = value !== undefined && value !== null ? String(value).trim() : '';
+    if (!raw) {
+      raw = readScriptProperty('ADOBE_SIGN_BASE_URL', ['ADOBESIGN_BASE_URL']) || defaultBaseUrl;
+    }
+    if (!/^https?:/i.test(raw)) {
+      raw = 'https://' + raw.replace(/^\/+/, '');
+    }
+    while (raw.endsWith('/')) {
+      raw = raw.slice(0, raw.length - 1);
+    }
+    return raw;
+  }
+
+  function normalizeTokenUrl(value) {
+    let raw = value !== undefined && value !== null ? String(value).trim() : '';
+    if (!raw) {
+      raw = readScriptProperty('ADOBE_SIGN_TOKEN_URL', ['ADOBESIGN_TOKEN_URL']) || defaultTokenUrl;
+    }
+    if (!/^https?:/i.test(raw)) {
+      raw = 'https://' + raw.replace(/^\/+/, '');
+    }
+    return raw;
+  }
+
+  function parseTimestamp(raw) {
+    if (!raw && raw !== 0) {
+      return null;
+    }
+    if (typeof raw === 'number' && !isNaN(raw)) {
+      return raw;
+    }
+    const numeric = Number(raw);
+    if (!isNaN(numeric) && numeric > 0) {
+      return numeric;
+    }
+    if (typeof raw === 'string') {
+      const parsed = Date.parse(raw);
+      if (!isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return null;
+  }
+
+  function resolveOptionalString(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    const raw = String(value);
+    const template = raw.trim();
+    if (!template) {
+      return '';
+    }
+    return interpolate(template, ctx).trim();
+  }
+
+  function resolveRequiredString(value, message) {
+    const resolved = resolveOptionalString(value);
+    if (!resolved) {
+      throw new Error(message);
+    }
+    return resolved;
+  }
+
+  function resolveAny(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value === null) {
+      return null;
+    }
+    if (typeof value === 'string') {
+      const template = value.trim();
+      if (!template) {
+        return '';
+      }
+      return interpolate(template, ctx);
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        const entry = resolveAny(value[i]);
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (Array.isArray(entry) && entry.length === 0) {
+          continue;
+        }
+        if (entry && typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0) {
+          continue;
+        }
+        result.push(entry);
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+          continue;
+        }
+        const entry = resolveAny(value[key]);
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (Array.isArray(entry) && entry.length === 0) {
+          continue;
+        }
+        if (entry && typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0) {
+          continue;
+        }
+        result[key] = entry;
+      }
+      return result;
+    }
+    return value;
+  }
+
+  function ensureNonEmptyArray(value, message) {
+    const arrayValue = Array.isArray(value) ? value : [];
+    const filtered = [];
+    for (let i = 0; i < arrayValue.length; i++) {
+      if (arrayValue[i] !== undefined && arrayValue[i] !== null) {
+        filtered.push(arrayValue[i]);
+      }
+    }
+    if (filtered.length === 0) {
+      throw new Error(message);
+    }
+    return filtered;
+  }
+
+  function extractAgreementId(payload, fallback) {
+    if (!payload || typeof payload !== 'object') {
+      return fallback || null;
+    }
+    if (payload.id) {
+      return payload.id;
+    }
+    if (payload.agreementId) {
+      return payload.agreementId;
+    }
+    if (payload.agreement_id) {
+      return payload.agreement_id;
+    }
+    if (payload.agreement && typeof payload.agreement === 'object') {
+      if (payload.agreement.id) {
+        return payload.agreement.id;
+      }
+      if (payload.agreement.agreementId) {
+        return payload.agreement.agreementId;
+      }
+    }
+    return fallback || null;
+  }
+
+  function handleAdobeSignError(error, metadata) {
+    metadata = metadata || {};
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const headers = error && error.headers ? error.headers : null;
+    const payload = error && Object.prototype.hasOwnProperty.call(error, 'body') ? error.body : null;
+    const details = [];
+    if (status) {
+      details.push('status ' + status);
+    }
+    if (payload) {
+      if (typeof payload === 'string') {
+        details.push(payload);
+      } else if (typeof payload === 'object') {
+        if (payload.message) {
+          details.push(String(payload.message));
+        }
+        if (payload.error) {
+          details.push(String(payload.error));
+        }
+        if (Array.isArray(payload.errors)) {
+          for (let i = 0; i < payload.errors.length; i++) {
+            const entry = payload.errors[i];
+            if (!entry) {
+              continue;
+            }
+            if (typeof entry === 'string') {
+              details.push(entry);
+            } else if (entry.message) {
+              details.push(String(entry.message));
+            } else {
+              details.push(JSON.stringify(entry));
+            }
+          }
+        }
+      }
+    }
+    const contextParts = [];
+    if (metadata && metadata.agreementId) {
+      contextParts.push('agreement ' + metadata.agreementId);
+    }
+    const context = contextParts.length > 0 ? ' for ' + contextParts.join(' ') : '';
+    const message = 'Adobe Sign ' + (metadata && metadata.operation ? metadata.operation : opLabel || 'request') + context + '. ' + (details.length > 0 ? details.join(' ') : 'Unexpected error.');
+    logError('adobesign_request_failed', {
+      operation: (metadata && metadata.operation) || opLabel || null,
+      agreementId: metadata && metadata.agreementId ? metadata.agreementId : null,
+      status: status,
+      message: message
+    });
+    const wrapped = new Error(message);
+    wrapped.status = status;
+    if (headers) {
+      wrapped.headers = headers;
+    }
+    wrapped.body = payload;
+    wrapped.cause = error;
+    throw wrapped;
+  }
+
+  function ensureAccessToken() {
+    const configuredToken = resolveOptionalString(config && config.accessToken);
+    if (configuredToken) {
+      return configuredToken;
+    }
+
+    const storedToken = readScriptProperty('ADOBE_SIGN_ACCESS_TOKEN', ['ADOBESIGN_ACCESS_TOKEN']);
+    const expiresAt = parseTimestamp(readScriptProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT', ['ADOBESIGN_TOKEN_EXPIRES_AT']));
+    const now = Date.now();
+    if (storedToken && (!expiresAt || expiresAt - now > 60000)) {
+      return storedToken;
+    }
+
+    const refreshToken = resolveOptionalString(config && config.refreshToken) || readScriptProperty('ADOBE_SIGN_REFRESH_TOKEN', ['ADOBESIGN_REFRESH_TOKEN']) || '';
+    const clientId = resolveOptionalString(config && config.clientId) || readScriptProperty('ADOBE_SIGN_CLIENT_ID', ['ADOBESIGN_CLIENT_ID']) || '';
+    const clientSecret = resolveOptionalString(config && config.clientSecret) || readScriptProperty('ADOBE_SIGN_CLIENT_SECRET', ['ADOBESIGN_CLIENT_SECRET']) || '';
+    const tokenEndpoint = normalizeTokenUrl(config && config.tokenUrl);
+
+    if (refreshToken && clientId && clientSecret) {
+      try {
+        const tokenResponse = withRetries(() => fetchJson({
+          url: tokenEndpoint,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/json'
+          },
+          payload: 'grant_type=refresh_token' + '&refresh_token=' + encodeURIComponent(refreshToken) + '&client_id=' + encodeURIComponent(clientId) + '&client_secret=' + encodeURIComponent(clientSecret),
+          contentType: 'application/x-www-form-urlencoded'
+        }), { attempts: 2, initialDelayMs: 500, maxDelayMs: 4000, jitter: 0.2 });
+        const body = tokenResponse && tokenResponse.body ? tokenResponse.body : null;
+        const newAccessToken = body && body.access_token ? String(body.access_token) : '';
+        if (!newAccessToken) {
+          throw new Error('Adobe Sign token refresh did not return an access token.');
+        }
+        scriptProps.setProperty('ADOBE_SIGN_ACCESS_TOKEN', newAccessToken);
+        if (body && body.refresh_token) {
+          scriptProps.setProperty('ADOBE_SIGN_REFRESH_TOKEN', String(body.refresh_token));
+        }
+        if (body && body.expires_in) {
+          const expiresMs = Date.now() + Number(body.expires_in) * 1000;
+          scriptProps.setProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT', String(expiresMs));
+        } else {
+          scriptProps.deleteProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT');
+        }
+        return newAccessToken;
+      } catch (refreshError) {
+        logError('adobesign_refresh_failed', {
+          operation: opLabel,
+          status: refreshError && refreshError.status ? refreshError.status : null,
+          message: refreshError && refreshError.message ? refreshError.message : String(refreshError)
+        });
+        if (storedToken) {
+          return storedToken;
+        }
+        throw new Error('Adobe Sign token refresh failed. Verify ADOBE_SIGN_REFRESH_TOKEN, ADOBE_SIGN_CLIENT_ID, and ADOBE_SIGN_CLIENT_SECRET.');
+      }
+    }
+
+    if (storedToken) {
+      return storedToken;
+    }
+
+    logError('adobesign_missing_access_token', { operation: opLabel });
+    throw new Error('Adobe Sign requires an access token. Configure ADOBE_SIGN_ACCESS_TOKEN or refresh credentials.');
+  }
+
+  const accessToken = ensureAccessToken();
+  const baseUrl = normalizeBaseUrl(config && config.baseUrl);
+  const configuredAccountId =
+    resolveOptionalString(config && config.accountId) ||
+    readScriptProperty('ADOBE_SIGN_ACCOUNT_ID', ['ADOBESIGN_ACCOUNT_ID']) ||
+    '';
+
+  function buildUrl(endpoint, query) {
+    let path = endpoint ? String(endpoint) : '';
+    if (!/^https?:/i.test(path)) {
+      if (path && path.charAt(0) !== '/') {
+        path = '/' + path;
+      }
+      path = baseUrl + path;
+    }
+    if (query && typeof query === 'object') {
+      const parts = [];
+      for (const key in query) {
+        if (!Object.prototype.hasOwnProperty.call(query, key)) {
+          continue;
+        }
+        const raw = query[key];
+        if (raw === undefined || raw === null || raw === '') {
+          continue;
+        }
+        if (Array.isArray(raw)) {
+          for (let i = 0; i < raw.length; i++) {
+            const entry = raw[i];
+            if (entry === undefined || entry === null || entry === '') {
+              continue;
+            }
+            parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(entry));
+          }
+        } else {
+          parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(raw));
+        }
+      }
+      if (parts.length > 0) {
+        path += (path.indexOf('?') === -1 ? '?' : '&') + parts.join('&');
+      }
+    }
+    return path;
+  }
+
+  function adobeSignRequest(options) {
+    options = options || {};
+    const method = options.method ? String(options.method).toUpperCase() : 'GET';
+    const endpoint = options.endpoint || '';
+    const url = buildUrl(endpoint, options.query);
+    const headers = Object.assign({ Authorization: 'Bearer ' + accessToken, Accept: 'application/json' }, options.headers || {});
+    if (configuredAccountId) {
+      headers['x-api-user'] = 'accountId:' + configuredAccountId;
+    }
+    const requestConfig = {
+      url: url,
+      method: method,
+      headers: headers,
+      muteHttpExceptions: true
+    };
+    if (Object.prototype.hasOwnProperty.call(options, 'body')) {
+      requestConfig.payload = JSON.stringify(options.body);
+      if (!headers['Content-Type']) {
+        headers['Content-Type'] = 'application/json';
+      }
+      requestConfig.contentType = headers['Content-Type'];
+    } else if (Object.prototype.hasOwnProperty.call(options, 'payload')) {
+      requestConfig.payload = options.payload;
+      if (options.contentType) {
+        headers['Content-Type'] = options.contentType;
+        requestConfig.contentType = options.contentType;
+      }
+    }
+    return withRetries(() => fetchJson(requestConfig), rateConfig);
+  }
+  const resolvedAccountId = resolveOptionalString(config && config.accountId) || readScriptProperty('ADOBE_SIGN_ACCOUNT_ID', ['ADOBESIGN_ACCOUNT_ID']) || '';
+  try {
+    const response = adobeSignRequest({ method: 'GET', endpoint: '/users/me' });
+    const body = response && response.body ? response.body : null;
+    ctx.adobeSignConnectionOk = true;
+    ctx.adobeSignCurrentUser = body;
+    if (resolvedAccountId) { ctx.adobeSignAccountId = resolvedAccountId; }
+    logInfo('adobesign_test_connection', { accountId: resolvedAccountId || null });
+    return ctx;
+  } catch (error) {
+    handleAdobeSignError(error, { operation: 'test_connection' });
+  }
+}
+
+`
+
+exports["Apps Script Adobe Sign REAL_OPS builds action.adobesign:create_agreement 1"] = `
+
+function step_action_adobesign_create_agreement(ctx) {
+  ctx = ctx || {};
+  const config = {};
+
+  const operationLabel = 'create_agreement';
+  const scriptProps = PropertiesService.getScriptProperties();
+  const rateConfig = { attempts: 4, initialDelayMs: 500, maxDelayMs: 12000, jitter: 0.2 };
+  const defaultBaseUrl = 'https://api.na1.echosign.com/api/rest/v6';
+  const defaultTokenUrl = 'https://api.na1.echosign.com/oauth/token';
+
+  function readScriptProperty(primary, aliases) {
+    const keys = [primary].concat(Array.isArray(aliases) ? aliases : []);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (!key) {
+        continue;
+      }
+      const raw = scriptProps.getProperty(key);
+      if (raw !== null && raw !== undefined && String(raw).trim() !== '') {
+        return raw;
+      }
+    }
+    return null;
+  }
+
+  function normalizeBaseUrl(value) {
+    let raw = value !== undefined && value !== null ? String(value).trim() : '';
+    if (!raw) {
+      raw = readScriptProperty('ADOBE_SIGN_BASE_URL', ['ADOBESIGN_BASE_URL']) || defaultBaseUrl;
+    }
+    if (!/^https?:/i.test(raw)) {
+      raw = 'https://' + raw.replace(/^\/+/, '');
+    }
+    while (raw.endsWith('/')) {
+      raw = raw.slice(0, raw.length - 1);
+    }
+    return raw;
+  }
+
+  function normalizeTokenUrl(value) {
+    let raw = value !== undefined && value !== null ? String(value).trim() : '';
+    if (!raw) {
+      raw = readScriptProperty('ADOBE_SIGN_TOKEN_URL', ['ADOBESIGN_TOKEN_URL']) || defaultTokenUrl;
+    }
+    if (!/^https?:/i.test(raw)) {
+      raw = 'https://' + raw.replace(/^\/+/, '');
+    }
+    return raw;
+  }
+
+  function parseTimestamp(raw) {
+    if (!raw && raw !== 0) {
+      return null;
+    }
+    if (typeof raw === 'number' && !isNaN(raw)) {
+      return raw;
+    }
+    const numeric = Number(raw);
+    if (!isNaN(numeric) && numeric > 0) {
+      return numeric;
+    }
+    if (typeof raw === 'string') {
+      const parsed = Date.parse(raw);
+      if (!isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return null;
+  }
+
+  function resolveOptionalString(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    const raw = String(value);
+    const template = raw.trim();
+    if (!template) {
+      return '';
+    }
+    return interpolate(template, ctx).trim();
+  }
+
+  function resolveRequiredString(value, message) {
+    const resolved = resolveOptionalString(value);
+    if (!resolved) {
+      throw new Error(message);
+    }
+    return resolved;
+  }
+
+  function resolveAny(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value === null) {
+      return null;
+    }
+    if (typeof value === 'string') {
+      const template = value.trim();
+      if (!template) {
+        return '';
+      }
+      return interpolate(template, ctx);
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        const entry = resolveAny(value[i]);
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (Array.isArray(entry) && entry.length === 0) {
+          continue;
+        }
+        if (entry && typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0) {
+          continue;
+        }
+        result.push(entry);
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+          continue;
+        }
+        const entry = resolveAny(value[key]);
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (Array.isArray(entry) && entry.length === 0) {
+          continue;
+        }
+        if (entry && typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0) {
+          continue;
+        }
+        result[key] = entry;
+      }
+      return result;
+    }
+    return value;
+  }
+
+  function ensureNonEmptyArray(value, message) {
+    const arrayValue = Array.isArray(value) ? value : [];
+    const filtered = [];
+    for (let i = 0; i < arrayValue.length; i++) {
+      if (arrayValue[i] !== undefined && arrayValue[i] !== null) {
+        filtered.push(arrayValue[i]);
+      }
+    }
+    if (filtered.length === 0) {
+      throw new Error(message);
+    }
+    return filtered;
+  }
+
+  function extractAgreementId(payload, fallback) {
+    if (!payload || typeof payload !== 'object') {
+      return fallback || null;
+    }
+    if (payload.id) {
+      return payload.id;
+    }
+    if (payload.agreementId) {
+      return payload.agreementId;
+    }
+    if (payload.agreement_id) {
+      return payload.agreement_id;
+    }
+    if (payload.agreement && typeof payload.agreement === 'object') {
+      if (payload.agreement.id) {
+        return payload.agreement.id;
+      }
+      if (payload.agreement.agreementId) {
+        return payload.agreement.agreementId;
+      }
+    }
+    return fallback || null;
+  }
+
+  function handleAdobeSignError(error, metadata) {
+    metadata = metadata || {};
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const headers = error && error.headers ? error.headers : null;
+    const payload = error && Object.prototype.hasOwnProperty.call(error, 'body') ? error.body : null;
+    const details = [];
+    if (status) {
+      details.push('status ' + status);
+    }
+    if (payload) {
+      if (typeof payload === 'string') {
+        details.push(payload);
+      } else if (typeof payload === 'object') {
+        if (payload.message) {
+          details.push(String(payload.message));
+        }
+        if (payload.error) {
+          details.push(String(payload.error));
+        }
+        if (Array.isArray(payload.errors)) {
+          for (let i = 0; i < payload.errors.length; i++) {
+            const entry = payload.errors[i];
+            if (!entry) {
+              continue;
+            }
+            if (typeof entry === 'string') {
+              details.push(entry);
+            } else if (entry.message) {
+              details.push(String(entry.message));
+            } else {
+              details.push(JSON.stringify(entry));
+            }
+          }
+        }
+      }
+    }
+    const contextParts = [];
+    if (metadata && metadata.agreementId) {
+      contextParts.push('agreement ' + metadata.agreementId);
+    }
+    const context = contextParts.length > 0 ? ' for ' + contextParts.join(' ') : '';
+    const message = 'Adobe Sign ' + (metadata && metadata.operation ? metadata.operation : opLabel || 'request') + context + '. ' + (details.length > 0 ? details.join(' ') : 'Unexpected error.');
+    logError('adobesign_request_failed', {
+      operation: (metadata && metadata.operation) || opLabel || null,
+      agreementId: metadata && metadata.agreementId ? metadata.agreementId : null,
+      status: status,
+      message: message
+    });
+    const wrapped = new Error(message);
+    wrapped.status = status;
+    if (headers) {
+      wrapped.headers = headers;
+    }
+    wrapped.body = payload;
+    wrapped.cause = error;
+    throw wrapped;
+  }
+
+  function ensureAccessToken() {
+    const configuredToken = resolveOptionalString(config && config.accessToken);
+    if (configuredToken) {
+      return configuredToken;
+    }
+
+    const storedToken = readScriptProperty('ADOBE_SIGN_ACCESS_TOKEN', ['ADOBESIGN_ACCESS_TOKEN']);
+    const expiresAt = parseTimestamp(readScriptProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT', ['ADOBESIGN_TOKEN_EXPIRES_AT']));
+    const now = Date.now();
+    if (storedToken && (!expiresAt || expiresAt - now > 60000)) {
+      return storedToken;
+    }
+
+    const refreshToken = resolveOptionalString(config && config.refreshToken) || readScriptProperty('ADOBE_SIGN_REFRESH_TOKEN', ['ADOBESIGN_REFRESH_TOKEN']) || '';
+    const clientId = resolveOptionalString(config && config.clientId) || readScriptProperty('ADOBE_SIGN_CLIENT_ID', ['ADOBESIGN_CLIENT_ID']) || '';
+    const clientSecret = resolveOptionalString(config && config.clientSecret) || readScriptProperty('ADOBE_SIGN_CLIENT_SECRET', ['ADOBESIGN_CLIENT_SECRET']) || '';
+    const tokenEndpoint = normalizeTokenUrl(config && config.tokenUrl);
+
+    if (refreshToken && clientId && clientSecret) {
+      try {
+        const tokenResponse = withRetries(() => fetchJson({
+          url: tokenEndpoint,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/json'
+          },
+          payload: 'grant_type=refresh_token' + '&refresh_token=' + encodeURIComponent(refreshToken) + '&client_id=' + encodeURIComponent(clientId) + '&client_secret=' + encodeURIComponent(clientSecret),
+          contentType: 'application/x-www-form-urlencoded'
+        }), { attempts: 2, initialDelayMs: 500, maxDelayMs: 4000, jitter: 0.2 });
+        const body = tokenResponse && tokenResponse.body ? tokenResponse.body : null;
+        const newAccessToken = body && body.access_token ? String(body.access_token) : '';
+        if (!newAccessToken) {
+          throw new Error('Adobe Sign token refresh did not return an access token.');
+        }
+        scriptProps.setProperty('ADOBE_SIGN_ACCESS_TOKEN', newAccessToken);
+        if (body && body.refresh_token) {
+          scriptProps.setProperty('ADOBE_SIGN_REFRESH_TOKEN', String(body.refresh_token));
+        }
+        if (body && body.expires_in) {
+          const expiresMs = Date.now() + Number(body.expires_in) * 1000;
+          scriptProps.setProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT', String(expiresMs));
+        } else {
+          scriptProps.deleteProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT');
+        }
+        return newAccessToken;
+      } catch (refreshError) {
+        logError('adobesign_refresh_failed', {
+          operation: opLabel,
+          status: refreshError && refreshError.status ? refreshError.status : null,
+          message: refreshError && refreshError.message ? refreshError.message : String(refreshError)
+        });
+        if (storedToken) {
+          return storedToken;
+        }
+        throw new Error('Adobe Sign token refresh failed. Verify ADOBE_SIGN_REFRESH_TOKEN, ADOBE_SIGN_CLIENT_ID, and ADOBE_SIGN_CLIENT_SECRET.');
+      }
+    }
+
+    if (storedToken) {
+      return storedToken;
+    }
+
+    logError('adobesign_missing_access_token', { operation: opLabel });
+    throw new Error('Adobe Sign requires an access token. Configure ADOBE_SIGN_ACCESS_TOKEN or refresh credentials.');
+  }
+
+  const accessToken = ensureAccessToken();
+  const baseUrl = normalizeBaseUrl(config && config.baseUrl);
+  const configuredAccountId =
+    resolveOptionalString(config && config.accountId) ||
+    readScriptProperty('ADOBE_SIGN_ACCOUNT_ID', ['ADOBESIGN_ACCOUNT_ID']) ||
+    '';
+
+  function buildUrl(endpoint, query) {
+    let path = endpoint ? String(endpoint) : '';
+    if (!/^https?:/i.test(path)) {
+      if (path && path.charAt(0) !== '/') {
+        path = '/' + path;
+      }
+      path = baseUrl + path;
+    }
+    if (query && typeof query === 'object') {
+      const parts = [];
+      for (const key in query) {
+        if (!Object.prototype.hasOwnProperty.call(query, key)) {
+          continue;
+        }
+        const raw = query[key];
+        if (raw === undefined || raw === null || raw === '') {
+          continue;
+        }
+        if (Array.isArray(raw)) {
+          for (let i = 0; i < raw.length; i++) {
+            const entry = raw[i];
+            if (entry === undefined || entry === null || entry === '') {
+              continue;
+            }
+            parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(entry));
+          }
+        } else {
+          parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(raw));
+        }
+      }
+      if (parts.length > 0) {
+        path += (path.indexOf('?') === -1 ? '?' : '&') + parts.join('&');
+      }
+    }
+    return path;
+  }
+
+  function adobeSignRequest(options) {
+    options = options || {};
+    const method = options.method ? String(options.method).toUpperCase() : 'GET';
+    const endpoint = options.endpoint || '';
+    const url = buildUrl(endpoint, options.query);
+    const headers = Object.assign({ Authorization: 'Bearer ' + accessToken, Accept: 'application/json' }, options.headers || {});
+    if (configuredAccountId) {
+      headers['x-api-user'] = 'accountId:' + configuredAccountId;
+    }
+    const requestConfig = {
+      url: url,
+      method: method,
+      headers: headers,
+      muteHttpExceptions: true
+    };
+    if (Object.prototype.hasOwnProperty.call(options, 'body')) {
+      requestConfig.payload = JSON.stringify(options.body);
+      if (!headers['Content-Type']) {
+        headers['Content-Type'] = 'application/json';
+      }
+      requestConfig.contentType = headers['Content-Type'];
+    } else if (Object.prototype.hasOwnProperty.call(options, 'payload')) {
+      requestConfig.payload = options.payload;
+      if (options.contentType) {
+        headers['Content-Type'] = options.contentType;
+        requestConfig.contentType = options.contentType;
+      }
+    }
+    return withRetries(() => fetchJson(requestConfig), rateConfig);
+  }
+  const agreementName = resolveRequiredString(config && config.name, 'Adobe Sign create_agreement requires the Agreement Name field. Provide a Name value.');
+  const fileInfos = ensureNonEmptyArray(resolveAny(config && config.fileInfos), 'Adobe Sign create_agreement requires at least one File Info entry.');
+  const participantSets = ensureNonEmptyArray(resolveAny(config && config.participantSetsInfo), 'Adobe Sign create_agreement requires at least one Participant Set.');
+  const signatureType = resolveOptionalString(config && config.signatureType) || 'ESIGN';
+  const agreementState = resolveOptionalString(config && config.state) || 'IN_PROCESS';
+  const emailOption = resolveAny(config && config.emailOption);
+  const externalId = resolveOptionalString(config && config.externalId);
+  const message = resolveOptionalString(config && config.message);
+  let createdAgreementId = '';
+  try {
+    const payload = {
+      name: agreementName,
+      fileInfos: fileInfos,
+      participantSetsInfo: participantSets,
+      signatureType: signatureType || 'ESIGN',
+      state: agreementState || 'IN_PROCESS'
+    };
+    if (emailOption && (typeof emailOption !== 'object' || Object.keys(emailOption).length > 0)) {
+      payload.emailOption = emailOption;
+    }
+    if (externalId) {
+      payload.externalId = externalId;
+    }
+    if (message) {
+      payload.message = message;
+    }
+    const response = adobeSignRequest({ method: 'POST', endpoint: '/agreements', body: payload });
+    const body = response && response.body ? response.body : null;
+    const agreementId = extractAgreementId(body, null);
+    createdAgreementId = agreementId || '';
+    ctx.adobeSignAgreementId = agreementId || null;
+    ctx.adobeSignAgreement = body;
+    ctx.adobeSignAgreementName = agreementName;
+    ctx.adobeSignAgreementState = agreementState || 'IN_PROCESS';
+    logInfo('adobesign_create_agreement', { agreementId: agreementId || null, name: agreementName });
+    return ctx;
+  } catch (error) {
+    handleAdobeSignError(error, { operation: 'create_agreement', agreementId: createdAgreementId || null });
+  }
+}
+
+`
+
+exports["Apps Script Adobe Sign REAL_OPS builds action.adobesign:send_agreement 1"] = `
+
+function step_action_adobesign_send_agreement(ctx) {
+  ctx = ctx || {};
+  const config = {};
+
+  const operationLabel = 'send_agreement';
+  const scriptProps = PropertiesService.getScriptProperties();
+  const rateConfig = { attempts: 4, initialDelayMs: 500, maxDelayMs: 12000, jitter: 0.2 };
+  const defaultBaseUrl = 'https://api.na1.echosign.com/api/rest/v6';
+  const defaultTokenUrl = 'https://api.na1.echosign.com/oauth/token';
+
+  function readScriptProperty(primary, aliases) {
+    const keys = [primary].concat(Array.isArray(aliases) ? aliases : []);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (!key) {
+        continue;
+      }
+      const raw = scriptProps.getProperty(key);
+      if (raw !== null && raw !== undefined && String(raw).trim() !== '') {
+        return raw;
+      }
+    }
+    return null;
+  }
+
+  function normalizeBaseUrl(value) {
+    let raw = value !== undefined && value !== null ? String(value).trim() : '';
+    if (!raw) {
+      raw = readScriptProperty('ADOBE_SIGN_BASE_URL', ['ADOBESIGN_BASE_URL']) || defaultBaseUrl;
+    }
+    if (!/^https?:/i.test(raw)) {
+      raw = 'https://' + raw.replace(/^\/+/, '');
+    }
+    while (raw.endsWith('/')) {
+      raw = raw.slice(0, raw.length - 1);
+    }
+    return raw;
+  }
+
+  function normalizeTokenUrl(value) {
+    let raw = value !== undefined && value !== null ? String(value).trim() : '';
+    if (!raw) {
+      raw = readScriptProperty('ADOBE_SIGN_TOKEN_URL', ['ADOBESIGN_TOKEN_URL']) || defaultTokenUrl;
+    }
+    if (!/^https?:/i.test(raw)) {
+      raw = 'https://' + raw.replace(/^\/+/, '');
+    }
+    return raw;
+  }
+
+  function parseTimestamp(raw) {
+    if (!raw && raw !== 0) {
+      return null;
+    }
+    if (typeof raw === 'number' && !isNaN(raw)) {
+      return raw;
+    }
+    const numeric = Number(raw);
+    if (!isNaN(numeric) && numeric > 0) {
+      return numeric;
+    }
+    if (typeof raw === 'string') {
+      const parsed = Date.parse(raw);
+      if (!isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return null;
+  }
+
+  function resolveOptionalString(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    const raw = String(value);
+    const template = raw.trim();
+    if (!template) {
+      return '';
+    }
+    return interpolate(template, ctx).trim();
+  }
+
+  function resolveRequiredString(value, message) {
+    const resolved = resolveOptionalString(value);
+    if (!resolved) {
+      throw new Error(message);
+    }
+    return resolved;
+  }
+
+  function resolveAny(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value === null) {
+      return null;
+    }
+    if (typeof value === 'string') {
+      const template = value.trim();
+      if (!template) {
+        return '';
+      }
+      return interpolate(template, ctx);
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        const entry = resolveAny(value[i]);
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (Array.isArray(entry) && entry.length === 0) {
+          continue;
+        }
+        if (entry && typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0) {
+          continue;
+        }
+        result.push(entry);
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+          continue;
+        }
+        const entry = resolveAny(value[key]);
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (Array.isArray(entry) && entry.length === 0) {
+          continue;
+        }
+        if (entry && typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0) {
+          continue;
+        }
+        result[key] = entry;
+      }
+      return result;
+    }
+    return value;
+  }
+
+  function ensureNonEmptyArray(value, message) {
+    const arrayValue = Array.isArray(value) ? value : [];
+    const filtered = [];
+    for (let i = 0; i < arrayValue.length; i++) {
+      if (arrayValue[i] !== undefined && arrayValue[i] !== null) {
+        filtered.push(arrayValue[i]);
+      }
+    }
+    if (filtered.length === 0) {
+      throw new Error(message);
+    }
+    return filtered;
+  }
+
+  function extractAgreementId(payload, fallback) {
+    if (!payload || typeof payload !== 'object') {
+      return fallback || null;
+    }
+    if (payload.id) {
+      return payload.id;
+    }
+    if (payload.agreementId) {
+      return payload.agreementId;
+    }
+    if (payload.agreement_id) {
+      return payload.agreement_id;
+    }
+    if (payload.agreement && typeof payload.agreement === 'object') {
+      if (payload.agreement.id) {
+        return payload.agreement.id;
+      }
+      if (payload.agreement.agreementId) {
+        return payload.agreement.agreementId;
+      }
+    }
+    return fallback || null;
+  }
+
+  function handleAdobeSignError(error, metadata) {
+    metadata = metadata || {};
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const headers = error && error.headers ? error.headers : null;
+    const payload = error && Object.prototype.hasOwnProperty.call(error, 'body') ? error.body : null;
+    const details = [];
+    if (status) {
+      details.push('status ' + status);
+    }
+    if (payload) {
+      if (typeof payload === 'string') {
+        details.push(payload);
+      } else if (typeof payload === 'object') {
+        if (payload.message) {
+          details.push(String(payload.message));
+        }
+        if (payload.error) {
+          details.push(String(payload.error));
+        }
+        if (Array.isArray(payload.errors)) {
+          for (let i = 0; i < payload.errors.length; i++) {
+            const entry = payload.errors[i];
+            if (!entry) {
+              continue;
+            }
+            if (typeof entry === 'string') {
+              details.push(entry);
+            } else if (entry.message) {
+              details.push(String(entry.message));
+            } else {
+              details.push(JSON.stringify(entry));
+            }
+          }
+        }
+      }
+    }
+    const contextParts = [];
+    if (metadata && metadata.agreementId) {
+      contextParts.push('agreement ' + metadata.agreementId);
+    }
+    const context = contextParts.length > 0 ? ' for ' + contextParts.join(' ') : '';
+    const message = 'Adobe Sign ' + (metadata && metadata.operation ? metadata.operation : opLabel || 'request') + context + '. ' + (details.length > 0 ? details.join(' ') : 'Unexpected error.');
+    logError('adobesign_request_failed', {
+      operation: (metadata && metadata.operation) || opLabel || null,
+      agreementId: metadata && metadata.agreementId ? metadata.agreementId : null,
+      status: status,
+      message: message
+    });
+    const wrapped = new Error(message);
+    wrapped.status = status;
+    if (headers) {
+      wrapped.headers = headers;
+    }
+    wrapped.body = payload;
+    wrapped.cause = error;
+    throw wrapped;
+  }
+
+  function ensureAccessToken() {
+    const configuredToken = resolveOptionalString(config && config.accessToken);
+    if (configuredToken) {
+      return configuredToken;
+    }
+
+    const storedToken = readScriptProperty('ADOBE_SIGN_ACCESS_TOKEN', ['ADOBESIGN_ACCESS_TOKEN']);
+    const expiresAt = parseTimestamp(readScriptProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT', ['ADOBESIGN_TOKEN_EXPIRES_AT']));
+    const now = Date.now();
+    if (storedToken && (!expiresAt || expiresAt - now > 60000)) {
+      return storedToken;
+    }
+
+    const refreshToken = resolveOptionalString(config && config.refreshToken) || readScriptProperty('ADOBE_SIGN_REFRESH_TOKEN', ['ADOBESIGN_REFRESH_TOKEN']) || '';
+    const clientId = resolveOptionalString(config && config.clientId) || readScriptProperty('ADOBE_SIGN_CLIENT_ID', ['ADOBESIGN_CLIENT_ID']) || '';
+    const clientSecret = resolveOptionalString(config && config.clientSecret) || readScriptProperty('ADOBE_SIGN_CLIENT_SECRET', ['ADOBESIGN_CLIENT_SECRET']) || '';
+    const tokenEndpoint = normalizeTokenUrl(config && config.tokenUrl);
+
+    if (refreshToken && clientId && clientSecret) {
+      try {
+        const tokenResponse = withRetries(() => fetchJson({
+          url: tokenEndpoint,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/json'
+          },
+          payload: 'grant_type=refresh_token' + '&refresh_token=' + encodeURIComponent(refreshToken) + '&client_id=' + encodeURIComponent(clientId) + '&client_secret=' + encodeURIComponent(clientSecret),
+          contentType: 'application/x-www-form-urlencoded'
+        }), { attempts: 2, initialDelayMs: 500, maxDelayMs: 4000, jitter: 0.2 });
+        const body = tokenResponse && tokenResponse.body ? tokenResponse.body : null;
+        const newAccessToken = body && body.access_token ? String(body.access_token) : '';
+        if (!newAccessToken) {
+          throw new Error('Adobe Sign token refresh did not return an access token.');
+        }
+        scriptProps.setProperty('ADOBE_SIGN_ACCESS_TOKEN', newAccessToken);
+        if (body && body.refresh_token) {
+          scriptProps.setProperty('ADOBE_SIGN_REFRESH_TOKEN', String(body.refresh_token));
+        }
+        if (body && body.expires_in) {
+          const expiresMs = Date.now() + Number(body.expires_in) * 1000;
+          scriptProps.setProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT', String(expiresMs));
+        } else {
+          scriptProps.deleteProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT');
+        }
+        return newAccessToken;
+      } catch (refreshError) {
+        logError('adobesign_refresh_failed', {
+          operation: opLabel,
+          status: refreshError && refreshError.status ? refreshError.status : null,
+          message: refreshError && refreshError.message ? refreshError.message : String(refreshError)
+        });
+        if (storedToken) {
+          return storedToken;
+        }
+        throw new Error('Adobe Sign token refresh failed. Verify ADOBE_SIGN_REFRESH_TOKEN, ADOBE_SIGN_CLIENT_ID, and ADOBE_SIGN_CLIENT_SECRET.');
+      }
+    }
+
+    if (storedToken) {
+      return storedToken;
+    }
+
+    logError('adobesign_missing_access_token', { operation: opLabel });
+    throw new Error('Adobe Sign requires an access token. Configure ADOBE_SIGN_ACCESS_TOKEN or refresh credentials.');
+  }
+
+  const accessToken = ensureAccessToken();
+  const baseUrl = normalizeBaseUrl(config && config.baseUrl);
+  const configuredAccountId =
+    resolveOptionalString(config && config.accountId) ||
+    readScriptProperty('ADOBE_SIGN_ACCOUNT_ID', ['ADOBESIGN_ACCOUNT_ID']) ||
+    '';
+
+  function buildUrl(endpoint, query) {
+    let path = endpoint ? String(endpoint) : '';
+    if (!/^https?:/i.test(path)) {
+      if (path && path.charAt(0) !== '/') {
+        path = '/' + path;
+      }
+      path = baseUrl + path;
+    }
+    if (query && typeof query === 'object') {
+      const parts = [];
+      for (const key in query) {
+        if (!Object.prototype.hasOwnProperty.call(query, key)) {
+          continue;
+        }
+        const raw = query[key];
+        if (raw === undefined || raw === null || raw === '') {
+          continue;
+        }
+        if (Array.isArray(raw)) {
+          for (let i = 0; i < raw.length; i++) {
+            const entry = raw[i];
+            if (entry === undefined || entry === null || entry === '') {
+              continue;
+            }
+            parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(entry));
+          }
+        } else {
+          parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(raw));
+        }
+      }
+      if (parts.length > 0) {
+        path += (path.indexOf('?') === -1 ? '?' : '&') + parts.join('&');
+      }
+    }
+    return path;
+  }
+
+  function adobeSignRequest(options) {
+    options = options || {};
+    const method = options.method ? String(options.method).toUpperCase() : 'GET';
+    const endpoint = options.endpoint || '';
+    const url = buildUrl(endpoint, options.query);
+    const headers = Object.assign({ Authorization: 'Bearer ' + accessToken, Accept: 'application/json' }, options.headers || {});
+    if (configuredAccountId) {
+      headers['x-api-user'] = 'accountId:' + configuredAccountId;
+    }
+    const requestConfig = {
+      url: url,
+      method: method,
+      headers: headers,
+      muteHttpExceptions: true
+    };
+    if (Object.prototype.hasOwnProperty.call(options, 'body')) {
+      requestConfig.payload = JSON.stringify(options.body);
+      if (!headers['Content-Type']) {
+        headers['Content-Type'] = 'application/json';
+      }
+      requestConfig.contentType = headers['Content-Type'];
+    } else if (Object.prototype.hasOwnProperty.call(options, 'payload')) {
+      requestConfig.payload = options.payload;
+      if (options.contentType) {
+        headers['Content-Type'] = options.contentType;
+        requestConfig.contentType = options.contentType;
+      }
+    }
+    return withRetries(() => fetchJson(requestConfig), rateConfig);
+  }
+  const agreementIdValue = resolveRequiredString(config && config.agreementId, 'Adobe Sign send_agreement requires the Agreement ID field. Provide an Agreement ID.');
+  const sendNoteTemplate = Object.prototype.hasOwnProperty.call(config || {}, 'note') ? config.note : (Object.prototype.hasOwnProperty.call(config || {}, 'comment') ? config.comment : '');
+  const sendNote = resolveOptionalString(sendNoteTemplate);
+  const notifySignerRaw = resolveAny(config && config.notifySigner);
+  const notifySigner = notifySignerRaw === false || (typeof notifySignerRaw === 'string' && notifySignerRaw.toLowerCase() === 'false') ? false : true;
+  try {
+    const payload = { state: 'IN_PROCESS' };
+    if (sendNote) {
+      payload.note = sendNote;
+    }
+    if (!notifySigner) {
+      payload.notifySigner = false;
+    }
+    const response = adobeSignRequest({ method: 'POST', endpoint: '/agreements/' + encodeURIComponent(agreementIdValue) + '/state', body: payload });
+    const body = response && response.body ? response.body : null;
+    ctx.adobeSignAgreementId = agreementIdValue;
+    ctx.adobeSignAgreement = body;
+    ctx.adobeSignAgreementState = 'IN_PROCESS';
+    if (sendNote) {
+      ctx.adobeSignAgreementNote = sendNote;
+    }
+    ctx.adobeSignNotifySigner = notifySigner;
+    logInfo('adobesign_send_agreement', { agreementId: agreementIdValue, notifySigner: notifySigner });
+    return ctx;
+  } catch (error) {
+    handleAdobeSignError(error, { operation: 'send_agreement', agreementId: agreementIdValue });
+  }
+}
+
+`
+
+exports["Apps Script Adobe Sign REAL_OPS builds action.adobesign:get_agreement 1"] = `
+
+function step_action_adobesign_get_agreement(ctx) {
+  ctx = ctx || {};
+  const config = {};
+
+  const operationLabel = 'get_agreement';
+  const scriptProps = PropertiesService.getScriptProperties();
+  const rateConfig = { attempts: 4, initialDelayMs: 500, maxDelayMs: 12000, jitter: 0.2 };
+  const defaultBaseUrl = 'https://api.na1.echosign.com/api/rest/v6';
+  const defaultTokenUrl = 'https://api.na1.echosign.com/oauth/token';
+
+  function readScriptProperty(primary, aliases) {
+    const keys = [primary].concat(Array.isArray(aliases) ? aliases : []);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (!key) {
+        continue;
+      }
+      const raw = scriptProps.getProperty(key);
+      if (raw !== null && raw !== undefined && String(raw).trim() !== '') {
+        return raw;
+      }
+    }
+    return null;
+  }
+
+  function normalizeBaseUrl(value) {
+    let raw = value !== undefined && value !== null ? String(value).trim() : '';
+    if (!raw) {
+      raw = readScriptProperty('ADOBE_SIGN_BASE_URL', ['ADOBESIGN_BASE_URL']) || defaultBaseUrl;
+    }
+    if (!/^https?:/i.test(raw)) {
+      raw = 'https://' + raw.replace(/^\/+/, '');
+    }
+    while (raw.endsWith('/')) {
+      raw = raw.slice(0, raw.length - 1);
+    }
+    return raw;
+  }
+
+  function normalizeTokenUrl(value) {
+    let raw = value !== undefined && value !== null ? String(value).trim() : '';
+    if (!raw) {
+      raw = readScriptProperty('ADOBE_SIGN_TOKEN_URL', ['ADOBESIGN_TOKEN_URL']) || defaultTokenUrl;
+    }
+    if (!/^https?:/i.test(raw)) {
+      raw = 'https://' + raw.replace(/^\/+/, '');
+    }
+    return raw;
+  }
+
+  function parseTimestamp(raw) {
+    if (!raw && raw !== 0) {
+      return null;
+    }
+    if (typeof raw === 'number' && !isNaN(raw)) {
+      return raw;
+    }
+    const numeric = Number(raw);
+    if (!isNaN(numeric) && numeric > 0) {
+      return numeric;
+    }
+    if (typeof raw === 'string') {
+      const parsed = Date.parse(raw);
+      if (!isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return null;
+  }
+
+  function resolveOptionalString(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    const raw = String(value);
+    const template = raw.trim();
+    if (!template) {
+      return '';
+    }
+    return interpolate(template, ctx).trim();
+  }
+
+  function resolveRequiredString(value, message) {
+    const resolved = resolveOptionalString(value);
+    if (!resolved) {
+      throw new Error(message);
+    }
+    return resolved;
+  }
+
+  function resolveAny(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value === null) {
+      return null;
+    }
+    if (typeof value === 'string') {
+      const template = value.trim();
+      if (!template) {
+        return '';
+      }
+      return interpolate(template, ctx);
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        const entry = resolveAny(value[i]);
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (Array.isArray(entry) && entry.length === 0) {
+          continue;
+        }
+        if (entry && typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0) {
+          continue;
+        }
+        result.push(entry);
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+          continue;
+        }
+        const entry = resolveAny(value[key]);
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (Array.isArray(entry) && entry.length === 0) {
+          continue;
+        }
+        if (entry && typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0) {
+          continue;
+        }
+        result[key] = entry;
+      }
+      return result;
+    }
+    return value;
+  }
+
+  function ensureNonEmptyArray(value, message) {
+    const arrayValue = Array.isArray(value) ? value : [];
+    const filtered = [];
+    for (let i = 0; i < arrayValue.length; i++) {
+      if (arrayValue[i] !== undefined && arrayValue[i] !== null) {
+        filtered.push(arrayValue[i]);
+      }
+    }
+    if (filtered.length === 0) {
+      throw new Error(message);
+    }
+    return filtered;
+  }
+
+  function extractAgreementId(payload, fallback) {
+    if (!payload || typeof payload !== 'object') {
+      return fallback || null;
+    }
+    if (payload.id) {
+      return payload.id;
+    }
+    if (payload.agreementId) {
+      return payload.agreementId;
+    }
+    if (payload.agreement_id) {
+      return payload.agreement_id;
+    }
+    if (payload.agreement && typeof payload.agreement === 'object') {
+      if (payload.agreement.id) {
+        return payload.agreement.id;
+      }
+      if (payload.agreement.agreementId) {
+        return payload.agreement.agreementId;
+      }
+    }
+    return fallback || null;
+  }
+
+  function handleAdobeSignError(error, metadata) {
+    metadata = metadata || {};
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const headers = error && error.headers ? error.headers : null;
+    const payload = error && Object.prototype.hasOwnProperty.call(error, 'body') ? error.body : null;
+    const details = [];
+    if (status) {
+      details.push('status ' + status);
+    }
+    if (payload) {
+      if (typeof payload === 'string') {
+        details.push(payload);
+      } else if (typeof payload === 'object') {
+        if (payload.message) {
+          details.push(String(payload.message));
+        }
+        if (payload.error) {
+          details.push(String(payload.error));
+        }
+        if (Array.isArray(payload.errors)) {
+          for (let i = 0; i < payload.errors.length; i++) {
+            const entry = payload.errors[i];
+            if (!entry) {
+              continue;
+            }
+            if (typeof entry === 'string') {
+              details.push(entry);
+            } else if (entry.message) {
+              details.push(String(entry.message));
+            } else {
+              details.push(JSON.stringify(entry));
+            }
+          }
+        }
+      }
+    }
+    const contextParts = [];
+    if (metadata && metadata.agreementId) {
+      contextParts.push('agreement ' + metadata.agreementId);
+    }
+    const context = contextParts.length > 0 ? ' for ' + contextParts.join(' ') : '';
+    const message = 'Adobe Sign ' + (metadata && metadata.operation ? metadata.operation : opLabel || 'request') + context + '. ' + (details.length > 0 ? details.join(' ') : 'Unexpected error.');
+    logError('adobesign_request_failed', {
+      operation: (metadata && metadata.operation) || opLabel || null,
+      agreementId: metadata && metadata.agreementId ? metadata.agreementId : null,
+      status: status,
+      message: message
+    });
+    const wrapped = new Error(message);
+    wrapped.status = status;
+    if (headers) {
+      wrapped.headers = headers;
+    }
+    wrapped.body = payload;
+    wrapped.cause = error;
+    throw wrapped;
+  }
+
+  function ensureAccessToken() {
+    const configuredToken = resolveOptionalString(config && config.accessToken);
+    if (configuredToken) {
+      return configuredToken;
+    }
+
+    const storedToken = readScriptProperty('ADOBE_SIGN_ACCESS_TOKEN', ['ADOBESIGN_ACCESS_TOKEN']);
+    const expiresAt = parseTimestamp(readScriptProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT', ['ADOBESIGN_TOKEN_EXPIRES_AT']));
+    const now = Date.now();
+    if (storedToken && (!expiresAt || expiresAt - now > 60000)) {
+      return storedToken;
+    }
+
+    const refreshToken = resolveOptionalString(config && config.refreshToken) || readScriptProperty('ADOBE_SIGN_REFRESH_TOKEN', ['ADOBESIGN_REFRESH_TOKEN']) || '';
+    const clientId = resolveOptionalString(config && config.clientId) || readScriptProperty('ADOBE_SIGN_CLIENT_ID', ['ADOBESIGN_CLIENT_ID']) || '';
+    const clientSecret = resolveOptionalString(config && config.clientSecret) || readScriptProperty('ADOBE_SIGN_CLIENT_SECRET', ['ADOBESIGN_CLIENT_SECRET']) || '';
+    const tokenEndpoint = normalizeTokenUrl(config && config.tokenUrl);
+
+    if (refreshToken && clientId && clientSecret) {
+      try {
+        const tokenResponse = withRetries(() => fetchJson({
+          url: tokenEndpoint,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/json'
+          },
+          payload: 'grant_type=refresh_token' + '&refresh_token=' + encodeURIComponent(refreshToken) + '&client_id=' + encodeURIComponent(clientId) + '&client_secret=' + encodeURIComponent(clientSecret),
+          contentType: 'application/x-www-form-urlencoded'
+        }), { attempts: 2, initialDelayMs: 500, maxDelayMs: 4000, jitter: 0.2 });
+        const body = tokenResponse && tokenResponse.body ? tokenResponse.body : null;
+        const newAccessToken = body && body.access_token ? String(body.access_token) : '';
+        if (!newAccessToken) {
+          throw new Error('Adobe Sign token refresh did not return an access token.');
+        }
+        scriptProps.setProperty('ADOBE_SIGN_ACCESS_TOKEN', newAccessToken);
+        if (body && body.refresh_token) {
+          scriptProps.setProperty('ADOBE_SIGN_REFRESH_TOKEN', String(body.refresh_token));
+        }
+        if (body && body.expires_in) {
+          const expiresMs = Date.now() + Number(body.expires_in) * 1000;
+          scriptProps.setProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT', String(expiresMs));
+        } else {
+          scriptProps.deleteProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT');
+        }
+        return newAccessToken;
+      } catch (refreshError) {
+        logError('adobesign_refresh_failed', {
+          operation: opLabel,
+          status: refreshError && refreshError.status ? refreshError.status : null,
+          message: refreshError && refreshError.message ? refreshError.message : String(refreshError)
+        });
+        if (storedToken) {
+          return storedToken;
+        }
+        throw new Error('Adobe Sign token refresh failed. Verify ADOBE_SIGN_REFRESH_TOKEN, ADOBE_SIGN_CLIENT_ID, and ADOBE_SIGN_CLIENT_SECRET.');
+      }
+    }
+
+    if (storedToken) {
+      return storedToken;
+    }
+
+    logError('adobesign_missing_access_token', { operation: opLabel });
+    throw new Error('Adobe Sign requires an access token. Configure ADOBE_SIGN_ACCESS_TOKEN or refresh credentials.');
+  }
+
+  const accessToken = ensureAccessToken();
+  const baseUrl = normalizeBaseUrl(config && config.baseUrl);
+  const configuredAccountId =
+    resolveOptionalString(config && config.accountId) ||
+    readScriptProperty('ADOBE_SIGN_ACCOUNT_ID', ['ADOBESIGN_ACCOUNT_ID']) ||
+    '';
+
+  function buildUrl(endpoint, query) {
+    let path = endpoint ? String(endpoint) : '';
+    if (!/^https?:/i.test(path)) {
+      if (path && path.charAt(0) !== '/') {
+        path = '/' + path;
+      }
+      path = baseUrl + path;
+    }
+    if (query && typeof query === 'object') {
+      const parts = [];
+      for (const key in query) {
+        if (!Object.prototype.hasOwnProperty.call(query, key)) {
+          continue;
+        }
+        const raw = query[key];
+        if (raw === undefined || raw === null || raw === '') {
+          continue;
+        }
+        if (Array.isArray(raw)) {
+          for (let i = 0; i < raw.length; i++) {
+            const entry = raw[i];
+            if (entry === undefined || entry === null || entry === '') {
+              continue;
+            }
+            parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(entry));
+          }
+        } else {
+          parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(raw));
+        }
+      }
+      if (parts.length > 0) {
+        path += (path.indexOf('?') === -1 ? '?' : '&') + parts.join('&');
+      }
+    }
+    return path;
+  }
+
+  function adobeSignRequest(options) {
+    options = options || {};
+    const method = options.method ? String(options.method).toUpperCase() : 'GET';
+    const endpoint = options.endpoint || '';
+    const url = buildUrl(endpoint, options.query);
+    const headers = Object.assign({ Authorization: 'Bearer ' + accessToken, Accept: 'application/json' }, options.headers || {});
+    if (configuredAccountId) {
+      headers['x-api-user'] = 'accountId:' + configuredAccountId;
+    }
+    const requestConfig = {
+      url: url,
+      method: method,
+      headers: headers,
+      muteHttpExceptions: true
+    };
+    if (Object.prototype.hasOwnProperty.call(options, 'body')) {
+      requestConfig.payload = JSON.stringify(options.body);
+      if (!headers['Content-Type']) {
+        headers['Content-Type'] = 'application/json';
+      }
+      requestConfig.contentType = headers['Content-Type'];
+    } else if (Object.prototype.hasOwnProperty.call(options, 'payload')) {
+      requestConfig.payload = options.payload;
+      if (options.contentType) {
+        headers['Content-Type'] = options.contentType;
+        requestConfig.contentType = options.contentType;
+      }
+    }
+    return withRetries(() => fetchJson(requestConfig), rateConfig);
+  }
+  const agreementIdValue = resolveRequiredString(config && config.agreementId, 'Adobe Sign get_agreement requires the Agreement ID field. Provide an Agreement ID.');
+  const includeDocumentsSource = Object.prototype.hasOwnProperty.call(config || {}, 'includeSupportingDocuments') ? config.includeSupportingDocuments : '';
+  const includeDocumentsRaw = resolveAny(includeDocumentsSource);
+  let includeDocumentsParam = '';
+  if (includeDocumentsRaw !== undefined && includeDocumentsRaw !== null && includeDocumentsRaw !== '') {
+    const rawValue = typeof includeDocumentsRaw === 'string' ? includeDocumentsRaw.trim().toLowerCase() : includeDocumentsRaw;
+    const includeDocuments = rawValue === true || rawValue === 'true' || rawValue === '1';
+    includeDocumentsParam = includeDocuments ? 'true' : 'false';
+  }
+  try {
+    const response = adobeSignRequest({
+      method: 'GET',
+      endpoint: '/agreements/' + encodeURIComponent(agreementIdValue),
+      query: includeDocumentsParam ? { includeSupportingDocuments: includeDocumentsParam } : undefined
+    });
+    const body = response && response.body ? response.body : null;
+    ctx.adobeSignAgreementId = agreementIdValue;
+    ctx.adobeSignAgreement = body;
+    if (includeDocumentsParam) {
+      ctx.adobeSignIncludeSupportingDocuments = includeDocumentsParam === 'true';
+    }
+    logInfo('adobesign_get_agreement', { agreementId: agreementIdValue });
+    return ctx;
+  } catch (error) {
+    handleAdobeSignError(error, { operation: 'get_agreement', agreementId: agreementIdValue });
+  }
+}
+
+`
+
+exports["Apps Script Adobe Sign REAL_OPS builds action.adobesign:cancel_agreement 1"] = `
+
+function step_action_adobesign_cancel_agreement(ctx) {
+  ctx = ctx || {};
+  const config = {};
+
+  const operationLabel = 'cancel_agreement';
+  const scriptProps = PropertiesService.getScriptProperties();
+  const rateConfig = { attempts: 4, initialDelayMs: 500, maxDelayMs: 12000, jitter: 0.2 };
+  const defaultBaseUrl = 'https://api.na1.echosign.com/api/rest/v6';
+  const defaultTokenUrl = 'https://api.na1.echosign.com/oauth/token';
+
+  function readScriptProperty(primary, aliases) {
+    const keys = [primary].concat(Array.isArray(aliases) ? aliases : []);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (!key) {
+        continue;
+      }
+      const raw = scriptProps.getProperty(key);
+      if (raw !== null && raw !== undefined && String(raw).trim() !== '') {
+        return raw;
+      }
+    }
+    return null;
+  }
+
+  function normalizeBaseUrl(value) {
+    let raw = value !== undefined && value !== null ? String(value).trim() : '';
+    if (!raw) {
+      raw = readScriptProperty('ADOBE_SIGN_BASE_URL', ['ADOBESIGN_BASE_URL']) || defaultBaseUrl;
+    }
+    if (!/^https?:/i.test(raw)) {
+      raw = 'https://' + raw.replace(/^\/+/, '');
+    }
+    while (raw.endsWith('/')) {
+      raw = raw.slice(0, raw.length - 1);
+    }
+    return raw;
+  }
+
+  function normalizeTokenUrl(value) {
+    let raw = value !== undefined && value !== null ? String(value).trim() : '';
+    if (!raw) {
+      raw = readScriptProperty('ADOBE_SIGN_TOKEN_URL', ['ADOBESIGN_TOKEN_URL']) || defaultTokenUrl;
+    }
+    if (!/^https?:/i.test(raw)) {
+      raw = 'https://' + raw.replace(/^\/+/, '');
+    }
+    return raw;
+  }
+
+  function parseTimestamp(raw) {
+    if (!raw && raw !== 0) {
+      return null;
+    }
+    if (typeof raw === 'number' && !isNaN(raw)) {
+      return raw;
+    }
+    const numeric = Number(raw);
+    if (!isNaN(numeric) && numeric > 0) {
+      return numeric;
+    }
+    if (typeof raw === 'string') {
+      const parsed = Date.parse(raw);
+      if (!isNaN(parsed)) {
+        return parsed;
+      }
+    }
+    return null;
+  }
+
+  function resolveOptionalString(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    const raw = String(value);
+    const template = raw.trim();
+    if (!template) {
+      return '';
+    }
+    return interpolate(template, ctx).trim();
+  }
+
+  function resolveRequiredString(value, message) {
+    const resolved = resolveOptionalString(value);
+    if (!resolved) {
+      throw new Error(message);
+    }
+    return resolved;
+  }
+
+  function resolveAny(value) {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value === null) {
+      return null;
+    }
+    if (typeof value === 'string') {
+      const template = value.trim();
+      if (!template) {
+        return '';
+      }
+      return interpolate(template, ctx);
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (let i = 0; i < value.length; i++) {
+        const entry = resolveAny(value[i]);
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (Array.isArray(entry) && entry.length === 0) {
+          continue;
+        }
+        if (entry && typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0) {
+          continue;
+        }
+        result.push(entry);
+      }
+      return result;
+    }
+    if (typeof value === 'object') {
+      const result = {};
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+          continue;
+        }
+        const entry = resolveAny(value[key]);
+        if (entry === undefined || entry === null) {
+          continue;
+        }
+        if (Array.isArray(entry) && entry.length === 0) {
+          continue;
+        }
+        if (entry && typeof entry === 'object' && !Array.isArray(entry) && Object.keys(entry).length === 0) {
+          continue;
+        }
+        result[key] = entry;
+      }
+      return result;
+    }
+    return value;
+  }
+
+  function ensureNonEmptyArray(value, message) {
+    const arrayValue = Array.isArray(value) ? value : [];
+    const filtered = [];
+    for (let i = 0; i < arrayValue.length; i++) {
+      if (arrayValue[i] !== undefined && arrayValue[i] !== null) {
+        filtered.push(arrayValue[i]);
+      }
+    }
+    if (filtered.length === 0) {
+      throw new Error(message);
+    }
+    return filtered;
+  }
+
+  function extractAgreementId(payload, fallback) {
+    if (!payload || typeof payload !== 'object') {
+      return fallback || null;
+    }
+    if (payload.id) {
+      return payload.id;
+    }
+    if (payload.agreementId) {
+      return payload.agreementId;
+    }
+    if (payload.agreement_id) {
+      return payload.agreement_id;
+    }
+    if (payload.agreement && typeof payload.agreement === 'object') {
+      if (payload.agreement.id) {
+        return payload.agreement.id;
+      }
+      if (payload.agreement.agreementId) {
+        return payload.agreement.agreementId;
+      }
+    }
+    return fallback || null;
+  }
+
+  function handleAdobeSignError(error, metadata) {
+    metadata = metadata || {};
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const headers = error && error.headers ? error.headers : null;
+    const payload = error && Object.prototype.hasOwnProperty.call(error, 'body') ? error.body : null;
+    const details = [];
+    if (status) {
+      details.push('status ' + status);
+    }
+    if (payload) {
+      if (typeof payload === 'string') {
+        details.push(payload);
+      } else if (typeof payload === 'object') {
+        if (payload.message) {
+          details.push(String(payload.message));
+        }
+        if (payload.error) {
+          details.push(String(payload.error));
+        }
+        if (Array.isArray(payload.errors)) {
+          for (let i = 0; i < payload.errors.length; i++) {
+            const entry = payload.errors[i];
+            if (!entry) {
+              continue;
+            }
+            if (typeof entry === 'string') {
+              details.push(entry);
+            } else if (entry.message) {
+              details.push(String(entry.message));
+            } else {
+              details.push(JSON.stringify(entry));
+            }
+          }
+        }
+      }
+    }
+    const contextParts = [];
+    if (metadata && metadata.agreementId) {
+      contextParts.push('agreement ' + metadata.agreementId);
+    }
+    const context = contextParts.length > 0 ? ' for ' + contextParts.join(' ') : '';
+    const message = 'Adobe Sign ' + (metadata && metadata.operation ? metadata.operation : opLabel || 'request') + context + '. ' + (details.length > 0 ? details.join(' ') : 'Unexpected error.');
+    logError('adobesign_request_failed', {
+      operation: (metadata && metadata.operation) || opLabel || null,
+      agreementId: metadata && metadata.agreementId ? metadata.agreementId : null,
+      status: status,
+      message: message
+    });
+    const wrapped = new Error(message);
+    wrapped.status = status;
+    if (headers) {
+      wrapped.headers = headers;
+    }
+    wrapped.body = payload;
+    wrapped.cause = error;
+    throw wrapped;
+  }
+
+  function ensureAccessToken() {
+    const configuredToken = resolveOptionalString(config && config.accessToken);
+    if (configuredToken) {
+      return configuredToken;
+    }
+
+    const storedToken = readScriptProperty('ADOBE_SIGN_ACCESS_TOKEN', ['ADOBESIGN_ACCESS_TOKEN']);
+    const expiresAt = parseTimestamp(readScriptProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT', ['ADOBESIGN_TOKEN_EXPIRES_AT']));
+    const now = Date.now();
+    if (storedToken && (!expiresAt || expiresAt - now > 60000)) {
+      return storedToken;
+    }
+
+    const refreshToken = resolveOptionalString(config && config.refreshToken) || readScriptProperty('ADOBE_SIGN_REFRESH_TOKEN', ['ADOBESIGN_REFRESH_TOKEN']) || '';
+    const clientId = resolveOptionalString(config && config.clientId) || readScriptProperty('ADOBE_SIGN_CLIENT_ID', ['ADOBESIGN_CLIENT_ID']) || '';
+    const clientSecret = resolveOptionalString(config && config.clientSecret) || readScriptProperty('ADOBE_SIGN_CLIENT_SECRET', ['ADOBESIGN_CLIENT_SECRET']) || '';
+    const tokenEndpoint = normalizeTokenUrl(config && config.tokenUrl);
+
+    if (refreshToken && clientId && clientSecret) {
+      try {
+        const tokenResponse = withRetries(() => fetchJson({
+          url: tokenEndpoint,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/json'
+          },
+          payload: 'grant_type=refresh_token' + '&refresh_token=' + encodeURIComponent(refreshToken) + '&client_id=' + encodeURIComponent(clientId) + '&client_secret=' + encodeURIComponent(clientSecret),
+          contentType: 'application/x-www-form-urlencoded'
+        }), { attempts: 2, initialDelayMs: 500, maxDelayMs: 4000, jitter: 0.2 });
+        const body = tokenResponse && tokenResponse.body ? tokenResponse.body : null;
+        const newAccessToken = body && body.access_token ? String(body.access_token) : '';
+        if (!newAccessToken) {
+          throw new Error('Adobe Sign token refresh did not return an access token.');
+        }
+        scriptProps.setProperty('ADOBE_SIGN_ACCESS_TOKEN', newAccessToken);
+        if (body && body.refresh_token) {
+          scriptProps.setProperty('ADOBE_SIGN_REFRESH_TOKEN', String(body.refresh_token));
+        }
+        if (body && body.expires_in) {
+          const expiresMs = Date.now() + Number(body.expires_in) * 1000;
+          scriptProps.setProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT', String(expiresMs));
+        } else {
+          scriptProps.deleteProperty('ADOBE_SIGN_TOKEN_EXPIRES_AT');
+        }
+        return newAccessToken;
+      } catch (refreshError) {
+        logError('adobesign_refresh_failed', {
+          operation: opLabel,
+          status: refreshError && refreshError.status ? refreshError.status : null,
+          message: refreshError && refreshError.message ? refreshError.message : String(refreshError)
+        });
+        if (storedToken) {
+          return storedToken;
+        }
+        throw new Error('Adobe Sign token refresh failed. Verify ADOBE_SIGN_REFRESH_TOKEN, ADOBE_SIGN_CLIENT_ID, and ADOBE_SIGN_CLIENT_SECRET.');
+      }
+    }
+
+    if (storedToken) {
+      return storedToken;
+    }
+
+    logError('adobesign_missing_access_token', { operation: opLabel });
+    throw new Error('Adobe Sign requires an access token. Configure ADOBE_SIGN_ACCESS_TOKEN or refresh credentials.');
+  }
+
+  const accessToken = ensureAccessToken();
+  const baseUrl = normalizeBaseUrl(config && config.baseUrl);
+  const configuredAccountId =
+    resolveOptionalString(config && config.accountId) ||
+    readScriptProperty('ADOBE_SIGN_ACCOUNT_ID', ['ADOBESIGN_ACCOUNT_ID']) ||
+    '';
+
+  function buildUrl(endpoint, query) {
+    let path = endpoint ? String(endpoint) : '';
+    if (!/^https?:/i.test(path)) {
+      if (path && path.charAt(0) !== '/') {
+        path = '/' + path;
+      }
+      path = baseUrl + path;
+    }
+    if (query && typeof query === 'object') {
+      const parts = [];
+      for (const key in query) {
+        if (!Object.prototype.hasOwnProperty.call(query, key)) {
+          continue;
+        }
+        const raw = query[key];
+        if (raw === undefined || raw === null || raw === '') {
+          continue;
+        }
+        if (Array.isArray(raw)) {
+          for (let i = 0; i < raw.length; i++) {
+            const entry = raw[i];
+            if (entry === undefined || entry === null || entry === '') {
+              continue;
+            }
+            parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(entry));
+          }
+        } else {
+          parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(raw));
+        }
+      }
+      if (parts.length > 0) {
+        path += (path.indexOf('?') === -1 ? '?' : '&') + parts.join('&');
+      }
+    }
+    return path;
+  }
+
+  function adobeSignRequest(options) {
+    options = options || {};
+    const method = options.method ? String(options.method).toUpperCase() : 'GET';
+    const endpoint = options.endpoint || '';
+    const url = buildUrl(endpoint, options.query);
+    const headers = Object.assign({ Authorization: 'Bearer ' + accessToken, Accept: 'application/json' }, options.headers || {});
+    if (configuredAccountId) {
+      headers['x-api-user'] = 'accountId:' + configuredAccountId;
+    }
+    const requestConfig = {
+      url: url,
+      method: method,
+      headers: headers,
+      muteHttpExceptions: true
+    };
+    if (Object.prototype.hasOwnProperty.call(options, 'body')) {
+      requestConfig.payload = JSON.stringify(options.body);
+      if (!headers['Content-Type']) {
+        headers['Content-Type'] = 'application/json';
+      }
+      requestConfig.contentType = headers['Content-Type'];
+    } else if (Object.prototype.hasOwnProperty.call(options, 'payload')) {
+      requestConfig.payload = options.payload;
+      if (options.contentType) {
+        headers['Content-Type'] = options.contentType;
+        requestConfig.contentType = options.contentType;
+      }
+    }
+    return withRetries(() => fetchJson(requestConfig), rateConfig);
+  }
+  const agreementIdValue = resolveRequiredString(config && config.agreementId, 'Adobe Sign cancel_agreement requires the Agreement ID field. Provide an Agreement ID.');
+  const cancelNoteTemplate = Object.prototype.hasOwnProperty.call(config || {}, 'comment') ? config.comment : (Object.prototype.hasOwnProperty.call(config || {}, 'note') ? config.note : '');
+  const cancelNote = resolveOptionalString(cancelNoteTemplate);
+  const notifySignerRaw = resolveAny(config && config.notifySigner);
+  const notifySigner = notifySignerRaw === false || (typeof notifySignerRaw === 'string' && notifySignerRaw.toLowerCase() === 'false') ? false : true;
+  try {
+    const payload = { state: 'CANCELLED' };
+    if (cancelNote) {
+      payload.note = cancelNote;
+    }
+    if (!notifySigner) {
+      payload.notifySigner = false;
+    }
+    const response = adobeSignRequest({ method: 'POST', endpoint: '/agreements/' + encodeURIComponent(agreementIdValue) + '/state', body: payload });
+    const body = response && response.body ? response.body : null;
+    ctx.adobeSignAgreementId = agreementIdValue;
+    ctx.adobeSignAgreement = body;
+    ctx.adobeSignAgreementState = 'CANCELLED';
+    if (cancelNote) {
+      ctx.adobeSignCancellationNote = cancelNote;
+    }
+    ctx.adobeSignNotifySigner = notifySigner;
+    logInfo('adobesign_cancel_agreement', { agreementId: agreementIdValue, notifySigner: notifySigner });
+    return ctx;
+  } catch (error) {
+    handleAdobeSignError(error, { operation: 'cancel_agreement', agreementId: agreementIdValue });
+  }
+}
+
+`
+
+exports["Apps Script Adobe Sign REAL_OPS builds trigger.adobesign:agreement_workflow_completed 1"] = `
+
+function trigger_trigger_adobesign_agreement_workflow_completed(ctx) {
+  ctx = ctx || {};
+  const config = {};
+  const payload = ctx && ctx.webhookPayload ? ctx.webhookPayload : (ctx && ctx.event ? ctx.event : {});
+  const eventData = payload && payload.event ? payload.event : payload;
+  const agreementId = extractAgreementIdFromPayload(payload);
+  const template = config && Object.prototype.hasOwnProperty.call(config, 'agreementId') ? config.agreementId : '';
+  const filterAgreementId = template ? interpolate(String(template), ctx).trim() : '';
+  if (filterAgreementId && agreementId && filterAgreementId !== agreementId) {
+    logInfo('adobesign_trigger_filtered', { trigger: 'agreement_workflow_completed', agreementId: agreementId, filterAgreementId: filterAgreementId });
+    ctx.adobeSignTrigger = 'agreement_workflow_completed';
+    ctx.adobeSignAgreementId = agreementId;
+    ctx.adobeSignTriggerFiltered = true;
+    ctx.adobeSignEvent = payload;
+    return ctx;
+  }
+  ctx.adobeSignTrigger = 'agreement_workflow_completed';
+  ctx.adobeSignAgreementId = agreementId;
+  ctx.adobeSignEvent = payload;
+  ctx.adobeSignEventDetail = eventData;
+  if (payload && payload.eventDate) {
+    ctx.adobeSignEventTimestamp = payload.eventDate;
+  }
+  if (payload && payload.eventType) {
+    ctx.adobeSignEventType = payload.eventType;
+  } else if (eventData && eventData.eventType) {
+    ctx.adobeSignEventType = eventData.eventType;
+  }
+  logInfo('adobesign_agreement_workflow_completed_received', { agreementId: agreementId || null });
+  return ctx;
+
+  function extractAgreementIdFromPayload(source) {
+    if (!source || typeof source !== 'object') {
+      return null;
+    }
+    if (source.agreement && typeof source.agreement === 'object') {
+      if (source.agreement.id) {
+        return source.agreement.id;
+      }
+      if (source.agreement.agreementId) {
+        return source.agreement.agreementId;
+      }
+    }
+    if (source.agreementId) {
+      return source.agreementId;
+    }
+    if (source.agreement_id) {
+      return source.agreement_id;
+    }
+    if (source.event && typeof source.event === 'object') {
+      if (source.event.agreementId) {
+        return source.event.agreementId;
+      }
+      if (source.event.agreement_id) {
+        return source.event.agreement_id;
+      }
+    }
+    if (source.payload && typeof source.payload === 'object') {
+      return extractAgreementIdFromPayload(source.payload);
+    }
+    return null;
+  }
+}
+
+`
+
+exports["Apps Script Adobe Sign REAL_OPS builds trigger.adobesign:agreement_action_completed 1"] = `
+
+function trigger_trigger_adobesign_agreement_action_completed(ctx) {
+  ctx = ctx || {};
+  const config = {};
+  const payload = ctx && ctx.webhookPayload ? ctx.webhookPayload : (ctx && ctx.event ? ctx.event : {});
+  const eventData = payload && payload.event ? payload.event : payload;
+  const agreementId = extractAgreementIdFromPayload(payload);
+  const template = config && Object.prototype.hasOwnProperty.call(config, 'agreementId') ? config.agreementId : '';
+  const filterAgreementId = template ? interpolate(String(template), ctx).trim() : '';
+  if (filterAgreementId && agreementId && filterAgreementId !== agreementId) {
+    logInfo('adobesign_trigger_filtered', { trigger: 'agreement_action_completed', agreementId: agreementId, filterAgreementId: filterAgreementId });
+    ctx.adobeSignTrigger = 'agreement_action_completed';
+    ctx.adobeSignAgreementId = agreementId;
+    ctx.adobeSignTriggerFiltered = true;
+    ctx.adobeSignEvent = payload;
+    return ctx;
+  }
+  ctx.adobeSignTrigger = 'agreement_action_completed';
+  ctx.adobeSignAgreementId = agreementId;
+  ctx.adobeSignEvent = payload;
+  ctx.adobeSignEventDetail = eventData;
+  if (payload && payload.eventDate) {
+    ctx.adobeSignEventTimestamp = payload.eventDate;
+  }
+  if (payload && payload.eventType) {
+    ctx.adobeSignEventType = payload.eventType;
+  } else if (eventData && eventData.eventType) {
+    ctx.adobeSignEventType = eventData.eventType;
+  }
+  logInfo('adobesign_agreement_action_completed_received', { agreementId: agreementId || null });
+  return ctx;
+
+  function extractAgreementIdFromPayload(source) {
+    if (!source || typeof source !== 'object') {
+      return null;
+    }
+    if (source.agreement && typeof source.agreement === 'object') {
+      if (source.agreement.id) {
+        return source.agreement.id;
+      }
+      if (source.agreement.agreementId) {
+        return source.agreement.agreementId;
+      }
+    }
+    if (source.agreementId) {
+      return source.agreementId;
+    }
+    if (source.agreement_id) {
+      return source.agreement_id;
+    }
+    if (source.event && typeof source.event === 'object') {
+      if (source.event.agreementId) {
+        return source.event.agreementId;
+      }
+      if (source.event.agreement_id) {
+        return source.event.agreement_id;
+      }
+    }
+    if (source.payload && typeof source.payload === 'object') {
+      return extractAgreementIdFromPayload(source.payload);
+    }
+    return null;
+  }
+}
+
+`
+

--- a/server/workflow/__tests__/apps-script.adobesign.test.ts
+++ b/server/workflow/__tests__/apps-script.adobesign.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { REAL_OPS } from '../compile-to-appsscript';
+
+const ADOBESIGN_OPERATIONS = [
+  'action.adobesign:test_connection',
+  'action.adobesign:create_agreement',
+  'action.adobesign:send_agreement',
+  'action.adobesign:get_agreement',
+  'action.adobesign:cancel_agreement',
+  'trigger.adobesign:agreement_workflow_completed',
+  'trigger.adobesign:agreement_action_completed',
+] as const;
+
+describe('Apps Script Adobe Sign REAL_OPS', () => {
+  for (const operation of ADOBESIGN_OPERATIONS) {
+    it(`builds ${operation}`, () => {
+      const builder = REAL_OPS[operation];
+      expect(builder).toBeDefined();
+      expect(builder({})).toMatchSnapshot();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- implement Adobe Sign Apps Script action and trigger builders using the shared helper
- wire up REAL_OPS mappings and update fallback generator to use the new builders
- document Adobe Sign script properties and add Vitest coverage with snapshots

## Testing
- `npx vitest --run server/workflow/__tests__/apps-script.adobesign.test.ts` *(fails: unable to download packages in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ece8833adc8331a3a226676a878a5a