### PR TITLE
Implement production Gmail Apps Script handlers

### DIFF
--- a/docs/apps-script-rollout/script-properties.md
+++ b/docs/apps-script-rollout/script-properties.md
@@ -174,9 +174,10 @@ Salesforce workflows must populate both properties before deployment. Access tok
 
 ### Gmail token management
 
-- Apps Script Gmail handlers require `GMAIL_ACCESS_TOKEN` scopes `https://www.googleapis.com/auth/gmail.send` and `https://www.googleapis.com/auth/gmail.readonly` to cover send, search, and polling flows. Provision tokens with both scopes so the same credential supports triggers and actions.
+- Apps Script Gmail handlers require `GMAIL_ACCESS_TOKEN` scopes `https://www.googleapis.com/auth/gmail.send`, `https://www.googleapis.com/auth/gmail.readonly`, **and** `https://www.googleapis.com/auth/gmail.modify` so the same token can poll, send, and update labels. Provision the access token with the full trio of scopes before promoting new handlers.
 - Populate `GMAIL_REFRESH_TOKEN` alongside the access token. A rotation job should exchange the refresh token at least daily; the Apps Script runtime expects fresh access tokens because Gmail REST calls fail once the one-hour access token expires.
 - Store both secrets in Script Properties (production and staging) before deploying new handlers. Missing tokens cause structured `gmail_missing_access_token` errors during runtime, surfacing misconfigurations quickly.
+- Polling triggers persist their `runtime.state` cursor back to Script Properties; confirm Script Properties writes succeed in staging before the Tier‑0 rollout so trigger runs continue from the last `internalDate` checkpoint.
 
 ## Machine-readable report
 

--- a/server/workflow/__tests__/__snapshots__/apps-script.gmail.test.ts.snap
+++ b/server/workflow/__tests__/__snapshots__/apps-script.gmail.test.ts.snap
@@ -1,15 +1,17 @@
-exports[`Apps Script Gmail REAL_OPS builds trigger.gmail:email_received 1`] = `
-function onNewEmail() {
-  return buildPollingWrapper('trigger.gmail:email_received', function (runtime) {
+exports[`Apps Script Gmail REAL_OPS builds trigger.gmail:new_email_received 1`] = `
+
+function onGmailNewEmailReceived() {
+  return buildPollingWrapper('trigger.gmail:new_email_received', function (runtime) {
     const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
     if (!accessToken) {
-      logError('gmail_missing_access_token', { operation: 'trigger.gmail:email_received' });
-      throw new Error('Missing Gmail access token for gmail.email_received trigger');
+      logError('gmail_missing_access_token', { operation: 'trigger.gmail:new_email_received' });
+      throw new Error('Missing Gmail access token for gmail.new_email_received trigger');
     }
 
     const interpolationContext = runtime.state && runtime.state.lastPayload ? runtime.state.lastPayload : {};
-    const query = interpolate('${esc(c.query || 'is:unread')}', interpolationContext).trim();
-    const labelIdsConfig = ${JSON.stringify(c.labelIds || [])};
+    const queryTemplate = 'is:unread';
+    const query = queryTemplate ? interpolate(queryTemplate, interpolationContext).trim() : '';
+    const labelIdsConfig = ["INBOX"];
     const labelIds = [];
     if (Array.isArray(labelIdsConfig)) {
       for (let i = 0; i < labelIdsConfig.length; i++) {
@@ -131,134 +133,172 @@ function onNewEmail() {
           params.push('q=' + encodeURIComponent(effectiveQuery));
         }
         if (Array.isArray(labelIds) && labelIds.length) {
-        for (let i = 0; i < labelIds.length; i++) {
-          params.push('labelIds=' + encodeURIComponent(labelIds[i]));
+          for (let i = 0; i < labelIds.length; i++) {
+            params.push('labelIds=' + encodeURIComponent(labelIds[i]));
+          }
         }
-      }
-      if (pageToken) {
-        params.push('pageToken=' + encodeURIComponent(pageToken));
-      }
-
-      const listResponse = rateLimitAware(
-        () => fetchJson({
-          url: baseUrl + '/messages?' + params.join('&'),
-          method: 'GET',
-          headers: headers
-        }),
-        { attempts: 5, backoffMs: 500 }
-      );
-
-      const listBody = listResponse.body || {};
-      const candidates = Array.isArray(listBody.messages) ? listBody.messages : [];
-      for (let i = 0; i < candidates.length; i++) {
-        const messageId = candidates[i] && candidates[i].id;
-        if (!messageId) {
-          continue;
+        if (pageToken) {
+          params.push('pageToken=' + encodeURIComponent(pageToken));
         }
 
-        const messageResponse = rateLimitAware(
+        const listResponse = rateLimitAware(
           () => fetchJson({
-            url: baseUrl + '/messages/' + encodeURIComponent(messageId) + '?format=full',
+            url: baseUrl + '/messages?' + params.join('&'),
             method: 'GET',
             headers: headers
           }),
           { attempts: 5, backoffMs: 500 }
         );
 
-        const detail = messageResponse.body || {};
-        const payload = detail.payload || {};
-        const headersList = payload.headers || [];
-        const bodies = extractBodies(payload);
-        const attachments = [];
-        collectAttachments(payload.parts, attachments);
+        const listBody = listResponse.body || {};
+        const candidates = Array.isArray(listBody.messages) ? listBody.messages : [];
+        for (let i = 0; i < candidates.length; i++) {
+          const messageId = candidates[i] && candidates[i].id;
+          if (!messageId) {
+            continue;
+          }
 
-        const internalDate = detail.internalDate ? Number(detail.internalDate) : null;
-        if (lastInternalDate && internalDate && internalDate <= lastInternalDate) {
-          continue;
+          const messageResponse = rateLimitAware(
+            () => fetchJson({
+              url: baseUrl + '/messages/' + encodeURIComponent(messageId) + '?format=full',
+              method: 'GET',
+              headers: headers
+            }),
+            { attempts: 5, backoffMs: 500 }
+          );
+
+          const detail = messageResponse.body || {};
+          const payload = detail.payload || {};
+          const headersList = payload.headers || [];
+          const bodies = extractBodies(payload);
+          const attachments = [];
+          collectAttachments(payload.parts, attachments);
+
+          const internalDate = detail.internalDate ? Number(detail.internalDate) : null;
+          if (lastInternalDate && internalDate && internalDate <= lastInternalDate) {
+            continue;
+          }
+
+          const from = extractHeader(headersList, 'From');
+          const to = parseAddressList(extractHeader(headersList, 'To'));
+          const cc = parseAddressList(extractHeader(headersList, 'Cc'));
+          const bcc = parseAddressList(extractHeader(headersList, 'Bcc'));
+          const replyTo = parseAddressList(extractHeader(headersList, 'Reply-To'));
+          const deliveredTo = extractHeader(headersList, 'Delivered-To');
+          const subject = extractHeader(headersList, 'Subject') || null;
+          const historyId = detail.historyId ? String(detail.historyId) : null;
+
+          const fromName = from && from.indexOf('<') !== -1 ? from.split('<')[0].trim() : null;
+          messages.push({
+            internalDate: internalDate || Date.now(),
+            historyId: historyId,
+            payload: {
+              id: detail.id || messageId,
+              threadId: detail.threadId || null,
+              historyId: historyId,
+              labelIds: Array.isArray(detail.labelIds) ? detail.labelIds : [],
+              subject: subject,
+              snippet: detail.snippet || '',
+              from: from,
+              fromName: fromName,
+              to: to,
+              cc: cc,
+              bcc: bcc,
+              replyTo: replyTo,
+              deliveredTo: deliveredTo || null,
+              receivedAt: internalDate ? new Date(internalDate).toISOString() : new Date().toISOString(),
+              sizeEstimate: detail.sizeEstimate || null,
+              bodyPlain: bodies.plain || null,
+              bodyHtml: bodies.html || null,
+              attachments: attachments,
+              threadSnippet: detail.snippet || null,
+              raw: detail
+            }
+          });
         }
 
-        const from = extractHeader(headersList, 'From');
-        const to = parseAddressList(extractHeader(headersList, 'To'));
-        const cc = parseAddressList(extractHeader(headersList, 'Cc'));
-        const bcc = parseAddressList(extractHeader(headersList, 'Bcc'));
-        const replyTo = parseAddressList(extractHeader(headersList, 'Reply-To'));
-        const deliveredTo = extractHeader(headersList, 'Delivered-To');
-        const subject = extractHeader(headersList, 'Subject') || null;
-        const historyId = detail.historyId ? String(detail.historyId) : null;
+        if (messages.length >= 50) {
+          pageToken = null;
+        } else {
+          pageToken = listBody.nextPageToken || null;
+        }
 
-        const fromName = from && from.indexOf('<') !== -1 ? from.split('<')[0].trim() : null;
-
-        messages.push({
-          internalDate: internalDate || Date.now(),
-          historyId: historyId,
-          payload: {
-            id: detail.id || messageId,
-            threadId: detail.threadId || null,
-            historyId: historyId,
-            labelIds: Array.isArray(detail.labelIds) ? detail.labelIds : [],
-            subject: subject,
-            snippet: detail.snippet || '',
-            from: from,
-            fromName: fromName,
-            to: to,
-            cc: cc,
-            bcc: bcc,
-            replyTo: replyTo,
-            deliveredTo: deliveredTo || null,
-            receivedAt: internalDate ? new Date(internalDate).toISOString() : new Date().toISOString(),
-            sizeEstimate: detail.sizeEstimate || null,
-            bodyPlain: bodies.plain || '',
-            bodyHtml: bodies.html || '',
-            attachments: attachments,
-            _meta: { raw: detail }
-          }
-        });
-      }
-
-      pageToken = listBody.nextPageToken || null;
-      pageCount += 1;
-    } while (pageToken && messages.length < 50 && pageCount < 5);
+        pageCount += 1;
+      } while (pageToken && pageCount < 5 && messages.length < 50);
 
       if (messages.length === 0) {
         runtime.summary({
           messagesAttempted: 0,
           messagesDispatched: 0,
           messagesFailed: 0,
-          query: effectiveQuery,
-          labelIds: labelIds
+      labelCount: labelIds.length,
+      query: effectiveQuery,
+          labelIds: labelIds,
+          lastInternalDate: lastInternalDate || null
         });
-        return { messagesAttempted: 0, messagesDispatched: 0, messagesFailed: 0, query: effectiveQuery, labelIds: labelIds };
+        return {
+          messagesAttempted: 0,
+          messagesDispatched: 0,
+          messagesFailed: 0,
+      labelCount: labelIds.length,
+      query: effectiveQuery,
+          labelIds: labelIds,
+          lastInternalDate: lastInternalDate || null
+        };
       }
 
       messages.sort(function (a, b) {
-        return (a.internalDate || 0) - (b.internalDate || 0);
+        return Number(a.internalDate) - Number(b.internalDate);
       });
 
+      let lastPayloadDispatched = null;
       const batch = runtime.dispatchBatch(messages, function (entry) {
-        return entry.payload;
+        const payload = {
+          id: entry.payload.id,
+          threadId: entry.payload.threadId,
+          historyId: entry.payload.historyId,
+          labelIds: entry.payload.labelIds,
+          subject: entry.payload.subject,
+          snippet: entry.payload.snippet,
+          from: entry.payload.from,
+          fromName: entry.payload.fromName,
+          to: entry.payload.to,
+          cc: entry.payload.cc,
+          bcc: entry.payload.bcc,
+          replyTo: entry.payload.replyTo,
+          deliveredTo: entry.payload.deliveredTo,
+          receivedAt: entry.payload.receivedAt,
+          sizeEstimate: entry.payload.sizeEstimate,
+          bodyPlain: entry.payload.bodyPlain,
+          bodyHtml: entry.payload.bodyHtml,
+          attachments: entry.payload.attachments,
+          threadSnippet: entry.payload.threadSnippet,
+          snippet: entry.payload.snippet,
+          _meta: { raw: entry.payload.raw || null }
+        };
+        lastPayloadDispatched = payload;
+        return payload;
       });
 
-      const last = messages[messages.length - 1];
+      runtime.state = runtime.state && typeof runtime.state === 'object' ? runtime.state : {};
       runtime.state.cursor = runtime.state.cursor && typeof runtime.state.cursor === 'object' ? runtime.state.cursor : {};
-      runtime.state.cursor.internalDate = String(last.internalDate || Date.now());
-      if (last.historyId) {
-        runtime.state.cursor.historyId = last.historyId;
-      }
-      runtime.state.cursor.lastMessageId = last.payload.id;
-      runtime.state.lastPayload = last.payload;
+      runtime.state.cursor.internalDate = messages[messages.length - 1].internalDate;
+      runtime.state.lastPayload = lastPayloadDispatched || runtime.state.lastPayload || null;
 
       runtime.summary({
         messagesAttempted: batch.attempted,
         messagesDispatched: batch.succeeded,
         messagesFailed: batch.failed,
-        query: effectiveQuery,
+      labelCount: labelIds.length,
+      query: effectiveQuery,
         labelIds: labelIds,
         lastInternalDate: runtime.state.cursor.internalDate
       });
 
-      logInfo('gmail_email_received_success', {
-        query: effectiveQuery,
+      logInfo('gmail_new_email_received_success', {
         dispatched: batch.succeeded,
+      labelCount: labelIds.length,
+      query: effectiveQuery,
         labelIds: labelIds,
         lastInternalDate: runtime.state.cursor.internalDate
       });
@@ -267,7 +307,8 @@ function onNewEmail() {
         messagesAttempted: batch.attempted,
         messagesDispatched: batch.succeeded,
         messagesFailed: batch.failed,
-        query: effectiveQuery,
+      labelCount: labelIds.length,
+      query: effectiveQuery,
         labelIds: labelIds,
         lastInternalDate: runtime.state.cursor.internalDate
       };
@@ -276,7 +317,7 @@ function onNewEmail() {
       const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
       const status = error && typeof error.status === 'number' ? error.status : null;
       const message = providerMessage || (error && error.message ? error.message : String(error));
-      logError('gmail_email_received_failed', {
+      logError('gmail_new_email_received_failed', {
         status: status,
         providerCode: providerCode,
         message: message
@@ -287,7 +328,845 @@ function onNewEmail() {
 }
 `;
 
+exports[`Apps Script Gmail REAL_OPS builds trigger.gmail:email_received_from 1`] = `
+
+function onGmailEmailReceivedFrom() {
+  return buildPollingWrapper('trigger.gmail:email_received_from', function (runtime) {
+    const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+    if (!accessToken) {
+      logError('gmail_missing_access_token', { operation: 'trigger.gmail:email_received_from' });
+      throw new Error('Missing Gmail access token for gmail.email_received_from trigger');
+    }
+
+    const interpolationContext = runtime.state && runtime.state.lastPayload ? runtime.state.lastPayload : {};
+    const fromTemplate = 'alerts@example.com';
+    const subjectTemplate = 'Status';
+    const fromFilter = fromTemplate ? interpolate(fromTemplate, interpolationContext).trim() : '';
+    if (!fromFilter) {
+      throw new Error('trigger.gmail:email_received_from requires a fromEmail value before deployment.');
+    }
+    const subjectFilter = subjectTemplate ? interpolate(subjectTemplate, interpolationContext).trim() : '';
+    const labelIds = [];
+    const parts = ['from:' + fromFilter];
+    if (subjectFilter) {
+      parts.push('subject:"' + subjectFilter.replace(/"/g, '\"') + '"');
+    }
+    const query = parts.join(' ');
+
+    const headers = { Authorization: 'Bearer ' + accessToken };
+    const baseUrl = 'https://gmail.googleapis.com/gmail/v1/users/me';
+    const cursor = (runtime.state && typeof runtime.state.cursor === 'object') ? runtime.state.cursor : {};
+    const lastInternalDate = cursor && cursor.internalDate ? Number(cursor.internalDate) : null;
+    const afterSeconds = lastInternalDate ? Math.floor(lastInternalDate / 1000) : null;
+    const effectiveQuery = afterSeconds ? ((query ? query + ' ' : '') + 'after:' + afterSeconds) : query;
+    const messages = [];
+    let pageToken = null;
+    let pageCount = 0;
+
+    function decodeBase64Url(data) {
+      if (!data) {
+        return '';
+      }
+      try {
+        const normalized = data.replace(/-/g, '+').replace(/_/g, '/');
+        const bytes = Utilities.base64Decode(normalized);
+        return Utilities.newBlob(bytes).getDataAsString('UTF-8');
+      } catch (error) {
+        logWarn('gmail_message_body_decode_failed', {
+          message: error && error.message ? error.message : String(error)
+        });
+        return '';
+      }
+    }
+
+    function extractHeader(all, name) {
+      if (!Array.isArray(all)) {
+        return '';
+      }
+      const target = name.toLowerCase();
+      for (let i = 0; i < all.length; i++) {
+        const header = all[i];
+        if (!header || typeof header.name !== 'string') {
+          continue;
+        }
+        if (header.name.toLowerCase() === target) {
+          return header.value || '';
+        }
+      }
+      return '';
+    }
+
+    function parseAddressList(value) {
+      if (!value) {
+        return [];
+      }
+      return value.split(',').map(part => part.trim()).filter(Boolean);
+    }
+
+    function collectAttachments(parts, bucket) {
+      if (!Array.isArray(parts)) {
+        return;
+      }
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        if (!part) {
+          continue;
+        }
+        if (part.filename && part.body && part.body.attachmentId) {
+          bucket.push({
+            attachmentId: part.body.attachmentId,
+            filename: part.filename,
+            mimeType: part.mimeType || 'application/octet-stream',
+            size: part.body.size || 0
+          });
+        }
+        if (Array.isArray(part.parts) && part.parts.length) {
+          collectAttachments(part.parts, bucket);
+        }
+      }
+    }
+
+    function extractBodies(payload) {
+      const result = {};
+      if (!payload) {
+        return result;
+      }
+
+      const queue = [payload];
+      while (queue.length > 0) {
+        const node = queue.shift();
+        if (!node) {
+          continue;
+        }
+        if (node.mimeType === 'text/plain' && node.body && node.body.data) {
+          result.plain = decodeBase64Url(node.body.data);
+        } else if (node.mimeType === 'text/html' && node.body && node.body.data) {
+          result.html = decodeBase64Url(node.body.data);
+        }
+        if (Array.isArray(node.parts)) {
+          for (let p = 0; p < node.parts.length; p++) {
+            queue.push(node.parts[p]);
+          }
+        }
+      }
+
+      if (!result.plain && payload.body && payload.body.data) {
+        result.plain = decodeBase64Url(payload.body.data);
+      }
+
+      return result;
+    }
+
+    try {
+      do {
+        const params = ['maxResults=25'];
+        if (effectiveQuery) {
+          params.push('q=' + encodeURIComponent(effectiveQuery));
+        }
+        if (Array.isArray(labelIds) && labelIds.length) {
+          for (let i = 0; i < labelIds.length; i++) {
+            params.push('labelIds=' + encodeURIComponent(labelIds[i]));
+          }
+        }
+        if (pageToken) {
+          params.push('pageToken=' + encodeURIComponent(pageToken));
+        }
+
+        const listResponse = rateLimitAware(
+          () => fetchJson({
+            url: baseUrl + '/messages?' + params.join('&'),
+            method: 'GET',
+            headers: headers
+          }),
+          { attempts: 5, backoffMs: 500 }
+        );
+
+        const listBody = listResponse.body || {};
+        const candidates = Array.isArray(listBody.messages) ? listBody.messages : [];
+        for (let i = 0; i < candidates.length; i++) {
+          const messageId = candidates[i] && candidates[i].id;
+          if (!messageId) {
+            continue;
+          }
+
+          const messageResponse = rateLimitAware(
+            () => fetchJson({
+              url: baseUrl + '/messages/' + encodeURIComponent(messageId) + '?format=full',
+              method: 'GET',
+              headers: headers
+            }),
+            { attempts: 5, backoffMs: 500 }
+          );
+
+          const detail = messageResponse.body || {};
+          const payload = detail.payload || {};
+          const headersList = payload.headers || [];
+          const bodies = extractBodies(payload);
+          const attachments = [];
+          collectAttachments(payload.parts, attachments);
+
+          const internalDate = detail.internalDate ? Number(detail.internalDate) : null;
+          if (lastInternalDate && internalDate && internalDate <= lastInternalDate) {
+            continue;
+          }
+
+          const from = extractHeader(headersList, 'From');
+          const to = parseAddressList(extractHeader(headersList, 'To'));
+          const cc = parseAddressList(extractHeader(headersList, 'Cc'));
+          const bcc = parseAddressList(extractHeader(headersList, 'Bcc'));
+          const replyTo = parseAddressList(extractHeader(headersList, 'Reply-To'));
+          const deliveredTo = extractHeader(headersList, 'Delivered-To');
+          const subject = extractHeader(headersList, 'Subject') || null;
+          const historyId = detail.historyId ? String(detail.historyId) : null;
+
+          const fromName = from && from.indexOf('<') !== -1 ? from.split('<')[0].trim() : null;
+          messages.push({
+            internalDate: internalDate || Date.now(),
+            historyId: historyId,
+            payload: {
+              id: detail.id || messageId,
+              threadId: detail.threadId || null,
+              historyId: historyId,
+              labelIds: Array.isArray(detail.labelIds) ? detail.labelIds : [],
+              subject: subject,
+              snippet: detail.snippet || '',
+              from: from,
+              fromName: fromName,
+              to: to,
+              cc: cc,
+              bcc: bcc,
+              replyTo: replyTo,
+              deliveredTo: deliveredTo || null,
+              receivedAt: internalDate ? new Date(internalDate).toISOString() : new Date().toISOString(),
+              sizeEstimate: detail.sizeEstimate || null,
+              bodyPlain: bodies.plain || null,
+              bodyHtml: bodies.html || null,
+              attachments: attachments,
+              threadSnippet: detail.snippet || null,
+              raw: detail
+            }
+          });
+        }
+
+        if (messages.length >= 50) {
+          pageToken = null;
+        } else {
+          pageToken = listBody.nextPageToken || null;
+        }
+
+        pageCount += 1;
+      } while (pageToken && pageCount < 5 && messages.length < 50);
+
+      if (messages.length === 0) {
+        runtime.summary({
+          messagesAttempted: 0,
+          messagesDispatched: 0,
+          messagesFailed: 0,
+      fromEmail: fromFilter,
+      subjectFilter: subjectFilter || null,
+      query: effectiveQuery,
+          labelIds: labelIds,
+          lastInternalDate: lastInternalDate || null
+        });
+        return {
+          messagesAttempted: 0,
+          messagesDispatched: 0,
+          messagesFailed: 0,
+      fromEmail: fromFilter,
+      subjectFilter: subjectFilter || null,
+      query: effectiveQuery,
+          labelIds: labelIds,
+          lastInternalDate: lastInternalDate || null
+        };
+      }
+
+      messages.sort(function (a, b) {
+        return Number(a.internalDate) - Number(b.internalDate);
+      });
+
+      let lastPayloadDispatched = null;
+      const batch = runtime.dispatchBatch(messages, function (entry) {
+        const payload = {
+          id: entry.payload.id,
+          threadId: entry.payload.threadId,
+          historyId: entry.payload.historyId,
+          labelIds: entry.payload.labelIds,
+          subject: entry.payload.subject,
+          snippet: entry.payload.snippet,
+          from: entry.payload.from,
+          fromName: entry.payload.fromName,
+          to: entry.payload.to,
+          cc: entry.payload.cc,
+          bcc: entry.payload.bcc,
+          replyTo: entry.payload.replyTo,
+          deliveredTo: entry.payload.deliveredTo,
+          receivedAt: entry.payload.receivedAt,
+          sizeEstimate: entry.payload.sizeEstimate,
+          bodyPlain: entry.payload.bodyPlain,
+          bodyHtml: entry.payload.bodyHtml,
+          attachments: entry.payload.attachments,
+          threadSnippet: entry.payload.threadSnippet,
+          snippet: entry.payload.snippet,
+          _meta: { raw: entry.payload.raw || null }
+        };
+        lastPayloadDispatched = payload;
+        return payload;
+      });
+
+      runtime.state = runtime.state && typeof runtime.state === 'object' ? runtime.state : {};
+      runtime.state.cursor = runtime.state.cursor && typeof runtime.state.cursor === 'object' ? runtime.state.cursor : {};
+      runtime.state.cursor.internalDate = messages[messages.length - 1].internalDate;
+      runtime.state.lastPayload = lastPayloadDispatched || runtime.state.lastPayload || null;
+
+      runtime.summary({
+        messagesAttempted: batch.attempted,
+        messagesDispatched: batch.succeeded,
+        messagesFailed: batch.failed,
+      fromEmail: fromFilter,
+      subjectFilter: subjectFilter || null,
+      query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      });
+
+      logInfo('gmail_email_received_from_success', {
+        dispatched: batch.succeeded,
+      fromEmail: fromFilter,
+      subjectFilter: subjectFilter || null,
+      query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      });
+
+      return {
+        messagesAttempted: batch.attempted,
+        messagesDispatched: batch.succeeded,
+        messagesFailed: batch.failed,
+      fromEmail: fromFilter,
+      subjectFilter: subjectFilter || null,
+      query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      };
+    } catch (error) {
+      const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+      const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+      const status = error && typeof error.status === 'number' ? error.status : null;
+      const message = providerMessage || (error && error.message ? error.message : String(error));
+      logError('gmail_email_received_from_failed', {
+        status: status,
+        providerCode: providerCode,
+        message: message
+      });
+      throw error;
+    }
+  });
+}
+`;
+
+exports[`Apps Script Gmail REAL_OPS builds trigger.gmail:email_with_attachment 1`] = `
+
+function onGmailEmailWithAttachment() {
+  return buildPollingWrapper('trigger.gmail:email_with_attachment', function (runtime) {
+    const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+    if (!accessToken) {
+      logError('gmail_missing_access_token', { operation: 'trigger.gmail:email_with_attachment' });
+      throw new Error('Missing Gmail access token for gmail.email_with_attachment trigger');
+    }
+
+    const interpolationContext = runtime.state && runtime.state.lastPayload ? runtime.state.lastPayload : {};
+    const fileTypesConfig = ["pdf"];
+    const fromTemplate = 'finance@example.com';
+    const fromFilter = fromTemplate ? interpolate(fromTemplate, interpolationContext).trim() : '';
+    const fileTypes = [];
+    if (Array.isArray(fileTypesConfig)) {
+      for (let i = 0; i < fileTypesConfig.length; i++) {
+        const value = typeof fileTypesConfig[i] === 'string' ? interpolate(fileTypesConfig[i], interpolationContext).trim() : '';
+        if (value) {
+          fileTypes.push(value.toLowerCase());
+        }
+      }
+    }
+    const queryParts = ['has:attachment'];
+    if (fromFilter) {
+      queryParts.push('from:' + fromFilter);
+    }
+    const query = queryParts.join(' ');
+    const labelIds = [];
+
+    const headers = { Authorization: 'Bearer ' + accessToken };
+    const baseUrl = 'https://gmail.googleapis.com/gmail/v1/users/me';
+    const cursor = (runtime.state && typeof runtime.state.cursor === 'object') ? runtime.state.cursor : {};
+    const lastInternalDate = cursor && cursor.internalDate ? Number(cursor.internalDate) : null;
+    const afterSeconds = lastInternalDate ? Math.floor(lastInternalDate / 1000) : null;
+    const effectiveQuery = afterSeconds ? ((query ? query + ' ' : '') + 'after:' + afterSeconds) : query;
+    const messages = [];
+    let pageToken = null;
+    let pageCount = 0;
+
+    function decodeBase64Url(data) {
+      if (!data) {
+        return '';
+      }
+      try {
+        const normalized = data.replace(/-/g, '+').replace(/_/g, '/');
+        const bytes = Utilities.base64Decode(normalized);
+        return Utilities.newBlob(bytes).getDataAsString('UTF-8');
+      } catch (error) {
+        logWarn('gmail_message_body_decode_failed', {
+          message: error && error.message ? error.message : String(error)
+        });
+        return '';
+      }
+    }
+
+    function extractHeader(all, name) {
+      if (!Array.isArray(all)) {
+        return '';
+      }
+      const target = name.toLowerCase();
+      for (let i = 0; i < all.length; i++) {
+        const header = all[i];
+        if (!header || typeof header.name !== 'string') {
+          continue;
+        }
+        if (header.name.toLowerCase() === target) {
+          return header.value || '';
+        }
+      }
+      return '';
+    }
+
+    function parseAddressList(value) {
+      if (!value) {
+        return [];
+      }
+      return value.split(',').map(part => part.trim()).filter(Boolean);
+    }
+
+    function collectAttachments(parts, bucket) {
+      if (!Array.isArray(parts)) {
+        return;
+      }
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        if (!part) {
+          continue;
+        }
+        if (part.filename && part.body && part.body.attachmentId) {
+          bucket.push({
+            attachmentId: part.body.attachmentId,
+            filename: part.filename,
+            mimeType: part.mimeType || 'application/octet-stream',
+            size: part.body.size || 0
+          });
+        }
+        if (Array.isArray(part.parts) && part.parts.length) {
+          collectAttachments(part.parts, bucket);
+        }
+      }
+    }
+
+    function extractBodies(payload) {
+      const result = {};
+      if (!payload) {
+        return result;
+      }
+
+      const queue = [payload];
+      while (queue.length > 0) {
+        const node = queue.shift();
+        if (!node) {
+          continue;
+        }
+        if (node.mimeType === 'text/plain' && node.body && node.body.data) {
+          result.plain = decodeBase64Url(node.body.data);
+        } else if (node.mimeType === 'text/html' && node.body && node.body.data) {
+          result.html = decodeBase64Url(node.body.data);
+        }
+        if (Array.isArray(node.parts)) {
+          for (let p = 0; p < node.parts.length; p++) {
+            queue.push(node.parts[p]);
+          }
+        }
+      }
+
+      if (!result.plain && payload.body && payload.body.data) {
+        result.plain = decodeBase64Url(payload.body.data);
+      }
+
+      return result;
+    }
+
+    try {
+      do {
+        const params = ['maxResults=25'];
+        if (effectiveQuery) {
+          params.push('q=' + encodeURIComponent(effectiveQuery));
+        }
+        if (Array.isArray(labelIds) && labelIds.length) {
+          for (let i = 0; i < labelIds.length; i++) {
+            params.push('labelIds=' + encodeURIComponent(labelIds[i]));
+          }
+        }
+        if (pageToken) {
+          params.push('pageToken=' + encodeURIComponent(pageToken));
+        }
+
+        const listResponse = rateLimitAware(
+          () => fetchJson({
+            url: baseUrl + '/messages?' + params.join('&'),
+            method: 'GET',
+            headers: headers
+          }),
+          { attempts: 5, backoffMs: 500 }
+        );
+
+        const listBody = listResponse.body || {};
+        const candidates = Array.isArray(listBody.messages) ? listBody.messages : [];
+        for (let i = 0; i < candidates.length; i++) {
+          const messageId = candidates[i] && candidates[i].id;
+          if (!messageId) {
+            continue;
+          }
+
+          const messageResponse = rateLimitAware(
+            () => fetchJson({
+              url: baseUrl + '/messages/' + encodeURIComponent(messageId) + '?format=full',
+              method: 'GET',
+              headers: headers
+            }),
+            { attempts: 5, backoffMs: 500 }
+          );
+
+          const detail = messageResponse.body || {};
+          const payload = detail.payload || {};
+          const headersList = payload.headers || [];
+          const bodies = extractBodies(payload);
+          const attachments = [];
+          collectAttachments(payload.parts, attachments);
+
+          const internalDate = detail.internalDate ? Number(detail.internalDate) : null;
+          if (lastInternalDate && internalDate && internalDate <= lastInternalDate) {
+            continue;
+          }
+
+          const from = extractHeader(headersList, 'From');
+          const to = parseAddressList(extractHeader(headersList, 'To'));
+          const cc = parseAddressList(extractHeader(headersList, 'Cc'));
+          const bcc = parseAddressList(extractHeader(headersList, 'Bcc'));
+          const replyTo = parseAddressList(extractHeader(headersList, 'Reply-To'));
+          const deliveredTo = extractHeader(headersList, 'Delivered-To');
+          const subject = extractHeader(headersList, 'Subject') || null;
+          const historyId = detail.historyId ? String(detail.historyId) : null;
+
+          const fromName = from && from.indexOf('<') !== -1 ? from.split('<')[0].trim() : null;
+
+        if (!attachments.length) {
+          continue;
+        }
+        if (fileTypes.length) {
+          let matchedType = false;
+          for (let ft = 0; ft < attachments.length && !matchedType; ft++) {
+            const attachment = attachments[ft] || {};
+            const filename = (attachment.filename || '').toLowerCase();
+            const mimeType = (attachment.mimeType || '').toLowerCase();
+            for (let j = 0; j < fileTypes.length; j++) {
+              const type = fileTypes[j];
+              if (!type) {
+                continue;
+              }
+              if ((filename && filename.endsWith('.' + type)) || (mimeType && mimeType.indexOf(type) !== -1)) {
+                matchedType = true;
+                break;
+              }
+            }
+          }
+          if (!matchedType) {
+            continue;
+          }
+        }
+          messages.push({
+            internalDate: internalDate || Date.now(),
+            historyId: historyId,
+            payload: {
+              id: detail.id || messageId,
+              threadId: detail.threadId || null,
+              historyId: historyId,
+              labelIds: Array.isArray(detail.labelIds) ? detail.labelIds : [],
+              subject: subject,
+              snippet: detail.snippet || '',
+              from: from,
+              fromName: fromName,
+              to: to,
+              cc: cc,
+              bcc: bcc,
+              replyTo: replyTo,
+              deliveredTo: deliveredTo || null,
+              receivedAt: internalDate ? new Date(internalDate).toISOString() : new Date().toISOString(),
+              sizeEstimate: detail.sizeEstimate || null,
+              bodyPlain: bodies.plain || null,
+              bodyHtml: bodies.html || null,
+              attachments: attachments,
+              threadSnippet: detail.snippet || null,
+              raw: detail
+            }
+          });
+        }
+
+        if (messages.length >= 50) {
+          pageToken = null;
+        } else {
+          pageToken = listBody.nextPageToken || null;
+        }
+
+        pageCount += 1;
+      } while (pageToken && pageCount < 5 && messages.length < 50);
+
+      if (messages.length === 0) {
+        runtime.summary({
+          messagesAttempted: 0,
+          messagesDispatched: 0,
+          messagesFailed: 0,
+      fromEmail: fromFilter || null,
+      fileTypes: fileTypes,
+      query: effectiveQuery,
+          labelIds: labelIds,
+          lastInternalDate: lastInternalDate || null
+        });
+        return {
+          messagesAttempted: 0,
+          messagesDispatched: 0,
+          messagesFailed: 0,
+      fromEmail: fromFilter || null,
+      fileTypes: fileTypes,
+      query: effectiveQuery,
+          labelIds: labelIds,
+          lastInternalDate: lastInternalDate || null
+        };
+      }
+
+      messages.sort(function (a, b) {
+        return Number(a.internalDate) - Number(b.internalDate);
+      });
+
+      let lastPayloadDispatched = null;
+      const batch = runtime.dispatchBatch(messages, function (entry) {
+        const payload = {
+          id: entry.payload.id,
+          threadId: entry.payload.threadId,
+          historyId: entry.payload.historyId,
+          labelIds: entry.payload.labelIds,
+          subject: entry.payload.subject,
+          snippet: entry.payload.snippet,
+          from: entry.payload.from,
+          fromName: entry.payload.fromName,
+          to: entry.payload.to,
+          cc: entry.payload.cc,
+          bcc: entry.payload.bcc,
+          replyTo: entry.payload.replyTo,
+          deliveredTo: entry.payload.deliveredTo,
+          receivedAt: entry.payload.receivedAt,
+          sizeEstimate: entry.payload.sizeEstimate,
+          bodyPlain: entry.payload.bodyPlain,
+          bodyHtml: entry.payload.bodyHtml,
+          attachments: entry.payload.attachments,
+          threadSnippet: entry.payload.threadSnippet,
+          snippet: entry.payload.snippet,
+          _meta: { raw: entry.payload.raw || null }
+        };
+        lastPayloadDispatched = payload;
+        return payload;
+      });
+
+      runtime.state = runtime.state && typeof runtime.state === 'object' ? runtime.state : {};
+      runtime.state.cursor = runtime.state.cursor && typeof runtime.state.cursor === 'object' ? runtime.state.cursor : {};
+      runtime.state.cursor.internalDate = messages[messages.length - 1].internalDate;
+      runtime.state.lastPayload = lastPayloadDispatched || runtime.state.lastPayload || null;
+
+      runtime.summary({
+        messagesAttempted: batch.attempted,
+        messagesDispatched: batch.succeeded,
+        messagesFailed: batch.failed,
+      fromEmail: fromFilter || null,
+      fileTypes: fileTypes,
+      query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      });
+
+      logInfo('gmail_email_with_attachment_success', {
+        dispatched: batch.succeeded,
+      fromEmail: fromFilter || null,
+      fileTypes: fileTypes,
+      query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      });
+
+      return {
+        messagesAttempted: batch.attempted,
+        messagesDispatched: batch.succeeded,
+        messagesFailed: batch.failed,
+      fromEmail: fromFilter || null,
+      fileTypes: fileTypes,
+      query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      };
+    } catch (error) {
+      const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+      const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+      const status = error && typeof error.status === 'number' ? error.status : null;
+      const message = providerMessage || (error && error.message ? error.message : String(error));
+      logError('gmail_email_with_attachment_failed', {
+        status: status,
+        providerCode: providerCode,
+        message: message
+      });
+      throw error;
+    }
+  });
+}
+`;
+
+exports[`Apps Script Gmail REAL_OPS builds action.gmail:test_connection 1`] = `
+
+function step_action_gmail_test_connection(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:test_connection' });
+    throw new Error('Missing Gmail access token for gmail.test_connection operation');
+  }
+
+  try {
+    const profile = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/profile',
+        method: 'GET',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        }
+      }),
+      { attempts: 3, backoffMs: 500 }
+    );
+
+    const body = profile.body || {};
+    ctx.gmailEmailAddress = body.emailAddress || ctx.gmailEmailAddress || null;
+    ctx.gmailHistoryId = body.historyId || ctx.gmailHistoryId || null;
+
+    logInfo('gmail_test_connection_success', {
+      emailAddress: ctx.gmailEmailAddress || null,
+      historyId: ctx.gmailHistoryId || null
+    });
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_test_connection_failed', {
+      operation: 'action.gmail:test_connection',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail test_connection failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}
+`;
+
+exports[`Apps Script Gmail REAL_OPS builds action.gmail:get_email 1`] = `
+
+function step_action_gmail_get_email(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:get_email' });
+    throw new Error('Missing Gmail access token for gmail.get_email operation');
+  }
+
+  const messageId = interpolate('abc123', ctx).trim();
+  const format = interpolate('full', ctx).trim() || 'full';
+  if (!messageId) {
+    logError('gmail_get_email_missing_param', { field: 'messageId' });
+    throw new Error('Missing required Gmail get_email param: messageId');
+  }
+
+  try {
+    const response = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/' + encodeURIComponent(messageId) + '?format=' + encodeURIComponent(format),
+        method: 'GET',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        }
+      }),
+      { attempts: 5, backoffMs: 500 }
+    );
+
+    const body = response.body || {};
+    ctx.gmailMessageId = body.id || ctx.gmailMessageId || null;
+    ctx.gmailThreadId = body.threadId || ctx.gmailThreadId || null;
+    ctx.gmailMessage = body;
+
+    const attachments = [];
+    function collect(parts) {
+      if (!Array.isArray(parts)) {
+        return;
+      }
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        if (!part) {
+          continue;
+        }
+        if (part.filename && part.body && part.body.attachmentId) {
+          attachments.push({
+            attachmentId: part.body.attachmentId,
+            filename: part.filename,
+            mimeType: part.mimeType || 'application/octet-stream',
+            size: part.body.size || 0
+          });
+        }
+        if (Array.isArray(part.parts) && part.parts.length) {
+          collect(part.parts);
+        }
+      }
+    }
+
+    collect(body.payload && body.payload.parts);
+    ctx.gmailAttachments = attachments;
+
+    logInfo('gmail_get_email_success', {
+      messageId: ctx.gmailMessageId || null,
+      threadId: ctx.gmailThreadId || null,
+      format: format,
+      attachments: attachments.length
+    });
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_get_email_failed', {
+      operation: 'action.gmail:get_email',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail get_email failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}
+`;
+
 exports[`Apps Script Gmail REAL_OPS builds action.gmail:send_email 1`] = `
+
 function step_action_gmail_send_email(ctx) {
   ctx = ctx || {};
   const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
@@ -296,12 +1175,12 @@ function step_action_gmail_send_email(ctx) {
     throw new Error('Missing Gmail access token for gmail.send_email operation');
   }
 
-  const to = interpolate('${esc(c.to || '')}', ctx).trim();
-  const subject = interpolate('${esc(c.subject || '')}', ctx).trim();
-  const body = interpolate('${esc(c.body || '')}', ctx);
-  const cc = interpolate('${esc(c.cc || '')}', ctx).trim();
-  const bcc = interpolate('${esc(c.bcc || '')}', ctx).trim();
-  const attachmentsConfig = ${JSON.stringify(c.attachments || [])};
+  const to = interpolate('user@example.com', ctx).trim();
+  const subject = interpolate('Hello', ctx).trim();
+  const body = interpolate('Hi there', ctx);
+  const cc = interpolate('', ctx).trim();
+  const bcc = interpolate('', ctx).trim();
+  const attachmentsConfig = [];
 
   function ensureParam(value, field) {
     if (!value) {
@@ -370,7 +1249,10 @@ function step_action_gmail_send_email(ctx) {
   if (attachments.length === 0) {
     headerLines.push('Content-Type: text/plain; charset="UTF-8"');
     headerLines.push('Content-Transfer-Encoding: 7bit');
-    messageBody = headerLines.join('\r\n') + '\r\n\r\n' + body;
+    messageBody = headerLines.join('
+') + '
+
+' + body;
   } else {
     const boundary = 'apps-script-gmail-' + Utilities.getUuid();
     headerLines.push('Content-Type: multipart/mixed; boundary="' + boundary + '"');
@@ -385,14 +1267,18 @@ function step_action_gmail_send_email(ctx) {
       const attachment = attachments[a];
       parts.push('--' + boundary);
       parts.push('Content-Type: ' + attachment.mimeType);
-      parts.push('Content-Disposition: attachment; filename="' + attachment.filename.replace(/"/g, '\\"') + '"');
+      parts.push('Content-Disposition: attachment; filename="' + attachment.filename.replace(/"/g, '\"') + '"');
       parts.push('Content-Transfer-Encoding: base64');
       parts.push('');
       parts.push(attachment.data);
       parts.push('');
     }
     parts.push('--' + boundary + '--');
-    messageBody = headerLines.join('\r\n') + '\r\n\r\n' + parts.join('\r\n');
+    messageBody = headerLines.join('
+') + '
+
+' + parts.join('
+');
   }
 
   const raw = Utilities.base64EncodeWebSafe(messageBody);
@@ -445,6 +1331,7 @@ function step_action_gmail_send_email(ctx) {
 `;
 
 exports[`Apps Script Gmail REAL_OPS builds action.gmail:search_emails 1`] = `
+
 function step_action_gmail_search_emails(ctx) {
   ctx = ctx || {};
   const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
@@ -453,25 +1340,25 @@ function step_action_gmail_search_emails(ctx) {
     throw new Error('Missing Gmail access token for gmail.search_emails operation');
   }
 
-  const query = interpolate('${esc(c.query || '')}', ctx).trim();
+  const query = interpolate('label:inbox', ctx).trim();
   if (!query) {
     logError('gmail_search_emails_missing_param', { field: 'query' });
     throw new Error('Missing required Gmail search_emails param: query');
   }
 
-  const rawMaxResults = interpolate('${esc(c.maxResults !== undefined ? String(c.maxResults) : '')}', ctx).trim();
-  let maxResults = rawMaxResults ? Number(rawMaxResults) : ${typeof c.maxResults === 'number' ? c.maxResults : 10};
+  const rawMaxResults = interpolate('', ctx).trim();
+  let maxResults = rawMaxResults ? Number(rawMaxResults) : 10;
   if (isNaN(maxResults) || maxResults <= 0) {
-    maxResults = ${typeof c.maxResults === 'number' ? c.maxResults : 10};
+    maxResults = 10;
   }
   maxResults = Math.max(1, Math.min(500, Math.floor(maxResults)));
 
-  const includeSpamRaw = interpolate('${esc(c.includeSpamTrash !== undefined ? String(c.includeSpamTrash) : '')}', ctx)
+  const includeSpamRaw = interpolate('false', ctx)
     .trim()
     .toLowerCase();
   const includeSpamTrash = includeSpamRaw
     ? includeSpamRaw === 'true' || includeSpamRaw === '1'
-    : ${c.includeSpamTrash ? 'true' : 'false'};
+    : false;
 
   const pageToken = ctx.nextPageToken || ctx.gmailNextPageToken || null;
   const params = ['maxResults=' + maxResults, 'q=' + encodeURIComponent(query)];
@@ -524,3 +1411,333 @@ function step_action_gmail_search_emails(ctx) {
   }
 }
 `;
+
+exports[`Apps Script Gmail REAL_OPS builds action.gmail:mark_as_read 1`] = `
+
+function step_action_gmail_mark_as_read(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:mark_as_read' });
+    throw new Error('Missing Gmail access token for gmail.mark_as_read operation');
+  }
+
+  const idsConfig = ["id-1","id-2"];
+  const messageIds = [];
+  if (Array.isArray(idsConfig)) {
+    for (let i = 0; i < idsConfig.length; i++) {
+      const value = typeof idsConfig[i] === 'string' ? interpolate(idsConfig[i], ctx).trim() : '';
+      if (value) {
+        messageIds.push(value);
+      }
+    }
+  }
+
+  if (!messageIds.length) {
+    logError('gmail_mark_as_read_missing_param', { field: 'messageIds' });
+    throw new Error('Missing required Gmail mark_as_read param: messageIds');
+  }
+
+  try {
+    rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/batchModify',
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        },
+        payload: JSON.stringify({ ids: messageIds, removeLabelIds: ['UNREAD'] })
+      }),
+      { attempts: 4, backoffMs: 500 }
+    );
+
+    ctx.gmailModifiedIds = messageIds;
+    logInfo('gmail_mark_as_read_success', { count: messageIds.length });
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_mark_as_read_failed', {
+      operation: 'action.gmail:mark_as_read',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail mark_as_read failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}
+`;
+
+exports[`Apps Script Gmail REAL_OPS builds action.gmail:add_label 1`] = `
+
+function step_action_gmail_add_label(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:add_label' });
+    throw new Error('Missing Gmail access token for gmail.add_label operation');
+  }
+
+  const idsConfig = ["id-9"];
+  const labelConfig = ["IMPORTANT"];
+  const messageIds = [];
+  if (Array.isArray(idsConfig)) {
+    for (let i = 0; i < idsConfig.length; i++) {
+      const value = typeof idsConfig[i] === 'string' ? interpolate(idsConfig[i], ctx).trim() : '';
+      if (value) {
+        messageIds.push(value);
+      }
+    }
+  }
+
+  const labelIds = [];
+  if (Array.isArray(labelConfig)) {
+    for (let j = 0; j < labelConfig.length; j++) {
+      const value = typeof labelConfig[j] === 'string' ? interpolate(labelConfig[j], ctx).trim() : '';
+      if (value) {
+        labelIds.push(value);
+      }
+    }
+  }
+
+  if (!messageIds.length) {
+    logError('gmail_add_label_missing_param', { field: 'messageIds' });
+    throw new Error('Missing required Gmail add_label param: messageIds');
+  }
+
+  if (!labelIds.length) {
+    logError('gmail_add_label_missing_param', { field: 'labelIds' });
+    throw new Error('Missing required Gmail add_label param: labelIds');
+  }
+
+  try {
+    rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/batchModify',
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        },
+        payload: JSON.stringify({ ids: messageIds, addLabelIds: labelIds })
+      }),
+      { attempts: 4, backoffMs: 500 }
+    );
+
+    ctx.gmailModifiedIds = messageIds;
+    ctx.gmailAppliedLabelIds = labelIds;
+    logInfo('gmail_add_label_success', {
+      messageCount: messageIds.length,
+      labelCount: labelIds.length
+    });
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_add_label_failed', {
+      operation: 'action.gmail:add_label',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail add_label failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}
+`;
+
+exports[`Apps Script Gmail REAL_OPS builds action.gmail:send_reply 1`] = `
+
+function step_action_gmail_send_reply(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:send_reply' });
+    throw new Error('Missing Gmail access token for gmail.send_reply operation');
+  }
+
+  const messageId = interpolate('abc123', ctx).trim();
+  if (!messageId) {
+    logError('gmail_send_reply_missing_param', { field: 'messageId' });
+    throw new Error('Missing required Gmail send_reply param: messageId');
+  }
+
+  const bodyTemplate = 'Thanks!';
+  const replyBody = interpolate(bodyTemplate, ctx);
+  if (!replyBody) {
+    logError('gmail_send_reply_missing_param', { field: 'body' });
+    throw new Error('Missing required Gmail send_reply param: body');
+  }
+
+  let replyAll = true;
+  const replyAllTemplate = 'true';
+  if (replyAllTemplate) {
+    const normalized = replyAllTemplate.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1' || normalized === 'yes') {
+      replyAll = true;
+    } else if (normalized === 'false' || normalized === '0' || normalized === 'no') {
+      replyAll = false;
+    }
+  }
+
+  function parseAddressList(value) {
+    if (!value) {
+      return [];
+    }
+    return value.split(',').map(function (entry) { return entry.trim(); }).filter(Boolean);
+  }
+
+  function extractHeader(all, name) {
+    if (!Array.isArray(all)) {
+      return '';
+    }
+    const target = name.toLowerCase();
+    for (let i = 0; i < all.length; i++) {
+      const header = all[i];
+      if (!header || typeof header.name !== 'string') {
+        continue;
+      }
+      if (header.name.toLowerCase() === target) {
+        return header.value || '';
+      }
+    }
+    return '';
+  }
+
+  try {
+    const messageResponse = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/' + encodeURIComponent(messageId) + '?format=full',
+        method: 'GET',
+        headers: { Authorization: 'Bearer ' + accessToken }
+      }),
+      { attempts: 5, backoffMs: 500 }
+    );
+
+    const message = messageResponse.body || {};
+    const payload = message.payload || {};
+    const headersList = payload.headers || [];
+
+    const fromHeader = extractHeader(headersList, 'From');
+    const replyToHeader = extractHeader(headersList, 'Reply-To');
+    const toHeader = parseAddressList(extractHeader(headersList, 'To'));
+    const ccHeader = parseAddressList(extractHeader(headersList, 'Cc'));
+
+    const baseReplyTo = parseAddressList(replyToHeader);
+    const baseRecipients = baseReplyTo.length ? baseReplyTo : parseAddressList(fromHeader);
+    const toRecipients = [];
+    const ccRecipients = [];
+    const seen = {};
+
+    function pushUnique(target, value) {
+      const key = value ? value.toLowerCase() : '';
+      if (!key || Object.prototype.hasOwnProperty.call(seen, key)) {
+        return;
+      }
+      seen[key] = true;
+      target.push(value);
+    }
+
+    for (let i = 0; i < baseRecipients.length; i++) {
+      pushUnique(toRecipients, baseRecipients[i]);
+    }
+
+    if (replyAll) {
+      for (let i = 0; i < toHeader.length; i++) {
+        pushUnique(toRecipients, toHeader[i]);
+      }
+      for (let i = 0; i < ccHeader.length; i++) {
+        pushUnique(ccRecipients, ccHeader[i]);
+      }
+    }
+
+    if (!toRecipients.length) {
+      logError('gmail_send_reply_unresolved_recipient', { messageId: messageId });
+      throw new Error('Unable to resolve reply recipients for Gmail send_reply operation');
+    }
+
+    const messageIdHeader = extractHeader(headersList, 'Message-ID') || ('<' + messageId + '>');
+    const referencesHeader = extractHeader(headersList, 'References');
+    const references = referencesHeader ? referencesHeader + ' ' + messageIdHeader : messageIdHeader;
+
+    const originalSubject = extractHeader(headersList, 'Subject') || '';
+    let subject = originalSubject;
+    if (!subject) {
+      subject = 'Re:';
+    } else if (!/^s*re:/i.test(subject)) {
+      subject = 'Re: ' + subject;
+    }
+
+    const headerLines = ['To: ' + toRecipients.join(', ')];
+    if (ccRecipients.length) {
+      headerLines.push('Cc: ' + ccRecipients.join(', '));
+    }
+    headerLines.push('Subject: ' + subject);
+    headerLines.push('In-Reply-To: ' + messageIdHeader);
+    headerLines.push('References: ' + references);
+    headerLines.push('MIME-Version: 1.0');
+    headerLines.push('Content-Type: text/plain; charset="UTF-8"');
+    headerLines.push('Content-Transfer-Encoding: 7bit');
+
+    const messageBody = headerLines.join('
+') + '
+
+' + replyBody;
+    const raw = Utilities.base64EncodeWebSafe(Utilities.newBlob(messageBody).getBytes()).replace(/=+$/, '');
+
+    const requestBody = { raw: raw };
+    if (message.threadId) {
+      requestBody.threadId = message.threadId;
+    }
+
+    const sendResponse = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/send',
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        },
+        payload: JSON.stringify(requestBody)
+      }),
+      { attempts: 5, backoffMs: 500 }
+    );
+
+    const responseBody = sendResponse.body || {};
+    ctx.gmailMessageId = responseBody.id || ctx.gmailMessageId || null;
+    ctx.gmailThreadId = responseBody.threadId || message.threadId || null;
+    ctx.gmailLabelIds = Array.isArray(responseBody.labelIds) ? responseBody.labelIds : [];
+    ctx.gmailSendReplyResponse = responseBody;
+    ctx.gmailReplyRecipients = toRecipients;
+    ctx.gmailReplyCc = ccRecipients;
+
+    logInfo('gmail_send_reply_success', {
+      messageId: ctx.gmailMessageId || null,
+      threadId: ctx.gmailThreadId || null,
+      replyAll: replyAll,
+      toCount: toRecipients.length,
+      ccCount: ccRecipients.length
+    });
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_send_reply_failed', {
+      operation: 'action.gmail:send_reply',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail send_reply failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}
+`;
+

--- a/server/workflow/__tests__/apps-script-fixtures/gmail-add-label.json
+++ b/server/workflow/__tests__/apps-script-fixtures/gmail-add-label.json
@@ -1,0 +1,75 @@
+{
+  "id": "gmail-add-label",
+  "description": "Runs action.gmail:add_label to apply labels to messages.",
+  "graph": {
+    "id": "fixture-gmail-add-label",
+    "name": "Gmail add label",
+    "nodes": [
+      {
+        "id": "gmail-add-label",
+        "type": "action.gmail",
+        "app": "gmail",
+        "name": "Apply Gmail label",
+        "op": "action.gmail:add_label",
+        "params": {
+          "operation": "add_label",
+          "messageIds": ["msg-9"],
+          "labelIds": ["Label_123"]
+        },
+        "data": {
+          "operation": "add_label",
+          "config": {
+            "messageIds": ["msg-9"],
+            "labelIds": ["Label_123"]
+          }
+        }
+      }
+    ],
+    "edges": []
+  },
+  "entry": {
+    "context": {}
+  },
+  "secrets": {
+    "GMAIL_ACCESS_TOKEN": "ya29.test-access-token"
+  },
+  "http": [
+    {
+      "name": "gmail-add-label",
+      "request": {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/batchModify",
+        "method": "POST",
+        "headers": {
+          "authorization": "Bearer ya29.test-access-token",
+          "content-type": "application/json"
+        },
+        "payload": {
+          "ids": ["msg-9"],
+          "addLabelIds": ["Label_123"]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": {}
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "gmailModifiedIds": ["msg-9"],
+      "gmailAppliedLabelIds": ["Label_123"]
+    },
+    "logs": [
+      {
+        "level": "log",
+        "includes": "gmail_add_label_success"
+      }
+    ],
+    "httpCalls": [
+      {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/batchModify",
+        "method": "POST"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script-fixtures/gmail-get-email.json
+++ b/server/workflow/__tests__/apps-script-fixtures/gmail-get-email.json
@@ -1,0 +1,111 @@
+{
+  "id": "gmail-get-email",
+  "description": "Runs action.gmail:get_email to hydrate a Gmail message payload.",
+  "graph": {
+    "id": "fixture-gmail-get-email",
+    "name": "Gmail get email",
+    "nodes": [
+      {
+        "id": "gmail-get",
+        "type": "action.gmail",
+        "app": "gmail",
+        "name": "Get Gmail message",
+        "op": "action.gmail:get_email",
+        "params": {
+          "operation": "get_email",
+          "messageId": "msg-42",
+          "format": "full"
+        },
+        "data": {
+          "operation": "get_email",
+          "config": {
+            "messageId": "msg-42",
+            "format": "full"
+          }
+        }
+      }
+    ],
+    "edges": []
+  },
+  "entry": {
+    "context": {}
+  },
+  "secrets": {
+    "GMAIL_ACCESS_TOKEN": "ya29.test-access-token"
+  },
+  "http": [
+    {
+      "name": "gmail-get-message",
+      "request": {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/msg-42?format=full",
+        "method": "GET",
+        "headers": {
+          "authorization": "Bearer ya29.test-access-token"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "id": "msg-42",
+          "threadId": "thread-42",
+          "labelIds": ["INBOX", "STARRED"],
+          "snippet": "Snippet preview",
+          "internalDate": "1700000000000",
+          "payload": {
+            "headers": [
+              { "name": "From", "value": "Sender <sender@example.com>" },
+              { "name": "To", "value": "user@example.com" },
+              { "name": "Subject", "value": "Important update" },
+              { "name": "Message-ID", "value": "<msg-42@example.com>" }
+            ],
+            "body": {
+              "data": "SGVsbG8gd29ybGQ=",
+              "size": 11
+            },
+            "parts": [
+              {
+                "filename": "report.pdf",
+                "mimeType": "application/pdf",
+                "body": {
+                  "attachmentId": "attach-1",
+                  "size": 2048
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "gmailMessageId": "msg-42",
+      "gmailThreadId": "thread-42",
+      "gmailLabelIds": ["INBOX", "STARRED"],
+      "gmailSnippet": "Snippet preview",
+      "gmailAttachments": [
+        {
+          "attachmentId": "attach-1",
+          "filename": "report.pdf",
+          "mimeType": "application/pdf",
+          "size": 2048
+        }
+      ],
+      "gmailFrom": "Sender <sender@example.com>",
+      "gmailSubject": "Important update",
+      "gmailBodyPlain": "Hello world"
+    },
+    "logs": [
+      {
+        "level": "log",
+        "includes": "gmail_get_email_success"
+      }
+    ],
+    "httpCalls": [
+      {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/msg-42?format=full",
+        "method": "GET"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script-fixtures/gmail-mark-as-read.json
+++ b/server/workflow/__tests__/apps-script-fixtures/gmail-mark-as-read.json
@@ -1,0 +1,72 @@
+{
+  "id": "gmail-mark-as-read",
+  "description": "Runs action.gmail:mark_as_read to remove the UNREAD label from messages.",
+  "graph": {
+    "id": "fixture-gmail-mark-as-read",
+    "name": "Gmail mark as read",
+    "nodes": [
+      {
+        "id": "gmail-mark",
+        "type": "action.gmail",
+        "app": "gmail",
+        "name": "Mark messages as read",
+        "op": "action.gmail:mark_as_read",
+        "params": {
+          "operation": "mark_as_read",
+          "messageIds": ["msg-1", "msg-2"]
+        },
+        "data": {
+          "operation": "mark_as_read",
+          "config": {
+            "messageIds": ["msg-1", "msg-2"]
+          }
+        }
+      }
+    ],
+    "edges": []
+  },
+  "entry": {
+    "context": {}
+  },
+  "secrets": {
+    "GMAIL_ACCESS_TOKEN": "ya29.test-access-token"
+  },
+  "http": [
+    {
+      "name": "gmail-mark-read",
+      "request": {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/batchModify",
+        "method": "POST",
+        "headers": {
+          "authorization": "Bearer ya29.test-access-token",
+          "content-type": "application/json"
+        },
+        "payload": {
+          "ids": ["msg-1", "msg-2"],
+          "removeLabelIds": ["UNREAD"]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": {}
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "gmailModifiedIds": ["msg-1", "msg-2"]
+    },
+    "logs": [
+      {
+        "level": "log",
+        "includes": "gmail_mark_as_read_success"
+      }
+    ],
+    "httpCalls": [
+      {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/batchModify",
+        "method": "POST"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script-fixtures/gmail-search-emails.json
+++ b/server/workflow/__tests__/apps-script-fixtures/gmail-search-emails.json
@@ -1,0 +1,84 @@
+{
+  "id": "gmail-search-emails",
+  "description": "Runs action.gmail:search_emails against a simulated Gmail list endpoint.",
+  "graph": {
+    "id": "fixture-gmail-search-emails",
+    "name": "Gmail search emails",
+    "nodes": [
+      {
+        "id": "gmail-search",
+        "type": "action.gmail",
+        "app": "gmail",
+        "name": "Search Gmail messages",
+        "op": "action.gmail:search_emails",
+        "params": {
+          "operation": "search_emails",
+          "query": "label:inbox",
+          "includeSpamTrash": false
+        },
+        "data": {
+          "operation": "search_emails",
+          "config": {
+            "query": "label:inbox",
+            "includeSpamTrash": false
+          }
+        }
+      }
+    ],
+    "edges": []
+  },
+  "entry": {
+    "context": {}
+  },
+  "secrets": {
+    "GMAIL_ACCESS_TOKEN": "ya29.test-access-token"
+  },
+  "http": [
+    {
+      "name": "gmail-message-list",
+      "request": {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=10&q=label%3Ainbox",
+        "method": "GET",
+        "headers": {
+          "authorization": "Bearer ya29.test-access-token"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "messages": [
+            { "id": "msg-1", "threadId": "thread-1" },
+            { "id": "msg-2", "threadId": "thread-2" }
+          ],
+          "nextPageToken": "next-token",
+          "resultSizeEstimate": 2
+        }
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "gmailMessages": [
+        { "id": "msg-1", "threadId": "thread-1" },
+        { "id": "msg-2", "threadId": "thread-2" }
+      ],
+      "gmailNextPageToken": "next-token",
+      "nextPageToken": "next-token",
+      "resultSizeEstimate": 2,
+      "gmailQuery": "label:inbox",
+      "gmailIncludeSpamTrash": false
+    },
+    "logs": [
+      {
+        "level": "log",
+        "includes": "gmail_search_emails_success"
+      }
+    ],
+    "httpCalls": [
+      {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=10&q=label%3Ainbox",
+        "method": "GET"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script-fixtures/gmail-send-reply.json
+++ b/server/workflow/__tests__/apps-script-fixtures/gmail-send-reply.json
@@ -1,0 +1,141 @@
+{
+  "id": "gmail-send-reply",
+  "description": "Runs action.gmail:send_reply to respond to an existing message thread.",
+  "graph": {
+    "id": "fixture-gmail-send-reply",
+    "name": "Gmail send reply",
+    "nodes": [
+      {
+        "id": "gmail-reply",
+        "type": "action.gmail",
+        "app": "gmail",
+        "name": "Reply to Gmail message",
+        "op": "action.gmail:send_reply",
+        "params": {
+          "operation": "send_reply",
+          "messageId": "msg-55",
+          "body": "Thanks for the update!",
+          "replyAll": false
+        },
+        "data": {
+          "operation": "send_reply",
+          "config": {
+            "messageId": "msg-55",
+            "body": "Thanks for the update!",
+            "replyAll": false
+          }
+        }
+      }
+    ],
+    "edges": []
+  },
+  "entry": {
+    "context": {}
+  },
+  "secrets": {
+    "GMAIL_ACCESS_TOKEN": "ya29.test-access-token"
+  },
+  "http": [
+    {
+      "name": "gmail-get-message",
+      "request": {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/msg-55?format=full",
+        "method": "GET",
+        "headers": {
+          "authorization": "Bearer ya29.test-access-token"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "id": "msg-55",
+          "threadId": "thread-55",
+          "labelIds": [
+            "INBOX"
+          ],
+          "payload": {
+            "headers": [
+              {
+                "name": "From",
+                "value": "Sender <sender@example.com>"
+              },
+              {
+                "name": "To",
+                "value": "user@example.com"
+              },
+              {
+                "name": "Subject",
+                "value": "Weekly report"
+              },
+              {
+                "name": "Message-ID",
+                "value": "<msg-55@example.com>"
+              },
+              {
+                "name": "References",
+                "value": "<msg-10@example.com>"
+              }
+            ],
+            "body": {
+              "data": "SGVsbG8=",
+              "size": 5
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "gmail-send",
+      "request": {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+        "method": "POST",
+        "headers": {
+          "authorization": "Bearer ya29.test-access-token",
+          "content-type": "application/json"
+        },
+        "payload": {
+          "threadId": "thread-55"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "id": "msg-200",
+          "threadId": "thread-55",
+          "labelIds": [
+            "SENT"
+          ]
+        }
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "gmailMessageId": "msg-200",
+      "gmailThreadId": "thread-55",
+      "gmailLabelIds": [
+        "SENT"
+      ],
+      "gmailReplyRecipients": [
+        "sender@example.com"
+      ],
+      "gmailReplyCc": []
+    },
+    "logs": [
+      {
+        "level": "log",
+        "includes": "gmail_send_reply_success"
+      }
+    ],
+    "httpCalls": [
+      {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/msg-55?format=full",
+        "method": "GET"
+      },
+      {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+        "method": "POST"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script-fixtures/gmail-test-connection.json
+++ b/server/workflow/__tests__/apps-script-fixtures/gmail-test-connection.json
@@ -1,0 +1,79 @@
+{
+  "id": "gmail-test-connection",
+  "description": "Exercises action.gmail:test_connection to fetch the Gmail profile.",
+  "graph": {
+    "id": "fixture-gmail-test-connection",
+    "name": "Gmail test connection",
+    "nodes": [
+      {
+        "id": "gmail-test",
+        "type": "action.gmail",
+        "app": "gmail",
+        "name": "Test Gmail connection",
+        "op": "action.gmail:test_connection",
+        "params": {
+          "operation": "test_connection"
+        },
+        "data": {
+          "operation": "test_connection",
+          "config": {}
+        }
+      }
+    ],
+    "edges": []
+  },
+  "entry": {
+    "context": {}
+  },
+  "secrets": {
+    "GMAIL_ACCESS_TOKEN": "ya29.test-access-token"
+  },
+  "http": [
+    {
+      "name": "gmail-profile",
+      "request": {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/profile",
+        "method": "GET",
+        "headers": {
+          "authorization": "Bearer ya29.test-access-token"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "emailAddress": "user@example.com",
+          "messagesTotal": 321,
+          "threadsTotal": 100,
+          "historyId": "123456789"
+        }
+      }
+    }
+  ],
+  "expect": {
+    "context": {
+      "gmailProfile": {
+        "emailAddress": "user@example.com",
+        "messagesTotal": 321,
+        "threadsTotal": 100,
+        "historyId": "123456789"
+      },
+      "gmailEmailAddress": "user@example.com",
+      "gmailMessagesTotal": 321,
+      "gmailThreadsTotal": 100,
+      "gmailHistoryId": "123456789",
+      "gmailTestConnectionSuccess": true
+    },
+    "logs": [
+      {
+        "level": "log",
+        "includes": "gmail_test_connection_success"
+      }
+    ],
+    "httpCalls": [
+      {
+        "url": "https://gmail.googleapis.com/gmail/v1/users/me/profile",
+        "method": "GET"
+      }
+    ]
+  }
+}

--- a/server/workflow/__tests__/apps-script.gmail.test.ts
+++ b/server/workflow/__tests__/apps-script.gmail.test.ts
@@ -10,16 +10,44 @@ const __dirname = path.dirname(__filename);
 const fixturesDir = path.join(__dirname, 'apps-script-fixtures');
 
 describe('Apps Script Gmail REAL_OPS', () => {
-  it('builds trigger.gmail:email_received', () => {
-    expect(REAL_OPS['trigger.gmail:email_received']({})).toMatchSnapshot();
+  it('builds trigger.gmail:new_email_received', () => {
+    expect(REAL_OPS['trigger.gmail:new_email_received']({ query: 'is:unread', labelIds: ['INBOX'] })).toMatchSnapshot();
+  });
+
+  it('builds trigger.gmail:email_received_from', () => {
+    expect(REAL_OPS['trigger.gmail:email_received_from']({ fromEmail: 'alerts@example.com', subject: 'Status' })).toMatchSnapshot();
+  });
+
+  it('builds trigger.gmail:email_with_attachment', () => {
+    expect(REAL_OPS['trigger.gmail:email_with_attachment']({ fileTypes: ['pdf'], fromEmail: 'finance@example.com' })).toMatchSnapshot();
+  });
+
+  it('builds action.gmail:test_connection', () => {
+    expect(REAL_OPS['action.gmail:test_connection']({})).toMatchSnapshot();
+  });
+
+  it('builds action.gmail:get_email', () => {
+    expect(REAL_OPS['action.gmail:get_email']({ messageId: 'abc123', format: 'full' })).toMatchSnapshot();
   });
 
   it('builds action.gmail:send_email', () => {
-    expect(REAL_OPS['action.gmail:send_email']({})).toMatchSnapshot();
+    expect(REAL_OPS['action.gmail:send_email']({ to: 'user@example.com', subject: 'Hello', body: 'Hi there' })).toMatchSnapshot();
   });
 
   it('builds action.gmail:search_emails', () => {
-    expect(REAL_OPS['action.gmail:search_emails']({})).toMatchSnapshot();
+    expect(REAL_OPS['action.gmail:search_emails']({ query: 'label:inbox', includeSpamTrash: false })).toMatchSnapshot();
+  });
+
+  it('builds action.gmail:mark_as_read', () => {
+    expect(REAL_OPS['action.gmail:mark_as_read']({ messageIds: ['id-1', 'id-2'] })).toMatchSnapshot();
+  });
+
+  it('builds action.gmail:add_label', () => {
+    expect(REAL_OPS['action.gmail:add_label']({ messageIds: ['id-9'], labelIds: ['IMPORTANT'] })).toMatchSnapshot();
+  });
+
+  it('builds action.gmail:send_reply', () => {
+    expect(REAL_OPS['action.gmail:send_reply']({ messageId: 'abc123', body: 'Thanks!', replyAll: true })).toMatchSnapshot();
   });
 });
 
@@ -32,5 +60,46 @@ describe('Apps Script Gmail integration', () => {
     expect(result.context.gmailLabelIds).toEqual(['SENT']);
     expect(result.httpCalls).toHaveLength(1);
     expect(result.httpCalls[0].url).toBe('https://gmail.googleapis.com/gmail/v1/users/me/messages/send');
+  });
+ 
+  it('tests Gmail connection profile', async () => {
+    const result = await runSingleFixture('gmail-test-connection', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.context.gmailEmailAddress).toBe('user@example.com');
+    expect(result.httpCalls[0].url).toBe('https://gmail.googleapis.com/gmail/v1/users/me/profile');
+  });
+
+  it('searches Gmail messages', async () => {
+    const result = await runSingleFixture('gmail-search-emails', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.context.gmailMessages).toHaveLength(2);
+    expect(result.context.gmailNextPageToken).toBe('next-token');
+  });
+
+  it('retrieves a Gmail message', async () => {
+    const result = await runSingleFixture('gmail-get-email', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.context.gmailMessageId).toBe('msg-42');
+    expect(result.context.gmailAttachments).toHaveLength(1);
+  });
+
+  it('sends a Gmail reply', async () => {
+    const result = await runSingleFixture('gmail-send-reply', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.context.gmailReplyRecipients).toEqual(['sender@example.com']);
+    expect(result.httpCalls).toHaveLength(2);
+    expect(result.httpCalls[1].url).toBe('https://gmail.googleapis.com/gmail/v1/users/me/messages/send');
+  });
+
+  it('marks Gmail messages as read', async () => {
+    const result = await runSingleFixture('gmail-mark-as-read', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.httpCalls[0].payload).toMatchObject({ removeLabelIds: ['UNREAD'] });
+  });
+
+  it('adds labels to Gmail messages', async () => {
+    const result = await runSingleFixture('gmail-add-label', fixturesDir);
+    expect(result.success).toBe(true);
+    expect(result.httpCalls[0].payload).toMatchObject({ addLabelIds: ['Label_123'] });
   });
 });

--- a/server/workflow/compile-to-appsscript.ts
+++ b/server/workflow/compile-to-appsscript.ts
@@ -168,6 +168,14 @@ function pascalCaseFromId(value: string): string {
     .join('');
 }
 
+function indentBlock(code: string, spaces = 2): string {
+  const indent = ' '.repeat(spaces);
+  return code
+    .split('\n')
+    .map(line => (line.length ? indent + line : ''))
+    .join('\n');
+}
+
 function appsScriptHttpHelpers(): string {
   return `
 var __HTTP_RETRY_DEFAULTS = {
@@ -997,6 +1005,347 @@ function buildPollingWrapper(triggerKey, executor) {
     });
     throw error;
   }
+}
+
+type GmailPollingTriggerOptions = {
+  handlerName: string;
+  triggerKey: string;
+  queryBlock: string;
+  messageFilterBlock?: string;
+  metadataProperties?: string;
+  logKey: string;
+};
+
+function buildGmailPollingTrigger(options: GmailPollingTriggerOptions): string {
+  const { handlerName, triggerKey, queryBlock, messageFilterBlock, metadataProperties, logKey } = options;
+  const friendlyOperation = triggerKey.replace('trigger.gmail:', 'gmail.');
+  const querySection = queryBlock && queryBlock.trim().length
+    ? `${indentBlock(queryBlock.trim(), 4)}\n\n`
+    : '';
+  const filterSection = messageFilterBlock && messageFilterBlock.trim().length
+    ? `\n${indentBlock(messageFilterBlock.trim(), 8)}\n`
+    : '';
+  const metadataLines = metadataProperties
+    ? metadataProperties
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean)
+    : [];
+  const formatMetadata = (spaces: number) =>
+    metadataLines.length ? metadataLines.map(line => ' '.repeat(spaces) + line).join('\n') + '\n' : '';
+  const metadataSummary = formatMetadata(6);
+  const metadataLog = formatMetadata(6);
+  const metadataReturn = formatMetadata(6);
+
+  return `
+function ${handlerName}() {
+  return buildPollingWrapper('${triggerKey}', function (runtime) {
+    const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+    if (!accessToken) {
+      logError('gmail_missing_access_token', { operation: '${triggerKey}' });
+      throw new Error('Missing Gmail access token for ${friendlyOperation} trigger');
+    }
+
+    const interpolationContext = runtime.state && runtime.state.lastPayload ? runtime.state.lastPayload : {};
+${querySection}    const headers = { Authorization: 'Bearer ' + accessToken };
+    const baseUrl = 'https://gmail.googleapis.com/gmail/v1/users/me';
+    const cursor = (runtime.state && typeof runtime.state.cursor === 'object') ? runtime.state.cursor : {};
+    const lastInternalDate = cursor && cursor.internalDate ? Number(cursor.internalDate) : null;
+    const afterSeconds = lastInternalDate ? Math.floor(lastInternalDate / 1000) : null;
+    const effectiveQuery = afterSeconds ? ((query ? query + ' ' : '') + 'after:' + afterSeconds) : query;
+    const messages = [];
+    let pageToken = null;
+    let pageCount = 0;
+
+    function decodeBase64Url(data) {
+      if (!data) {
+        return '';
+      }
+      try {
+        const normalized = data.replace(/-/g, '+').replace(/_/g, '/');
+        const bytes = Utilities.base64Decode(normalized);
+        return Utilities.newBlob(bytes).getDataAsString('UTF-8');
+      } catch (error) {
+        logWarn('gmail_message_body_decode_failed', {
+          message: error && error.message ? error.message : String(error)
+        });
+        return '';
+      }
+    }
+
+    function extractHeader(all, name) {
+      if (!Array.isArray(all)) {
+        return '';
+      }
+      const target = name.toLowerCase();
+      for (let i = 0; i < all.length; i++) {
+        const header = all[i];
+        if (!header || typeof header.name !== 'string') {
+          continue;
+        }
+        if (header.name.toLowerCase() === target) {
+          return header.value || '';
+        }
+      }
+      return '';
+    }
+
+    function parseAddressList(value) {
+      if (!value) {
+        return [];
+      }
+      return value.split(',').map(part => part.trim()).filter(Boolean);
+    }
+
+    function collectAttachments(parts, bucket) {
+      if (!Array.isArray(parts)) {
+        return;
+      }
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        if (!part) {
+          continue;
+        }
+        if (part.filename && part.body && part.body.attachmentId) {
+          bucket.push({
+            attachmentId: part.body.attachmentId,
+            filename: part.filename,
+            mimeType: part.mimeType || 'application/octet-stream',
+            size: part.body.size || 0
+          });
+        }
+        if (Array.isArray(part.parts) && part.parts.length) {
+          collectAttachments(part.parts, bucket);
+        }
+      }
+    }
+
+    function extractBodies(payload) {
+      const result = {};
+      if (!payload) {
+        return result;
+      }
+
+      const queue = [payload];
+      while (queue.length > 0) {
+        const node = queue.shift();
+        if (!node) {
+          continue;
+        }
+        if (node.mimeType === 'text/plain' && node.body && node.body.data) {
+          result.plain = decodeBase64Url(node.body.data);
+        } else if (node.mimeType === 'text/html' && node.body && node.body.data) {
+          result.html = decodeBase64Url(node.body.data);
+        }
+        if (Array.isArray(node.parts)) {
+          for (let p = 0; p < node.parts.length; p++) {
+            queue.push(node.parts[p]);
+          }
+        }
+      }
+
+      if (!result.plain && payload.body && payload.body.data) {
+        result.plain = decodeBase64Url(payload.body.data);
+      }
+
+      return result;
+    }
+
+    try {
+      do {
+        const params = ['maxResults=25'];
+        if (effectiveQuery) {
+          params.push('q=' + encodeURIComponent(effectiveQuery));
+        }
+        if (Array.isArray(labelIds) && labelIds.length) {
+          for (let i = 0; i < labelIds.length; i++) {
+            params.push('labelIds=' + encodeURIComponent(labelIds[i]));
+          }
+        }
+        if (pageToken) {
+          params.push('pageToken=' + encodeURIComponent(pageToken));
+        }
+
+        const listResponse = rateLimitAware(
+          () => fetchJson({
+            url: baseUrl + '/messages?' + params.join('&'),
+            method: 'GET',
+            headers: headers
+          }),
+          { attempts: 5, backoffMs: 500 }
+        );
+
+        const listBody = listResponse.body || {};
+        const candidates = Array.isArray(listBody.messages) ? listBody.messages : [];
+        for (let i = 0; i < candidates.length; i++) {
+          const messageId = candidates[i] && candidates[i].id;
+          if (!messageId) {
+            continue;
+          }
+
+          const messageResponse = rateLimitAware(
+            () => fetchJson({
+              url: baseUrl + '/messages/' + encodeURIComponent(messageId) + '?format=full',
+              method: 'GET',
+              headers: headers
+            }),
+            { attempts: 5, backoffMs: 500 }
+          );
+
+          const detail = messageResponse.body || {};
+          const payload = detail.payload || {};
+          const headersList = payload.headers || [];
+          const bodies = extractBodies(payload);
+          const attachments = [];
+          collectAttachments(payload.parts, attachments);
+
+          const internalDate = detail.internalDate ? Number(detail.internalDate) : null;
+          if (lastInternalDate && internalDate && internalDate <= lastInternalDate) {
+            continue;
+          }
+
+          const from = extractHeader(headersList, 'From');
+          const to = parseAddressList(extractHeader(headersList, 'To'));
+          const cc = parseAddressList(extractHeader(headersList, 'Cc'));
+          const bcc = parseAddressList(extractHeader(headersList, 'Bcc'));
+          const replyTo = parseAddressList(extractHeader(headersList, 'Reply-To'));
+          const deliveredTo = extractHeader(headersList, 'Delivered-To');
+          const subject = extractHeader(headersList, 'Subject') || null;
+          const historyId = detail.historyId ? String(detail.historyId) : null;
+
+          const fromName = from && from.indexOf('<') !== -1 ? from.split('<')[0].trim() : null;
+${filterSection}          messages.push({
+            internalDate: internalDate || Date.now(),
+            historyId: historyId,
+            payload: {
+              id: detail.id || messageId,
+              threadId: detail.threadId || null,
+              historyId: historyId,
+              labelIds: Array.isArray(detail.labelIds) ? detail.labelIds : [],
+              subject: subject,
+              snippet: detail.snippet || '',
+              sizeEstimate: detail.sizeEstimate || null,
+              from: from,
+              fromName: fromName,
+              to: to,
+              cc: cc,
+              bcc: bcc,
+              replyTo: replyTo,
+              deliveredTo: deliveredTo || null,
+              receivedAt: internalDate ? new Date(internalDate).toISOString() : new Date().toISOString(),
+              bodyPlain: bodies.plain || null,
+              bodyHtml: bodies.html || null,
+              attachments: attachments,
+              threadSnippet: detail.snippet || null,
+              raw: detail
+            }
+          });
+        }
+
+        if (messages.length >= 50) {
+          pageToken = null;
+        } else {
+          pageToken = listBody.nextPageToken || null;
+        }
+
+        pageCount += 1;
+      } while (pageToken && pageCount < 5 && messages.length < 50);
+
+      if (messages.length === 0) {
+        runtime.summary({
+          messagesAttempted: 0,
+          messagesDispatched: 0,
+          messagesFailed: 0,
+${metadataSummary}      query: effectiveQuery,
+          labelIds: labelIds,
+          lastInternalDate: lastInternalDate || null
+        });
+        return {
+          messagesAttempted: 0,
+          messagesDispatched: 0,
+          messagesFailed: 0,
+${metadataReturn}      query: effectiveQuery,
+          labelIds: labelIds,
+          lastInternalDate: lastInternalDate || null
+        };
+      }
+
+      messages.sort(function (a, b) {
+        return Number(a.internalDate) - Number(b.internalDate);
+      });
+
+      let lastPayloadDispatched = null;
+      const batch = runtime.dispatchBatch(messages, function (entry) {
+        const payload = {
+          id: entry.payload.id,
+          threadId: entry.payload.threadId,
+          historyId: entry.payload.historyId,
+          labelIds: entry.payload.labelIds,
+          subject: entry.payload.subject,
+          snippet: entry.payload.snippet,
+          from: entry.payload.from,
+          fromName: entry.payload.fromName,
+          to: entry.payload.to,
+          cc: entry.payload.cc,
+          bcc: entry.payload.bcc,
+          replyTo: entry.payload.replyTo,
+          deliveredTo: entry.payload.deliveredTo,
+          receivedAt: entry.payload.receivedAt,
+          sizeEstimate: entry.payload.sizeEstimate,
+          bodyPlain: entry.payload.bodyPlain,
+          bodyHtml: entry.payload.bodyHtml,
+          attachments: entry.payload.attachments,
+          threadSnippet: entry.payload.threadSnippet,
+          snippet: entry.payload.snippet,
+          _meta: { raw: entry.payload.raw || null }
+        };
+        lastPayloadDispatched = payload;
+        return payload;
+      });
+
+      runtime.state = runtime.state && typeof runtime.state === 'object' ? runtime.state : {};
+      runtime.state.cursor = runtime.state.cursor && typeof runtime.state.cursor === 'object' ? runtime.state.cursor : {};
+      runtime.state.cursor.internalDate = messages[messages.length - 1].internalDate;
+      runtime.state.lastPayload = lastPayloadDispatched || runtime.state.lastPayload || null;
+
+      runtime.summary({
+        messagesAttempted: batch.attempted,
+        messagesDispatched: batch.succeeded,
+        messagesFailed: batch.failed,
+${metadataSummary}      query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      });
+
+      logInfo('${logKey}_success', {
+        dispatched: batch.succeeded,
+${metadataLog}      query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      });
+
+      return {
+        messagesAttempted: batch.attempted,
+        messagesDispatched: batch.succeeded,
+        messagesFailed: batch.failed,
+${metadataReturn}      query: effectiveQuery,
+        labelIds: labelIds,
+        lastInternalDate: runtime.state.cursor.internalDate
+      };
+    } catch (error) {
+      const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+      const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+      const status = error && typeof error.status === 'number' ? error.status : null;
+      const message = providerMessage || (error && error.message ? error.message : String(error));
+      logError('${logKey}_failed', {
+        status: status,
+        providerCode: providerCode,
+        message: message
+      });
+      throw error;
+    }
+  });
+}`;
 }
 
 function __slackResolveString(template, ctx, options) {
@@ -3949,95 +4298,54 @@ async function ${functionName}(inputData, params) {
 }
 
 function generateGmailFunction(functionName: string, node: WorkflowNode): string {
-  const operation = node.params?.operation || node.op?.split('.').pop() || 'email_received';
-  
-  return `
-function ${esc(functionName)}(inputData, params) {
-  console.log('📧 Executing Gmail: ' + (params.operation || '${operation}'));
-  
-  try {
-    const operation = params.operation || '${operation}';
-    
-    if (operation === 'email_received' || operation === 'trigger') {
-      const query = params.query || 'is:unread';
-      const maxResults = params.maxResults || 10;
-      
-      const threads = GmailApp.search(query, 0, maxResults);
-      const emails = [];
-      
-      threads.forEach(thread => {
-        const messages = thread.getMessages();
-        messages.forEach(message => {
-          emails.push({
-            id: message.getId(),
-            subject: message.getSubject(),
-            from: message.getFrom(),
-            date: message.getDate(),
-            body: message.getPlainBody(),
-            threadId: thread.getId(),
-            thread: thread
-          });
-        });
-      });
-      
-      console.log('📧 Found ' + emails.length + ' emails matching query: ' + query);
-      return { ...inputData, emails: emails, emailsFound: emails.length };
-    }
-    
-    if (operation === 'send_reply' || operation === 'reply') {
-      const responseTemplate = params.responseTemplate || 'Thank you for your email. We will get back to you soon.';
-      const emails = inputData.emails || [];
-      let repliesSent = 0;
-      
-      emails.forEach(email => {
-        if (email.thread) {
-          // Personalize response with sender name
-          const senderName = email.from.split('<')[0].trim() || 'Valued Customer';
-          let personalizedResponse = responseTemplate;
-          personalizedResponse = personalizedResponse.replace(/{{name}}/g, senderName);
-          personalizedResponse = personalizedResponse.replace(/{{subject}}/g, email.subject);
-          
-          // Send reply
-          email.thread.reply(personalizedResponse);
-          repliesSent++;
-          
-          // Mark as processed
-          if (params.markAsReplied) {
-            const label = GmailApp.getUserLabelByName('Auto-Replied');
-            if (label) {
-              email.thread.addLabel(label);
-            } else {
-              email.thread.addLabel(GmailApp.createLabel('Auto-Replied'));
-            }
-          }
-        }
-      });
-      
-      console.log('📧 Sent ' + repliesSent + ' auto-replies');
-      return { ...inputData, repliesSent: repliesSent, responseTemplate: responseTemplate };
-    }
-    
-    if (operation === 'send_email') {
-      const to = params.to || inputData.to;
-      const subject = params.subject || inputData.subject || 'Automated Email';
-      const body = params.body || inputData.body || 'Automated message';
-      
-      if (!to) {
-        console.warn('⚠️ Missing recipient email');
-        return { ...inputData, gmailError: 'Missing recipient' };
-      }
-      
-      GmailApp.sendEmail(to, subject, body);
-      console.log('📧 Email sent to: ' + to);
-      return { ...inputData, emailSent: true, recipient: to };
-    }
-    
-    console.log('✅ Gmail operation completed:', operation);
-    return { ...inputData, gmailResult: 'success', operation };
-  } catch (error) {
-    console.error('❌ Gmail error:', error);
-    return { ...inputData, gmailError: error.toString() };
+  const rawOperationKey = typeof node.op === 'string' ? node.op : '';
+  const nodeType = typeof node.type === 'string' ? node.type : '';
+  const isTrigger = rawOperationKey.startsWith('trigger.gmail')
+    || nodeType.startsWith('trigger.gmail')
+    || nodeType.startsWith('trigger:')
+    || nodeType.startsWith('trigger.');
+
+  const operationFromNode =
+    (typeof node.data?.operation === 'string' && node.data.operation)
+      || (typeof (node.params as any)?.operation === 'string' && (node.params as any).operation)
+      || (rawOperationKey.includes(':') ? rawOperationKey.split(':')[1]
+        : rawOperationKey.includes('.') ? rawOperationKey.split('.').pop() || ''
+        : '');
+
+  const defaultOperation = isTrigger ? 'new_email_received' : 'test_connection';
+  const operationName = operationFromNode || defaultOperation;
+
+  const prefix = isTrigger ? 'trigger.gmail' : 'action.gmail';
+  let resolvedKey = rawOperationKey;
+
+  if (!resolvedKey) {
+    resolvedKey = `${prefix}:${operationName}`;
+  } else if (!resolvedKey.startsWith('action.gmail') && !resolvedKey.startsWith('trigger.gmail')) {
+    const suffix = resolvedKey.includes(':')
+      ? resolvedKey.split(':').pop() || operationName
+      : resolvedKey.includes('.') ? resolvedKey.split('.').pop() || operationName
+      : operationName;
+    resolvedKey = `${prefix}:${suffix}`;
   }
+
+  const config = node.data?.config ?? node.params ?? {};
+  const builder = REAL_OPS[resolvedKey];
+
+  if (typeof builder === 'function') {
+    const generated = builder(config);
+    if (typeof generated === 'string' && generated.trim().length > 0) {
+      return generated.replace(/function\s+[^(]+\(/, match => `function ${functionName}(`);
+    }
+  }
+
+  const safeKey = esc(resolvedKey || `${prefix}:${operationName}`);
+  const safeOperation = esc(operationName);
+
+  return `
+function ${functionName}(ctx) {
+  ctx = ctx || {};
+  logWarn('gmail_operation_missing', { operation: '${safeKey}' });
+  throw new Error('Gmail operation "${safeOperation}" is not implemented in Apps Script runtime.');
 }`;
 }
 
@@ -15235,21 +15543,13 @@ function ${functionName}(inputData, params) {
 const opKey = (n: any) => `${n.type}:${n.data?.operation}`;
 
 const OPS: Record<string, (c: any) => string> = {
-  'trigger.gmail:email_received': (c) => REAL_OPS['trigger.gmail:email_received']
-    ? REAL_OPS['trigger.gmail:email_received'](c)
+  'trigger.gmail:new_email_received': (c) => REAL_OPS['trigger.gmail:new_email_received']
+    ? REAL_OPS['trigger.gmail:new_email_received'](c)
     : '',
 
-  'action.gmail:send_reply': (c) => `
-function step_sendReply(ctx) {
-  if (ctx.thread) {
-    const template = '${c.responseTemplate || 'Thank you for your email.'}';
-    const senderName = ctx.from.split('<')[0].trim() || 'Valued Customer';
-    const personalizedResponse = template.replace(/{{name}}/g, senderName);
-    ctx.thread.reply(personalizedResponse);
-    ${c.markAsReplied ? 'ctx.thread.addLabel(GmailApp.getUserLabelByName("Auto-Replied") || GmailApp.createLabel("Auto-Replied"));' : ''}
-  }
-  return ctx;
-}`,
+  'action.gmail:send_reply': (c) => REAL_OPS['action.gmail:send_reply']
+    ? REAL_OPS['action.gmail:send_reply'](c)
+    : '',,
 
   'action.sheets:append_row': (c) => `
 function step_logData(ctx) {
@@ -17396,293 +17696,102 @@ const REAL_OPS: Record<string, (c: any) => string> = {
   'action.adyen:capture_payment': (c) => buildAdyenAction('capture_payment', c),
   'action.adyen:refund_payment': (c) => buildAdyenAction('refund_payment', c),
   'trigger.adyen:payment_success': (c) => buildAdyenTrigger(c),
-  'trigger.gmail:email_received': (c) => `
-function onNewEmail() {
-  return buildPollingWrapper('trigger.gmail:email_received', function (runtime) {
-    const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
-    if (!accessToken) {
-      logError('gmail_missing_access_token', { operation: 'trigger.gmail:email_received' });
-      throw new Error('Missing Gmail access token for gmail.email_received trigger');
+  'trigger.gmail:new_email_received': (c) =>
+    buildGmailPollingTrigger({
+      handlerName: 'onGmailNewEmailReceived',
+      triggerKey: 'trigger.gmail:new_email_received',
+      logKey: 'gmail_new_email_received',
+      queryBlock: `
+const queryTemplate = '${esc(c.query || 'is:unread')}';
+const query = queryTemplate ? interpolate(queryTemplate, interpolationContext).trim() : '';
+const labelIdsConfig = ${JSON.stringify(c.labelIds || [])};
+const labelIds = [];
+if (Array.isArray(labelIdsConfig)) {
+  for (let i = 0; i < labelIdsConfig.length; i++) {
+    const value = typeof labelIdsConfig[i] === 'string' ? interpolate(labelIdsConfig[i], interpolationContext).trim() : '';
+    if (value) {
+      labelIds.push(value);
     }
-
-    const interpolationContext = runtime.state && runtime.state.lastPayload ? runtime.state.lastPayload : {};
-    const query = interpolate('${esc(c.query || 'is:unread')}', interpolationContext).trim();
-    const labelIdsConfig = ${JSON.stringify(c.labelIds || [])};
-    const labelIds = [];
-    if (Array.isArray(labelIdsConfig)) {
-      for (let i = 0; i < labelIdsConfig.length; i++) {
-        const value = typeof labelIdsConfig[i] === 'string' ? interpolate(labelIdsConfig[i], interpolationContext).trim() : '';
-        if (value) {
-          labelIds.push(value);
-        }
-      }
+  }
+}
+`,
+      metadataProperties: 'labelCount: labelIds.length,'
+    }),
+  'trigger.gmail:email_received_from': (c) =>
+    buildGmailPollingTrigger({
+      handlerName: 'onGmailEmailReceivedFrom',
+      triggerKey: 'trigger.gmail:email_received_from',
+      logKey: 'gmail_email_received_from',
+      queryBlock: `
+const fromTemplate = '${esc(c.fromEmail || '')}';
+const subjectTemplate = '${esc(c.subject || '')}';
+const fromFilter = fromTemplate ? interpolate(fromTemplate, interpolationContext).trim() : '';
+if (!fromFilter) {
+  throw new Error('trigger.gmail:email_received_from requires a fromEmail value before deployment.');
+}
+const subjectFilter = subjectTemplate ? interpolate(subjectTemplate, interpolationContext).trim() : '';
+const labelIds = [];
+const parts = ['from:' + fromFilter];
+if (subjectFilter) {
+  parts.push('subject:"' + subjectFilter.replace(/"/g, '\"') + '"');
+}
+const query = parts.join(' ');
+`,
+      metadataProperties: 'fromEmail: fromFilter,\nsubjectFilter: subjectFilter || null,'
+    }),
+  'trigger.gmail:email_with_attachment': (c) =>
+    buildGmailPollingTrigger({
+      handlerName: 'onGmailEmailWithAttachment',
+      triggerKey: 'trigger.gmail:email_with_attachment',
+      logKey: 'gmail_email_with_attachment',
+      queryBlock: `
+const fileTypesConfig = ${JSON.stringify(c.fileTypes || [])};
+const fromTemplate = '${esc(c.fromEmail || '')}';
+const fromFilter = fromTemplate ? interpolate(fromTemplate, interpolationContext).trim() : '';
+const fileTypes = [];
+if (Array.isArray(fileTypesConfig)) {
+  for (let i = 0; i < fileTypesConfig.length; i++) {
+    const value = typeof fileTypesConfig[i] === 'string' ? interpolate(fileTypesConfig[i], interpolationContext).trim() : '';
+    if (value) {
+      fileTypes.push(value.toLowerCase());
     }
-
-    const headers = { Authorization: 'Bearer ' + accessToken };
-    const baseUrl = 'https://gmail.googleapis.com/gmail/v1/users/me';
-    const cursor = (runtime.state && typeof runtime.state.cursor === 'object') ? runtime.state.cursor : {};
-    const lastInternalDate = cursor && cursor.internalDate ? Number(cursor.internalDate) : null;
-    const afterSeconds = lastInternalDate ? Math.floor(lastInternalDate / 1000) : null;
-    const effectiveQuery = afterSeconds ? ((query ? query + ' ' : '') + 'after:' + afterSeconds) : query;
-    const messages = [];
-    let pageToken = null;
-    let pageCount = 0;
-
-    function decodeBase64Url(data) {
-      if (!data) {
-        return '';
+  }
+}
+const queryParts = ['has:attachment'];
+if (fromFilter) {
+  queryParts.push('from:' + fromFilter);
+}
+const query = queryParts.join(' ');
+const labelIds = [];
+`,
+      metadataProperties: 'fromEmail: fromFilter || null,\nfileTypes: fileTypes,',
+      messageFilterBlock: `
+if (!attachments.length) {
+  continue;
+}
+if (fileTypes.length) {
+  let matchedType = false;
+  for (let ft = 0; ft < attachments.length && !matchedType; ft++) {
+    const attachment = attachments[ft] || {};
+    const filename = (attachment.filename || '').toLowerCase();
+    const mimeType = (attachment.mimeType || '').toLowerCase();
+    for (let j = 0; j < fileTypes.length; j++) {
+      const type = fileTypes[j];
+      if (!type) {
+        continue;
       }
-      try {
-        const normalized = data.replace(/-/g, '+').replace(/_/g, '/');
-        const bytes = Utilities.base64Decode(normalized);
-        return Utilities.newBlob(bytes).getDataAsString('UTF-8');
-      } catch (error) {
-        logWarn('gmail_message_body_decode_failed', {
-          message: error && error.message ? error.message : String(error)
-        });
-        return '';
-      }
-    }
-
-    function extractHeader(all, name) {
-      if (!Array.isArray(all)) {
-        return '';
-      }
-      const target = name.toLowerCase();
-      for (let i = 0; i < all.length; i++) {
-        const header = all[i];
-        if (!header || typeof header.name !== 'string') {
-          continue;
-        }
-        if (header.name.toLowerCase() === target) {
-          return header.value || '';
-        }
-      }
-      return '';
-    }
-
-    function parseAddressList(value) {
-      if (!value) {
-        return [];
-      }
-      return value.split(',').map(part => part.trim()).filter(Boolean);
-    }
-
-    function collectAttachments(parts, bucket) {
-      if (!Array.isArray(parts)) {
-        return;
-      }
-      for (let i = 0; i < parts.length; i++) {
-        const part = parts[i];
-        if (!part) {
-          continue;
-        }
-        if (part.filename && part.body && part.body.attachmentId) {
-          bucket.push({
-            attachmentId: part.body.attachmentId,
-            filename: part.filename,
-            mimeType: part.mimeType || 'application/octet-stream',
-            size: part.body.size || 0
-          });
-        }
-        if (Array.isArray(part.parts) && part.parts.length) {
-          collectAttachments(part.parts, bucket);
-        }
+      if ((filename && filename.endsWith('.' + type)) || (mimeType && mimeType.indexOf(type) !== -1)) {
+        matchedType = true;
+        break;
       }
     }
-
-    function extractBodies(payload) {
-      const result = {};
-      if (!payload) {
-        return result;
-      }
-
-      const queue = [payload];
-      while (queue.length > 0) {
-        const node = queue.shift();
-        if (!node) {
-          continue;
-        }
-        if (node.mimeType === 'text/plain' && node.body && node.body.data) {
-          result.plain = decodeBase64Url(node.body.data);
-        } else if (node.mimeType === 'text/html' && node.body && node.body.data) {
-          result.html = decodeBase64Url(node.body.data);
-        }
-        if (Array.isArray(node.parts)) {
-          for (let p = 0; p < node.parts.length; p++) {
-            queue.push(node.parts[p]);
-          }
-        }
-      }
-
-      if (!result.plain && payload.body && payload.body.data) {
-        result.plain = decodeBase64Url(payload.body.data);
-      }
-
-      return result;
-    }
-
-    try {
-      do {
-        const params = ['maxResults=25'];
-        if (effectiveQuery) {
-          params.push('q=' + encodeURIComponent(effectiveQuery));
-        }
-        if (Array.isArray(labelIds) && labelIds.length) {
-        for (let i = 0; i < labelIds.length; i++) {
-          params.push('labelIds=' + encodeURIComponent(labelIds[i]));
-        }
-      }
-      if (pageToken) {
-        params.push('pageToken=' + encodeURIComponent(pageToken));
-      }
-
-      const listResponse = rateLimitAware(
-        () => fetchJson({
-          url: baseUrl + '/messages?' + params.join('&'),
-          method: 'GET',
-          headers: headers
-        }),
-        { attempts: 5, backoffMs: 500 }
-      );
-
-      const listBody = listResponse.body || {};
-      const candidates = Array.isArray(listBody.messages) ? listBody.messages : [];
-      for (let i = 0; i < candidates.length; i++) {
-        const messageId = candidates[i] && candidates[i].id;
-        if (!messageId) {
-          continue;
-        }
-
-        const messageResponse = rateLimitAware(
-          () => fetchJson({
-            url: baseUrl + '/messages/' + encodeURIComponent(messageId) + '?format=full',
-            method: 'GET',
-            headers: headers
-          }),
-          { attempts: 5, backoffMs: 500 }
-        );
-
-        const detail = messageResponse.body || {};
-        const payload = detail.payload || {};
-        const headersList = payload.headers || [];
-        const bodies = extractBodies(payload);
-        const attachments = [];
-        collectAttachments(payload.parts, attachments);
-
-        const internalDate = detail.internalDate ? Number(detail.internalDate) : null;
-        if (lastInternalDate && internalDate && internalDate <= lastInternalDate) {
-          continue;
-        }
-
-        const from = extractHeader(headersList, 'From');
-        const to = parseAddressList(extractHeader(headersList, 'To'));
-        const cc = parseAddressList(extractHeader(headersList, 'Cc'));
-        const bcc = parseAddressList(extractHeader(headersList, 'Bcc'));
-        const replyTo = parseAddressList(extractHeader(headersList, 'Reply-To'));
-        const deliveredTo = extractHeader(headersList, 'Delivered-To');
-        const subject = extractHeader(headersList, 'Subject') || null;
-        const historyId = detail.historyId ? String(detail.historyId) : null;
-
-        const fromName = from && from.indexOf('<') !== -1 ? from.split('<')[0].trim() : null;
-
-        messages.push({
-          internalDate: internalDate || Date.now(),
-          historyId: historyId,
-          payload: {
-            id: detail.id || messageId,
-            threadId: detail.threadId || null,
-            historyId: historyId,
-            labelIds: Array.isArray(detail.labelIds) ? detail.labelIds : [],
-            subject: subject,
-            snippet: detail.snippet || '',
-            from: from,
-            fromName: fromName,
-            to: to,
-            cc: cc,
-            bcc: bcc,
-            replyTo: replyTo,
-            deliveredTo: deliveredTo || null,
-            receivedAt: internalDate ? new Date(internalDate).toISOString() : new Date().toISOString(),
-            sizeEstimate: detail.sizeEstimate || null,
-            bodyPlain: bodies.plain || '',
-            bodyHtml: bodies.html || '',
-            attachments: attachments,
-            _meta: { raw: detail }
-          }
-        });
-      }
-
-      pageToken = listBody.nextPageToken || null;
-      pageCount += 1;
-    } while (pageToken && messages.length < 50 && pageCount < 5);
-
-      if (messages.length === 0) {
-        runtime.summary({
-          messagesAttempted: 0,
-          messagesDispatched: 0,
-          messagesFailed: 0,
-          query: effectiveQuery,
-          labelIds: labelIds
-        });
-        return { messagesAttempted: 0, messagesDispatched: 0, messagesFailed: 0, query: effectiveQuery, labelIds: labelIds };
-      }
-
-      messages.sort(function (a, b) {
-        return (a.internalDate || 0) - (b.internalDate || 0);
-      });
-
-      const batch = runtime.dispatchBatch(messages, function (entry) {
-        return entry.payload;
-      });
-
-      const last = messages[messages.length - 1];
-      runtime.state.cursor = runtime.state.cursor && typeof runtime.state.cursor === 'object' ? runtime.state.cursor : {};
-      runtime.state.cursor.internalDate = String(last.internalDate || Date.now());
-      if (last.historyId) {
-        runtime.state.cursor.historyId = last.historyId;
-      }
-      runtime.state.cursor.lastMessageId = last.payload.id;
-      runtime.state.lastPayload = last.payload;
-
-      runtime.summary({
-        messagesAttempted: batch.attempted,
-        messagesDispatched: batch.succeeded,
-        messagesFailed: batch.failed,
-        query: effectiveQuery,
-        labelIds: labelIds,
-        lastInternalDate: runtime.state.cursor.internalDate
-      });
-
-      logInfo('gmail_email_received_success', {
-        query: effectiveQuery,
-        dispatched: batch.succeeded,
-        labelIds: labelIds,
-        lastInternalDate: runtime.state.cursor.internalDate
-      });
-
-      return {
-        messagesAttempted: batch.attempted,
-        messagesDispatched: batch.succeeded,
-        messagesFailed: batch.failed,
-        query: effectiveQuery,
-        labelIds: labelIds,
-        lastInternalDate: runtime.state.cursor.internalDate
-      };
-    } catch (error) {
-      const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
-      const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
-      const status = error && typeof error.status === 'number' ? error.status : null;
-      const message = providerMessage || (error && error.message ? error.message : String(error));
-      logError('gmail_email_received_failed', {
-        status: status,
-        providerCode: providerCode,
-        message: message
-      });
-      throw error;
-    }
-  });
-}`,
+  }
+  if (!matchedType) {
+    continue;
+  }
+}
+`
+    }),
   'trigger.sheets:onEdit': (c) => `
 function onEdit(e) {
   return buildPollingWrapper('trigger.sheets:onEdit', function (runtime) {
@@ -18161,6 +18270,236 @@ function step_getRow(ctx) {
   }
 }`,
 
+  'action.gmail:test_connection': (c) => `
+function step_action_gmail_test_connection(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:test_connection' });
+    throw new Error('Missing Gmail access token for gmail.test_connection operation');
+  }
+
+  try {
+    const response = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/profile',
+        method: 'GET',
+        headers: { Authorization: 'Bearer ' + accessToken }
+      }),
+      { attempts: 3, backoffMs: 500 }
+    );
+
+    const profile = response.body || {};
+    ctx.gmailProfile = profile;
+    ctx.gmailEmailAddress = profile.emailAddress || null;
+    ctx.gmailMessagesTotal = typeof profile.messagesTotal === 'number' ? profile.messagesTotal : null;
+    ctx.gmailThreadsTotal = typeof profile.threadsTotal === 'number' ? profile.threadsTotal : null;
+    ctx.gmailHistoryId = profile.historyId ? String(profile.historyId) : null;
+    ctx.gmailTestConnectionSuccess = true;
+
+    logInfo('gmail_test_connection_success', {
+      emailAddress: ctx.gmailEmailAddress,
+      messagesTotal: ctx.gmailMessagesTotal,
+      threadsTotal: ctx.gmailThreadsTotal
+    });
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_test_connection_failed', {
+      operation: 'action.gmail:test_connection',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail test_connection failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}`,
+  'action.gmail:get_email': (c) => `
+function step_action_gmail_get_email(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:get_email' });
+    throw new Error('Missing Gmail access token for gmail.get_email operation');
+  }
+
+  const messageId = interpolate('${esc(c.messageId || '')}', ctx).trim();
+  if (!messageId) {
+    logError('gmail_get_email_missing_param', { field: 'messageId' });
+    throw new Error('Missing required Gmail get_email param: messageId');
+  }
+
+  const formatTemplate = '${esc(c.format || 'full')}';
+  let format = formatTemplate ? interpolate(formatTemplate, ctx).trim().toLowerCase() : 'full';
+  if (!format || ['minimal', 'full', 'raw', 'metadata'].indexOf(format) === -1) {
+    format = 'full';
+  }
+
+  function decodeBase64Url(data) {
+    if (!data) {
+      return '';
+    }
+    try {
+      const normalized = data.replace(/-/g, '+').replace(/_/g, '/');
+      const bytes = Utilities.base64Decode(normalized);
+      return Utilities.newBlob(bytes).getDataAsString('UTF-8');
+    } catch (error) {
+      logWarn('gmail_message_body_decode_failed', {
+        message: error && error.message ? error.message : String(error)
+      });
+      return '';
+    }
+  }
+
+  function extractHeader(all, name) {
+    if (!Array.isArray(all)) {
+      return '';
+    }
+    const target = name.toLowerCase();
+    for (let i = 0; i < all.length; i++) {
+      const header = all[i];
+      if (!header || typeof header.name !== 'string') {
+        continue;
+      }
+      if (header.name.toLowerCase() === target) {
+        return header.value || '';
+      }
+    }
+    return '';
+  }
+
+  function parseAddressList(value) {
+    if (!value) {
+      return [];
+    }
+    return value.split(',').map(part => part.trim()).filter(Boolean);
+  }
+
+  function collectAttachments(parts, bucket) {
+    if (!Array.isArray(parts)) {
+      return;
+    }
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (!part) {
+        continue;
+      }
+      if (part.filename && part.body && part.body.attachmentId) {
+        bucket.push({
+          attachmentId: part.body.attachmentId,
+          filename: part.filename,
+          mimeType: part.mimeType || 'application/octet-stream',
+          size: part.body.size || 0
+        });
+      }
+      if (Array.isArray(part.parts) && part.parts.length) {
+        collectAttachments(part.parts, bucket);
+      }
+    }
+  }
+
+  function extractBodies(payload) {
+    const result = {};
+    if (!payload) {
+      return result;
+    }
+
+    const queue = [payload];
+    while (queue.length > 0) {
+      const node = queue.shift();
+      if (!node) {
+        continue;
+      }
+      if (node.mimeType === 'text/plain' && node.body && node.body.data) {
+        result.plain = decodeBase64Url(node.body.data);
+      } else if (node.mimeType === 'text/html' && node.body && node.body.data) {
+        result.html = decodeBase64Url(node.body.data);
+      }
+      if (Array.isArray(node.parts)) {
+        for (let p = 0; p < node.parts.length; p++) {
+          queue.push(node.parts[p]);
+        }
+      }
+    }
+
+    if (!result.plain && payload.body && payload.body.data) {
+      result.plain = decodeBase64Url(payload.body.data);
+    }
+
+    return result;
+  }
+
+  try {
+    const response = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/' + encodeURIComponent(messageId) + '?format=' + format,
+        method: 'GET',
+        headers: { Authorization: 'Bearer ' + accessToken }
+      }),
+      { attempts: 5, backoffMs: 500 }
+    );
+
+    const message = response.body || {};
+    const payload = message.payload || {};
+    const headersList = payload.headers || [];
+    const bodies = extractBodies(payload);
+    const attachments = [];
+    collectAttachments(payload.parts, attachments);
+
+    const from = extractHeader(headersList, 'From');
+    const subject = extractHeader(headersList, 'Subject') || null;
+    const toList = parseAddressList(extractHeader(headersList, 'To'));
+    const ccList = parseAddressList(extractHeader(headersList, 'Cc'));
+    const bccList = parseAddressList(extractHeader(headersList, 'Bcc'));
+    const replyToList = parseAddressList(extractHeader(headersList, 'Reply-To'));
+    const deliveredTo = extractHeader(headersList, 'Delivered-To') || null;
+
+    ctx.gmailMessage = message;
+    ctx.gmailMessageId = message.id || messageId;
+    ctx.gmailThreadId = message.threadId || null;
+    ctx.gmailLabelIds = Array.isArray(message.labelIds) ? message.labelIds : [];
+    ctx.gmailSnippet = message.snippet || '';
+    ctx.gmailInternalDate = message.internalDate ? String(message.internalDate) : null;
+    ctx.gmailPayload = payload;
+    ctx.gmailHeaders = headersList;
+    ctx.gmailBodyPlain = bodies.plain || null;
+    ctx.gmailBodyHtml = bodies.html || null;
+    ctx.gmailAttachments = attachments;
+
+    ctx.gmailFrom = from;
+    ctx.gmailSubject = subject;
+    ctx.gmailTo = toList;
+    ctx.gmailCc = ccList;
+    ctx.gmailBcc = bccList;
+    ctx.gmailReplyTo = replyToList;
+    ctx.gmailDeliveredTo = deliveredTo;
+
+    logInfo('gmail_get_email_success', {
+      messageId: ctx.gmailMessageId || null,
+      threadId: ctx.gmailThreadId || null,
+      format: format,
+      attachments: attachments.length
+    });
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_get_email_failed', {
+      operation: 'action.gmail:get_email',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail get_email failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}`,
   'action.gmail:send_email': (c) => `
 function step_action_gmail_send_email(ctx) {
   ctx = ctx || {};
@@ -18394,6 +18733,323 @@ function step_action_gmail_search_emails(ctx) {
       message: message
     });
     throw new Error('Gmail search_emails failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}`,
+  'action.gmail:mark_as_read': (c) => `
+function step_action_gmail_mark_as_read(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:mark_as_read' });
+    throw new Error('Missing Gmail access token for gmail.mark_as_read operation');
+  }
+
+  const idsConfig = ${JSON.stringify(c.messageIds || [])};
+  const messageIds = [];
+  if (Array.isArray(idsConfig)) {
+    for (let i = 0; i < idsConfig.length; i++) {
+      const value = typeof idsConfig[i] === 'string' ? interpolate(idsConfig[i], ctx).trim() : '';
+      if (value) {
+        messageIds.push(value);
+      }
+    }
+  }
+
+  if (!messageIds.length) {
+    logError('gmail_mark_as_read_missing_param', { field: 'messageIds' });
+    throw new Error('Missing required Gmail mark_as_read param: messageIds');
+  }
+
+  try {
+    rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/batchModify',
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        },
+        payload: JSON.stringify({ ids: messageIds, removeLabelIds: ['UNREAD'] })
+      }),
+      { attempts: 4, backoffMs: 500 }
+    );
+
+    ctx.gmailModifiedIds = messageIds;
+    logInfo('gmail_mark_as_read_success', { count: messageIds.length });
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_mark_as_read_failed', {
+      operation: 'action.gmail:mark_as_read',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail mark_as_read failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}`,
+  'action.gmail:add_label': (c) => `
+function step_action_gmail_add_label(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:add_label' });
+    throw new Error('Missing Gmail access token for gmail.add_label operation');
+  }
+
+  const idsConfig = ${JSON.stringify(c.messageIds || [])};
+  const labelConfig = ${JSON.stringify(c.labelIds || [])};
+  const messageIds = [];
+  if (Array.isArray(idsConfig)) {
+    for (let i = 0; i < idsConfig.length; i++) {
+      const value = typeof idsConfig[i] === 'string' ? interpolate(idsConfig[i], ctx).trim() : '';
+      if (value) {
+        messageIds.push(value);
+      }
+    }
+  }
+
+  const labelIds = [];
+  if (Array.isArray(labelConfig)) {
+    for (let j = 0; j < labelConfig.length; j++) {
+      const value = typeof labelConfig[j] === 'string' ? interpolate(labelConfig[j], ctx).trim() : '';
+      if (value) {
+        labelIds.push(value);
+      }
+    }
+  }
+
+  if (!messageIds.length) {
+    logError('gmail_add_label_missing_param', { field: 'messageIds' });
+    throw new Error('Missing required Gmail add_label param: messageIds');
+  }
+
+  if (!labelIds.length) {
+    logError('gmail_add_label_missing_param', { field: 'labelIds' });
+    throw new Error('Missing required Gmail add_label param: labelIds');
+  }
+
+  try {
+    rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/batchModify',
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        },
+        payload: JSON.stringify({ ids: messageIds, addLabelIds: labelIds })
+      }),
+      { attempts: 4, backoffMs: 500 }
+    );
+
+    ctx.gmailModifiedIds = messageIds;
+    ctx.gmailAppliedLabelIds = labelIds;
+    logInfo('gmail_add_label_success', {
+      messageCount: messageIds.length,
+      labelCount: labelIds.length
+    });
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_add_label_failed', {
+      operation: 'action.gmail:add_label',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail add_label failed: ' + (providerCode ? providerCode + ' ' : '') + message);
+  }
+}`,
+  'action.gmail:send_reply': (c) => `
+function step_action_gmail_send_reply(ctx) {
+  ctx = ctx || {};
+  const accessToken = getSecret('GMAIL_ACCESS_TOKEN', { connectorKey: 'gmail' });
+  if (!accessToken) {
+    logError('gmail_missing_access_token', { operation: 'action.gmail:send_reply' });
+    throw new Error('Missing Gmail access token for gmail.send_reply operation');
+  }
+
+  const messageId = interpolate('${esc(c.messageId || '')}', ctx).trim();
+  if (!messageId) {
+    logError('gmail_send_reply_missing_param', { field: 'messageId' });
+    throw new Error('Missing required Gmail send_reply param: messageId');
+  }
+
+  const bodyTemplate = '${esc(c.body || '')}';
+  const replyBody = interpolate(bodyTemplate, ctx);
+  if (!replyBody) {
+    logError('gmail_send_reply_missing_param', { field: 'body' });
+    throw new Error('Missing required Gmail send_reply param: body');
+  }
+
+  let replyAll = ${c.replyAll === true ? 'true' : 'false'};
+  const replyAllTemplate = '${esc(c.replyAll !== undefined ? String(c.replyAll) : '')}';
+  if (replyAllTemplate) {
+    const normalized = replyAllTemplate.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1' || normalized === 'yes') {
+      replyAll = true;
+    } else if (normalized === 'false' || normalized === '0' || normalized === 'no') {
+      replyAll = false;
+    }
+  }
+
+  function parseAddressList(value) {
+    if (!value) {
+      return [];
+    }
+    return value.split(',').map(function (entry) { return entry.trim(); }).filter(Boolean);
+  }
+
+  function extractHeader(all, name) {
+    if (!Array.isArray(all)) {
+      return '';
+    }
+    const target = name.toLowerCase();
+    for (let i = 0; i < all.length; i++) {
+      const header = all[i];
+      if (!header || typeof header.name !== 'string') {
+        continue;
+      }
+      if (header.name.toLowerCase() === target) {
+        return header.value || '';
+      }
+    }
+    return '';
+  }
+
+  try {
+    const messageResponse = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/' + encodeURIComponent(messageId) + '?format=full',
+        method: 'GET',
+        headers: { Authorization: 'Bearer ' + accessToken }
+      }),
+      { attempts: 5, backoffMs: 500 }
+    );
+
+    const message = messageResponse.body || {};
+    const payload = message.payload || {};
+    const headersList = payload.headers || [];
+
+    const fromHeader = extractHeader(headersList, 'From');
+    const replyToHeader = extractHeader(headersList, 'Reply-To');
+    const toHeader = parseAddressList(extractHeader(headersList, 'To'));
+    const ccHeader = parseAddressList(extractHeader(headersList, 'Cc'));
+
+    const baseReplyTo = parseAddressList(replyToHeader);
+    const baseRecipients = baseReplyTo.length ? baseReplyTo : parseAddressList(fromHeader);
+    const toRecipients = [];
+    const ccRecipients = [];
+    const seen = {};
+
+    function pushUnique(target, value) {
+      const key = value ? value.toLowerCase() : '';
+      if (!key || Object.prototype.hasOwnProperty.call(seen, key)) {
+        return;
+      }
+      seen[key] = true;
+      target.push(value);
+    }
+
+    for (let i = 0; i < baseRecipients.length; i++) {
+      pushUnique(toRecipients, baseRecipients[i]);
+    }
+
+    if (replyAll) {
+      for (let i = 0; i < toHeader.length; i++) {
+        pushUnique(toRecipients, toHeader[i]);
+      }
+      for (let i = 0; i < ccHeader.length; i++) {
+        pushUnique(ccRecipients, ccHeader[i]);
+      }
+    }
+
+    if (!toRecipients.length) {
+      logError('gmail_send_reply_unresolved_recipient', { messageId: messageId });
+      throw new Error('Unable to resolve reply recipients for Gmail send_reply operation');
+    }
+
+    const messageIdHeader = extractHeader(headersList, 'Message-ID') || ('<' + messageId + '>');
+    const referencesHeader = extractHeader(headersList, 'References');
+    const references = referencesHeader ? referencesHeader + ' ' + messageIdHeader : messageIdHeader;
+
+    const originalSubject = extractHeader(headersList, 'Subject') || '';
+    let subject = originalSubject;
+    if (!subject) {
+      subject = 'Re:';
+    } else if (!/^\s*re:/i.test(subject)) {
+      subject = 'Re: ' + subject;
+    }
+
+    const headerLines = ['To: ' + toRecipients.join(', ')];
+    if (ccRecipients.length) {
+      headerLines.push('Cc: ' + ccRecipients.join(', '));
+    }
+    headerLines.push('Subject: ' + subject);
+    headerLines.push('In-Reply-To: ' + messageIdHeader);
+    headerLines.push('References: ' + references);
+    headerLines.push('MIME-Version: 1.0');
+    headerLines.push('Content-Type: text/plain; charset="UTF-8"');
+    headerLines.push('Content-Transfer-Encoding: 7bit');
+
+    const messageBody = headerLines.join('\r\n') + '\r\n\r\n' + replyBody;
+    const raw = Utilities.base64EncodeWebSafe(Utilities.newBlob(messageBody).getBytes()).replace(/=+$/, '');
+
+    const requestBody = { raw: raw };
+    if (message.threadId) {
+      requestBody.threadId = message.threadId;
+    }
+
+    const sendResponse = rateLimitAware(
+      () => fetchJson({
+        url: 'https://gmail.googleapis.com/gmail/v1/users/me/messages/send',
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + accessToken,
+          'Content-Type': 'application/json'
+        },
+        payload: JSON.stringify(requestBody)
+      }),
+      { attempts: 5, backoffMs: 500 }
+    );
+
+    const responseBody = sendResponse.body || {};
+    ctx.gmailMessageId = responseBody.id || ctx.gmailMessageId || null;
+    ctx.gmailThreadId = responseBody.threadId || message.threadId || null;
+    ctx.gmailLabelIds = Array.isArray(responseBody.labelIds) ? responseBody.labelIds : [];
+    ctx.gmailSendReplyResponse = responseBody;
+    ctx.gmailReplyRecipients = toRecipients;
+    ctx.gmailReplyCc = ccRecipients;
+
+    logInfo('gmail_send_reply_success', {
+      messageId: ctx.gmailMessageId || null,
+      threadId: ctx.gmailThreadId || null,
+      replyAll: replyAll,
+      toCount: toRecipients.length,
+      ccCount: ccRecipients.length
+    });
+
+    return ctx;
+  } catch (error) {
+    const providerCode = error && error.body && error.body.error ? (error.body.error.status || error.body.error.code || null) : null;
+    const providerMessage = error && error.body && error.body.error ? error.body.error.message : null;
+    const status = error && typeof error.status === 'number' ? error.status : null;
+    const message = providerMessage || (error && error.message ? error.message : String(error));
+    logError('gmail_send_reply_failed', {
+      operation: 'action.gmail:send_reply',
+      status: status,
+      providerCode: providerCode,
+      message: message
+    });
+    throw new Error('Gmail send_reply failed: ' + (providerCode ? providerCode + ' ' : '') + message);
   }
 }`,
 


### PR DESCRIPTION
## Summary
- replace the Gmail Apps Script stubs with production-ready polling triggers and actions, including a shared `buildGmailPollingTrigger` helper
- expand the Gmail Apps Script test suite with new snapshots and dry-run coverage for every Tier-0 Gmail trigger and action
- document the Gmail Script Properties scope requirements and add fixtures covering Gmail connection, search, retrieval, replies, mark-as-read, and add-label flows

## Testing
- `npx vitest -u server/workflow/__tests__/apps-script.gmail.test.ts` *(fails: npm registry access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed14b139548331a7725a8dd1455658